### PR TITLE
fix: require value based on for sum and average dashboard charts

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
@@ -90,7 +90,8 @@
    "depends_on": "eval: ['Sum', 'Average'].includes(doc.chart_type)\n",
    "fieldname": "value_based_on",
    "fieldtype": "Select",
-   "label": "Value Based On"
+   "label": "Value Based On",
+   "mandatory_depends_on": "eval: ['Sum', 'Average'].includes(doc.chart_type)"
   },
   {
    "fieldname": "column_break_6",
@@ -308,7 +309,7 @@
   }
  ],
  "links": [],
- "modified": "2026-07-17 11:42:00.000000",
+ "modified": "2026-07-20 10:15:00.000000",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Dashboard Chart",

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -419,6 +419,8 @@ class DashboardChart(Document):
 		else:
 			if not self.based_on:
 				frappe.throw(_("Time series based on is required to create a dashboard chart"))
+			if self.chart_type in ["Sum", "Average"] and not self.value_based_on:
+				frappe.throw(_("Value Based On field is required to create a dashboard chart"))
 
 	def check_document_type(self):
 		if frappe.get_meta(self.document_type).issingle:

--- a/frappe/desk/doctype/dashboard_chart/test_dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/test_dashboard_chart.py
@@ -185,6 +185,34 @@ class TestDashboardChart(IntegrationTestCase):
 
 		self.assertEqual(result.get("datasets")[0].get("values")[0], todo_status_count)
 
+	def test_value_based_on_required_for_sum_and_average(self):
+		for chart_type in ("Sum", "Average"):
+			chart = frappe.get_doc(
+				doctype="Dashboard Chart",
+				chart_name=f"Test {chart_type} Without Value Field",
+				chart_type=chart_type,
+				document_type=self.doctype_name,
+				based_on="date",
+				timespan="Last Year",
+				time_interval="Monthly",
+				filters_json="[]",
+				timeseries=1,
+			)
+			self.assertRaises(frappe.ValidationError, chart.insert)
+
+		chart = frappe.get_doc(
+			doctype="Dashboard Chart",
+			chart_name="Test Count Without Value Field",
+			chart_type="Count",
+			document_type=self.doctype_name,
+			based_on="date",
+			timespan="Last Year",
+			time_interval="Monthly",
+			filters_json="[]",
+			timeseries=1,
+		)
+		chart.insert()
+
 	def test_daily_dashboard_chart(self):
 		insert_test_records(self.doctype_name)
 

--- a/frappe/desk/doctype/dashboard_chart/test_dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/test_dashboard_chart.py
@@ -212,6 +212,7 @@ class TestDashboardChart(IntegrationTestCase):
 			timeseries=1,
 		)
 		chart.insert()
+		self.addCleanup(chart.delete)
 
 	def test_daily_dashboard_chart(self):
 		insert_test_records(self.doctype_name)

--- a/frappe/public/js/frappe/views/dashboard/dashboard_view.js
+++ b/frappe/public/js/frappe/views/dashboard/dashboard_view.js
@@ -348,9 +348,10 @@ frappe.views.DashboardView = class DashboardView extends frappe.views.ListView {
 				{
 					label: "Value Based On",
 					fieldtype: "Select",
-					fieldname: "based_on",
+					fieldname: "value_based_on",
 					options: fields.value_fields,
-					depends_on: 'eval: doc.chart_function=="Sum"',
+					depends_on: 'eval: ["Sum", "Average"].includes(doc.chart_function)',
+					mandatory_depends_on: 'eval: ["Sum", "Average"].includes(doc.chart_function)',
 				},
 				{
 					label: "Time Series Based On",


### PR DESCRIPTION
## Description

`check_required_field` validates the aggregate field for Group By charts (`group_by_type` in `["Sum", "Average"]` requires `aggregate_function_based_on`), but the Time Series path only validates `based_on`. As a result, `value_based_on` is never enforced for `Sum` and `Average` charts, allowing them to be saved with an empty value field.

Both chart types later fall back to the literal `"1"`:

```python
value_field = chart.value_based_on or "1"
```

This produces incorrect results without any validation error:

- **Sum** charts plot `SUM(1)`, which is effectively the row count while being labeled as a sum.
- **Average** charts plot `SUM(1) / COUNT(*)`, producing a constant value of `1`.

## Fix

- Add the missing server-side validation for `value_based_on` in the Time Series path, matching the existing Group By validation.
- Add the corresponding `mandatory_depends_on` condition so the field is also enforced in the form UI.

The existing fallback to `"1"` is intentionally unchanged, as it is the correct behavior for **Count** charts.

## Notes

Existing charts already saved without `value_based_on` are not migrated. They will continue to render incorrectly until they are edited and saved again, at which point the new validation will prevent the invalid configuration.

A migration to clean up existing records could be added if maintainers prefer that approach.

Closes #40972.