### PR TITLE
fix(ux): show warning over same label

### DIFF
--- a/frappe/desk/doctype/workspace/test_workspace.py
+++ b/frappe/desk/doctype/workspace/test_workspace.py
@@ -68,6 +68,72 @@ class TestWorkspace(IntegrationTestCase):
 		finally:
 			frappe.db.delete("Workspace", {"name": workspace.name})
 
+	def test_duplicate_shortcut_labels_are_rejected(self):
+		"""Two shortcuts sharing a label would collapse into one row on save, so block it."""
+		workspace = frappe.new_doc("Workspace")
+		workspace.label = "Duplicate Shortcut Workspace"
+		workspace.title = "Duplicate Shortcut Workspace"
+		workspace.public = 0
+		workspace.for_user = frappe.session.user
+		workspace.content = "[]"
+
+		for stats_filter in (
+			'[["ToDo","status","!=","Open",false]]',
+			'[["ToDo","status","=","Closed",false]]',
+		):
+			workspace.append(
+				"shortcuts",
+				{"type": "DocType", "link_to": "ToDo", "label": "Tasks", "stats_filter": stats_filter},
+			)
+
+		try:
+			with self.assertRaises(frappe.ValidationError):
+				workspace.insert()
+		finally:
+			frappe.db.delete("Workspace", {"name": workspace.name})
+
+	def test_preexisting_duplicate_labels_stay_editable(self):
+		"""Duplicates already stored (shipped app data, older sites) must not lock the workspace."""
+		workspace = frappe.new_doc("Workspace")
+		workspace.label = "Legacy Duplicate Workspace"
+		workspace.title = "Legacy Duplicate Workspace"
+		workspace.public = 0
+		workspace.for_user = frappe.session.user
+		workspace.content = "[]"
+		workspace.insert()
+
+		try:
+			# simulate data that predates the check, bypassing validate()
+			for idx in (1, 2):
+				frappe.get_doc(
+					{
+						"doctype": "Workspace Shortcut",
+						"parent": workspace.name,
+						"parenttype": "Workspace",
+						"parentfield": "shortcuts",
+						"idx": idx,
+						"type": "DocType",
+						"link_to": "ToDo",
+						"label": "Tasks",
+					}
+				).db_insert()
+
+			workspace.reload()
+			self.assertEqual(len(workspace.shortcuts), 2)
+
+			# an unrelated edit still saves; the grandfathered duplicate is not re-raised
+			workspace.title = "Legacy Duplicate Workspace Renamed"
+			workspace.save()
+
+			# but adding a *third* clashing shortcut is still refused
+			workspace.append("shortcuts", {"type": "DocType", "link_to": "ToDo", "label": "Notes"})
+			workspace.append("shortcuts", {"type": "DocType", "link_to": "ToDo", "label": "Notes"})
+			with self.assertRaises(frappe.ValidationError):
+				workspace.save()
+		finally:
+			frappe.db.delete("Workspace Shortcut", {"parent": workspace.name})
+			frappe.db.delete("Workspace", {"name": workspace.name})
+
 	def test_role_restricted_non_public_workspace_visible_to_permitted_user(self):
 		"""Non-public workspace with roles should be visible to users with matching role."""
 		from frappe.desk.desktop import get_workspaces

--- a/frappe/desk/doctype/workspace/test_workspace.py
+++ b/frappe/desk/doctype/workspace/test_workspace.py
@@ -125,11 +125,24 @@ class TestWorkspace(IntegrationTestCase):
 			workspace.title = "Legacy Duplicate Workspace Renamed"
 			workspace.save()
 
-			# but adding a *third* clashing shortcut is still refused
-			workspace.append("shortcuts", {"type": "DocType", "link_to": "ToDo", "label": "Notes"})
-			workspace.append("shortcuts", {"type": "DocType", "link_to": "ToDo", "label": "Notes"})
+			# deepening the existing clash -- a *third* row under the grandfathered label -- is a
+			# new duplicate all the same, so it is still refused
+			workspace.append("shortcuts", {"type": "DocType", "link_to": "ToDo", "label": "Tasks"})
 			with self.assertRaises(frappe.ValidationError):
 				workspace.save()
+
+			# and so is a fresh clash on a label that was unique before
+			workspace.reload()
+			for _ in range(2):
+				workspace.append("shortcuts", {"type": "DocType", "link_to": "ToDo", "label": "Notes"})
+			with self.assertRaises(frappe.ValidationError):
+				workspace.save()
+
+			# dropping one of the grandfathered rows is a repair, not a new clash
+			workspace.reload()
+			workspace.shortcuts.pop()
+			workspace.save()
+			self.assertEqual(len(workspace.shortcuts), 1)
 		finally:
 			frappe.db.delete("Workspace Shortcut", {"parent": workspace.name})
 			frappe.db.delete("Workspace", {"name": workspace.name})

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies and contributors
 # License: MIT. See LICENSE
 
-from collections import defaultdict
+from collections import Counter, defaultdict
 from json import loads
 
 import frappe
@@ -131,22 +131,19 @@ class Workspace(Document, DeskViews):
 			frappe.throw(_("{0} is not an installed app.").format(frappe.bold(self.app)))
 
 	@staticmethod
-	def get_duplicate_widget_labels(doc, parentfield):
+	def get_widget_label_counts(doc, parentfield) -> Counter:
+		"""How many rows of `parentfield` carry each label."""
 		rows = doc.get(parentfield) or []
 		if parentfield == "links":
 			# only `Card Break` rows name a card; the link rows beneath them aren't addressed by label
 			rows = [row for row in rows if row.type == "Card Break"]
 
-		seen, duplicates = set(), set()
+		counts = Counter()
 		for row in rows:
-			label = (row.label or "").strip()
-			if not label:
-				continue
-			if label in seen:
-				duplicates.add(label)
-			seen.add(label)
+			if label := (row.label or "").strip():
+				counts[label] += 1
 
-		return duplicates
+		return counts
 
 	def validate_duplicate_widget_labels(self):
 		"""Widget blocks in `content` reference their child row by label (see `clean_up` in
@@ -179,12 +176,14 @@ class Workspace(Document, DeskViews):
 		before_save = self.get_doc_before_save()
 
 		for parentfield, widget_label in widget_labels.items():
-			duplicates = self.get_duplicate_widget_labels(self, parentfield)
-			if not duplicates:
-				continue
+			counts = self.get_widget_label_counts(self, parentfield)
+			stored = self.get_widget_label_counts(before_save, parentfield) if before_save else {}
 
-			if before_save:
-				duplicates -= self.get_duplicate_widget_labels(before_save, parentfield)
+			# Compare counts, not just presence: a label already stored twice is grandfathered at
+			# two, but a third row under it is a clash *this* save introduces and still has to go.
+			duplicates = {
+				label for label, count in counts.items() if count > 1 and count > stored.get(label, 0)
+			}
 
 			if duplicates:
 				frappe.throw(

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -116,6 +116,8 @@ class Workspace(Document, DeskViews):
 			if shortcut.type == "Report":
 				shortcut.report_ref_doctype = frappe.get_value("Report", shortcut.link_to, "ref_doctype")
 
+		self.validate_duplicate_widget_labels()
+
 		if self.standard:
 			if not self.app and self.module:
 				from frappe.modules.utils import get_module_app
@@ -127,6 +129,69 @@ class Workspace(Document, DeskViews):
 		# so reject it here rather than let it strand the workspace.
 		if self.app and self.app not in frappe.get_installed_apps():
 			frappe.throw(_("{0} is not an installed app.").format(frappe.bold(self.app)))
+	@staticmethod
+	def get_duplicate_widget_labels(doc, parentfield):
+		rows = doc.get(parentfield) or []
+		if parentfield == "links":
+			# only `Card Break` rows name a card; the link rows beneath them aren't addressed by label
+			rows = [row for row in rows if row.type == "Card Break"]
+
+		seen, duplicates = set(), set()
+		for row in rows:
+			label = (row.label or "").strip()
+			if not label:
+				continue
+			if label in seen:
+				duplicates.add(label)
+			seen.add(label)
+
+		return duplicates
+
+	def validate_duplicate_widget_labels(self):
+		"""Widget blocks in `content` reference their child row by label (see `clean_up` in
+		frappe/desk/desktop.py), so two widgets of the same type sharing a label collapse into a
+		single row on save and one of them silently loses its settings.
+
+		Only duplicates that *this* save introduces are rejected. Ones already stored — shipped app
+		data, sites saved before this check existed — are left alone, so an affected workspace
+		doesn't become impossible to edit.
+		"""
+		# app-shipped workspaces are imported verbatim; a duplicate in one is the app's bug to fix
+		# and shouldn't take down install/migrate
+		if (
+			frappe.flags.in_install
+			or frappe.flags.in_migrate
+			or frappe.flags.in_import
+			or frappe.flags.in_patch
+		):
+			return
+
+		widget_labels = {
+			"shortcuts": _("Shortcut"),
+			"charts": _("Chart"),
+			"quick_lists": _("Quick List"),
+			"number_cards": _("Number Card"),
+			"custom_blocks": _("Custom Block"),
+			"links": _("Card"),
+		}
+
+		before_save = self.get_doc_before_save()
+
+		for parentfield, widget_label in widget_labels.items():
+			duplicates = self.get_duplicate_widget_labels(self, parentfield)
+			if not duplicates:
+				continue
+
+			if before_save:
+				duplicates -= self.get_duplicate_widget_labels(before_save, parentfield)
+
+			if duplicates:
+				frappe.throw(
+					_(
+						"Duplicate {0} labels: {1}. Labels are used to tell widgets apart when a workspace is saved, so each {0} needs a unique label."
+					).format(widget_label, frappe.bold(", ".join(sorted(duplicates)))),
+					title=_("Duplicate Label"),
+				)
 
 	def before_rename(self, old_name, new_name, merge=False):
 		if self.public and not is_workspace_manager() and not disable_saving_as_public():

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -129,6 +129,7 @@ class Workspace(Document, DeskViews):
 		# so reject it here rather than let it strand the workspace.
 		if self.app and self.app not in frappe.get_installed_apps():
 			frappe.throw(_("{0} is not an installed app.").format(frappe.bold(self.app)))
+
 	@staticmethod
 	def get_duplicate_widget_labels(doc, parentfield):
 		rows = doc.get(parentfield) or []

--- a/frappe/integrations/workspace/integrations/integrations.json
+++ b/frappe/integrations/workspace/integrations/integrations.json
@@ -320,7 +320,7 @@
    "type": "Link"
   }
  ],
- "modified": "2026-07-06 18:21:45.545054",
+ "modified": "2026-07-20 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Integrations",
@@ -338,21 +338,6 @@
    "doc_view": "List",
    "label": "Google Settings",
    "link_to": "Google Settings",
-   "type": "DocType"
-  },
-  {
-   "color": "Grey",
-   "doc_view": "List",
-   "label": "Google Settings",
-   "link_to": "Google Settings",
-   "type": "DocType"
-  },
-  {
-   "color": "Grey",
-   "doc_view": "List",
-   "label": "Webhook",
-   "link_to": "Webhook",
-   "stats_filter": "[]",
    "type": "DocType"
   },
   {

--- a/frappe/integrations/workspace/integrations/integrations.json
+++ b/frappe/integrations/workspace/integrations/integrations.json
@@ -22,42 +22,12 @@
    "type": "Card Break"
   },
   {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Google Services",
-   "link_count": 0,
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
    "dependencies": "",
    "hidden": 0,
    "is_query_report": 0,
    "label": "Google Settings",
    "link_count": 0,
    "link_to": "Google Settings",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "dependencies": "",
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Google Settings",
-   "link_count": 0,
-   "link_to": "Google Settings",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "dependencies": "",
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Google Contacts",
-   "link_count": 0,
-   "link_to": "Google Contacts",
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"
@@ -85,42 +55,12 @@
    "type": "Link"
   },
   {
-   "dependencies": "",
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Google Calendar",
-   "link_count": 0,
-   "link_to": "Google Calendar",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
    "hidden": 0,
    "is_query_report": 0,
    "label": "Settings",
    "link_count": 0,
    "onboard": 0,
    "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Settings",
-   "link_count": 0,
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "dependencies": "",
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Webhook",
-   "link_count": 0,
-   "link_to": "Webhook",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
   },
   {
    "dependencies": "",
@@ -148,28 +88,6 @@
    "dependencies": "",
    "hidden": 0,
    "is_query_report": 0,
-   "label": "Slack Webhook URL",
-   "link_count": 0,
-   "link_to": "Slack Webhook URL",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "dependencies": "",
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "SMS Settings",
-   "link_count": 0,
-   "link_to": "SMS Settings",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "dependencies": "",
-   "hidden": 0,
-   "is_query_report": 0,
    "label": "SMS Settings",
    "link_count": 0,
    "link_to": "SMS Settings",
@@ -186,42 +104,12 @@
    "type": "Card Break"
   },
   {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Authentication",
-   "link_count": 4,
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
    "dependencies": "",
    "hidden": 0,
    "is_query_report": 0,
    "label": "Social Login Key",
    "link_count": 0,
    "link_to": "Social Login Key",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "dependencies": "",
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Social Login Key",
-   "link_count": 0,
-   "link_to": "Social Login Key",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "dependencies": "",
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "LDAP Settings",
-   "link_count": 0,
-   "link_to": "LDAP Settings",
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"
@@ -252,28 +140,6 @@
    "dependencies": "",
    "hidden": 0,
    "is_query_report": 0,
-   "label": "OAuth Client",
-   "link_count": 0,
-   "link_to": "OAuth Client",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "dependencies": "",
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "OAuth Provider Settings",
-   "link_count": 0,
-   "link_to": "OAuth Provider Settings",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "dependencies": "",
-   "hidden": 0,
-   "is_query_report": 0,
    "label": "OAuth Provider Settings",
    "link_count": 0,
    "link_to": "OAuth Provider Settings",
@@ -289,25 +155,6 @@
    "link_type": "DocType",
    "onboard": 0,
    "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Push Notifications",
-   "link_count": 1,
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Push Notification Settings",
-   "link_count": 0,
-   "link_to": "Push Notification Settings",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
   },
   {
    "hidden": 0,
@@ -320,7 +167,7 @@
    "type": "Link"
   }
  ],
- "modified": "2026-07-20 12:00:00.000000",
+ "modified": "2026-08-05 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Integrations",

--- a/frappe/public/js/frappe/widgets/widget_dialog.js
+++ b/frappe/public/js/frappe/widgets/widget_dialog.js
@@ -7,6 +7,7 @@ class WidgetDialog {
 	make() {
 		this.make_dialog();
 		this.setup_dialog_events();
+		this.setup_duplicate_label_warning();
 		this.dialog.show();
 
 		window.cur_dialog = this.dialog;
@@ -19,6 +20,7 @@ class WidgetDialog {
 			fields: this.get_fields(),
 			primary_action: (data) => {
 				data = this.process_data(data);
+				this.validate_duplicate_label(data);
 
 				if (!this.editing && !data.name) {
 					data.name = `${this.type}-${this.label}-${frappe.utils.get_random(20)}`;
@@ -87,6 +89,86 @@ class WidgetDialog {
 
 	setup_dialog_events() {
 		//
+	}
+
+	get_type_label() {
+		return (
+			{
+				chart: __("chart"),
+				shortcut: __("shortcut"),
+				links: __("card"),
+				onboarding: __("onboarding"),
+				quick_list: __("quick list"),
+				number_card: __("number card"),
+				custom_block: __("custom block"),
+			}[this.type] || __("widget")
+		);
+	}
+
+	// A workspace widget is joined to its content block by `label` (see `clean_up` in
+	// frappe/desk/desktop.py), so two widgets of the same type sharing a label collapse into a
+	// single child row on save and one of them silently loses its settings. Collect the labels
+	// currently on the page so we can refuse the duplicate while it is still an easy fix.
+	get_sibling_labels() {
+		const editor = document.getElementById("editorjs");
+		if (!editor) return [];
+
+		// blocks carry their widget's label in a `<type>_name` attribute; `links` blocks are
+		// called `card` everywhere except in the dialog registry
+		const attribute = `${this.type == "links" ? "card" : this.type}_name`;
+
+		// the widget being edited is still on the page under its old label — don't clash with it
+		const own_block = this.values?.name
+			? editor
+					.querySelector(`[data-widget-name="${CSS.escape(this.values.name)}"]`)
+					?.closest(`[${attribute}]`)
+			: null;
+
+		return Array.from(editor.querySelectorAll(`[${attribute}]`))
+			.filter((block) => block !== own_block)
+			.map((block) => frappe.utils.unescape_html(block.getAttribute(attribute)));
+	}
+
+	is_duplicate_label(label) {
+		if (!this.for_workspace || !label) return false;
+		return this.get_sibling_labels().includes(frappe.utils.unescape_html(label));
+	}
+
+	validate_duplicate_label(data) {
+		if (!this.is_duplicate_label(data.label)) return;
+
+		frappe.throw({
+			message: __(
+				"Another {0} in this workspace is already labelled {1}. Labels are used to tell widgets apart when the workspace is saved, so the two would overwrite each other. Please pick a different label.",
+				[this.get_type_label(), frappe.utils.bold(data.label)]
+			),
+			title: __("Duplicate Label"),
+			indicator: "red",
+		});
+	}
+
+	// warn while typing, so the user doesn't only find out when they hit save. This writes to its
+	// own node instead of going through `set_df_property`, which refreshes the control on every
+	// keystroke and would wipe out what is being typed.
+	setup_duplicate_label_warning() {
+		const field = this.dialog.get_field("label");
+		if (!field?.$input || !this.for_workspace) return;
+
+		const $warning = $('<div class="help-box small text-danger hide"></div>').appendTo(
+			field.$wrapper.find(".control-input-wrapper")
+		);
+
+		field.$input.on("input", () => {
+			const duplicate = this.is_duplicate_label(field.$input.val());
+			if (duplicate) {
+				$warning.text(
+					__("This label is already used by another {0} in this workspace.", [
+						this.get_type_label(),
+					])
+				);
+			}
+			$warning.toggleClass("hide", !duplicate);
+		});
 	}
 
 	hide_field(fieldname) {

--- a/frappe/public/js/frappe/widgets/widget_dialog.js
+++ b/frappe/public/js/frappe/widgets/widget_dialog.js
@@ -131,7 +131,18 @@ class WidgetDialog {
 
 	is_duplicate_label(label) {
 		if (!this.for_workspace || !label) return false;
-		return this.get_sibling_labels().includes(frappe.utils.unescape_html(label));
+
+		const unescaped = frappe.utils.unescape_html(label);
+
+		// Mirror the server (`validate_duplicate_widget_labels`): only a clash *this* edit
+		// introduces is refused. A workspace saved before this check existed can already carry
+		// two widgets under one label, and editing either of them — without touching the label —
+		// has to stay possible, or the clash could never be cleaned up from the UI.
+		if (this.editing && unescaped == frappe.utils.unescape_html(this.values.label || "")) {
+			return false;
+		}
+
+		return this.get_sibling_labels().includes(unescaped);
 	}
 
 	validate_duplicate_label(data) {


### PR DESCRIPTION
You can not have shortcuts with same label. It is bad UX for the end user. The workspace editor ux for this was also bad

<img width="760" height="318" alt="Screenshot 2026-07-20 at 3 25 34 PM" src="https://github.com/user-attachments/assets/a53500b3-5878-4368-a748-1c5f05e5b1df" />

