### PR TITLE
fix(print): render a top page number above the page margin

### DIFF
--- a/frappe/utils/pdf_generator/browser.py
+++ b/frappe/utils/pdf_generator/browser.py
@@ -326,8 +326,13 @@ class Browser:
 		footer_with_bottom_margin = 0
 		footer_height = 0
 
+		# When the caller already reserved the top margin inside the header markup
+		# (so a page number can sit flush to the page edge), the measured header
+		# height covers it and Chrome must not add it a second time.
+		header_owns_top_margin = bool(options.get("header-includes-top-margin"))
+
 		if self.header_page:
-			header_with_top_margin = self.header_height + margin_top
+			header_with_top_margin = self.header_height + (0 if header_owns_top_margin else margin_top)
 			header_spacing = options.get("header-spacing", 0)
 			header_with_spacing_top_margin = header_with_top_margin + header_spacing
 			self.header_page.options["paperHeight"] = (
@@ -339,7 +344,7 @@ class Browser:
 		margin_top = convert_uom(margin_top, "px", "in", only_number=True)
 
 		if self.header_page:
-			self.header_page.options["marginTop"] = margin_top
+			self.header_page.options["marginTop"] = 0 if header_owns_top_margin else margin_top
 		else:
 			self.body_page.options["marginTop"] = margin_top
 

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -300,6 +300,7 @@ class PrintFormatGenerator:
 		    overlay so they continue to repeat on every page if the user enabled them.
 		"""
 		self.context.for_chrome = True
+		self._header_absorbs_top_margin = False
 		self.context.repeat_frame = False
 		self.context.header_height = 0
 		self.context.footer_height = 0
@@ -325,6 +326,19 @@ class PrintFormatGenerator:
 
 		return self.get_main_html()
 
+	def _reserve_top_margin(self, html: str) -> str:
+		"""Reserve the page's top margin *below* the page number.
+
+		browser.py then drops the header page's own ``marginTop`` (via the
+		``header-includes-top-margin`` option), so the number sits flush to the
+		paper edge while everything after it keeps the configured margin.
+		"""
+		top_margin = float(self.print_format.margin_top or 0)
+		if not top_margin:
+			return html
+		self._header_absorbs_top_margin = True
+		return f'<div style="padding-top:{top_margin}mm">{html}</div>'
+
 	def _render_page_no_overlay(self, kind: str) -> str | None:
 		"""Return only the page-number HTML for kind ('header'/'footer'), or None."""
 		is_header = kind == "header"
@@ -332,7 +346,10 @@ class PrintFormatGenerator:
 		valid_positions = self._TOP_POSITIONS if is_header else self._BOTTOM_POSITIONS
 		if page_pos not in valid_positions:
 			return None
-		return self._page_number_html(page_pos)
+		page_no_html = self._page_number_html(page_pos)
+		if not is_header:
+			return page_no_html
+		return page_no_html + self._reserve_top_margin("")
 
 	def _render_overlay(self, kind: str, with_page_no: bool = True) -> str | None:
 		"""Render letterhead, layout.header/footer, and page number for the Chrome overlay.
@@ -381,12 +398,8 @@ class PrintFormatGenerator:
 		if not is_header and page_no_html:
 			body_parts.append(page_no_html)
 
-		top_margin = float(self.print_format.margin_top or 0)
-		if is_header and page_no_html and body_parts and top_margin:
-			body_parts = [
-				f'<div style="padding-top:{top_margin}mm">' + "\n".join(body_parts) + "</div>"
-			]
-			self._header_absorbs_top_margin = True
+		if is_header and page_no_html:
+			body_parts = [self._reserve_top_margin("\n".join(body_parts))]
 		parts.extend(body_parts)
 		return "\n".join(parts) or None
 

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -186,6 +186,7 @@ class PrintFormatGenerator:
 		self.doc = doc
 		self.style = style
 		self.settings_override = settings or {}
+		self._header_absorbs_top_margin = False
 
 		if letterhead == _("No Letterhead"):
 			letterhead = None
@@ -266,17 +267,20 @@ class PrintFormatGenerator:
 		from frappe.utils.pdf import get_chrome_pdf
 
 		pf = self.print_format
+		html = self._build_html_for_chrome()
 		options = {
 			"margin-top": f"{pf.margin_top}mm",
 			"margin-bottom": f"{pf.margin_bottom}mm",
 			"margin-left": f"{pf.margin_left}mm",
 			"margin-right": f"{pf.margin_right}mm",
 		}
+		if self._header_absorbs_top_margin:
+			options["header-includes-top-margin"] = True
 		if password:
 			options["password"] = password
 		return get_chrome_pdf(
 			print_format=pf.name,
-			html=self._build_html_for_chrome(),
+			html=html,
 			options=options,
 			output=None,
 			pdf_generator="chrome",
@@ -356,10 +360,11 @@ class PrintFormatGenerator:
 		ctx = {"doc": self.context.doc}
 
 		parts = []
+		body_parts = []
 		if is_header and page_no_html:
 			parts.append(page_no_html)
 		if letterhead_html:
-			parts.append(
+			body_parts.append(
 				'<div class="letter-head">' + frappe.render_template(letterhead_html, ctx) + "</div>"
 			)
 		if layout_template:
@@ -372,9 +377,17 @@ class PrintFormatGenerator:
 				# Section object — render using the same logic as print_format.html
 				zone_html = self._render_zone_section(layout_template, ctx["doc"])
 			if zone_html:
-				parts.append('<div class="document-header-content">' + zone_html + "</div>")
+				body_parts.append('<div class="document-header-content">' + zone_html + "</div>")
 		if not is_header and page_no_html:
-			parts.append(page_no_html)
+			body_parts.append(page_no_html)
+
+		top_margin = float(self.print_format.margin_top or 0)
+		if is_header and page_no_html and body_parts and top_margin:
+			body_parts = [
+				f'<div style="padding-top:{top_margin}mm">' + "\n".join(body_parts) + "</div>"
+			]
+			self._header_absorbs_top_margin = True
+		parts.extend(body_parts)
 		return "\n".join(parts) or None
 
 	_ZONE_SECTION_TEMPLATE = """\

--- a/frappe/utils/test_print_format_generator.py
+++ b/frappe/utils/test_print_format_generator.py
@@ -201,9 +201,7 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 		def chrome_options(letterhead=True, **pf_kwargs):
 			pf_kwargs.setdefault("margin_top", 12)
 			pf = self._make_print_format(**pf_kwargs)
-			generator = PrintFormatGenerator(
-				pf, todo, letterhead=letterhead_doc.name if letterhead else None
-			)
+			generator = PrintFormatGenerator(pf, todo, letterhead=letterhead_doc.name if letterhead else None)
 			with patch("frappe.utils.pdf.get_chrome_pdf", return_value=b"%PDF-") as chrome_pdf:
 				generator.render_pdf()
 			return chrome_pdf.call_args.kwargs

--- a/frappe/utils/test_print_format_generator.py
+++ b/frappe/utils/test_print_format_generator.py
@@ -196,11 +196,14 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 		from frappe.utils.print_format_generator import PrintFormatGenerator
 
 		todo = self._make_todo()
-		letterhead = self._make_letterhead()
+		letterhead_doc = self._make_letterhead()
 
-		def chrome_options(**pf_kwargs):
-			pf = self._make_print_format(margin_top=12, **pf_kwargs)
-			generator = PrintFormatGenerator(pf, todo, letterhead=letterhead.name)
+		def chrome_options(letterhead=True, **pf_kwargs):
+			pf_kwargs.setdefault("margin_top", 12)
+			pf = self._make_print_format(**pf_kwargs)
+			generator = PrintFormatGenerator(
+				pf, todo, letterhead=letterhead_doc.name if letterhead else None
+			)
 			with patch("frappe.utils.pdf.get_chrome_pdf", return_value=b"%PDF-") as chrome_pdf:
 				generator.render_pdf()
 			return chrome_pdf.call_args.kwargs
@@ -209,9 +212,25 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 		self.assertTrue(top["options"]["header-includes-top-margin"])
 		self.assertIn("padding-top:12.0mm", top["html"])
 
+		# No letterhead and no header template: the page number is still the only
+		# thing above the margin, so the margin must still be reserved below it.
+		bare = chrome_options(page_number="Top Left", letterhead=False)
+		self.assertTrue(bare["options"]["header-includes-top-margin"])
+		self.assertIn("padding-top:12.0mm", bare["html"])
+
+		# repeat_header_footer off routes page numbers through the minimal overlay.
+		no_repeat = chrome_options(page_number="Top Left", repeat_header_footer=0)
+		self.assertTrue(no_repeat["options"]["header-includes-top-margin"])
+
 		for pos in ("Hide", "Bottom Center"):
 			opts = chrome_options(page_number=pos)["options"]
 			self.assertNotIn("header-includes-top-margin", opts)
+
+		# margin_top 0 has nothing to reserve.
+		self.assertNotIn(
+			"header-includes-top-margin",
+			chrome_options(page_number="Top Left", margin_top=0)["options"],
+		)
 
 	def test_render_pdf_passes_password_to_chrome(self):
 		"""Encrypted PDFs (attach_print(password=...)) must stay encrypted on the

--- a/frappe/utils/test_print_format_generator.py
+++ b/frappe/utils/test_print_format_generator.py
@@ -186,6 +186,33 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 		self.assertNotIn("margin: 0;", page_rule)
 		self.assertLess(html.find("@media screen"), html.find("padding: 20mm"))
 
+	def test_top_page_number_sits_above_the_page_margin(self):
+		"""A top page number renders flush to the page edge, not below margin_top.
+		The header markup absorbs the margin (padding on everything after the page
+		number) and flags it so browser.py drops the header page's own marginTop —
+		otherwise the margin would be applied twice and the body would shift."""
+		from unittest.mock import patch
+
+		from frappe.utils.print_format_generator import PrintFormatGenerator
+
+		todo = self._make_todo()
+		letterhead = self._make_letterhead()
+
+		def chrome_options(**pf_kwargs):
+			pf = self._make_print_format(margin_top=12, **pf_kwargs)
+			generator = PrintFormatGenerator(pf, todo, letterhead=letterhead.name)
+			with patch("frappe.utils.pdf.get_chrome_pdf", return_value=b"%PDF-") as chrome_pdf:
+				generator.render_pdf()
+			return chrome_pdf.call_args.kwargs
+
+		top = chrome_options(page_number="Top Left")
+		self.assertTrue(top["options"]["header-includes-top-margin"])
+		self.assertIn("padding-top:12.0mm", top["html"])
+
+		for pos in ("Hide", "Bottom Center"):
+			opts = chrome_options(page_number=pos)["options"]
+			self.assertNotIn("header-includes-top-margin", opts)
+
 	def test_render_pdf_passes_password_to_chrome(self):
 		"""Encrypted PDFs (attach_print(password=...)) must stay encrypted on the
 		generator path — the chrome pipeline encrypts from options['password']."""


### PR DESCRIPTION
A top page number rendered *below* the page's top margin instead of at the top of the page.

- `browser.py` gives the header its own PDF page with `marginTop = margin_top`, so **all** header content — page number included — starts below the margin.
- The page number now sits flush to the page edge: the generator pads everything after it by `margin_top` and sets a new `header-includes-top-margin` option, so `browser.py` drops the header page's own `marginTop` instead of applying the margin twice.
- Opt-in via that option, so classic and print-designer headers are untouched.

Why not CSS: `margin-top: -12mm` on the page number does move it, but Chrome clips anything above the header page's `marginTop` — the number disappears entirely. The margin has to come off the page itself.

Body content does not move. Measured on a real invoice (12mm top margin), before → after: page number `36.9pt → 3.1pt`, letterhead `123.3pt → 123.3pt`, page count unchanged. At `margin_top: 25` the letterhead correctly shifts to `160.1pt`; at `margin_top: 0` the flag stays off. `page_number = Hide` and `Bottom Center` are unaffected (flag off, identical layout).

`test_print_format_generator` (65, incl. a new regression test), `test_print_format_parity` (5), `test_print_format` (28), `test_printview` (2) green.
