### PR TITLE
revert(print): drop the repeating child-table footer edge

### DIFF
--- a/frappe/public/js/print_format_builder/components/editor/FieldPreviewTable.vue
+++ b/frappe/public/js/print_format_builder/components/editor/FieldPreviewTable.vue
@@ -33,11 +33,6 @@
 				</th>
 			</tr>
 		</thead>
-		<tfoot>
-			<tr>
-				<td class="table-foot" :colspan="df.table_columns?.length || 1"></td>
-			</tr>
-		</tfoot>
 		<tbody>
 			<tr
 				v-for="(row, i) in (preview_doc[df.fieldname] || []).slice(0, 4)"

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -31,9 +31,6 @@
 			</tr>
 		</thead>
 		{%- endif -%}
-		<tfoot>
-			<tr class="table-row"><td class="table-foot" colspan="{{ columns|length }}"></td></tr>
-		</tfoot>
 		<tbody>
 			{% for row in _rows %}
 			<tr class="table-row {{ loop.cycle('odd', 'even') }}" data-idx="{{ row.idx }}"{% if row.get("page_break") and not loop.first %} style="page-break-before: always"{% endif %}>

--- a/frappe/templates/print_format/print_format_doc.css
+++ b/frappe/templates/print_format/print_format_doc.css
@@ -213,11 +213,11 @@
 	border-bottom-right-radius: var(--pfb-radius, 0);
 }
 
-.print-format-doc .child-table .table .table-foot {
-	padding: 0;
-	height: 0;
-	border: none !important;
+.print-format-doc .child-table .table tbody tr:last-child td:first-child {
 	border-bottom-left-radius: var(--pfb-radius, 0);
+}
+
+.print-format-doc .child-table .table tbody tr:last-child td:last-child {
 	border-bottom-right-radius: var(--pfb-radius, 0);
 }
 
@@ -249,13 +249,6 @@
 
 .print-format-doc .child-table--bordered .table thead th {
 	border-top: 1px solid var(--gray-300) !important;
-}
-
-.print-format-doc .child-table--bordered .table .table-foot {
-	height: var(--pfb-radius, 0);
-	border-left: 1px solid var(--gray-300) !important;
-	border-right: 1px solid var(--gray-300) !important;
-	border-bottom: 1px solid var(--gray-300) !important;
 }
 
 /* plain header: no fill, a single rule under the header row instead */


### PR DESCRIPTION
Reverts the `<tfoot>` bottom edge added in #41050.

- The footer repeated a rounded bottom on every page, but it renders as an empty ~22px band under the last row — on a real wide invoice table it reads as a broken blank row, not a card edge.
- Back to the previous behaviour: the bottom corners round where the table actually ends; page-break edges are square cuts.

I verified the original change on a narrow 2-column table where the band looked like a deliberate bottom edge; on a 6-column invoice it does not. My mistake for not checking it against a realistic table before shipping.

`test_print_format_parity` (5), `test_print_format` (28), `test_print_format_generator` (64) green; re-rendered the reporter's real Sales Invoice format — band gone, table ends cleanly.
