### PR TITLE
feat(print): reland the per-page rounded bottom without the empty band

### DIFF
--- a/frappe/public/js/print_format_builder/components/editor/FieldPreviewTable.vue
+++ b/frappe/public/js/print_format_builder/components/editor/FieldPreviewTable.vue
@@ -33,6 +33,11 @@
 				</th>
 			</tr>
 		</thead>
+		<tfoot>
+			<tr>
+				<td class="table-foot" :colspan="df.table_columns?.length || 1"></td>
+			</tr>
+		</tfoot>
 		<tbody>
 			<tr
 				v-for="(row, i) in (preview_doc[df.fieldname] || []).slice(0, 4)"

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -31,6 +31,9 @@
 			</tr>
 		</thead>
 		{%- endif -%}
+		<tfoot>
+			<tr class="table-row"><td class="table-foot" colspan="{{ columns|length }}"></td></tr>
+		</tfoot>
 		<tbody>
 			{% for row in _rows %}
 			<tr class="table-row {{ loop.cycle('odd', 'even') }}" data-idx="{{ row.idx }}"{% if row.get("page_break") and not loop.first %} style="page-break-before: always"{% endif %}>

--- a/frappe/templates/print_format/print_format_doc.css
+++ b/frappe/templates/print_format/print_format_doc.css
@@ -239,6 +239,14 @@
 .print-format-doc .child-table--bordered .table th,
 .print-format-doc .child-table--bordered .table td {
 	border-right: 1px solid var(--gray-300) !important;
+	border-bottom: none !important;
+}
+
+.print-format-doc .child-table--bordered .table tbody td {
+	border-top: 1px solid var(--gray-300) !important;
+}
+
+.print-format-doc .child-table--bordered .table thead th {
 	border-bottom: 1px solid var(--gray-300) !important;
 }
 
@@ -249,6 +257,20 @@
 
 .print-format-doc .child-table--bordered .table thead th {
 	border-top: 1px solid var(--gray-300) !important;
+}
+
+.print-format-doc .child-table .table .table-foot {
+	padding: 0;
+	height: var(--pfb-radius, 0);
+	border: none !important;
+	border-bottom-left-radius: var(--pfb-radius, 0);
+	border-bottom-right-radius: var(--pfb-radius, 0);
+}
+
+.print-format-doc .child-table--bordered .table .table-foot {
+	border-left: 1px solid var(--gray-300) !important;
+	border-right: 1px solid var(--gray-300) !important;
+	border-bottom: 1px solid var(--gray-300) !important;
 }
 
 /* plain header: no fill, a single rule under the header row instead */


### PR DESCRIPTION
Supersedes #41068. Reverts the footer edge from #41050, then relands it without the artefact.

- **What was wrong:** the footer band sat below the last row's `border-bottom`. That separator line made the reserved space read as an empty row — obvious on a wide invoice table, invisible on the narrow table I originally tested.
- **Fix:** for the bordered look, horizontal grid lines now come from `border-top` on body cells instead of `border-bottom`. The last row therefore has no closing line, and the footer becomes a seamless continuation that simply curves — it reads as the card's bottom edge.
- Net effect unchanged elsewhere: `Rows`/`Striped` (unbordered) keep `--lined`'s `border-bottom` and are untouched; the header/body divider still comes from `thead th`.

The bottom now rounds on every page — at real page breaks and at the table's true end — with no empty band.

Verified by rendering the reporter's actual Sales Invoice format (6 columns, merged image cells, 8 pages): mid-table page break and final page both close cleanly. Canvas checked for Grid and Rows. `test_print_format_generator` (64), `test_print_format_parity` (5), `test_print_format` (28) green.

If you'd rather not carry the footer at all, merge #41068 instead and close this.

`no-docs`
