### PR TITLE
fix(google_oauth): store OAuth state server-side instead

### DIFF
--- a/frappe/integrations/google_oauth.py
+++ b/frappe/integrations/google_oauth.py
@@ -33,8 +33,7 @@ GOOGLE_OAUTH_STATE_CACHE_PREFIX = "frappe_google_oauth_state"
 def create_google_oauth_state(state: dict) -> str:
 	"""Store this authorization attempt's state server-side and return a single-use token for it.
 
-	The returned token is what gets sent to Google as `state`, so the client never sees or
-	controls the actual state (redirect target, domain, callback kwargs, etc).
+	The returned token is what gets sent to Google as `state`.
 	"""
 	token = frappe.generate_hash(length=32)
 	frappe.cache.set_value(f"{GOOGLE_OAUTH_STATE_CACHE_PREFIX}:{token}", state, expires_in_sec=600)

--- a/frappe/integrations/google_oauth.py
+++ b/frappe/integrations/google_oauth.py
@@ -1,5 +1,3 @@
-import json
-
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 from requests import get, post
@@ -27,6 +25,33 @@ _DOMAIN_CALLBACK_METHODS = {
 
 class GoogleAuthenticationError(Exception):
 	pass
+
+
+GOOGLE_OAUTH_STATE_CACHE_PREFIX = "frappe_google_oauth_state"
+
+
+def create_google_oauth_state(state: dict) -> str:
+	"""Store this authorization attempt's state server-side and return a single-use token for it.
+
+	The returned token is what gets sent to Google as `state`, so the client never sees or
+	controls the actual state (redirect target, domain, callback kwargs, etc).
+	"""
+	token = frappe.generate_hash(length=32)
+	frappe.cache.set_value(f"{GOOGLE_OAUTH_STATE_CACHE_PREFIX}:{token}", state, expires_in_sec=600)
+	return token
+
+
+def consume_google_oauth_state(token: str) -> dict | None:
+	"""Look up and invalidate the state stored for this authorization attempt.
+
+	Returns None if `token` doesn't reference a known, unused authorization attempt.
+	"""
+	if not token:
+		return None
+	key = f"{GOOGLE_OAUTH_STATE_CACHE_PREFIX}:{token}"
+	state = frappe.cache.get_value(key)
+	frappe.cache.delete_value(key)
+	return state
 
 
 class GoogleOAuth:
@@ -107,14 +132,14 @@ class GoogleOAuth:
 		"""
 
 		state.update({"domain": self.domain})
-		state = json.dumps(state)
+		state_token = create_google_oauth_state(state)
 		callback_url = get_request_site_address(True) + CALLBACK_METHOD
 
 		return {
 			"url": "https://accounts.google.com/o/oauth2/v2/auth?"
 			+ "access_type=offline&response_type=code&prompt=consent&include_granted_scopes=true&"
 			+ "client_id={}&scope={}&redirect_uri={}&state={}".format(
-				self.google_settings.client_id, self.scopes, callback_url, state
+				self.google_settings.client_id, self.scopes, callback_url, state_token
 			)
 		}
 
@@ -167,12 +192,19 @@ def is_valid_access_token(access_token: str) -> bool:
 
 
 @frappe.whitelist(methods=["GET"])
-def callback(state: str | dict, code: str | None = None, error: str | None = None) -> None:
+def callback(state: str, code: str | None = None, error: str | None = None) -> None:
 	"""Common callback for google integrations.
 	Invokes functions using `frappe.get_attr` and also adds required (keyworded) arguments
 	along with committing and redirecting us back to frappe site."""
 
-	state = frappe.parse_json(state)
+	state = consume_google_oauth_state(state)
+	if state is None:
+		return frappe.respond_as_web_page(
+			frappe._("Invalid Request"),
+			frappe._("Your authorization attempt is invalid or has expired. Please try again."),
+			http_status_code=417,
+		)
+
 	redirect = state.pop("redirect", "/desk")
 	success_query_param = state.pop("success_query_param", "")
 	failure_query_param = state.pop("failure_query_param", "")

--- a/frappe/integrations/test_google_oauth.py
+++ b/frappe/integrations/test_google_oauth.py
@@ -1,19 +1,61 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
+import json
+from unittest.mock import patch
+
 import frappe
-from frappe.integrations.google_oauth import callback
+from frappe.integrations import google_oauth
+from frappe.integrations.google_oauth import callback, create_google_oauth_state
 from frappe.tests import IntegrationTestCase
+
+_dispatched_calls = []
+
+
+def _fake_domain_callback(code=None, **kwargs):
+	"""Stand-in for a real domain callback (e.g. authorize_access) so tests don't hit Google."""
+	_dispatched_calls.append({"code": code, **kwargs})
 
 
 class TestGoogleOAuth(IntegrationTestCase):
-	def test_callback_accepts_native_state_dict(self):
+	def test_callback_uses_server_side_state(self):
 		frappe.local.response = frappe._dict()
-		# state as a native dict instead of a JSON string (frappe.parse_json passthrough);
+		state_token = create_google_oauth_state({"redirect": "/app/todo", "failure_query_param": "failed=1"})
 		# an error short-circuits the domain dispatch and just redirects back
-		callback(
-			state={"redirect": "/app/todo", "failure_query_param": "failed=1"},
-			error="access_denied",
-		)
+		callback(state=state_token, error="access_denied")
 		self.assertEqual(frappe.local.response["type"], "redirect")
 		self.assertEqual(frappe.local.response["location"], "/app/todo?failed=1")
+
+	def test_callback_success_dispatches_domain_and_redirects(self):
+		"""The normal, non-error flow: domain callback is invoked and the success redirect fires."""
+		_dispatched_calls.clear()
+		frappe.local.response = frappe._dict()
+		state_token = create_google_oauth_state(
+			{
+				"domain": "test-domain",
+				"redirect": "/app/todo",
+				"success_query_param": "connected=1",
+				"doc_name": "abc",
+			}
+		)
+		fake_path = "frappe.integrations.test_google_oauth._fake_domain_callback"
+		with patch.dict(google_oauth._DOMAIN_CALLBACK_METHODS, {"test-domain": fake_path}):
+			callback(state=state_token, code="real-auth-code")
+
+		self.assertEqual(_dispatched_calls, [{"code": "real-auth-code", "doc_name": "abc"}])
+		self.assertEqual(frappe.local.response["type"], "redirect")
+		self.assertEqual(frappe.local.response["location"], "/app/todo?connected=1")
+
+	def test_callback_rejects_unknown_state(self):
+		frappe.local.response = frappe._dict()
+		callback(state="not-a-real-token", error="access_denied")
+		self.assertEqual(frappe.local.response["type"], "page")
+		self.assertEqual(frappe.local.response["http_status_code"], 417)
+
+	def test_callback_rejects_client_supplied_state(self):
+		"""A caller can no longer smuggle a redirect target in via the `state` param itself."""
+		frappe.local.response = frappe._dict()
+		forged = json.dumps({"redirect": "https://evil.example.com", "domain": "contacts"})
+		callback(state=forged, error="access_denied")
+		self.assertEqual(frappe.local.response["type"], "page")
+		self.assertNotIn("evil.example.com", frappe.local.response.get("location", ""))


### PR DESCRIPTION
Some Google OAuth hardening, quite similar to the one done in #40962.
Store OAuth state server-side instead of JSON now.

related to closing Ticket 72600