### PR TITLE
fix: add vertical divider for indented sidebar

### DIFF
--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -410,7 +410,8 @@
 }
 
 .indent + .nested-container {
-	margin-left: 16px;
+	margin-left: calc(var(--margin-sm) + 1px);
+	border-left: 1px solid var(--border-color);
 }
 
 .sidebar-item-suffix {


### PR DESCRIPTION
Added a divider for sidebar
<img width="496" height="335" alt="Screenshot 2026-07-20 at 6 21 52 PM" src="https://github.com/user-attachments/assets/690a22d7-fa47-40d6-bb80-125576adcc0d" />

