### PR TITLE
feat(model): add guard hooks to open_mapped_doc

### DIFF
--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -377,8 +377,16 @@ $.extend(frappe.model, {
 				if (r.exc) {
 					return;
 				}
-				if (!(await frappe.model.should_open_mapped_doc(r.message, opts))) {
-					return;
+				// the request's own freeze lifts as soon as this async callback
+				// yields, so hold our own freeze while guards run; confirmation
+				// dialogs stay usable above the freeze backdrop
+				frappe.dom.freeze(opts.freeze_message || "");
+				try {
+					if (!(await frappe.model.should_open_mapped_doc(r.message, opts))) {
+						return;
+					}
+				} finally {
+					frappe.dom.unfreeze();
 				}
 				frappe.model.sync(r.message);
 				if (opts.run_link_triggers) {

--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -326,7 +326,15 @@ $.extend(frappe.model, {
 
 	add_mapped_doc_guard: function (fn) {
 		// fn(mapped_doc, opts) -> boolean | Promise<boolean>; false blocks opening the doc
-		frappe.model._mapped_doc_guards.push(fn);
+		if (!frappe.model._mapped_doc_guards.includes(fn)) {
+			frappe.model._mapped_doc_guards.push(fn);
+		}
+	},
+
+	remove_mapped_doc_guard: function (fn) {
+		frappe.model._mapped_doc_guards = frappe.model._mapped_doc_guards.filter(
+			(guard) => guard !== fn
+		);
 	},
 
 	should_open_mapped_doc: async function (mapped_doc, opts) {

--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -322,6 +322,27 @@ $.extend(frappe.model, {
 		return newdoc;
 	},
 
+	_mapped_doc_guards: [],
+
+	add_mapped_doc_guard: function (fn) {
+		// fn(mapped_doc, opts) -> boolean | Promise<boolean>; false blocks opening the doc
+		frappe.model._mapped_doc_guards.push(fn);
+	},
+
+	should_open_mapped_doc: async function (mapped_doc, opts) {
+		for (const guard of frappe.model._mapped_doc_guards) {
+			try {
+				if (!(await guard(mapped_doc, opts))) {
+					return false;
+				}
+			} catch (e) {
+				// a broken guard must never block document creation
+				console.error(e);
+			}
+		}
+		return true;
+	},
+
 	open_mapped_doc: function (opts) {
 		if (opts.frm && opts.frm.doc.__unsaved) {
 			frappe.throw(
@@ -344,17 +365,18 @@ $.extend(frappe.model, {
 			},
 			freeze: true,
 			freeze_message: opts.freeze_message || "",
-			callback: function (r) {
-				if (!r.exc) {
-					frappe.model.sync(r.message);
-					if (opts.run_link_triggers) {
-						frappe.get_doc(
-							r.message.doctype,
-							r.message.name
-						).__run_link_triggers = true;
-					}
-					frappe.set_route("Form", r.message.doctype, r.message.name);
+			callback: async function (r) {
+				if (r.exc) {
+					return;
 				}
+				if (!(await frappe.model.should_open_mapped_doc(r.message, opts))) {
+					return;
+				}
+				frappe.model.sync(r.message);
+				if (opts.run_link_triggers) {
+					frappe.get_doc(r.message.doctype, r.message.name).__run_link_triggers = true;
+				}
+				frappe.set_route("Form", r.message.doctype, r.message.name);
 			},
 		});
 	},


### PR DESCRIPTION
## Summary

Adds a small, sanctioned extension point to `frappe.model.open_mapped_doc`:

- `frappe.model.add_mapped_doc_guard(fn)` — register a guard `fn(mapped_doc, opts) -> boolean | Promise<boolean>`
- `frappe.model.should_open_mapped_doc(mapped_doc, opts)` — runs all registered guards

Guards run **after** `make_mapped_doc` returns and **before** the mapped document is synced and routed to. Returning `false` from a guard skips opening the new form (nothing is created — the mapped doc only exists in memory at that point). A guard that throws is logged and ignored, so a broken guard can never block document creation.

## Motivation

Apps want to intervene between mapping and opening — e.g. ERPNext needs to warn users when a draft of the target document already exists for the same source (frappe/erpnext#48350). Today the only way to do that is monkey-patching `open_mapped_doc` and *guessing* the target doctype from the mapper method name, which is fragile and breaks flows whose method names don't match a doctype (inter-company, returns, etc.). Since the mapping response already carries the exact target doctype, a post-mapping hook removes the guesswork entirely and needs zero per-doctype configuration in consuming apps.

The change is backwards compatible: with no guards registered, behavior is identical.

## How to test

1. In the browser console, register a guard:
   ```js
   frappe.model.add_mapped_doc_guard(
       (mapped_doc) =>
           new Promise((resolve) =>
               frappe.confirm(`Open ${mapped_doc.doctype}?`, () => resolve(true), () => resolve(false))
           )
   );
   ```
2. Open any submitted Sales Order → Create → Delivery Note: confirming opens the form, cancelling leaves the source form untouched.
3. Register a guard that throws — creation must proceed normally (error only in console).


> no-docs — developer-facing hook; will document on frappeframework.com client-script API pages once the API is reviewed and stable.

