### PR TITLE
feat(print): store builder snippets in a DocType

### DIFF
--- a/frappe/printing/doctype/print_format_snippet/print_format_snippet.json
+++ b/frappe/printing/doctype/print_format_snippet/print_format_snippet.json
@@ -4,7 +4,6 @@
  "autoname": "Prompt",
  "creation": "2026-07-20 12:00:00.000000",
  "doctype": "DocType",
- "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
   "snippet_type",
@@ -69,7 +68,6 @@
    "label": "Standard"
   }
  ],
- "index_web_pages_for_search": 1,
  "links": [],
  "modified": "2026-07-20 12:00:00.000000",
  "modified_by": "Administrator",
@@ -81,9 +79,7 @@
   {
    "create": 1,
    "delete": 1,
-   "email": 1,
    "export": 1,
-   "print": 1,
    "read": 1,
    "report": 1,
    "role": "System Manager",
@@ -91,8 +87,8 @@
    "write": 1
   }
  ],
- "sort_field": "modified",
- "sort_order": "DESC",
+ "sort_field": "name",
+ "sort_order": "ASC",
  "states": [],
  "track_changes": 1
 }

--- a/frappe/printing/doctype/print_format_snippet/print_format_snippet.json
+++ b/frappe/printing/doctype/print_format_snippet/print_format_snippet.json
@@ -1,0 +1,98 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "Prompt",
+ "creation": "2026-07-20 12:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "snippet_type",
+  "document_type",
+  "column_break_3",
+  "standard",
+  "module",
+  "section_break_5",
+  "content"
+ ],
+ "fields": [
+  {
+   "default": "Section",
+   "fieldname": "snippet_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Snippet Type",
+   "options": "Section\nField",
+   "reqd": 1
+  },
+  {
+   "description": "Leave blank to make this snippet available for all document types",
+   "fieldname": "document_type",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Document Type",
+   "options": "DocType"
+  },
+  {
+   "fieldname": "content",
+   "fieldtype": "Code",
+   "label": "Content",
+   "options": "JSON",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_3",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_5",
+   "fieldtype": "Section Break",
+   "hide_border": 1
+  },
+  {
+   "depends_on": "eval:doc.standard",
+   "fieldname": "module",
+   "fieldtype": "Link",
+   "label": "Module",
+   "mandatory_depends_on": "eval:doc.standard",
+   "options": "Module Def"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:frappe.boot.developer_mode",
+   "description": "Export this snippet to its module so it ships with the app. Requires developer mode.",
+   "fieldname": "standard",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Standard"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-07-20 12:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Printing",
+ "name": "Print Format Snippet",
+ "naming_rule": "Set by user",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/frappe/printing/doctype/print_format_snippet/print_format_snippet.py
+++ b/frappe/printing/doctype/print_format_snippet/print_format_snippet.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2026, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+import json
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+
+
+class PrintFormatSnippet(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		content: DF.Code
+		document_type: DF.Link | None
+		module: DF.Link | None
+		snippet_type: DF.Literal["Section", "Field"]
+		standard: DF.Check
+	# end: auto-generated types
+
+	def validate(self):
+		self.validate_content()
+
+		if self.standard:
+			if not frappe.conf.developer_mode and not frappe.flags.in_patch:
+				frappe.throw(_("Enable developer mode to create a standard Print Format Snippet"))
+			if not self.module:
+				frappe.throw(_("Module is required for a standard Print Format Snippet"))
+
+	def validate_content(self):
+		try:
+			content = json.loads(self.content)
+		except ValueError:
+			frappe.throw(_("Content must be valid JSON"), title=_("Invalid Snippet"))
+
+		if not isinstance(content, dict):
+			frappe.throw(_("Content must be a JSON object"), title=_("Invalid Snippet"))
+
+	def on_update(self):
+		self.export_doc()
+
+	def export_doc(self):
+		from frappe.modules.utils import export_module_json
+
+		export_module_json(self, self.standard, self.module)

--- a/frappe/printing/doctype/print_format_snippet/print_format_snippet.py
+++ b/frappe/printing/doctype/print_format_snippet/print_format_snippet.py
@@ -34,9 +34,13 @@ class PrintFormatSnippet(Document):
 				frappe.throw(_("Module is required for a standard Print Format Snippet"))
 
 	def validate_content(self):
+		# validate() runs before the mandatory check, so content can still be None here
+		if not self.content:
+			return
+
 		try:
 			content = json.loads(self.content)
-		except ValueError:
+		except (TypeError, ValueError):
 			frappe.throw(_("Content must be valid JSON"), title=_("Invalid Snippet"))
 
 		if not isinstance(content, dict):

--- a/frappe/printing/doctype/print_format_snippet/test_print_format_snippet.py
+++ b/frappe/printing/doctype/print_format_snippet/test_print_format_snippet.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026, Frappe Technologies and Contributors
+# See license.txt
+
+import json
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+SECTION = {"label": "Totals", "columns": [{"label": "", "fields": []}]}
+
+
+class TestPrintFormatSnippet(IntegrationTestCase):
+	def make(self, name, **kwargs):
+		kwargs.setdefault("snippet_type", "Section")
+		kwargs.setdefault("content", json.dumps(SECTION))
+		doc = frappe.get_doc({"doctype": "Print Format Snippet", "name": name, **kwargs})
+		doc.insert()
+		self.addCleanup(frappe.delete_doc, "Print Format Snippet", name, force=True)
+		return doc
+
+	def test_content_round_trips(self):
+		doc = self.make("_Test Section Snippet", document_type="ToDo")
+		self.assertEqual(json.loads(doc.content), SECTION)
+
+	def test_field_snippet_without_document_type_is_global(self):
+		doc = self.make(
+			"_Test Field Snippet", snippet_type="Field", content=json.dumps({"fieldname": "status"})
+		)
+		self.assertFalse(doc.document_type)
+
+	def test_content_must_be_a_json_object(self):
+		for bad in ("not json", "[1, 2]", '"a string"'):
+			with self.subTest(content=bad):
+				doc = frappe.get_doc(
+					{
+						"doctype": "Print Format Snippet",
+						"name": "_Test Bad Snippet",
+						"snippet_type": "Section",
+						"content": bad,
+					}
+				)
+				self.assertRaises(frappe.ValidationError, doc.insert)
+
+	def test_standard_requires_developer_mode(self):
+		doc = frappe.get_doc(
+			{
+				"doctype": "Print Format Snippet",
+				"name": "_Test Standard Snippet",
+				"snippet_type": "Section",
+				"content": json.dumps(SECTION),
+				"standard": 1,
+				"module": "Printing",
+			}
+		)
+		with patch.dict(frappe.conf, {"developer_mode": 0}):
+			self.assertRaises(frappe.ValidationError, doc.insert)

--- a/frappe/printing/doctype/print_format_snippet/test_print_format_snippet.py
+++ b/frappe/printing/doctype/print_format_snippet/test_print_format_snippet.py
@@ -42,6 +42,16 @@ class TestPrintFormatSnippet(IntegrationTestCase):
 				)
 				self.assertRaises(frappe.ValidationError, doc.insert)
 
+	def test_missing_content_reports_mandatory_not_a_crash(self):
+		doc = frappe.get_doc(
+			{
+				"doctype": "Print Format Snippet",
+				"name": "_Test Empty Snippet",
+				"snippet_type": "Section",
+			}
+		)
+		self.assertRaises(frappe.MandatoryError, doc.insert)
+
 	def test_standard_requires_developer_mode(self):
 		doc = frappe.get_doc(
 			{

--- a/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
@@ -32,10 +32,6 @@
 					<span v-if="!$store.preview_doc.value" class="canvas-no-data-hint">
 						← {{ __("Pick a record to see real values") }}
 					</span>
-					<span v-if="$store.preview_doc.value" class="es-badge" data-theme="green">{{
-						__("Live")
-					}}</span>
-
 					<div class="canvas-zoom-control" role="group" :aria-label="__('Zoom')">
 						<button
 							class="canvas-zoom-btn"

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -642,12 +642,18 @@ function import_snippets() {
 		} catch {
 			frappe.throw(__("{0} is not a valid JSON file", [file.name]));
 		}
-		const { imported, other_doctypes } = await store.import_snippets(payload);
+		const { imported, other_doctypes, skipped } = await store.import_snippets(payload);
 		let message = __("Imported {0} snippet(s)", [imported]);
 		if (other_doctypes) {
 			message += " " + __("({0} belong to other document types)", [other_doctypes]);
 		}
-		frappe.show_alert({ message, indicator: "green" }, 5);
+		if (skipped.length) {
+			message += " — " + __("skipped {0}", [skipped.join(", ")]);
+		}
+		frappe.show_alert(
+			{ message, indicator: skipped.length ? "orange" : "green" },
+			skipped.length ? 7 : 5
+		);
 	};
 	input.click();
 }

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -141,8 +141,11 @@
 					</div>
 				</template>
 			</draggable>
+		</div>
 
-			<div class="pfb-group-label mt-3">
+		<!-- ── Templates ─────────────────────────────────────── -->
+		<div v-else-if="activeTab === 'templates'" class="pfb-tab-body">
+			<div class="pfb-group-label">
 				{{ __("Saved Snippets") }}
 				<span class="pfb-label-actions">
 					<button
@@ -195,9 +198,7 @@
 							></span>
 							<div class="pfb-block-info">
 								<div class="pfb-block-name">{{ snip.name }}</div>
-								<div class="pfb-block-desc text-muted">
-									{{ __("Drag or click to insert") }}
-								</div>
+								<div class="pfb-block-desc text-muted">{{ grp.desc }}</div>
 							</div>
 							<button
 								class="es-button"
@@ -213,72 +214,55 @@
 					</template>
 				</draggable>
 			</template>
-		</div>
 
-		<!-- ── Templates ─────────────────────────────────────── -->
-		<div v-else-if="activeTab === 'templates'" class="pfb-tab-body">
-			<div v-if="!print_templates_list.length" class="pfb-templates-empty">
-				<div class="pfb-empty">
-					{{ __("No field templates for this document type.") }}
-				</div>
-				<p class="pfb-templates-hint text-muted">
-					{{
-						__(
-							"Field templates let you render specific fields with custom Jinja/HTML, e.g. a custom items table layout."
-						)
-					}}
-				</p>
-				<a :href="new_template_link" target="_blank" class="es-button mt-2" data-size="xs">
-					{{ __("Create Field Template") }}
+			<div class="pfb-group-label mt-3">
+				{{ __("Field Templates") }}
+				<a
+					:href="'/app/print-format-field-template'"
+					target="_blank"
+					class="pfb-manage-link text-muted"
+				>
+					{{ __("Manage") }}
 				</a>
 			</div>
-
-			<template v-else>
-				<div class="pfb-group-label">
-					{{ __("Field Templates") }}
-					<a
-						:href="'/app/print-format-field-template'"
-						target="_blank"
-						class="pfb-manage-link text-muted"
+			<div v-if="!print_templates_list.length" class="pfb-empty">
+				{{
+					__(
+						"Field templates render a specific field with custom Jinja/HTML, e.g. a custom items table."
+					)
+				}}
+				<a :href="new_template_link" target="_blank">{{ __("Create one") }}</a>
+			</div>
+			<draggable
+				v-else
+				:list="print_templates_list"
+				:group="{ name: 'fields', pull: 'clone', put: false }"
+				:sort="false"
+				:clone="clone_field"
+				item-key="fieldname"
+				v-bind="DRAG_OPTIONS"
+				@start="setDragging(true)"
+				@end="setDragging(false)"
+			>
+				<template #item="{ element }">
+					<div
+						class="pfb-block-card"
+						:title="element.fieldname"
+						@click="add_to_layout(element)"
 					>
-						{{ __("Manage") }}
-					</a>
-				</div>
-				<draggable
-					:list="print_templates_list"
-					:group="{ name: 'fields', pull: 'clone', put: false }"
-					:sort="false"
-					:clone="clone_field"
-					item-key="fieldname"
-					v-bind="DRAG_OPTIONS"
-					@start="setDragging(true)"
-					@end="setDragging(false)"
-				>
-					<template #item="{ element }">
-						<div
-							class="pfb-template-card"
-							:title="element.fieldname"
-							@click="add_to_layout(element)"
-						>
-							<div class="pfb-template-thumb">
-								<span
-									class="text-muted"
-									v-html="frappe.utils.icon('table', 'sm')"
-								></span>
-							</div>
-							<div class="pfb-template-info">
-								<div class="pfb-template-name">{{ element.display_label }}</div>
-								<div class="pfb-template-field text-muted">
-									{{ element.field_label || __("Custom block") }}
-								</div>
+						<span
+							class="pfb-block-icon"
+							v-html="frappe.utils.icon('code', 'sm')"
+						></span>
+						<div class="pfb-block-info">
+							<div class="pfb-block-name">{{ element.display_label }}</div>
+							<div class="pfb-block-desc text-muted">
+								{{ element.field_label || __("Custom block") }}
 							</div>
 						</div>
-					</template>
-				</draggable>
-				<div class="pfb-templates-hint text-muted mt-2">
-					{{ __("Drag or click to add a field template to the last section.") }}
-				</div>
-			</template>
+					</div>
+				</template>
+			</draggable>
 		</div>
 
 		<!-- ── Outline ────────────────────────────────────────── -->
@@ -818,8 +802,8 @@ function clone_snippet(snip) {
 }
 
 const SNIPPET_GROUPS = [
-	{ type: "Section", drag_group: "sections", icon: "layout-template" },
-	{ type: "Field", drag_group: "fields", icon: "text-cursor-input" },
+	{ type: "Section", drag_group: "sections", icon: "layout-template", desc: __("Section") },
+	{ type: "Field", drag_group: "fields", icon: "text-cursor-input", desc: __("Field") },
 ];
 
 let snippet_groups = computed(() =>
@@ -1199,9 +1183,8 @@ function handle_slash_key(e) {
 	flex-shrink: 0;
 }
 
-/* ── Block card (Blocks tab) ─────────────────────────────── */
-.pfb-block-card,
-.pfb-template-card {
+/* ── Block card (Blocks + Templates tabs) ────────────────── */
+.pfb-block-card {
 	display: flex;
 	align-items: center;
 	gap: 10px;
@@ -1213,8 +1196,7 @@ function handle_slash_key(e) {
 	margin-top: 6px;
 }
 
-.pfb-block-card:hover,
-.pfb-template-card:hover {
+.pfb-block-card:hover {
 	background: var(--gray-100);
 	border-color: var(--gray-500);
 }
@@ -1243,49 +1225,6 @@ function handle_slash_key(e) {
 .pfb-block-desc {
 	font-size: var(--text-tiny);
 	margin-top: 1px;
-}
-
-/* ── Template card (Templates tab) ──────────────────────── */
-.pfb-template-thumb {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	width: 32px;
-	height: 32px;
-	border-radius: var(--radius);
-	background: var(--gray-200);
-	flex-shrink: 0;
-}
-
-.pfb-template-info {
-	flex: 1;
-	min-width: 0;
-}
-
-.pfb-template-name {
-	font-size: var(--text-sm);
-	font-weight: 500;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-
-.pfb-template-field {
-	font-size: var(--text-tiny);
-	margin-top: 1px;
-}
-
-.pfb-templates-empty {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	padding: 16px 0;
-}
-
-.pfb-templates-hint {
-	font-size: var(--text-tiny);
-	line-height: 1.5;
-	margin-top: 6px;
 }
 
 .pfb-manage-link {

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -142,51 +142,77 @@
 				</template>
 			</draggable>
 
-			<div class="pfb-group-label mt-3">{{ __("Saved Sections") }}</div>
-			<div v-if="!store.section_snippets.value.length" class="pfb-empty">
-				{{ __("Save a section as a snippet to reuse it here.") }}
+			<div class="pfb-group-label mt-3">
+				{{ __("Saved Snippets") }}
+				<span class="pfb-label-actions">
+					<button
+						class="es-button"
+						data-size="xs"
+						data-variant="ghost"
+						data-icon-button="true"
+						:disabled="!store.snippets.value.length"
+						:title="__('Export snippets')"
+						@click="store.export_snippets()"
+						v-html="frappe.utils.icon('download', 'xs')"
+					></button>
+					<button
+						class="es-button"
+						data-size="xs"
+						data-variant="ghost"
+						data-icon-button="true"
+						:title="__('Import snippets')"
+						@click="import_snippets"
+						v-html="frappe.utils.icon('upload', 'xs')"
+					></button>
+				</span>
 			</div>
-			<draggable
-				:list="store.section_snippets.value"
-				:group="{ name: 'sections', pull: 'clone', put: false }"
-				:sort="false"
-				:clone="clone_snippet_section"
-				item-key="name"
-				filter="button"
-				:preventOnFilter="false"
-				v-bind="DRAG_OPTIONS"
-				@start="setDragging(true)"
-				@end="setDragging(false)"
-			>
-				<template #item="{ element: snip }">
-					<div
-						class="pfb-block-card"
-						:title="__('Drag into the layout, or click to insert')"
-						@click="store.insert_section_snippet(snip.name)"
-					>
-						<span
-							class="pfb-block-icon"
-							v-html="frappe.utils.icon('layout-template', 'sm')"
-						></span>
-						<div class="pfb-block-info">
-							<div class="pfb-block-name">{{ snip.name }}</div>
-							<div class="pfb-block-desc text-muted">
-								{{ __("Drag or click to insert") }}
+			<div v-if="!store.snippets.value.length" class="pfb-empty">
+				{{ __("Save a section or field as a snippet to reuse it here.") }}
+			</div>
+			<template v-for="grp in snippet_groups" :key="grp.type">
+				<draggable
+					v-if="grp.items.length"
+					:list="grp.items"
+					:group="{ name: grp.drag_group, pull: 'clone', put: false }"
+					:sort="false"
+					:clone="clone_snippet"
+					item-key="name"
+					filter="button"
+					:preventOnFilter="false"
+					v-bind="DRAG_OPTIONS"
+					@start="setDragging(true)"
+					@end="setDragging(false)"
+				>
+					<template #item="{ element: snip }">
+						<div
+							class="pfb-block-card"
+							:title="__('Drag into the layout, or click to insert')"
+							@click="store.insert_snippet(snip.name)"
+						>
+							<span
+								class="pfb-block-icon"
+								v-html="frappe.utils.icon(grp.icon, 'sm')"
+							></span>
+							<div class="pfb-block-info">
+								<div class="pfb-block-name">{{ snip.name }}</div>
+								<div class="pfb-block-desc text-muted">
+									{{ __("Drag or click to insert") }}
+								</div>
 							</div>
+							<button
+								class="es-button"
+								data-size="xs"
+								data-variant="ghost"
+								data-theme="red"
+								data-icon-button="true"
+								:title="__('Delete snippet')"
+								@click.stop="confirm_delete_snippet(snip.name)"
+								v-html="frappe.utils.icon('trash', 'xs')"
+							></button>
 						</div>
-						<button
-							class="es-button"
-							data-size="xs"
-							data-variant="ghost"
-							data-theme="red"
-							data-icon-button="true"
-							:title="__('Delete snippet')"
-							@click.stop="confirm_delete_snippet(snip.name)"
-							v-html="frappe.utils.icon('trash', 'xs')"
-						></button>
-					</div>
-				</template>
-			</draggable>
+					</template>
+				</draggable>
+			</template>
 		</div>
 
 		<!-- ── Templates ─────────────────────────────────────── -->
@@ -609,9 +635,30 @@ function delete_preset() {
 	});
 }
 function confirm_delete_snippet(name) {
-	frappe.confirm(__("Delete the section snippet '{0}'?", [name]), () =>
-		store.delete_section_snippet(name)
-	);
+	frappe.confirm(__("Delete the snippet '{0}'?", [name]), () => store.delete_snippet(name));
+}
+
+function import_snippets() {
+	const input = document.createElement("input");
+	input.type = "file";
+	input.accept = "application/json,.json";
+	input.onchange = async () => {
+		const file = input.files?.[0];
+		if (!file) return;
+		let payload;
+		try {
+			payload = JSON.parse(await file.text());
+		} catch {
+			frappe.throw(__("{0} is not a valid JSON file", [file.name]));
+		}
+		const { imported, other_doctypes } = await store.import_snippets(payload);
+		let message = __("Imported {0} snippet(s)", [imported]);
+		if (other_doctypes) {
+			message += " " + __("({0} belong to other document types)", [other_doctypes]);
+		}
+		frappe.show_alert({ message, indicator: "green" }, 5);
+	};
+	input.click();
 }
 
 // ── helpers ────────────────────────────────────────────────
@@ -766,9 +813,21 @@ function clone_as_section() {
 	return { label: "", columns: [{ label: "", fields: [] }], page_break: true };
 }
 
-function clone_snippet_section(snip) {
-	return clone_plain(snip.section);
+function clone_snippet(snip) {
+	return clone_plain(snip.content);
 }
+
+const SNIPPET_GROUPS = [
+	{ type: "Section", drag_group: "sections", icon: "layout-template" },
+	{ type: "Field", drag_group: "fields", icon: "text-cursor-input" },
+];
+
+let snippet_groups = computed(() =>
+	SNIPPET_GROUPS.map((grp) => ({
+		...grp,
+		items: store.snippets.value.filter((s) => s.snippet_type === grp.type),
+	}))
+);
 
 function add_page_break() {
 	if (!layout.value) return;
@@ -1234,6 +1293,12 @@ function handle_slash_key(e) {
 	font-weight: 400;
 	text-transform: none;
 	letter-spacing: 0;
+}
+
+.pfb-label-actions {
+	display: flex;
+	gap: 2px;
+	margin-right: -4px;
 }
 
 /* ── Outline tab (tree) ──────────────────────────────────── */

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -143,8 +143,8 @@
 			</draggable>
 		</div>
 
-		<!-- ── Templates ─────────────────────────────────────── -->
-		<div v-else-if="activeTab === 'templates'" class="pfb-tab-body">
+		<!-- ── Library ───────────────────────────────────────── -->
+		<div v-else-if="activeTab === 'library'" class="pfb-tab-body">
 			<div class="pfb-group-label">
 				{{ __("Saved Snippets") }}
 				<span class="pfb-label-actions">
@@ -490,7 +490,7 @@ let { meta, print_format, layout } = useStore();
 const tabs = computed(() => [
 	{ id: "fields", label: __("Fields") },
 	{ id: "blocks", label: __("Blocks") },
-	{ id: "templates", label: __("Templates") },
+	{ id: "library", label: __("Library") },
 	{ id: "outline", label: __("Outline") },
 	{ id: "format", label: __("Setting") },
 ]);
@@ -884,7 +884,7 @@ let field_groups = computed(() => {
 	return groups.filter((g) => g.fields.length);
 });
 
-// ── templates tab ─────────────────────────────────────────
+// ── library tab ───────────────────────────────────────────
 function fetch_templates() {
 	const doctype = meta.value?.name;
 	if (!doctype) return;
@@ -909,7 +909,7 @@ function fetch_templates() {
 }
 
 watch(activeTab, (tab) => {
-	if (tab === "templates") fetch_templates();
+	if (tab === "library") fetch_templates();
 	if (tab === "format") nextTick(mount_color_controls);
 });
 

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -454,7 +454,14 @@
 <script setup>
 import draggable from "vuedraggable";
 import Autocomplete from "../../vue-components/Autocomplete.vue";
-import { DRAG_OPTIONS, clone_plain, get_table_columns, pluck, setDragging } from "../utils";
+import {
+	DRAG_OPTIONS,
+	clone_plain,
+	freshen_field,
+	get_table_columns,
+	pluck,
+	setDragging,
+} from "../utils";
 import { mountColorControl } from "./inspector/useColorControl";
 import { useStore } from "../stores";
 import { computed, onMounted, onUnmounted, nextTick, ref, watch, inject } from "vue";
@@ -797,8 +804,14 @@ function clone_as_section() {
 	return { label: "", columns: [{ label: "", fields: [] }], page_break: true };
 }
 
+// Drag-insert bypasses insert_field/insert_section, so freshen here too — a custom
+// field dropped twice would otherwise carry the same fieldname into both copies.
 function clone_snippet(snip) {
-	return clone_plain(snip.content);
+	const clone = clone_plain(snip.content);
+	if (snip.snippet_type === "Field") return freshen_field(clone);
+	delete clone.remove;
+	(clone.columns || []).forEach((c) => (c.fields || []).forEach(freshen_field));
+	return clone;
 }
 
 const SNIPPET_GROUPS = [

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -302,7 +302,10 @@ const props = defineProps(["df", "field_orientation"]);
 
 // Per-field text colour for the label and value lines.
 function label_text_style(df) {
-	return df.label_color ? { color: df.label_color } : {};
+	return {
+		...(df.label_color ? { color: df.label_color } : {}),
+		...(df.label_bold ? { fontWeight: 600 } : {}),
+	};
 }
 function value_text_style(df) {
 	return df.value_color ? { color: df.value_color } : {};

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -151,6 +151,15 @@
 					class="es-button"
 					data-size="xs"
 					data-variant="ghost"
+					data-icon-button="true"
+					:title="__('Save as snippet')"
+					@click.stop="save_as_snippet"
+					v-html="frappe.utils.icon('bookmark-plus', 'xs')"
+				></button>
+				<button
+					class="es-button"
+					data-size="xs"
+					data-variant="ghost"
 					data-theme="red"
 					data-icon-button="true"
 					:title="__('Remove field')"
@@ -489,6 +498,28 @@ function edit_html() {
 	});
 	d.set_value("html", props.df.html);
 	d.show();
+}
+
+function save_as_snippet() {
+	frappe.prompt(
+		{
+			label: __("Snippet name"),
+			fieldname: "name",
+			fieldtype: "Data",
+			reqd: 1,
+			default: props.df.label || props.df.fieldname || "",
+		},
+		({ name }) => {
+			store.save_snippet(name, props.df, "Field").then(() => {
+				frappe.show_alert(
+					{ message: __("Field saved as snippet"), indicator: "green" },
+					3
+				);
+			});
+		},
+		__("Save Field as Snippet"),
+		__("Save")
+	);
 }
 
 function configure_columns() {

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -308,7 +308,10 @@ function label_text_style(df) {
 	};
 }
 function value_text_style(df) {
-	return df.value_color ? { color: df.value_color } : {};
+	return {
+		...(df.value_color ? { color: df.value_color } : {}),
+		...(df.value_bold ? { fontWeight: 600 } : {}),
+	};
 }
 
 let store = inject("$store");
@@ -513,12 +516,14 @@ function save_as_snippet() {
 			default: props.df.label || props.df.fieldname || "",
 		},
 		({ name }) => {
-			store.save_snippet(name, props.df, "Field").then(() => {
-				frappe.show_alert(
-					{ message: __("Field saved as snippet"), indicator: "green" },
-					3
-				);
-			});
+			store.save_snippet(name, props.df, "Field").then(
+				() =>
+					frappe.show_alert(
+						{ message: __("Field saved as snippet"), indicator: "green" },
+						3
+					),
+				() => {}
+			);
 		},
 		__("Save Field as Snippet"),
 		__("Save")

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -326,12 +326,14 @@ function save_as_snippet() {
 			default: props.section.label || "",
 		},
 		({ name }) => {
-			store.save_snippet(name, props.section, "Section").then(() => {
-				frappe.show_alert(
-					{ message: __("Section saved as snippet"), indicator: "green" },
-					3
-				);
-			});
+			store.save_snippet(name, props.section, "Section").then(
+				() =>
+					frappe.show_alert(
+						{ message: __("Section saved as snippet"), indicator: "green" },
+						3
+					),
+				() => {}
+			);
 		},
 		__("Save Section as Snippet"),
 		__("Save")

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -326,8 +326,12 @@ function save_as_snippet() {
 			default: props.section.label || "",
 		},
 		({ name }) => {
-			store.save_section_snippet(name, props.section);
-			frappe.show_alert({ message: __("Section saved as snippet"), indicator: "green" }, 3);
+			store.save_snippet(name, props.section, "Section").then(() => {
+				frappe.show_alert(
+					{ message: __("Section saved as snippet"), indicator: "green" },
+					3
+				);
+			});
 		},
 		__("Save Section as Snippet"),
 		__("Save")

--- a/frappe/public/js/print_format_builder/components/inspector/ColorField.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/ColorField.vue
@@ -1,10 +1,7 @@
 <template>
 	<div class="pfb-insp-row">
 		<span class="pfb-insp-label">{{ label }}</span>
-		<div class="pfb-insp-color">
-			<div ref="host" class="pfb-insp-color-input"></div>
-			<slot />
-		</div>
+		<div ref="host"></div>
 	</div>
 </template>
 
@@ -48,14 +45,5 @@ watch(
    which unbalances the row's vertical centering against the label */
 .pfb-insp-row :deep(.form-group) {
 	margin-bottom: 0;
-}
-.pfb-insp-color {
-	display: flex;
-	align-items: center;
-	gap: 6px;
-}
-.pfb-insp-color-input {
-	flex: 1;
-	min-width: 0;
 }
 </style>

--- a/frappe/public/js/print_format_builder/components/inspector/ColorField.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/ColorField.vue
@@ -1,7 +1,10 @@
 <template>
 	<div class="pfb-insp-row">
 		<span class="pfb-insp-label">{{ label }}</span>
-		<div ref="host"></div>
+		<div class="pfb-insp-color">
+			<div ref="host" class="pfb-insp-color-input"></div>
+			<slot />
+		</div>
 	</div>
 </template>
 
@@ -45,5 +48,14 @@ watch(
    which unbalances the row's vertical centering against the label */
 .pfb-insp-row :deep(.form-group) {
 	margin-bottom: 0;
+}
+.pfb-insp-color {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+}
+.pfb-insp-color-input {
+	flex: 1;
+	min-width: 0;
 }
 </style>

--- a/frappe/public/js/print_format_builder/components/inspector/ColorField.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/ColorField.vue
@@ -1,7 +1,10 @@
 <template>
 	<div class="pfb-insp-row">
 		<span class="pfb-insp-label">{{ label }}</span>
-		<div ref="host"></div>
+		<div class="pfb-insp-color">
+			<div ref="host" class="pfb-insp-color-input"></div>
+			<slot />
+		</div>
 	</div>
 </template>
 
@@ -45,5 +48,14 @@ watch(
    which unbalances the row's vertical centering against the label */
 .pfb-insp-row :deep(.form-group) {
 	margin-bottom: 0;
+}
+.pfb-insp-color {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+.pfb-insp-color-input {
+	flex: 1;
+	min-width: 0;
 }
 </style>

--- a/frappe/public/js/print_format_builder/components/inspector/FieldPropertiesPanel.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldPropertiesPanel.vue
@@ -153,7 +153,19 @@
 					:label="__('Label')"
 					:model-value="selected_field.label_color || ''"
 					@update:model-value="(v) => set_field_prop('label_color', v)"
-				/>
+				>
+					<button
+						type="button"
+						class="es-button"
+						data-size="sm"
+						data-icon-button="true"
+						:data-variant="selected_field.label_bold ? 'subtle' : 'ghost'"
+						:aria-pressed="!!selected_field.label_bold"
+						:title="__('Bold label')"
+						@click="set_field_prop('label_bold', !selected_field.label_bold)"
+						v-html="frappe.utils.icon('bold', 'sm')"
+					></button>
+				</ColorField>
 				<ColorField
 					:label="__('Value')"
 					:model-value="selected_field.value_color || ''"

--- a/frappe/public/js/print_format_builder/components/inspector/FieldPropertiesPanel.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldPropertiesPanel.vue
@@ -153,26 +153,27 @@
 					:label="__('Label')"
 					:model-value="selected_field.label_color || ''"
 					@update:model-value="(v) => set_field_prop('label_color', v)"
-				>
-					<IconToggle
-						icon="bold"
-						:title="__('Bold label')"
-						:model-value="!!selected_field.label_bold"
-						@update:model-value="(v) => set_field_prop('label_bold', v)"
-					/>
-				</ColorField>
+				/>
 				<ColorField
 					:label="__('Value')"
 					:model-value="selected_field.value_color || ''"
 					@update:model-value="(v) => set_field_prop('value_color', v)"
-				>
-					<IconToggle
-						icon="bold"
-						:title="__('Bold value')"
-						:model-value="!!selected_field.value_bold"
-						@update:model-value="(v) => set_field_prop('value_bold', v)"
-					/>
-				</ColorField>
+				/>
+				<div class="pfb-insp-row">
+					<span class="pfb-insp-label">{{ __("Bold") }}</span>
+					<div class="pfb-insp-toggles">
+						<ToggleButton
+							:label="__('Label')"
+							:model-value="!!selected_field.label_bold"
+							@update:model-value="(v) => set_field_prop('label_bold', v)"
+						/>
+						<ToggleButton
+							:label="__('Value')"
+							:model-value="!!selected_field.value_bold"
+							@update:model-value="(v) => set_field_prop('value_bold', v)"
+						/>
+					</div>
+				</div>
 			</div>
 			<StyleSection :label="__('Custom CSS')" v-model="selected_field.custom_style" />
 		</InspectorSection>
@@ -191,7 +192,7 @@ import InspectorSection from "./InspectorSection.vue";
 import StepperRow from "./StepperRow.vue";
 import StyleSection from "./StyleSection.vue";
 import ColorField from "./ColorField.vue";
-import IconToggle from "./IconToggle.vue";
+import ToggleButton from "./ToggleButton.vue";
 import VisibilitySection from "./VisibilitySection.vue";
 import ImageUploadControl from "./ImageUploadControl.vue";
 import { get_image_dimensions } from "../../utils";

--- a/frappe/public/js/print_format_builder/components/inspector/FieldPropertiesPanel.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldPropertiesPanel.vue
@@ -154,23 +154,25 @@
 					:model-value="selected_field.label_color || ''"
 					@update:model-value="(v) => set_field_prop('label_color', v)"
 				>
-					<button
-						type="button"
-						class="es-button"
-						data-size="sm"
-						data-icon-button="true"
-						:data-variant="selected_field.label_bold ? 'subtle' : 'ghost'"
-						:aria-pressed="!!selected_field.label_bold"
+					<IconToggle
+						icon="bold"
 						:title="__('Bold label')"
-						@click="set_field_prop('label_bold', !selected_field.label_bold)"
-						v-html="frappe.utils.icon('bold', 'sm')"
-					></button>
+						:model-value="!!selected_field.label_bold"
+						@update:model-value="(v) => set_field_prop('label_bold', v)"
+					/>
 				</ColorField>
 				<ColorField
 					:label="__('Value')"
 					:model-value="selected_field.value_color || ''"
 					@update:model-value="(v) => set_field_prop('value_color', v)"
-				/>
+				>
+					<IconToggle
+						icon="bold"
+						:title="__('Bold value')"
+						:model-value="!!selected_field.value_bold"
+						@update:model-value="(v) => set_field_prop('value_bold', v)"
+					/>
+				</ColorField>
 			</div>
 			<StyleSection :label="__('Custom CSS')" v-model="selected_field.custom_style" />
 		</InspectorSection>
@@ -189,6 +191,7 @@ import InspectorSection from "./InspectorSection.vue";
 import StepperRow from "./StepperRow.vue";
 import StyleSection from "./StyleSection.vue";
 import ColorField from "./ColorField.vue";
+import IconToggle from "./IconToggle.vue";
 import VisibilitySection from "./VisibilitySection.vue";
 import ImageUploadControl from "./ImageUploadControl.vue";
 import { get_image_dimensions } from "../../utils";

--- a/frappe/public/js/print_format_builder/components/inspector/FieldPropertiesPanel.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldPropertiesPanel.vue
@@ -153,27 +153,26 @@
 					:label="__('Label')"
 					:model-value="selected_field.label_color || ''"
 					@update:model-value="(v) => set_field_prop('label_color', v)"
-				/>
+				>
+					<ToggleButton
+						label="B"
+						:title="__('Bold label')"
+						:model-value="!!selected_field.label_bold"
+						@update:model-value="(v) => set_field_prop('label_bold', v)"
+					/>
+				</ColorField>
 				<ColorField
 					:label="__('Value')"
 					:model-value="selected_field.value_color || ''"
 					@update:model-value="(v) => set_field_prop('value_color', v)"
-				/>
-				<div class="pfb-insp-row">
-					<span class="pfb-insp-label">{{ __("Bold") }}</span>
-					<div class="pfb-insp-toggles">
-						<ToggleButton
-							:label="__('Label')"
-							:model-value="!!selected_field.label_bold"
-							@update:model-value="(v) => set_field_prop('label_bold', v)"
-						/>
-						<ToggleButton
-							:label="__('Value')"
-							:model-value="!!selected_field.value_bold"
-							@update:model-value="(v) => set_field_prop('value_bold', v)"
-						/>
-					</div>
-				</div>
+				>
+					<ToggleButton
+						label="B"
+						:title="__('Bold value')"
+						:model-value="!!selected_field.value_bold"
+						@update:model-value="(v) => set_field_prop('value_bold', v)"
+					/>
+				</ColorField>
 			</div>
 			<StyleSection :label="__('Custom CSS')" v-model="selected_field.custom_style" />
 		</InspectorSection>

--- a/frappe/public/js/print_format_builder/components/inspector/IconToggle.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/IconToggle.vue
@@ -1,0 +1,46 @@
+<template>
+	<button
+		type="button"
+		class="pfb-insp-toggle"
+		:class="{ active: modelValue }"
+		:aria-pressed="!!modelValue"
+		:title="title"
+		@click="$emit('update:modelValue', !modelValue)"
+		v-html="frappe.utils.icon(icon, 'sm')"
+	></button>
+</template>
+
+<script setup>
+defineProps({
+	modelValue: { type: Boolean, default: false },
+	icon: { type: String, required: true },
+	title: { type: String, default: "" },
+});
+defineEmits(["update:modelValue"]);
+</script>
+
+<style scoped>
+.pfb-insp-toggle {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	align-self: stretch;
+	width: 32px;
+	flex-shrink: 0;
+	padding: 0;
+	border: 1px solid var(--border-color);
+	border-radius: var(--radius);
+	background: var(--control-bg);
+	color: var(--text-muted);
+	cursor: pointer;
+}
+.pfb-insp-toggle:hover {
+	background: var(--gray-200);
+	color: var(--text-color);
+}
+.pfb-insp-toggle.active {
+	background: var(--gray-300);
+	border-color: var(--gray-400);
+	color: var(--text-color);
+}
+</style>

--- a/frappe/public/js/print_format_builder/components/inspector/ToggleButton.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/ToggleButton.vue
@@ -6,14 +6,17 @@
 		:aria-pressed="!!modelValue"
 		:title="title"
 		@click="$emit('update:modelValue', !modelValue)"
-		v-html="frappe.utils.icon(icon, 'sm')"
-	></button>
+	>
+		<span v-if="icon" v-html="frappe.utils.icon(icon, 'sm')"></span>
+		<template v-else>{{ label }}</template>
+	</button>
 </template>
 
 <script setup>
 defineProps({
 	modelValue: { type: Boolean, default: false },
-	icon: { type: String, required: true },
+	label: { type: String, default: "" },
+	icon: { type: String, default: "" },
 	title: { type: String, default: "" },
 });
 defineEmits(["update:modelValue"]);
@@ -24,10 +27,10 @@ defineEmits(["update:modelValue"]);
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	align-self: stretch;
-	width: 32px;
-	flex-shrink: 0;
-	padding: 0;
+	min-width: 32px;
+	padding: 5px 10px;
+	font-size: var(--text-sm);
+	line-height: 1;
 	border: 1px solid var(--border-color);
 	border-radius: var(--radius);
 	background: var(--control-bg);
@@ -42,5 +45,6 @@ defineEmits(["update:modelValue"]);
 	background: var(--gray-300);
 	border-color: var(--gray-400);
 	color: var(--text-color);
+	font-weight: var(--weight-medium);
 }
 </style>

--- a/frappe/public/js/print_format_builder/components/inspector/ToggleButton.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/ToggleButton.vue
@@ -7,44 +7,45 @@
 		:title="title"
 		@click="$emit('update:modelValue', !modelValue)"
 	>
-		<span v-if="icon" v-html="frappe.utils.icon(icon, 'sm')"></span>
-		<template v-else>{{ label }}</template>
+		{{ label }}
 	</button>
 </template>
 
 <script setup>
 defineProps({
 	modelValue: { type: Boolean, default: false },
-	label: { type: String, default: "" },
-	icon: { type: String, default: "" },
+	label: { type: String, required: true },
 	title: { type: String, default: "" },
 });
 defineEmits(["update:modelValue"]);
 </script>
 
 <style scoped>
+/* No border or fill at rest: the row it sits on supplies the context, and a
+   resting outline is what made these read as permanently pressed. */
 .pfb-insp-toggle {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	min-width: 32px;
-	padding: 5px 10px;
-	font-size: var(--text-sm);
-	line-height: 1;
-	border: 1px solid var(--border-color);
+	width: 26px;
+	height: 26px;
+	flex-shrink: 0;
+	padding: 0;
+	border: none;
 	border-radius: var(--radius);
-	background: var(--control-bg);
+	background: transparent;
 	color: var(--text-muted);
+	font-size: var(--text-md);
+	font-weight: 700;
+	line-height: 1;
 	cursor: pointer;
 }
 .pfb-insp-toggle:hover {
-	background: var(--gray-200);
+	background: var(--gray-100);
 	color: var(--text-color);
 }
 .pfb-insp-toggle.active {
-	background: var(--gray-300);
-	border-color: var(--gray-400);
-	color: var(--text-color);
-	font-weight: var(--weight-medium);
+	background: var(--text-color);
+	color: var(--fg-color);
 }
 </style>

--- a/frappe/public/js/print_format_builder/composables/useClipboard.js
+++ b/frappe/public/js/print_format_builder/composables/useClipboard.js
@@ -1,5 +1,5 @@
 import { ref } from "vue";
-import { clone_plain, freshen_field } from "../utils";
+import { clone_plain } from "../utils";
 
 const CLIPBOARD_KEY = "pfb_clipboard";
 
@@ -31,7 +31,7 @@ if (typeof window !== "undefined") {
 	});
 }
 
-export function useClipboard({ selection, layout, find_field_column, insert_section }) {
+export function useClipboard({ selection, layout, insert_section, insert_field }) {
 	const { selected_field, selected_section } = selection;
 
 	function copy_field(df) {
@@ -52,19 +52,7 @@ export function useClipboard({ selection, layout, find_field_column, insert_sect
 		if (!clip || !layout.value) return;
 
 		if (clip.type === "field") {
-			const clone = freshen_field(clone_plain(clip.data));
-			const col = selected_field.value && find_field_column(selected_field.value);
-			if (col) {
-				col.fields.splice(col.fields.indexOf(selected_field.value) + 1, 0, clone);
-			} else {
-				const sections = layout.value.sections || [];
-				const target = selected_section.value || sections[sections.length - 1];
-				const first_col = target?.columns?.[0];
-				if (!first_col) return;
-				first_col.fields.push(clone);
-			}
-			selected_section.value = null;
-			selected_field.value = clone;
+			insert_field(clip.data);
 		} else if (clip.type === "section") {
 			insert_section(clip.data);
 		}

--- a/frappe/public/js/print_format_builder/composables/useLayoutMutations.js
+++ b/frappe/public/js/print_format_builder/composables/useLayoutMutations.js
@@ -100,6 +100,22 @@ export function useLayoutMutations(layout, selection) {
 		selected_field.value = null;
 		selected_section.value = clone;
 	}
+	function insert_field(data) {
+		if (!data || !layout.value) return;
+		const clone = freshen_field(clone_plain(data));
+		const col = selected_field.value && find_field_column(selected_field.value);
+		if (col) {
+			col.fields.splice(col.fields.indexOf(selected_field.value) + 1, 0, clone);
+		} else {
+			const sections = layout.value.sections || [];
+			const target = selected_section.value || sections[sections.length - 1];
+			const first_col = target?.columns?.[0];
+			if (!first_col) return;
+			first_col.fields.push(clone);
+		}
+		selected_section.value = null;
+		selected_field.value = clone;
+	}
 	function remove_section(section) {
 		const idx = layout.value.sections.indexOf(section);
 		if (idx === -1) return;
@@ -116,12 +132,12 @@ export function useLayoutMutations(layout, selection) {
 	}
 
 	return {
-		find_field_column,
 		duplicate_field,
 		duplicate_section,
 		duplicate_selection,
 		move_selection,
 		insert_section,
+		insert_field,
 		remove_section,
 	};
 }

--- a/frappe/public/js/print_format_builder/composables/useSnippets.js
+++ b/frappe/public/js/print_format_builder/composables/useSnippets.js
@@ -29,38 +29,54 @@ export function useSnippets({ insert_section, insert_field, doc_type }) {
 		}
 	}
 
+	// frappe.db.get_list never settles its promise on failure, so go through
+	// xcall — a permission error must reject, not hang the builder forever.
 	async function reload() {
-		let rows;
-		try {
-			rows = await frappe.db.get_list(DOCTYPE, {
-				fields: ["name", "snippet_type", "document_type", "content"],
-				limit: 0,
-				order_by: "name asc",
-			});
-		} catch {
-			all_snippets.value = [];
-			return;
-		}
-		all_snippets.value = rows.map(parse).filter(Boolean);
+		const rows = await frappe.xcall("frappe.client.get_list", {
+			doctype: DOCTYPE,
+			fields: ["name", "snippet_type", "document_type", "content"],
+			limit_page_length: 0,
+			order_by: "name asc",
+		});
+		all_snippets.value = (rows || []).map(parse).filter(Boolean);
 	}
 
-	async function save_snippet(name, data, snippet_type = "Section", document_type) {
+	// Writes without reloading, so bulk callers pay for one round trip instead of N.
+	// The optimistic push keeps the "already exists" check honest within a batch.
+	async function write_snippet(name, data, snippet_type, document_type) {
 		name = (name || "").trim();
-		if (!name || !data) return;
-		const content = JSON.stringify(clone_plain(data));
+		if (!name || !data) return null;
+		const parsed = clone_plain(data);
+		const content = JSON.stringify(parsed);
 		const existing = all_snippets.value.find((s) => s.name === name);
+		// The docname is global, so a name taken by another document type would be
+		// silently rewritten — refuse instead of destroying a snippet the user can't see.
+		const scope = document_type ?? doc_type?.value ?? "";
+		if (existing && existing.document_type && existing.document_type !== scope) {
+			frappe.throw(
+				__("A snippet named {0} already exists for {1}.", [name, existing.document_type])
+			);
+		}
 		if (existing) {
-			await frappe.db.set_value(DOCTYPE, name, { content, snippet_type });
+			const update = { content, snippet_type };
+			if (document_type !== undefined) update.document_type = document_type;
+			await frappe.db.set_value(DOCTYPE, name, update);
+			Object.assign(existing, update, { content: parsed });
 		} else {
-			await frappe.db.insert({
-				doctype: DOCTYPE,
-				__newname: name,
+			const row = {
+				name,
 				snippet_type,
 				document_type: document_type ?? doc_type?.value ?? "",
 				content,
-			});
+			};
+			await frappe.db.insert({ doctype: DOCTYPE, __newname: name, ...row });
+			all_snippets.value.push({ ...row, content: parsed });
 		}
-		await reload();
+		return name;
+	}
+
+	async function save_snippet(name, data, snippet_type = "Section", document_type) {
+		if (await write_snippet(name, data, snippet_type, document_type)) await reload();
 	}
 
 	function insert_snippet(name) {
@@ -75,14 +91,11 @@ export function useSnippets({ insert_section, insert_field, doc_type }) {
 		await reload();
 	}
 
-	function export_snippets(names) {
-		const picked = names?.length
-			? snippets.value.filter((s) => names.includes(s.name))
-			: snippets.value;
-		if (!picked.length) return;
+	function export_snippets() {
+		if (!snippets.value.length) return;
 		const payload = {
 			version: 1,
-			snippets: picked.map((s) => ({
+			snippets: snippets.value.map((s) => ({
 				name: s.name,
 				snippet_type: s.snippet_type,
 				document_type: s.document_type || "",
@@ -103,34 +116,58 @@ export function useSnippets({ insert_section, insert_field, doc_type }) {
 		if (!Array.isArray(rows)) {
 			frappe.throw(__("This file does not contain any snippets"));
 		}
-		let imported = 0;
-		let other_doctypes = 0;
-		const current = doc_type?.value;
+		const imported = [];
 		for (const row of rows) {
 			if (!row?.name || !row?.content) continue;
-			const document_type = row.document_type || "";
-			await save_snippet(
+			const name = await write_snippet(
 				row.name,
 				row.content,
 				row.snippet_type || "Section",
-				document_type
+				row.document_type || ""
 			);
-			imported++;
-			if (document_type && current && document_type !== current) other_doctypes++;
+			if (name) imported.push(name);
 		}
 		await reload();
-		return { imported, other_doctypes };
+		const current = doc_type?.value;
+		const other_doctypes = all_snippets.value.filter(
+			(s) =>
+				imported.includes(s.name) &&
+				s.document_type &&
+				current &&
+				s.document_type !== current
+		).length;
+		return { imported: imported.length, other_doctypes };
 	}
 
+	// One-time lift of the old browser-local snippets. Anything whose name is already
+	// taken on the server stays in localStorage rather than being dropped on the floor.
 	async function migrate_legacy() {
 		const legacy = read_legacy();
 		if (!legacy.length) return;
+		const kept = [];
 		for (const snip of legacy) {
 			if (!snip?.name || !snip?.section) continue;
-			if (all_snippets.value.some((s) => s.name === snip.name)) continue;
-			await save_snippet(snip.name, snip.section, "Section", "");
+			if (all_snippets.value.some((s) => s.name === snip.name)) {
+				kept.push(snip);
+				continue;
+			}
+			await write_snippet(snip.name, snip.section, "Section", "");
 		}
-		localStorage.removeItem(LEGACY_KEY);
+		if (kept.length) {
+			localStorage.setItem(LEGACY_KEY, JSON.stringify(kept));
+			frappe.show_alert(
+				{
+					message: __(
+						"{0} saved section(s) already exist by name and were not imported",
+						[kept.length]
+					),
+					indicator: "orange",
+				},
+				7
+			);
+		} else {
+			localStorage.removeItem(LEGACY_KEY);
+		}
 		await reload();
 	}
 
@@ -139,7 +176,7 @@ export function useSnippets({ insert_section, insert_field, doc_type }) {
 		await migrate_legacy();
 	}
 
-	init().catch(() => {});
+	init().catch((e) => console.error("Could not load print format snippets", e));
 
 	return {
 		snippets,
@@ -148,6 +185,5 @@ export function useSnippets({ insert_section, insert_field, doc_type }) {
 		delete_snippet,
 		export_snippets,
 		import_snippets,
-		reload_snippets: reload,
 	};
 }

--- a/frappe/public/js/print_format_builder/composables/useSnippets.js
+++ b/frappe/public/js/print_format_builder/composables/useSnippets.js
@@ -58,8 +58,9 @@ export function useSnippets({ insert_section, insert_field, doc_type }) {
 			);
 		}
 		if (existing) {
+			// Scope is never rewritten by a write: importing a Sales Invoice snippet
+			// over a global one would otherwise narrow it and hide it from everyone else.
 			const update = { content, snippet_type };
-			if (document_type !== undefined) update.document_type = document_type;
 			await frappe.db.set_value(DOCTYPE, name, update);
 			Object.assign(existing, update, { content: parsed });
 		} else {

--- a/frappe/public/js/print_format_builder/composables/useSnippets.js
+++ b/frappe/public/js/print_format_builder/composables/useSnippets.js
@@ -104,11 +104,14 @@ export function useSnippets({ insert_section, insert_field, doc_type }) {
 		};
 		const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
 		const a = document.createElement("a");
-		a.href = URL.createObjectURL(blob);
+		const url = URL.createObjectURL(blob);
+		a.href = url;
 		a.download = "print-format-snippets.json";
 		document.body.appendChild(a);
 		a.click();
 		document.body.removeChild(a);
+		// revoking in the same task can cancel the download in some browsers
+		setTimeout(() => URL.revokeObjectURL(url), 0);
 	}
 
 	async function import_snippets(payload) {
@@ -117,15 +120,22 @@ export function useSnippets({ insert_section, insert_field, doc_type }) {
 			frappe.throw(__("This file does not contain any snippets"));
 		}
 		const imported = [];
+		const skipped = [];
 		for (const row of rows) {
 			if (!row?.name || !row?.content) continue;
-			const name = await write_snippet(
-				row.name,
-				row.content,
-				row.snippet_type || "Section",
-				row.document_type || ""
-			);
-			if (name) imported.push(name);
+			// One unusable row (name taken by another document type, server refusal)
+			// must not abandon the rest of the file half-imported.
+			try {
+				const name = await write_snippet(
+					row.name,
+					row.content,
+					row.snippet_type || "Section",
+					row.document_type || ""
+				);
+				if (name) imported.push(name);
+			} catch {
+				skipped.push(row.name);
+			}
 		}
 		await reload();
 		const current = doc_type?.value;
@@ -136,7 +146,7 @@ export function useSnippets({ insert_section, insert_field, doc_type }) {
 				current &&
 				s.document_type !== current
 		).length;
-		return { imported: imported.length, other_doctypes };
+		return { imported: imported.length, other_doctypes, skipped };
 	}
 
 	// One-time lift of the old browser-local snippets. Anything whose name is already

--- a/frappe/public/js/print_format_builder/composables/useSnippets.js
+++ b/frappe/public/js/print_format_builder/composables/useSnippets.js
@@ -1,47 +1,153 @@
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import { clone_plain } from "../utils";
 
-const SECTION_SNIPPETS_KEY = "pfb_section_snippets";
+const DOCTYPE = "Print Format Snippet";
+const LEGACY_KEY = "pfb_section_snippets";
 
-function load() {
+function read_legacy() {
 	try {
-		return JSON.parse(localStorage.getItem(SECTION_SNIPPETS_KEY)) || [];
+		return JSON.parse(localStorage.getItem(LEGACY_KEY)) || [];
 	} catch {
 		return [];
 	}
 }
-function persist(list) {
-	try {
-		localStorage.setItem(SECTION_SNIPPETS_KEY, JSON.stringify(list));
-		return true;
-	} catch {
-		return false;
-	}
-}
 
-export function useSnippets({ insert_section }) {
-	const section_snippets = ref(load());
-	function save_section_snippet(name, section) {
+export function useSnippets({ insert_section, insert_field, doc_type }) {
+	const all_snippets = ref([]);
+	const snippets = computed(() => {
+		const current = doc_type?.value;
+		return all_snippets.value.filter(
+			(s) => !s.document_type || !current || s.document_type === current
+		);
+	});
+
+	function parse(row) {
+		try {
+			return { ...row, content: JSON.parse(row.content) };
+		} catch {
+			return null;
+		}
+	}
+
+	async function reload() {
+		let rows;
+		try {
+			rows = await frappe.db.get_list(DOCTYPE, {
+				fields: ["name", "snippet_type", "document_type", "content"],
+				limit: 0,
+				order_by: "name asc",
+			});
+		} catch {
+			all_snippets.value = [];
+			return;
+		}
+		all_snippets.value = rows.map(parse).filter(Boolean);
+	}
+
+	async function save_snippet(name, data, snippet_type = "Section", document_type) {
 		name = (name || "").trim();
-		if (!name || !section) return;
-		const list = section_snippets.value.filter((s) => s.name !== name);
-		list.push({ name, section: clone_plain(section) });
-		list.sort((a, b) => a.name.localeCompare(b.name));
-		section_snippets.value = list;
-		persist(list);
+		if (!name || !data) return;
+		const content = JSON.stringify(clone_plain(data));
+		const existing = all_snippets.value.find((s) => s.name === name);
+		if (existing) {
+			await frappe.db.set_value(DOCTYPE, name, { content, snippet_type });
+		} else {
+			await frappe.db.insert({
+				doctype: DOCTYPE,
+				__newname: name,
+				snippet_type,
+				document_type: document_type ?? doc_type?.value ?? "",
+				content,
+			});
+		}
+		await reload();
 	}
-	function insert_section_snippet(name) {
-		const snip = section_snippets.value.find((s) => s.name === name);
-		if (snip) insert_section(snip.section);
+
+	function insert_snippet(name) {
+		const snip = snippets.value.find((s) => s.name === name);
+		if (!snip) return;
+		if (snip.snippet_type === "Field") insert_field(snip.content);
+		else insert_section(snip.content);
 	}
-	function delete_section_snippet(name) {
-		section_snippets.value = section_snippets.value.filter((s) => s.name !== name);
-		persist(section_snippets.value);
+
+	async function delete_snippet(name) {
+		await frappe.db.delete_doc(DOCTYPE, name);
+		await reload();
 	}
+
+	function export_snippets(names) {
+		const picked = names?.length
+			? snippets.value.filter((s) => names.includes(s.name))
+			: snippets.value;
+		if (!picked.length) return;
+		const payload = {
+			version: 1,
+			snippets: picked.map((s) => ({
+				name: s.name,
+				snippet_type: s.snippet_type,
+				document_type: s.document_type || "",
+				content: s.content,
+			})),
+		};
+		const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+		const a = document.createElement("a");
+		a.href = URL.createObjectURL(blob);
+		a.download = "print-format-snippets.json";
+		document.body.appendChild(a);
+		a.click();
+		document.body.removeChild(a);
+	}
+
+	async function import_snippets(payload) {
+		const rows = Array.isArray(payload) ? payload : payload?.snippets;
+		if (!Array.isArray(rows)) {
+			frappe.throw(__("This file does not contain any snippets"));
+		}
+		let imported = 0;
+		let other_doctypes = 0;
+		const current = doc_type?.value;
+		for (const row of rows) {
+			if (!row?.name || !row?.content) continue;
+			const document_type = row.document_type || "";
+			await save_snippet(
+				row.name,
+				row.content,
+				row.snippet_type || "Section",
+				document_type
+			);
+			imported++;
+			if (document_type && current && document_type !== current) other_doctypes++;
+		}
+		await reload();
+		return { imported, other_doctypes };
+	}
+
+	async function migrate_legacy() {
+		const legacy = read_legacy();
+		if (!legacy.length) return;
+		for (const snip of legacy) {
+			if (!snip?.name || !snip?.section) continue;
+			if (all_snippets.value.some((s) => s.name === snip.name)) continue;
+			await save_snippet(snip.name, snip.section, "Section", "");
+		}
+		localStorage.removeItem(LEGACY_KEY);
+		await reload();
+	}
+
+	async function init() {
+		await reload();
+		await migrate_legacy();
+	}
+
+	init().catch(() => {});
+
 	return {
-		section_snippets,
-		save_section_snippet,
-		insert_section_snippet,
-		delete_section_snippet,
+		snippets,
+		save_snippet,
+		insert_snippet,
+		delete_snippet,
+		export_snippets,
+		import_snippets,
+		reload_snippets: reload,
 	};
 }

--- a/frappe/public/js/print_format_builder/inspector.css
+++ b/frappe/public/js/print_format_builder/inspector.css
@@ -56,10 +56,6 @@
 	grid-template-columns: 1fr;
 	gap: 4px;
 }
-.pfb-insp-toggles {
-	display: flex;
-	gap: 6px;
-}
 .pfb-insp-label {
 	font-size: var(--text-sm);
 	color: var(--text-muted);

--- a/frappe/public/js/print_format_builder/inspector.css
+++ b/frappe/public/js/print_format_builder/inspector.css
@@ -304,7 +304,6 @@
 
 .pfb-field-row,
 .pfb-block-card,
-.pfb-template-card,
 .drag-container .field,
 .sections-container .section-drag-handle {
 	user-select: none;

--- a/frappe/public/js/print_format_builder/inspector.css
+++ b/frappe/public/js/print_format_builder/inspector.css
@@ -56,6 +56,10 @@
 	grid-template-columns: 1fr;
 	gap: 4px;
 }
+.pfb-insp-toggles {
+	display: flex;
+	gap: 6px;
+}
 .pfb-insp-label {
 	font-size: var(--text-sm);
 	color: var(--text-muted);

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -33,12 +33,12 @@ export function getStore(print_format_name) {
 		align_selected_fields,
 	} = selection;
 	const {
-		find_field_column,
 		duplicate_field,
 		duplicate_section,
 		duplicate_selection,
 		move_selection,
 		insert_section,
+		insert_field,
 		remove_section,
 	} = useLayoutMutations(layout, selection);
 	const {
@@ -244,15 +244,21 @@ export function getStore(print_format_name) {
 	const { clipboard, copy_field, copy_section, copy_selection, paste_clipboard } = useClipboard({
 		selection,
 		layout,
-		find_field_column,
 		insert_section,
+		insert_field,
 	});
 	const {
-		section_snippets,
-		save_section_snippet,
-		insert_section_snippet,
-		delete_section_snippet,
-	} = useSnippets({ insert_section });
+		snippets,
+		save_snippet,
+		insert_snippet,
+		delete_snippet,
+		export_snippets,
+		import_snippets,
+	} = useSnippets({
+		insert_section,
+		insert_field,
+		doc_type: computed(() => print_format.value?.doc_type),
+	});
 
 	return {
 		print_format,
@@ -300,10 +306,12 @@ export function getStore(print_format_name) {
 		save_style_preset,
 		apply_style_preset,
 		delete_style_preset,
-		section_snippets,
-		save_section_snippet,
-		insert_section_snippet,
-		delete_section_snippet,
+		snippets,
+		save_snippet,
+		insert_snippet,
+		delete_snippet,
+		export_snippets,
+		import_snippets,
 		paste_clipboard,
 		undo,
 		redo,

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -200,6 +200,7 @@ export const FIELD_PLUCK_KEYS = [
 	"custom_style",
 	"value_color",
 	"label_color",
+	"label_bold",
 	"custom",
 	"image_url",
 	"width",

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -199,6 +199,7 @@ export const FIELD_PLUCK_KEYS = [
 	"visible_if",
 	"custom_style",
 	"value_color",
+	"value_bold",
 	"label_color",
 	"label_bold",
 	"custom",

--- a/frappe/templates/print_format/macros/Data.html
+++ b/frappe/templates/print_format/macros/Data.html
@@ -6,7 +6,7 @@
 {%- set _justify = df.label_justify if df.label_justify else '' -%}
 {%- set _fstyle = (('gap: ' + df.label_gap|int|string + 'px;') if (_inline and df.label_gap is defined and df.label_gap is not none) else '') + (df.custom_style or '') -%}
 {%- set _lbl_style = (('color:' + df.label_color + ';') if df.label_color else '') + ('font-weight:600;' if df.label_bold else '') -%}
-{%- set _val_style = ('color:' + df.value_color + ';') if df.value_color else '' -%}
+{%- set _val_style = (('color:' + df.value_color + ';') if df.value_color else '') + ('font-weight:600;' if df.value_bold else '') -%}
 <div class="field {{ _orientation }}{% if _inline and _orientation != 'left-right' %} field-inline{% endif %}{% if _align %} field-align-{{ _align }}{% endif %}{% if _justify and _orientation == 'left-right' and _align not in ('center', 'right') %} field-justify-{{ _justify }}{% endif %}" {% if _fstyle %}style="{{ _fstyle|e }}"{% endif %} {{ field_attributes(df) }}>
 	{%- block label -%}
 	{%- if _show_label != 'hide' -%}

--- a/frappe/templates/print_format/macros/Data.html
+++ b/frappe/templates/print_format/macros/Data.html
@@ -5,7 +5,7 @@
 {%- set _inline = (_show_label == 'inline') or (_orientation == 'left-right') -%}
 {%- set _justify = df.label_justify if df.label_justify else '' -%}
 {%- set _fstyle = (('gap: ' + df.label_gap|int|string + 'px;') if (_inline and df.label_gap is defined and df.label_gap is not none) else '') + (df.custom_style or '') -%}
-{%- set _lbl_style = ('color:' + df.label_color + ';') if df.label_color else '' -%}
+{%- set _lbl_style = (('color:' + df.label_color + ';') if df.label_color else '') + ('font-weight:600;' if df.label_bold else '') -%}
 {%- set _val_style = ('color:' + df.value_color + ';') if df.value_color else '' -%}
 <div class="field {{ _orientation }}{% if _inline and _orientation != 'left-right' %} field-inline{% endif %}{% if _align %} field-align-{{ _align }}{% endif %}{% if _justify and _orientation == 'left-right' and _align not in ('center', 'right') %} field-justify-{{ _justify }}{% endif %}" {% if _fstyle %}style="{{ _fstyle|e }}"{% endif %} {{ field_attributes(df) }}>
 	{%- block label -%}


### PR DESCRIPTION
Builder snippets lived in `localStorage`, so they were per-browser, per-device, shared across every site on the origin, and lost on a cache clear. This moves them to a DocType, makes them exportable, and tidies the surfaces around them.

### Snippets
- New **Print Format Snippet** DocType — `snippet_type` (Section/Field), `document_type` scope, `content` (JSON), plus `module`/`standard` so snippets ship with an app like Field Templates do
- Existing `localStorage` snippets migrate on first builder open; any whose name is already taken stay put instead of being dropped
- Export/import snippets as JSON
- Fields can be saved as snippets, not just sections

https://github.com/user-attachments/assets/0c2e6376-62f6-42e7-8d23-f194dbc77abb



### Builder UI
- Snippets and Field Templates now share one **Library** tab (they were split across Blocks and Templates), with one card style
- Bold toggles for field label and value, inline on their colour rows
- Removed the "Live" badge — it only appeared when a record was already named in the picker beside it

### Notes
- Snippet docnames are global, so saving over a name owned by another document type is refused rather than silently overwriting it, and an existing snippet's scope is never rewritten by a write
- `frappe.db.get_list` never settles its promise on failure, so the snippet load goes through `frappe.xcall` — otherwise a permission error hangs the builder
- Drag-inserting a snippet now runs `freshen_field`, matching click-insert; without it a custom field dropped twice shared a fieldname
- Import skips an unusable row and reports it instead of abandoning the rest of the file
- `label_bold`/`value_bold` emit inline `font-weight`, mirroring `label_color`, so neither surface needed a stylesheet change. Like `label_color`, they're no-ops for Table/Repeater fields, which render their own label markup

no-docs
