### PR TITLE
fix: duplicate title in list view settings dialog

### DIFF
--- a/frappe/public/js/frappe/list/list_settings.js
+++ b/frappe/public/js/frappe/list/list_settings.js
@@ -30,7 +30,10 @@ export default class ListSettings {
 		let list_view_settings = frappe.get_meta("List View Settings");
 
 		me.dialog = new frappe.ui.Dialog({
-			title: __("{0} List View Settings", [__(me.doctype)]),
+			title:
+				me.doctype === "List View Settings"
+					? __("List View Settings")
+					: __("{0} List View Settings", [__(me.doctype)]),
 			fields: list_view_settings.fields,
 		});
 		me.dialog.set_values(me.settings);


### PR DESCRIPTION
Just looks good.

## Before

<img width="686" height="520" alt="Screenshot 2026-07-21 at 12 33 46 PM" src="https://github.com/user-attachments/assets/edc518fa-bc39-4483-8ac0-b2781b812074" />


## After

<img width="673" height="533" alt="Screenshot 2026-07-21 at 12 32 54 PM" src="https://github.com/user-attachments/assets/9c9f9a28-cb04-40d9-8aca-77d0b638c74b" />
