### PR TITLE
fix: rename to add_to_workspace_dock

### DIFF
--- a/frappe/apps.py
+++ b/frappe/apps.py
@@ -19,10 +19,24 @@ from frappe.utils.caching import request_cache
 DESK_APP_PATTERN = re.compile(r"^/desk(/.*)?$")
 
 
+@request_cache
+def get_docked_apps() -> set[str]:
+	"""Apps that surface their workspaces inside another app's workspace dock.
+
+	A companion app (e.g. India Compliance for ERPNext) pins its workspaces into a host app's dock
+	via the `add_to_workspace_dock` hook instead of taking an apps-screen slot of its own. It is
+	kept off the apps screen even when it also declares `add_to_apps_screen` -- companion apps keep
+	that hook so they still appear on older versions, so here the dock hook wins."""
+	from frappe.boot import get_app_rail_host_map
+
+	return set(get_app_rail_host_map())
+
+
 @frappe.whitelist()
 @request_cache
 def get_apps():
 	apps = frappe.get_installed_apps()
+	docked_apps = get_docked_apps()
 	app_list = []
 	for app in apps:
 		if (
@@ -34,6 +48,10 @@ def get_apps():
 
 		if app == "frappe":
 			continue
+
+		if app in docked_apps:
+			continue
+
 		app_details = frappe.get_hooks("add_to_apps_screen", app_name=app)
 		if not len(app_details):
 			continue

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -196,13 +196,14 @@ def get_app_rail_map():
 
 	A companion app (e.g. India Compliance for ERPNext, India Payroll for HRMS) stays off the
 	apps screen and instead surfaces its workspaces inside a host app's rail via the
-	`add_app_to_dock` hook. Each entry names the host `app` and the `workspace` to pin, with an
-	optional `has_permission` path to gate it. Returns a map of host app name -> ordered list of
-	permitted workspace names."""
-	rail_map = {}
-	permission_cache = {}
+	`add_to_workspace_dock` hook. Each entry names the host `app` and the `workspace` to pin.
+	Returns a map of host app name -> ordered list of workspace names.
 
-	for entry in frappe.get_hooks("add_app_to_dock") or []:
+	Nothing is permission-filtered here: the caller keeps only workspaces the user is allowed to
+	see, so a pinned workspace is gated by its own Roles table like any other workspace."""
+	rail_map = {}
+
+	for entry in frappe.get_hooks("add_to_workspace_dock") or []:
 		if not isinstance(entry, dict):
 			continue
 
@@ -211,24 +212,13 @@ def get_app_rail_map():
 		if not host_app or not workspace:
 			continue
 
-		has_permission = entry.get("has_permission")
-		if has_permission:
-			if has_permission not in permission_cache:
-				try:
-					permission_cache[has_permission] = bool(frappe.get_attr(has_permission)())
-				except Exception:
-					frappe.log_error(f"Failed to call add_app_to_dock has_permission hook ({has_permission})")
-					permission_cache[has_permission] = False
-			if not permission_cache[has_permission]:
-				continue
-
 		rail_map.setdefault(host_app, []).append(workspace)
 
 	return rail_map
 
 
 def get_app_rail_host_map():
-	"""Map of companion app -> the host app it pins into via `add_app_to_dock`.
+	"""Map of companion app -> the host app it pins into via `add_to_workspace_dock`.
 
 	A companion app has no shell of its own; its workspaces live inside the host app's rail. This
 	map lets the desk resolve the app context (dock + header) of a companion app's workspaces to
@@ -236,7 +226,7 @@ def get_app_rail_host_map():
 	into more than one host, the first host wins."""
 	host_map = {}
 	for app_name in frappe.get_installed_apps():
-		for entry in frappe.get_hooks("add_app_to_dock", app_name=app_name) or []:
+		for entry in frappe.get_hooks("add_to_workspace_dock", app_name=app_name) or []:
 			if isinstance(entry, dict) and entry.get("app") and entry.get("workspace"):
 				host_map[app_name] = entry["app"]
 				break
@@ -252,7 +242,7 @@ def load_desktop_data(bootinfo):
 	from frappe.desk.desktop import get_user_workspaces
 
 	allowed_pages = [d.name for d in bootinfo.workspaces.get("pages")]
-	# Companion apps pin their workspaces into a host app's dock (rail) via `add_app_to_dock`,
+	# Companion apps pin their workspaces into a host app's dock (rail) via `add_to_workspace_dock`,
 	# instead of taking an apps-screen slot of their own. Resolved once, merged per host app below.
 	rail_map = get_app_rail_map()
 	# ...and their own workspaces resolve their app context (dock + header) to that host app, so a
@@ -332,8 +322,10 @@ def load_desktop_data(bootinfo):
 
 		bootinfo.app_data.append(
 			dict(
-				# whether the app opts into the apps screen via the add_to_apps_screen hook
-				on_apps_screen=bool(apps),
+				# whether the app opts into the apps screen via the add_to_apps_screen hook. An app
+				# that pins into a host app's dock never takes a slot of its own, even if it still
+				# declares add_to_apps_screen from before the dock existed -- the dock hook wins.
+				on_apps_screen=bool(apps) and app_name not in bootinfo.app_rail_host,
 				# Sort order for the apps (desktop) screen; lower shows first, Framework is pinned
 				# last (sequence_id 1000). Apps that don't declare one fall to a middle default.
 				sequence_id=app_info.get("sequence_id") or DEFAULT_APP_SEQUENCE_ID,

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -97,7 +97,7 @@ frappe.ui.Sidebar = class Sidebar {
 		return frappe.boot.module_app[frappe.scrub(meta.module)];
 	}
 
-	// Resolve a companion app to the host app it's pinned into (via the `add_app_to_dock` hook,
+	// Resolve a companion app to the host app it's pinned into (via the `add_to_workspace_dock` hook,
 	// surfaced as `frappe.boot.app_rail_host`). A companion app has no shell of its own -- its
 	// workspaces live inside the host app's rail -- so its app context (dock + header) is the host's.
 	// Non-companion apps (and unknown/null names) pass through unchanged.

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -431,12 +431,13 @@ use_json_request_body = True
 # ]
 
 # Companion apps that extend a host app (instead of taking their own apps-screen icon) can pin
-# their workspaces into the host app's workspace dock (rail) with this hook.
-# add_app_to_dock = [
+# their workspaces into the host app's workspace dock (rail) with this hook. Declaring it keeps
+# the app off the apps screen, so it takes precedence over any add_to_apps_screen above. Who can
+# see a pinned workspace is controlled by that workspace's own Roles table.
+# add_to_workspace_dock = [
 # 	{{
 # 		"app": "erpnext",
 # 		"workspace": "My Workspace",
-# 		"has_permission": "{app_name}.api.permission.has_app_permission",
 # 	}}
 # ]
 


### PR DESCRIPTION
Rename again to `add_to_workspace_dock`. It is more semantic than the last iteration.
