### PR TITLE
fix(pfb): don't flag builder blocks as missing fields in the outline

### DIFF
--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -455,6 +455,7 @@
 import draggable from "vuedraggable";
 import Autocomplete from "../../vue-components/Autocomplete.vue";
 import {
+	BLOCK_FIELDTYPES,
 	DRAG_OPTIONS,
 	clone_plain,
 	freshen_field,
@@ -762,6 +763,7 @@ let known_fieldnames = computed(() => {
 });
 function field_broken(f) {
 	if (f.custom || f.fieldtype === "Field Template" || !f.fieldname) return false;
+	if (BLOCK_FIELDTYPES.has(f.fieldtype)) return false;
 	return !known_fieldnames.value.has(f.fieldname);
 }
 

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -2,6 +2,9 @@ export function clone_plain(obj) {
 	return JSON.parse(JSON.stringify(obj));
 }
 
+// Blocks the builder invents — they never map to a docfield on the document type
+export const BLOCK_FIELDTYPES = new Set(["Spacer", "Divider", "Repeater"]);
+
 export function freshen_field(f) {
 	delete f.remove;
 	if (f.custom && f.fieldname) f.fieldname += "_" + frappe.utils.get_random(8);


### PR DESCRIPTION
The outline flagged Repeater blocks with `Field "repeater" no longer exists on Sales Invoice`. Repeater is a builder block, not a docfield, so it can never exist on the document type — the warning is always wrong there.

- `field_broken` skipped the check for `custom` fields only; a block whose `custom` flag was lost on the way into the layout fell through and got warned about
- Builder-only fieldtypes (Spacer, Divider, Repeater) now never report as broken, independent of the flag
- Outline is now the first tab, and the builder reopens on whichever tab you last used (falling back to Outline) instead of always resetting to Fields
