### PR TITLE
fix(ui): keep es-alert content start-aligned regardless of page context

### DIFF
--- a/frappe/public/css/espresso/components/alert.css
+++ b/frappe/public/css/espresso/components/alert.css
@@ -31,6 +31,9 @@
     padding-block: calc(var(--spacing) * 3.5);
     border-radius: var(--radius-md);
     font-size: var(--text-base);
+    /* pin alignment so the icon and text stay start-aligned regardless of any
+       inherited text-align from the surrounding page (e.g. the login card). */
+    text-align: start;
     background: var(--es-al-bg);
 }
 


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

On the login "check your email" screen, the green success banner rendered with the check icon on the far left and the message pushed to the right edge, split by a large empty gap — instead of the icon and text sitting together.

> Explain the **details** for making this change. What existing problem does the pull request solve?

The `es-alert` espresso component (`frappe/public/css/espresso/components/alert.css`) is a CSS grid but never pinned its own text alignment. `text-align` is an **inherited** property, so the banner picked up the surrounding page's alignment. Inside the login card's cascade this resolved to a right alignment, pushing the `.es-alert__title` to the end of its grid column and producing the gap.

The fix pins `text-align: start` on `.es-alert`, so the icon and text stay together and start-aligned in any context. `start` (rather than `left`) keeps it correct under RTL. Because the fix lives in the shared component, every `es-alert` call site (~19 places) becomes robust to whatever page hosts it — not just the login banner.

```css
.es-alert {
    ...
    font-size: var(--text-base);
    /* pin alignment so the icon and text stay start-aligned regardless of any
       inherited text-align from the surrounding page (e.g. the login card). */
    text-align: start;
    background: var(--es-al-bg);
}
```

> Screenshots/GIFs

| Before | After |
| --- | --- |
| _icon and text split by a large gap, message right-aligned_ | _icon and text together, message left-aligned_ |
| <!-- paste before.png here --> | <!-- paste after.png here --> |

<!-- The before/after images are attached in the conversation; drag them into the two cells above. -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKtttqEEpqBVM8WosCJC2m)_