### PR TITLE
fix: make the create new button subtle

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -724,7 +724,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		if (this.can_create) {
 			actions.push({
 				label: new_button_label,
-				variant: "solid",
+				variant: "subtle",
 				icon: "plus",
 				css_class: "btn-new-doc",
 			});


### PR DESCRIPTION
Before
<img width="1440" height="898" alt="Screenshot 2026-07-21 at 3 56 07 PM" src="https://github.com/user-attachments/assets/d845167c-115e-4136-b058-487be4221f48" />

After
<img width="1440" height="900" alt="Screenshot 2026-07-21 at 3 49 08 PM" src="https://github.com/user-attachments/assets/30ef48fd-e896-487e-9e59-573335bb11d4" />

