### PR TITLE
fix: missing doctype name in breadcrumbs

### DIFF
--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -48,6 +48,21 @@ frappe.breadcrumbs = {
 		return frappe.get_route_str();
 	},
 
+	set_tree_breadcrumb(breadcrumbs) {
+		const doctype = breadcrumbs.doctype;
+
+		const tree_title =frappe.treeview_settings?.[doctype]?.title || __(doctype);
+
+		this.append_breadcrumb_element(
+			`/desk/${frappe.router.slug(doctype)}`,
+			__(tree_title),
+			"title-text"
+		);
+
+		let tree_crumb = this.$breadcrumbs.find("li a.title-text").last();
+		tree_crumb.parent().addClass("ellipsis");
+	},
+
 	update() {
 		var breadcrumbs = this.all[frappe.breadcrumbs.current_page()];
 
@@ -73,13 +88,21 @@ frappe.breadcrumbs = {
 			// workspace
 			this.set_workspace_breadcrumb(breadcrumbs);
 
-			// form / print
 			let view = frappe.get_route()[0];
 			view = view ? view.toLowerCase() : null;
+			// Use the active sidebar hierarchy for Desk views that are
+			// directly represented by sidebar navigation items.
+			if (breadcrumbs.doctype && ["tree", "list"].includes(view)) {
+    			this.set_sidebar_breadcrumbs(breadcrumbs);
+			}
+			// form / print
 			if (breadcrumbs.doctype && ["print", "form"].includes(view)) {
 				this.set_list_breadcrumb(breadcrumbs);
 				this.set_form_breadcrumb(breadcrumbs, view);
-			} else if (breadcrumbs.doctype && view === "list") {
+			}else if (breadcrumbs.doctype && view === "tree"){
+				//this.set_sidebar_breadcrumbs(breadcrumbs);
+				this.set_tree_breadcrumb(breadcrumbs);
+			}else if (breadcrumbs.doctype && view === "list") {
 				this.set_list_breadcrumb(breadcrumbs);
 				if (breadcrumbs.layout_name) {
 					const layout_info = (frappe.boot.doctype_layouts || []).find(
@@ -104,6 +127,8 @@ frappe.breadcrumbs = {
 
 		this.toggle(true);
 	},
+	// // In breadcrumb.js, in the update() method, after the workspace breadcrumb and before the form/print check:
+
 
 	set_custom_breadcrumbs(breadcrumbs) {
 		this.append_breadcrumb_element(breadcrumbs.route, breadcrumbs.label);
@@ -125,6 +150,30 @@ frappe.breadcrumbs = {
 
 	get last_route() {
 		return frappe.route_history.slice(-2)[0];
+	},
+
+	set_sidebar_breadcrumbs(breadcrumbs) {
+		if (!frappe.app?.sidebar) {
+			return;
+		}
+
+		const sidebar = frappe.app.sidebar;
+
+		// Current workspace/sidebar, e.g. "Accounts Setup"
+		const sidebar_title = sidebar.sidebar_title;
+
+		if (sidebar_title) {
+			this.append_breadcrumb_element("", __(sidebar_title));
+		}
+
+		// Current section, e.g. "Setup"
+		const section_title = sidebar.active_item
+			?.closest(".section-item")
+			.attr("data-id");
+
+		if (section_title && section_title !== sidebar_title) {
+			this.append_breadcrumb_element("", __(section_title));
+		}
 	},
 
 	set_workspace_breadcrumb(breadcrumbs) {

--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -51,7 +51,7 @@ frappe.breadcrumbs = {
 	set_tree_breadcrumb(breadcrumbs) {
 		const doctype = breadcrumbs.doctype;
 
-		const tree_title =frappe.treeview_settings?.[doctype]?.title || __(doctype);
+		const tree_title = frappe.treeview_settings?.[doctype]?.title || doctype;
 
 		this.append_breadcrumb_element(
 			`/desk/${frappe.router.slug(doctype)}`,
@@ -100,7 +100,6 @@ frappe.breadcrumbs = {
 				this.set_list_breadcrumb(breadcrumbs);
 				this.set_form_breadcrumb(breadcrumbs, view);
 			}else if (breadcrumbs.doctype && view === "tree"){
-				//this.set_sidebar_breadcrumbs(breadcrumbs);
 				this.set_tree_breadcrumb(breadcrumbs);
 			}else if (breadcrumbs.doctype && view === "list") {
 				this.set_list_breadcrumb(breadcrumbs);
@@ -127,8 +126,6 @@ frappe.breadcrumbs = {
 
 		this.toggle(true);
 	},
-	// // In breadcrumb.js, in the update() method, after the workspace breadcrumb and before the form/print check:
-
 
 	set_custom_breadcrumbs(breadcrumbs) {
 		this.append_breadcrumb_element(breadcrumbs.route, breadcrumbs.label);
@@ -167,9 +164,7 @@ frappe.breadcrumbs = {
 		}
 
 		// Current section, e.g. "Setup"
-		const section_title = sidebar.active_item
-			?.closest(".section-item")
-			.attr("data-id");
+		const section_title = sidebar.active_item?.closest(".section-item").attr("data-id");
 
 		if (section_title && section_title !== sidebar_title) {
 			this.append_breadcrumb_element("", __(section_title));

--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -50,7 +50,6 @@ frappe.breadcrumbs = {
 
 	set_tree_breadcrumb(breadcrumbs) {
 		const doctype = breadcrumbs.doctype;
-
 		const tree_title = frappe.treeview_settings?.[doctype]?.title || doctype;
 
 		this.append_breadcrumb_element(
@@ -88,20 +87,15 @@ frappe.breadcrumbs = {
 			// workspace
 			this.set_workspace_breadcrumb(breadcrumbs);
 
+			// form / print
 			let view = frappe.get_route()[0];
 			view = view ? view.toLowerCase() : null;
-			// Use the active sidebar hierarchy for Desk views that are
-			// directly represented by sidebar navigation items.
-			if (breadcrumbs.doctype && ["tree", "list"].includes(view)) {
-    			this.set_sidebar_breadcrumbs(breadcrumbs);
-			}
-			// form / print
 			if (breadcrumbs.doctype && ["print", "form"].includes(view)) {
 				this.set_list_breadcrumb(breadcrumbs);
 				this.set_form_breadcrumb(breadcrumbs, view);
-			}else if (breadcrumbs.doctype && view === "tree"){
+			} else if (breadcrumbs.doctype && view === "tree") {
 				this.set_tree_breadcrumb(breadcrumbs);
-			}else if (breadcrumbs.doctype && view === "list") {
+			} else if (breadcrumbs.doctype && view === "list") {
 				this.set_list_breadcrumb(breadcrumbs);
 				if (breadcrumbs.layout_name) {
 					const layout_info = (frappe.boot.doctype_layouts || []).find(
@@ -147,28 +141,6 @@ frappe.breadcrumbs = {
 
 	get last_route() {
 		return frappe.route_history.slice(-2)[0];
-	},
-
-	set_sidebar_breadcrumbs(breadcrumbs) {
-		if (!frappe.app?.sidebar) {
-			return;
-		}
-
-		const sidebar = frappe.app.sidebar;
-
-		// Current workspace/sidebar, e.g. "Accounts Setup"
-		const sidebar_title = sidebar.sidebar_title;
-
-		if (sidebar_title) {
-			this.append_breadcrumb_element("", __(sidebar_title));
-		}
-
-		// Current section, e.g. "Setup"
-		const section_title = sidebar.active_item?.closest(".section-item").attr("data-id");
-
-		if (section_title && section_title !== sidebar_title) {
-			this.append_breadcrumb_element("", __(section_title));
-		}
 	},
 
 	set_workspace_breadcrumb(breadcrumbs) {


### PR DESCRIPTION
Closes https://github.com/frappe/frappe/issues/37798

Raises on behalf of @rameensh