### PR TITLE
fix: constrain read-only Text Editor field height with scroll

### DIFF
--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -136,10 +136,11 @@ Quill.register(CustomColor, true);
 frappe.ui.form.ControlTextEditor = class ControlTextEditor extends frappe.ui.form.ControlCode {
 	make_wrapper() {
 		super.make_wrapper();
-		if (!this.df.max_height) {
-			this.$wrapper
-				.find(".like-disabled-input")
-				.css({ "max-height": "400px", overflow: "auto" });
+		const disp_area = this.$wrapper.find(".like-disabled-input");
+		if (this.df.max_height) {
+			disp_area.css({ "max-height": this.df.max_height, overflow: "auto" });
+		} else {
+			disp_area.css({ "max-height": "400px", overflow: "auto" });
 		}
 	}
 

--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -136,6 +136,11 @@ Quill.register(CustomColor, true);
 frappe.ui.form.ControlTextEditor = class ControlTextEditor extends frappe.ui.form.ControlCode {
 	make_wrapper() {
 		super.make_wrapper();
+		if (!this.df.max_height) {
+			this.$wrapper
+				.find(".like-disabled-input")
+				.css({ "max-height": "400px", overflow: "auto" });
+		}
 	}
 
 	make_input() {

--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -136,12 +136,6 @@ Quill.register(CustomColor, true);
 frappe.ui.form.ControlTextEditor = class ControlTextEditor extends frappe.ui.form.ControlCode {
 	make_wrapper() {
 		super.make_wrapper();
-		const disp_area = this.$wrapper.find(".like-disabled-input");
-		if (this.df.max_height) {
-			disp_area.css({ "max-height": this.df.max_height, overflow: "auto" });
-		} else {
-			disp_area.css({ "max-height": "400px", overflow: "auto" });
-		}
 	}
 
 	make_input() {

--- a/frappe/public/scss/common/controls.scss
+++ b/frappe/public/scss/common/controls.scss
@@ -407,6 +407,11 @@ textarea.form-control {
 	overflow-wrap: break-word;
 }
 
+.frappe-control[data-fieldtype="Text Editor"] .control-value {
+	max-height: 300px;
+	overflow: auto;
+}
+
 .frappe-control[data-fieldtype="Data"] .control-input,
 .control-value {
 	position: relative;


### PR DESCRIPTION
Resolve: #39973

---
**Before:**

https://github.com/user-attachments/assets/474feee6-0200-4a94-85d8-245874ecd2e6




**After**



https://github.com/user-attachments/assets/8c16b157-24a8-4e3b-982b-31a20c4a0eae

