### PR TITLE
fix: Respect select field ordering

### DIFF
--- a/frappe/desk/doctype/system_console/system_console.py
+++ b/frappe/desk/doctype/system_console/system_console.py
@@ -1,8 +1,11 @@
 # Copyright (c) 2020, Frappe Technologies and contributors
 # License: MIT. See LICENSE
 
+import json
+
 import frappe
 from frappe.model.document import Document
+from frappe.utils.response import json_handler
 from frappe.utils.safe_exec import read_sql, safe_exec
 
 
@@ -33,7 +36,9 @@ class SystemConsole(Document):
 				self.output = "\n".join(frappe.debug_log)
 			elif self.type == "SQL":
 				frappe.db.begin(read_only=True)
-				self.output = frappe.as_json(read_sql(self.console, as_dict=1))
+				# Use json module directly to preserve key order.
+				frappe.as_json
+				self.output = json.dumps(read_sql(self.console, as_dict=1), default=json_handler)
 		except Exception:
 			self.commit = False
 			self.output = frappe.get_traceback()


### PR DESCRIPTION
System console output columns were always sorted, makes no sense. 