### PR TITLE
fix: restore compact email button size

### DIFF
--- a/frappe/public/scss/email.bundle.scss
+++ b/frappe/public/scss/email.bundle.scss
@@ -286,17 +286,16 @@ hr {
 
 .btn {
 	text-decoration: none;
-	padding: 11px 22px;
+	padding: 4px 20px;
 	font-size: 13px;
 	font-weight: 600;
-	letter-spacing: -0.01em;
 	border: 1px solid;
-	border-radius: $border-radius-lg;
+	border-radius: $border-radius;
 	color: $gray-800;
 	background-color: $gray-100;
 	border-color: transparent;
 	display: inline-block;
-	line-height: 18px;
+	line-height: 20px;
 	margin: 8px 0;
 
 	&.btn-primary {


### PR DESCRIPTION
- restore the previous compact button size (`padding: 4px 20px`, `line-height: 20px`, default border radius) — #41026 made buttons noticeably oversized
- keeps the new dark button colors

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/fx_password_reset.png" width="380"> | <img src="https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/btn_password_reset.png" width="380"> |
| <img src="https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/fx_workflow_action.png" width="380"> | <img src="https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/btn_workflow_action.png" width="380"> |
