### PR TITLE
feat: QUERY HTTP method (RFC 10008)

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -594,11 +594,14 @@ def whitelist(allow_guest=False, xss_safe=False, methods=None, force_types=None)
 	"""
 
 	if not methods:
-		methods = ("GET", "POST", "PUT", "DELETE")
+		methods = ("GET", "POST", "PUT", "DELETE", "QUERY")
 	elif isinstance(methods, str):
 		methods = (methods,)
 	else:
 		methods = tuple(methods)
+
+	if "GET" in methods and "QUERY" not in methods:
+		methods = (*methods, "QUERY")
 
 	def innerfn(fn):
 		from frappe.utils.typing_validations import validate_argument_types

--- a/frappe/api/v1.py
+++ b/frappe/api/v1.py
@@ -12,11 +12,12 @@ from frappe.utils.data import sbool
 
 
 def document_list(doctype: str):
-	if frappe.form_dict.get("fields"):
-		frappe.form_dict["fields"] = json.loads(frappe.form_dict["fields"])
+	# QUERY requests send these as native JSON types in body, GET sends JSON-encoded strings
+	if isinstance(fields := frappe.form_dict.get("fields"), str) and fields:
+		frappe.form_dict["fields"] = json.loads(fields)
 
-	if frappe.form_dict.get("expand"):
-		frappe.form_dict["expand"] = json.loads(frappe.form_dict["expand"])
+	if isinstance(expand := frappe.form_dict.get("expand"), str) and expand:
+		frappe.form_dict["expand"] = json.loads(expand)
 
 	# set limit of records for frappe.get_list
 	frappe.form_dict.setdefault(
@@ -125,14 +126,17 @@ def execute_doc_method(doctype: str, name: str, method: str | None = None):
 	fn = getattr(method_obj, "__func__", method_obj)
 	is_valid_http_method(fn)
 
-	assert frappe.request.method in ("GET", "POST"), "execute_doc_method route is only mounted for GET/POST"
-	if frappe.request.method == "GET":
-		doc.check_permission("read")
-		return doc.run_method(method, **frappe.form_dict)
-
-	elif frappe.request.method == "POST":
+	assert frappe.request.method in (
+		"GET",
+		"POST",
+		"QUERY",
+	), "execute_doc_method route is only mounted for GET/POST/QUERY"
+	if frappe.request.method == "POST":
 		doc.check_permission("write")
-		return doc.run_method(method, **frappe.form_dict)
+	else:
+		doc.check_permission("read")
+
+	return doc.run_method(method, **frappe.form_dict)
 
 
 def get_request_form_data():
@@ -149,10 +153,10 @@ def get_request_form_data():
 
 url_rules = [
 	Rule("/method/<path:method>", endpoint=handle_rpc_call),
-	Rule("/resource/<doctype>", methods=["GET"], endpoint=document_list),
+	Rule("/resource/<doctype>", methods=["GET", "QUERY"], endpoint=document_list),
 	Rule("/resource/<doctype>", methods=["POST"], endpoint=create_doc),
 	Rule("/resource/<doctype>/<path:name>/", methods=["GET"], endpoint=read_doc),
 	Rule("/resource/<doctype>/<path:name>/", methods=["PUT"], endpoint=update_doc),
 	Rule("/resource/<doctype>/<path:name>/", methods=["DELETE"], endpoint=delete_doc),
-	Rule("/resource/<doctype>/<path:name>/", methods=["POST"], endpoint=execute_doc_method),
+	Rule("/resource/<doctype>/<path:name>/", methods=["POST", "QUERY"], endpoint=execute_doc_method),
 ]

--- a/frappe/api/v1.py
+++ b/frappe/api/v1.py
@@ -1,5 +1,3 @@
-import json
-
 from werkzeug.routing import Rule
 
 import frappe
@@ -12,12 +10,11 @@ from frappe.utils.data import sbool
 
 
 def document_list(doctype: str):
-	# QUERY requests send these as native JSON types in body, GET sends JSON-encoded strings
-	if isinstance(fields := frappe.form_dict.get("fields"), str) and fields:
-		frappe.form_dict["fields"] = json.loads(fields)
+	if frappe.form_dict.get("fields"):
+		frappe.form_dict["fields"] = frappe.parse_json(frappe.form_dict["fields"])
 
-	if isinstance(expand := frappe.form_dict.get("expand"), str) and expand:
-		frappe.form_dict["expand"] = json.loads(expand)
+	if frappe.form_dict.get("expand"):
+		frappe.form_dict["expand"] = frappe.parse_json(frappe.form_dict["expand"])
 
 	# set limit of records for frappe.get_list
 	frappe.form_dict.setdefault(

--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -24,6 +24,7 @@ from frappe.handler import is_valid_http_method, run_server_script, upload_file
 PERMISSION_MAP = {
 	"GET": "read",
 	"POST": "write",
+	"QUERY": "read",
 }
 
 
@@ -258,7 +259,9 @@ def execute_doc_method(doctype: str, name: str, method: str | None = None):
 	fn = getattr(method_obj, "__func__", method_obj)
 	is_valid_http_method(fn)
 
-	assert frappe.request.method in PERMISSION_MAP, "execute_doc_method route is only mounted for GET/POST"
+	assert frappe.request.method in PERMISSION_MAP, (
+		"execute_doc_method route is only mounted for GET/POST/QUERY"
+	)
 	doc.check_permission(PERMISSION_MAP[frappe.request.method])
 	result = doc.run_method(method, **frappe.form_dict)
 	doc.apply_fieldlevel_read_permissions()
@@ -579,7 +582,7 @@ def run_doc_method(method: str, document: dict[str, Any] | str, kwargs=None):
 	if kwargs is None:
 		kwargs = {}
 
-	assert frappe.request.method in PERMISSION_MAP, "run_doc_method route is only mounted for GET/POST"
+	assert frappe.request.method in PERMISSION_MAP, "run_doc_method route is only mounted for GET/POST/QUERY"
 	doc = frappe.get_doc(document, check_permission=PERMISSION_MAP[frappe.request.method])
 	doc._original_modified = doc.modified
 	doc.check_if_latest()
@@ -622,12 +625,12 @@ url_rules = [
 	Rule("/method/<method>", endpoint=handle_rpc_call),
 	Rule(
 		"/method/run_doc_method",
-		methods=["GET", "POST"],
+		methods=["GET", "POST", "QUERY"],
 		endpoint=lambda: frappe.call(run_doc_method, **frappe.form_dict),
 	),
 	Rule("/method/<doctype>/<method>", endpoint=handle_rpc_call),
 	# Document level APIs
-	Rule("/document/<doctype>", methods=["GET"], endpoint=document_list),
+	Rule("/document/<doctype>", methods=["GET", "QUERY"], endpoint=document_list),
 	Rule("/document/<doctype>", methods=["POST"], endpoint=create_doc),
 	Rule("/document/<doctype>/bulk_delete", methods=["POST"], endpoint=bulk_delete_docs),
 	Rule("/document/<doctype>/bulk_update", methods=["POST"], endpoint=bulk_update_docs),
@@ -637,10 +640,10 @@ url_rules = [
 	Rule("/document/<doctype>/<path:name>/", methods=["DELETE"], endpoint=delete_doc),
 	Rule(
 		"/document/<doctype>/<path:name>/method/<method>/",
-		methods=["GET", "POST"],
+		methods=["GET", "POST", "QUERY"],
 		endpoint=execute_doc_method,
 	),
 	# Collection level APIs
 	Rule("/doctype/<doctype>/meta", methods=["GET"], endpoint=get_meta),
-	Rule("/doctype/<doctype>/count", methods=["GET"], endpoint=count),
+	Rule("/doctype/<doctype>/count", methods=["GET", "QUERY"], endpoint=count),
 ]

--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -25,7 +25,7 @@ from frappe.utils import cint, date_diff, datetime, get_datetime, today
 from frappe.utils.password import check_password, get_decrypted_password
 from frappe.website.utils import get_home_page
 
-SAFE_HTTP_METHODS = frozenset(("GET", "HEAD", "OPTIONS"))
+SAFE_HTTP_METHODS = frozenset(("GET", "HEAD", "OPTIONS", "QUERY"))
 UNSAFE_HTTP_METHODS = frozenset(("POST", "PUT", "DELETE", "PATCH"))
 assert SAFE_HTTP_METHODS.isdisjoint(UNSAFE_HTTP_METHODS), "a HTTP method cannot be both safe and unsafe"
 MAX_PASSWORD_SIZE = 512

--- a/frappe/tests/test_api.py
+++ b/frappe/tests/test_api.py
@@ -110,11 +110,17 @@ class FrappeAPITestCase(IntegrationTestCase):
 		from frappe.auth import CookieManager, LoginManager
 		from frappe.utils import set_request
 
+		# restore the original request afterwards, the fake one has "localhost" as
+		# host which changes what get_url() returns for rest of the test process
+		original_request = getattr(frappe.local, "request", None)
 		set_request(path="/")
-		frappe.local.cookie_manager = CookieManager()
-		frappe.local.login_manager = LoginManager()
-		frappe.local.login_manager.login_as("Administrator")
-		return frappe.session.sid
+		try:
+			frappe.local.cookie_manager = CookieManager()
+			frappe.local.login_manager = LoginManager()
+			frappe.local.login_manager.login_as("Administrator")
+			return frappe.session.sid
+		finally:
+			frappe.local.request = original_request
 
 	def get(self, path: str, params: dict | None = None, **kwargs) -> TestResponse:
 		return make_request(target=self.TEST_CLIENT.get, args=(path,), kwargs={"json": params, **kwargs})

--- a/frappe/tests/test_api.py
+++ b/frappe/tests/test_api.py
@@ -110,8 +110,7 @@ class FrappeAPITestCase(IntegrationTestCase):
 		from frappe.auth import CookieManager, LoginManager
 		from frappe.utils import set_request
 
-		# restore the original request afterwards, the fake one has "localhost" as
-		# host which changes what get_url() returns for rest of the test process
+		# the fake request's "localhost" host changes what get_url() returns, restore afterwards
 		original_request = getattr(frappe.local, "request", None)
 		set_request(path="/")
 		try:
@@ -136,6 +135,11 @@ class FrappeAPITestCase(IntegrationTestCase):
 
 	def delete(self, path, **kwargs) -> TestResponse:
 		return make_request(target=self.TEST_CLIENT.delete, args=(path,), kwargs=kwargs)
+
+	def query(self, path, data, **kwargs) -> TestResponse:
+		return make_request(
+			target=self.TEST_CLIENT.open, args=(path,), kwargs={"method": "QUERY", "json": data, **kwargs}
+		)
 
 	def tearDown(self) -> None:
 		frappe.db.rollback()
@@ -419,6 +423,131 @@ class TestMethodAPI(FrappeAPITestCase):
 		self.assertIn("Integer exceeds 64-bit range", response.json["exception"])
 
 
+class TestQueryMethod(FrappeAPITestCase):
+	"""QUERY (RFC 10008) is a safe method with a request body: parsed like POST,
+	but DB transactions are rolled back like GET."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.todo = frappe.get_doc(
+			{"doctype": "ToDo", "description": f"query method test {frappe.generate_hash()}"}
+		).insert()
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.db.rollback()
+		frappe.delete_doc_if_exists("ToDo", cls.todo.name)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def test_document_list_v1(self):
+		response = self.query(
+			self.resource("ToDo"),
+			{
+				"sid": self.sid,
+				"fields": ["name", "description"],
+				"filters": [["ToDo", "description", "=", self.todo.description]],
+			},
+		)
+		self.assertEqual(response.status_code, 200)
+		self.assertEqual(len(response.json["data"]), 1)
+		self.assertEqual(response.json["data"][0]["name"], self.todo.name)
+
+	def test_document_list_v2(self):
+		response = self.query(
+			"/api/v2/document/ToDo",
+			{
+				"sid": self.sid,
+				"fields": ["name"],
+				"filters": {"description": self.todo.description},
+			},
+		)
+		self.assertEqual(response.status_code, 200)
+		self.assertEqual(len(response.json["data"]), 1)
+		self.assertEqual(response.json["data"][0]["name"], self.todo.name)
+
+	def test_count_v2(self):
+		response = self.query(
+			"/api/v2/doctype/ToDo/count",
+			{"sid": self.sid, "filters": {"description": self.todo.description}},
+		)
+		self.assertEqual(response.status_code, 200)
+		self.assertEqual(response.json["data"], 1)
+
+	def test_rpc_call(self):
+		response = self.query(self.method("frappe.tests.test_api.test"), {"sid": self.sid, "message": "hi"})
+		self.assertEqual(response.status_code, 200)
+
+	def test_get_only_endpoints_accept_query(self):
+		# get_boot_translations is whitelisted with methods=["GET"]
+		response = self.query(
+			self.method("frappe.translate.get_boot_translations"),
+			{"sid": self.sid, "lang": "en"},
+		)
+		self.assertEqual(response.status_code, 200)
+
+	def test_respects_allowed_methods(self):
+		method = frappe.get_attr("frappe.tests.test_api.test")
+
+		with (
+			patch.dict(frappe.allowed_http_methods_for_whitelisted_func, {method: ["POST"]}),
+			suppress_stdout(),
+		):
+			response = self.query(self.method("frappe.tests.test_api.test"), {"sid": self.sid})
+
+		self.assertEqual(response.status_code, 403)
+
+	def test_execute_doc_method_v1(self):
+		response = self.query(
+			self.resource("Website Theme", "Standard"),
+			{"sid": self.sid, "run_method": "get_apps"},
+		)
+		self.assertEqual(response.status_code, 200)
+		self.assertTrue(response.json["data"])
+
+	def test_execute_doc_method_v2(self):
+		response = self.query(
+			"/api/v2/document/Website Theme/Standard/method/get_apps",
+			{"sid": self.sid},
+		)
+		self.assertEqual(response.status_code, 200)
+		self.assertTrue(response.json["data"])
+
+	def test_run_doc_method_v2(self):
+		dns = frappe.get_doc("Document Naming Settings")
+		response = self.query(
+			"/api/v2/method/run_doc_method",
+			{
+				"sid": self.sid,
+				"document": dns.as_dict(),
+				"method": "get_transactions_and_prefixes",
+			},
+		)
+		self.assertEqual(response.status_code, 200)
+		self.assertTrue(response.json["data"])
+		self.assertGreaterEqual(len(response.json["docs"]), 1)
+
+	def test_writes_are_rolled_back(self):
+		description = f"must not persist {frappe.generate_hash()}"
+		response = self.query(
+			self.method("frappe.tests.test_api.create_todo_for_testing"),
+			{"sid": self.sid, "description": description},
+		)
+		self.assertEqual(response.status_code, 200)
+		name = response.json["message"]
+		self.assertTrue(name)
+
+		frappe.db.rollback()  # discard our own snapshot so we see the latest committed state
+		self.assertFalse(frappe.db.exists("ToDo", name))
+		self.assertFalse(frappe.db.exists("ToDo", {"description": description}))
+
+	def test_website_routes_not_served(self):
+		response = self.query("/login", {"sid": self.sid})
+		self.assertEqual(response.status_code, 404)
+
+
 class TestReadOnlyMode(FrappeAPITestCase):
 	"""During migration if read only mode can be enabled.
 	Test if reads work well and writes are blocked"""
@@ -596,3 +725,8 @@ def test_array(data: typing.Any):
 @whitelist_for_tests()
 def test_unserializable_response():
 	frappe.response["value"] = 2**70
+
+
+@whitelist_for_tests()
+def create_todo_for_testing(description: str):
+	return frappe.get_doc({"doctype": "ToDo", "description": description}).insert().name

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -1443,11 +1443,13 @@ class TestTypingValidations(IntegrationTestCase):
 
 		self.assertEqual(
 			frappe.allowed_http_methods_for_whitelisted_func[default_methods],
-			("GET", "POST", "PUT", "DELETE"),
+			("GET", "POST", "PUT", "DELETE", "QUERY"),
 		)
-		self.assertEqual(frappe.allowed_http_methods_for_whitelisted_func[list_methods], ("GET", "POST"))
+		self.assertEqual(
+			frappe.allowed_http_methods_for_whitelisted_func[list_methods], ("GET", "POST", "QUERY")
+		)
 		self.assertEqual(frappe.allowed_http_methods_for_whitelisted_func[tuple_methods], ("PUT", "DELETE"))
-		self.assertEqual(frappe.allowed_http_methods_for_whitelisted_func[string_method], ("GET",))
+		self.assertEqual(frappe.allowed_http_methods_for_whitelisted_func[string_method], ("GET", "QUERY"))
 
 
 class TestTBSanitization(IntegrationTestCase):


### PR DESCRIPTION
In Frappe terms, QUERY = GET like transaction semantics and POST like body semantics.

This is not standardized yet, so don't consider it stable in Frappe either. It seems like a useful feature so adding it.

closes https://github.com/frappe/frappe/issues/40797 

Ref https://datatracker.ietf.org/doc/html/rfc10008 