### PR TITLE
fix(ui): empty state text for list views

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -691,40 +691,27 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		return fields_order;
 	}
 
-	get_documentation_link() {
-		if (this.meta.documentation) {
-			return `<a href="${
-				this.meta.documentation
-			}" target="_blank" class="meta-description small text-muted">${__("Need Help?")}</a>`;
-		}
-		return "";
-	}
-
 	get_no_result_message() {
 		let filters = this.filter_area && this.filter_area.get();
 
 		let has_filters_set = filters && filters.length;
-		const no_result_message = has_filters_set
-			? __("No {0} found with matching filters. Clear filters to see all {0}.", [
-					__(this.doctype),
-			  ])
+
+		let title = has_filters_set
+			? __("No {0} found", [__(this.doctype)])
+			: __("No {0} created", [__(this.doctype)]);
+
+		let description = has_filters_set
+			? __("Clear the filters to see all records.")
 			: this.meta.description
 			? __(this.meta.description)
-			: __("You haven't created a {0} yet", [__(this.doctype)]);
-
-		const new_button_label = has_filters_set
-			? __("Create a new {0}", [__(this.doctype)], "Create a new document from list view")
-			: __(
-					"Create your first {0}",
-					[__(this.doctype)],
-					"Create a new document from list view"
-			  );
+			: this.can_create
+			? __("Create your first {0} to get started.", [__(this.doctype)])
+			: __("Nothing has been added yet.");
 
 		const actions = [];
 		if (this.can_create) {
 			actions.push({
-				label: new_button_label,
-				variant: "subtle",
+				label: __("Create"),
 				icon: "plus",
 				css_class: "btn-new-doc",
 			});
@@ -732,18 +719,24 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 		if (this.meta.documentation) {
 			actions.push({
-				label: __("Need Help?"),
+				label: __("Documentation"),
 				href: this.meta.documentation,
 				icon: "external-link",
+				variant: "outline",
 			});
 		}
 
-		return frappe.ui.empty_state.html({
-			icon: "file",
-			title: no_result_message,
+		let icon = "file";
+		if (this.meta.icon && !this.meta.icon.startsWith("fa fa-")) {
+			icon = this.meta.icon;
+		}
+
+		return frappe.ui.empty_state({
+			icon,
+			title,
+			description,
 			actions,
-			css_class: "msg-box no-border",
-		});
+		})[0].outerHTML;
 	}
 
 	freeze() {

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -731,12 +731,12 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			icon = this.meta.icon;
 		}
 
-		return frappe.ui.empty_state({
+		return frappe.ui.empty_state.html({
 			icon,
 			title,
 			description,
 			actions,
-		})[0].outerHTML;
+		});
 	}
 
 	freeze() {


### PR DESCRIPTION
Empty state in list views rendered a primary button - explicitly set in the variant as "solid". I am not sure why @sumitjain236 .

The Empty state component renders a subtle button by default anyway - so this fix: https://github.com/frappe/frappe/pull/41113 was correct in output but we don't need to pass in any variant at all.

Also cleaned up the text in the buttons and empty state to make it simpler - instead of repeating the DocType name multiple times. Also added support for DocType icons. This was already done in a previous PR - but then the list view virtualisation PR reverted it again.

@sumitjain236 - please validate the UI output before pushing commits :/

cc: @sokumon @iamejaaz 

<img width="1511" height="859" alt="image" src="https://github.com/user-attachments/assets/b547d3de-305e-40a8-b3cd-87512439c80c" />


<img width="1511" height="859" alt="image" src="https://github.com/user-attachments/assets/4dca22d4-1b10-420e-8039-7d4de45eb242" />
