### PR TITLE
perf: Reduce dev server reloader watches

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -4,6 +4,7 @@
 import functools
 import logging
 import os
+import sys
 
 import orjson
 from werkzeug.exceptions import HTTPException, NotFound
@@ -521,6 +522,46 @@ def _tolerate_reloader_crashes():
 	ReloaderLoop.restart_with_reloader = restart_with_reloader
 
 
+_RELOADER_EXCLUDED_DIRS = ("node_modules", ".git")
+
+
+def _get_reloader_watch_config(sites_path) -> tuple[list[str], list[str]]:
+	"""Keep the reloader from watching node_modules, .git and the sites directory.
+
+	See #41147
+	"""
+	try:
+		__import__("watchdog.observers")  # same check werkzeug uses to pick the reloader
+	except ImportError:
+		# The stat reloader polls only .py files and skips the venv already; the
+		# watch-root surgery below would just make it walk the app packages twice.
+		return [], ["test_*"]
+
+	sites_dir = os.path.abspath(sites_path)
+	extra_dirs = []
+	exclude_patterns = ["test_*", sites_dir, *[f"*/{d}/*" for d in _RELOADER_EXCLUDED_DIRS]]
+
+	# the stat reloader never scans the venv or the stdlib; skip them here too
+	prefixes = {sys.prefix, sys.exec_prefix, sys.base_prefix, sys.base_exec_prefix}
+	exclude_patterns.extend(f"{os.path.abspath(p)}{os.sep}*" for p in prefixes)
+
+	for path in sys.path:
+		path = os.path.abspath(path)
+		if path == sites_dir or not os.path.isdir(path):
+			continue
+		if not any(os.path.lexists(os.path.join(path, d)) for d in _RELOADER_EXCLUDED_DIRS):
+			continue
+
+		exclude_patterns.append(path)
+		extra_dirs.extend(
+			os.path.join(path, child)
+			for child in sorted(os.listdir(path))
+			if os.path.isfile(os.path.join(path, child, "__init__.py"))
+		)
+
+	return extra_dirs, exclude_patterns
+
+
 def serve(
 	port=8000,
 	profile=False,
@@ -556,14 +597,17 @@ def serve(
 		log.setLevel(logging.ERROR)
 
 	use_reloader = False if in_test_env else not no_reload
+	extra_dirs, exclude_patterns = [], ["test_*"]
 	if use_reloader:
 		_tolerate_reloader_crashes()
+		extra_dirs, exclude_patterns = _get_reloader_watch_config(sites_path)
 
 	run_simple(
 		"0.0.0.0",
 		int(port),
 		application,
-		exclude_patterns=["test_*"],
+		extra_files=extra_dirs,
+		exclude_patterns=exclude_patterns,
 		use_reloader=use_reloader,
 		use_debugger=not in_test_env,
 		use_evalex=not in_test_env,


### PR DESCRIPTION
## Why

`bench serve` lets werkzeug watch every `sys.path` entry recursively. On a bench that means each app's **whole repo** — `node_modules`, `.git` — plus the entire `sites/` folder and the virtualenv. On my bench: ~53k directories / ~370k files watched, of which ~4.5k directories contain the Python code the reloader actually cares about.

This isn't just wasteful, it's silently broken: `fs.inotify.max_user_watches` defaults to 65536, shared by everything the user runs. My serve got 30k of the 53k watches it asked for, and werkzeug swallows the `OSError` for the rest ← the bug. Edits under the unwatched trees simply never trigger a reload. Every IDE/watcher on the machine competes for the same budget, so this degrades unpredictably.

## How

You can't fix this with patterns alone. inotify has no subtree-exclusion concept, and werkzeug applies `exclude_patterns` to the candidate watch *roots* before scheduling — `*/node_modules/*` matches nothing because `node_modules` is never itself a root. The only lever is swapping the roots:

- Any `sys.path` entry containing `node_modules`/`.git` (i.e. an app repo root) is excluded wholesale, and its top-level Python packages are passed to werkzeug as `extra_files` instead.
- `sites/` is excluded.
- The venv and stdlib are excluded — mirroring what werkzeug's stat reloader already skips (`_stat_ignore_scan`), so both reloaders now have the same semantics.
- Watch roots are deliberately few (~10): watchdog opens **one inotify instance per root** and `fs.inotify.max_user_instances` defaults to 128. Splitting into fine-grained roots exhausts that limit instead (found out the hard way).
- All of this only runs when watchdog is importable. The stat reloader never had the problem (it polls only `.py` files) and the extra dirs would just make it walk the app packages twice.

## Numbers

Measured on a 7-app bench (frappe, erpnext, hrms, lms, crm + 2):

| | before | after |
|---|---|---|
| inotify watches wanted | 53,368 | 4,461 |
| inotify watches actually held | 30,151 (capped, silently broken) | 4,460 |
| files covered | ~374k | ~22k |
| watcher arm-up after each reload | ~60s | ~2s |

The arm-up one matters more than it looks: after *every* reload the observer spent a minute re-registering watches, during which changes could go unseen.

## Behavior changes

- Upgrading a package in the venv no longer triggers a reload — same as stat reloader behavior, and you restart after `bench pip install` anyway.
- `.py` files sitting at an app's repo root (outside any package) are no longer watched.

## Tests

Verified E2E on a running bench: edit inside any app package → reload fires; files created in `node_modules`, `sites/`, or the venv → nothing; watch/instance counts confirmed via `/proc/<pid>/fdinfo`.
