### PR TITLE
fix(filter): remove invalid options from DOM instead of hiding via CSS

### DIFF
--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -361,9 +361,8 @@ frappe.ui.Filter = class {
 	make_field(df, old_fieldtype) {
 		let old_text = this.field ? this.field.get_value() : null;
 		let current_condition = this.filter_edit_area.find(".condition").val();
-		this.hide_invalid_conditions(df.fieldtype, df.original_type, current_condition);
+		this.refresh_condition_options(df, current_condition);
 		this.set_special_condition_labels(df.original_type);
-		this.toggle_nested_set_conditions(df, current_condition);
 		let field_area = this.filter_edit_area.find(".filter-field").empty().get(0);
 		df.input_class = "input-xs";
 		let f = frappe.ui.form.make_control({
@@ -516,29 +515,48 @@ frappe.ui.Filter = class {
 		</div>`);
 	}
 
-	hide_invalid_conditions(fieldtype, original_type, current_value) {
-		// Safari's native <select> popup does not honor display:none on <option>
-		// elements, so invalid conditions must be removed from the DOM rather
-		// than just visually hidden.
+	refresh_condition_options(df, current_value) {
+		// Safari doesn't honor display:none on <option>, so options are removed
+		// from the DOM; normal and nested-set options are rebuilt together to
+		// keep order and restore logic in one place.
 		let invalid_conditions =
-			this.invalid_condition_map[original_type] ||
-			this.invalid_condition_map[fieldtype] ||
+			this.invalid_condition_map[df.original_type] ||
+			this.invalid_condition_map[df.fieldtype] ||
 			[];
 
-		let $select = this.filter_edit_area.find(".condition");
+		let show_nested_set_conditions =
+			df.fieldtype === "Link" && frappe.boot.nested_set_doctypes.includes(df.options);
+
 		let is_nested_set_condition = (value) =>
 			this.nested_set_conditions.some(([condition]) => condition === value);
 
+		let $select = this.filter_edit_area.find(".condition");
 		$select.empty();
+
 		for (let condition of this.conditions) {
-			if (is_nested_set_condition(condition[0])) continue;
-			if (!invalid_conditions.includes(condition[0])) {
-				$select.append($("<option>").attr("value", condition[0]).text(condition[1]));
-			}
+			if (is_nested_set_condition(condition[0]) && !show_nested_set_conditions) continue;
+			if (invalid_conditions.includes(condition[0])) continue;
+			$select.append($("<option>").attr("value", condition[0]).text(condition[1]));
 		}
 
 		if ($select.find(`option[value="${current_value}"]`).length) {
 			$select.val(current_value);
+		} else if (
+			current_value &&
+			!(is_nested_set_condition(current_value) && !show_nested_set_conditions)
+		) {
+			// preserve a saved/URL condition even if invalid_condition_map excludes it,
+			// but never a nested-set condition on a field that can't use one
+			let existing_condition = this.conditions.find(
+				([condition]) => condition === current_value
+			);
+			$select
+				.append(
+					$("<option>")
+						.attr("value", current_value)
+						.text(existing_condition ? existing_condition[1] : current_value)
+				)
+				.val(current_value);
 		}
 	}
 
@@ -555,29 +573,6 @@ frappe.ui.Filter = class {
 					.find(`.condition option[value="${condition[0]}"]`)
 					.text(__(condition[1]));
 			}
-		}
-	}
-
-	toggle_nested_set_conditions(df, current_value) {
-		let show_condition =
-			df.fieldtype === "Link" && frappe.boot.nested_set_doctypes.includes(df.options);
-		let $select = this.filter_edit_area.find(".condition");
-		this.nested_set_conditions.forEach((condition) => {
-			let $option = $select.find(`option[value="${condition[0]}"]`);
-			if (show_condition && !$option.length) {
-				$select.append($("<option>").attr("value", condition[0]).text(condition[1]));
-			} else if (!show_condition) {
-				$option.remove();
-			}
-		});
-
-		// hide_invalid_conditions can't restore a nested-set selection since those
-		// options don't exist until this method re-inserts them above
-		if (
-			show_condition &&
-			this.nested_set_conditions.some(([condition]) => condition === current_value)
-		) {
-			$select.val(current_value);
 		}
 	}
 };

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -360,9 +360,10 @@ frappe.ui.Filter = class {
 
 	make_field(df, old_fieldtype) {
 		let old_text = this.field ? this.field.get_value() : null;
-		this.hide_invalid_conditions(df.fieldtype, df.original_type);
+		let current_condition = this.filter_edit_area.find(".condition").val();
+		this.hide_invalid_conditions(df.fieldtype, df.original_type, current_condition);
 		this.set_special_condition_labels(df.original_type);
-		this.toggle_nested_set_conditions(df);
+		this.toggle_nested_set_conditions(df, current_condition);
 		let field_area = this.filter_edit_area.find(".filter-field").empty().get(0);
 		df.input_class = "input-xs";
 		let f = frappe.ui.form.make_control({
@@ -515,16 +516,29 @@ frappe.ui.Filter = class {
 		</div>`);
 	}
 
-	hide_invalid_conditions(fieldtype, original_type) {
+	hide_invalid_conditions(fieldtype, original_type, current_value) {
+		// Safari's native <select> popup does not honor display:none on <option>
+		// elements, so invalid conditions must be removed from the DOM rather
+		// than just visually hidden.
 		let invalid_conditions =
 			this.invalid_condition_map[original_type] ||
 			this.invalid_condition_map[fieldtype] ||
 			[];
 
+		let $select = this.filter_edit_area.find(".condition");
+		let is_nested_set_condition = (value) =>
+			this.nested_set_conditions.some(([condition]) => condition === value);
+
+		$select.empty();
 		for (let condition of this.conditions) {
-			this.filter_edit_area
-				.find(`.condition option[value="${condition[0]}"]`)
-				.toggle(!invalid_conditions.includes(condition[0]));
+			if (is_nested_set_condition(condition[0])) continue;
+			if (!invalid_conditions.includes(condition[0])) {
+				$select.append($("<option>").attr("value", condition[0]).text(condition[1]));
+			}
+		}
+
+		if ($select.find(`option[value="${current_value}"]`).length) {
+			$select.val(current_value);
 		}
 	}
 
@@ -544,14 +558,27 @@ frappe.ui.Filter = class {
 		}
 	}
 
-	toggle_nested_set_conditions(df) {
+	toggle_nested_set_conditions(df, current_value) {
 		let show_condition =
 			df.fieldtype === "Link" && frappe.boot.nested_set_doctypes.includes(df.options);
+		let $select = this.filter_edit_area.find(".condition");
 		this.nested_set_conditions.forEach((condition) => {
-			this.filter_edit_area
-				.find(`.condition option[value="${condition[0]}"]`)
-				.toggle(show_condition);
+			let $option = $select.find(`option[value="${condition[0]}"]`);
+			if (show_condition && !$option.length) {
+				$select.append($("<option>").attr("value", condition[0]).text(condition[1]));
+			} else if (!show_condition) {
+				$option.remove();
+			}
 		});
+
+		// hide_invalid_conditions can't restore a nested-set selection since those
+		// options don't exist until this method re-inserts them above
+		if (
+			show_condition &&
+			this.nested_set_conditions.some(([condition]) => condition === current_value)
+		) {
+			$select.val(current_value);
+		}
 	}
 };
 


### PR DESCRIPTION
This specifically fixes a bug wherein all filter options were displayed in dropdown in Safari Browser.

TIL:

Chrome and Firefox correctly exclude CSS-hidden (display:none) <option> elements from a native <select>'s dropdown popup. Safari's WebKit rendering of native <select> popups doesn't honor that — it shows every <option> that exists in the DOM regardless of its display style. So all three browsers had the exact same DOM and the exact same "hidden" options, but only Safari ignored the hiding and showed everything, including irrelevant stuff like `Timespan` or `Descendants Of` on a plain `Select/Data` field.

**Before**:

<img width="2860" height="1626" alt="image" src="https://github.com/user-attachments/assets/52013d43-51ac-4519-880f-5b58099dba38" />


**After**:

<img width="2860" height="1626" alt="image" src="https://github.com/user-attachments/assets/770f9554-f47a-46d6-a3b4-9eeae2128701" />



closes Ticket 73382