### PR TITLE
fix(dev): Disable Werkzeug debugger

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -565,8 +565,8 @@ def serve(
 		application,
 		exclude_patterns=["test_*"],
 		use_reloader=use_reloader,
-		use_debugger=not in_test_env,
-		use_evalex=not in_test_env,
+		use_debugger=False,
+		use_evalex=False,
 		threaded=not no_threading,
 	)
 


### PR DESCRIPTION
We never use this in development, because we never let our code reach
that point in app.py
