### PR TITLE
refactor: unbuffered sync from mariadb to duckdb

### DIFF
--- a/frappe/core/doctype/duckdb_sync/duckdb_sync.py
+++ b/frappe/core/doctype/duckdb_sync/duckdb_sync.py
@@ -1,6 +1,10 @@
 # Copyright (c) 2026, Frappe Technologies and contributors
 # For license information, please see license.txt
 
+import copy
+
+import pyarrow as pa
+
 import frappe
 from frappe import qb
 from frappe.database import get_duckdb
@@ -106,7 +110,6 @@ def cleanup_old_syncs():
 
 
 def sync_data_to_duckdb(docname: str):
-	# TODO: permissions
 	sync_dt = qb.DocType("DuckDB Sync Item")
 	if (
 		unsynced := qb.from_(sync_dt)
@@ -122,39 +125,59 @@ def sync_data_to_duckdb(docname: str):
 		duck_tb = DuckDBTable(dt)
 
 		timeout = frappe.db.get_single_value("System Settings", "sync_timeout") or 25 * 60
-		# connect to mariadb
 		conn = frappe.get_doc("DuckDB Sync", docname).get_duckdb_conn()
-		try:
-			conn.sql(
-				f"attach 'user={frappe.conf.db_name} password={frappe.conf.db_password} host={frappe.conf.db_host} database={frappe.conf.db_name} port={frappe.conf.db_port}' as mariadb_db (TYPE mysql);"
-			)
-			columns = frappe.get_meta(dt).get_valid_columns()
-			# quotted fields
-			columns_sql = ", ".join([f'"{x}"' for x in columns])
-			query = f'insert into "{duck_tb.table_name}" ({columns_sql}) select {columns_sql} from mariadb_db."{duck_tb.table_name}";'
-			conn.sql(query)
-		except Exception as e:
-			import re
 
-			sanitized = re.sub(
-				r"(user|password)=\S+",
-				lambda m: f"{m.group(1)}=***",
-				str(e),
-			)
+		conn.execute(f'delete from "{duck_tb.table_name}";').fetchall()
 
-			raise Exception(sanitized) from None
-		else:
-			# update flag
-			frappe.db.set_value("DuckDB Sync Item", name, "synced", True)
+		_dt = qb.DocType(dt)
+		columns = frappe.get_meta(dt).get_valid_columns()
+		query = qb.from_(_dt)
+		for col in columns:
+			query = query.select(_dt[col])
+		schema = duck_tb.get_arrow_schema()
 
-			# schedule next
-			frappe.enqueue(
-				method="frappe.core.doctype.duckdb_sync.duckdb_sync.sync_data_to_duckdb",
-				queue="long",
-				timeout=timeout,
-				is_async=True,
-				enqueue_after_commit=True,
-				docname=docname,
-			)
-		finally:
-			conn.close()
+		with frappe.db.unbuffered_cursor():
+			iter = query.run(as_dict=True, as_iterator=True)
+			field_list = ", ".join(f'"{c}"' for c in schema.names)
+
+			# an iterator to create RecordBatch from list
+			def recordbatch_from_list(iter, schema):
+				batch_size = 204800
+				rows = []
+				for row in iter:
+					rows.append(row)
+					if len(rows) >= batch_size:
+						batch = pa.RecordBatch.from_pylist(rows, schema=schema)
+						yield batch
+						rows.clear()
+
+				if rows:
+					batch = pa.RecordBatch.from_pylist(rows, schema=schema)
+					yield batch
+
+			# streaming RecordBatch on demand
+			# sets backpressure on sql cursor through 'recordbatch_from_list' iterator
+			reader = pa.RecordBatchReader.from_batches(schema, recordbatch_from_list(iter, schema))
+
+			for batch in reader:
+				# zero-copy streaming: duckdb understands arrow table's memory layout
+				arrow_table = pa.Table.from_batches([batch])
+				conn.register("arrow_table", arrow_table)
+				conn.execute(
+					f'insert into "{duck_tb.table_name}" ({field_list}) select {field_list} from arrow_table;'
+				).fetchall()
+				conn.unregister("arrow_table")
+
+		conn.close()
+		# update flag
+		frappe.db.set_value("DuckDB Sync Item", name, "synced", True)
+
+		# schedule next
+		frappe.enqueue(
+			method="frappe.core.doctype.duckdb_sync.duckdb_sync.sync_data_to_duckdb",
+			queue="long",
+			timeout=timeout,
+			is_async=True,
+			enqueue_after_commit=True,
+			docname=docname,
+		)

--- a/frappe/core/doctype/duckdb_sync/duckdb_sync.py
+++ b/frappe/core/doctype/duckdb_sync/duckdb_sync.py
@@ -2,6 +2,7 @@
 # For license information, please see license.txt
 
 import copy
+from datetime import time, timedelta
 
 import pyarrow as pa
 
@@ -139,12 +140,26 @@ def sync_data_to_duckdb(docname: str):
 		with frappe.db.unbuffered_cursor():
 			iter = query.run(as_dict=True, as_iterator=True)
 			field_list = ", ".join(f'"{c}"' for c in schema.names)
+			time_columns = [
+				name
+				for name, dtype in zip(schema.names, schema.types, strict=False)
+				if pa.types.is_time(dtype)
+			]
+
+			def timedelta_to_time(td):
+				total_seconds = int(td.total_seconds()) % 86400
+				hours, remainder = divmod(total_seconds, 3600)
+				minutes, seconds = divmod(remainder, 60)
+				return time(hours, minutes, seconds, td.microseconds)
 
 			# an iterator to create RecordBatch from list
 			def recordbatch_from_list(iter, schema):
 				batch_size = 204800
 				rows = []
 				for row in iter:
+					for col in time_columns:
+						if isinstance(row.get(col), timedelta):
+							row[col] = timedelta_to_time(row[col])
 					rows.append(row)
 					if len(rows) >= batch_size:
 						batch = pa.RecordBatch.from_pylist(rows, schema=schema)

--- a/frappe/database/duckdb/database.py
+++ b/frappe/database/duckdb/database.py
@@ -62,7 +62,7 @@ def get_pyarrow_type_map():
 		"HTML Editor": pa.string(),
 		"Date": pa.date32(),
 		"Datetime": pa.timestamp("us"),
-		"Time": pa.time32("ms"),
+		"Time": pa.time64("us"),
 		"Text": pa.string(),
 		"Data": pa.string(),
 		"Link": pa.string(),

--- a/frappe/database/duckdb/database.py
+++ b/frappe/database/duckdb/database.py
@@ -44,6 +44,47 @@ def get_type_map():
 	}
 
 
+def get_pyarrow_type_map():
+	import pyarrow as pa
+
+	return {
+		"Currency": pa.float64(),
+		"Int": pa.int32(),
+		"Long Int": pa.int64(),
+		"Float": pa.float64(),
+		"Percent": pa.float64(),
+		"Check": pa.int8(),
+		"Small Text": pa.string(),
+		"Long Text": pa.string(),
+		"Code": pa.string(),
+		"Text Editor": pa.string(),
+		"Markdown Editor": pa.string(),
+		"HTML Editor": pa.string(),
+		"Date": pa.date32(),
+		"Datetime": pa.timestamp("us"),
+		"Time": pa.time32("ms"),
+		"Text": pa.string(),
+		"Data": pa.string(),
+		"Link": pa.string(),
+		"Dynamic Link": pa.string(),
+		"Password": pa.string(),
+		"Select": pa.string(),
+		"Rating": pa.float64(),
+		"Read Only": pa.string(),
+		"Attach": pa.string(),
+		"Attach Image": pa.string(),
+		"Signature": pa.string(),
+		"Color": pa.string(),
+		"Barcode": pa.string(),
+		"Geolocation": pa.string(),
+		"Duration": pa.float64(),
+		"Icon": pa.string(),
+		"Phone": pa.string(),
+		"Autocomplete": pa.string(),
+		"JSON": pa.large_string(),
+	}
+
+
 def get_latest_sync(doctype: str | None = None):
 	if doctype:
 		if latest_sync := frappe.db.get_all(

--- a/frappe/database/duckdb/schema.py
+++ b/frappe/database/duckdb/schema.py
@@ -1,3 +1,7 @@
+from collections import OrderedDict
+
+import pyarrow as pa
+
 import frappe
 from frappe.database.schema import DbColumn, DBTable, get_definition
 from frappe.utils import cint, cstr, flt
@@ -77,6 +81,7 @@ class DuckDBTable(DBTable):
 	def get_column_definitions(self):
 		column_list = [*frappe.db.DEFAULT_COLUMNS]
 		ret = []
+
 		for k in list(self.columns):
 			if k not in column_list:
 				d = self.columns[k].get_definition()
@@ -85,10 +90,39 @@ class DuckDBTable(DBTable):
 					column_list.append(k)
 		return ret
 
-	def get_columns_from_docfields(self):
-		"""
-		get columns from docfields and custom fields
-		"""
+	def get_all_column_definitions(self):
+		fields = []
+
+		# meta
+		varchar_len = frappe.db.VARCHAR_LEN
+		fields.extend(
+			[
+				f'"name" varchar({varchar_len})',
+				'"creation" datetime(6)',
+				'"modified" datetime(6)',
+				f'"modified_by" varchar({varchar_len})',
+				f'"owner" varchar({varchar_len})',
+				'"docstatus" tinyint not null default 0',
+				'"idx" int not null default 0',
+			]
+		)
+
+		# doctype fields
+		fields.extend(self.get_column_definitions())
+
+		# child table meta
+		if self.meta.get("istable", default=0):
+			fields.extend(
+				[
+					f'"parent" varchar({varchar_len})',
+					f'"parentfield" varchar({varchar_len})',
+					f'"parenttype" varchar({varchar_len})',
+				]
+			)
+
+		return fields
+
+	def _get_docfields(self):
 		fields = self.meta.get_fieldnames_with_value(with_field_meta=True)
 
 		# optional fields like _comments
@@ -102,7 +136,13 @@ class DuckDBTable(DBTable):
 
 		# amended_from
 		fields.append({"fieldname": "amended_from", "fieldtype": "Data"})
-		for field in fields:
+		return fields
+
+	def get_columns_from_docfields(self):
+		"""
+		get columns from docfields and custom fields
+		"""
+		for field in self._get_docfields():
 			if field.get("is_virtual"):
 				continue
 
@@ -119,35 +159,59 @@ class DuckDBTable(DBTable):
 				not_nullable=field.get("not_nullable"),
 			)
 
-	def create(self, conn):
-		additional_definitions = []
-		varchar_len = frappe.db.VARCHAR_LEN
-		name_column = f"name varchar({varchar_len})"
+	def get_all_columns(self):
+		# meta
+		fields = [
+			{"fieldname": "name", "fieldtype": "Data"},
+			{"fieldname": "creation", "fieldtype": "Datetime"},
+			{"fieldname": "modified", "fieldtype": "Datetime"},
+			{"fieldname": "modified_by", "fieldtype": "Data"},
+			{"fieldname": "owner", "fieldtype": "Data"},
+			{"fieldname": "docstatus", "fieldtype": "Int"},
+			{"fieldname": "idx", "fieldtype": "Int"},
+		]
 
-		# columns
-		column_defs = self.get_column_definitions()
-		if column_defs:
-			additional_definitions += column_defs
+		# doctype fields
+		fields.extend(self._get_docfields())
 
-		# child table columns
+		# child table meta fields
 		if self.meta.get("istable", default=0):
-			additional_definitions += [
-				f"parent varchar({varchar_len})",
-				f"parentfield varchar({varchar_len})",
-				f"parenttype varchar({varchar_len})",
-			]
-		additional_definitions = ",\n".join(additional_definitions)
+			fields.extend(
+				[
+					{"fieldname": "parent", "fieldtype": "Data"},
+					{"fieldname": "parentfield", "fieldtype": "Data"},
+					{"fieldname": "parenttype", "fieldtype": "Data"},
+				]
+			)
+		columns = OrderedDict()
+		for field in fields:
+			if field.get("is_virtual"):
+				continue
 
+			columns[field.get("fieldname")] = DuckDBColumn(
+				table=self,
+				fieldname=field.get("fieldname"),
+				fieldtype=field.get("fieldtype"),
+				length=field.get("length"),
+				default=field.get("default"),
+				set_index=field.get("search_index"),
+				options=field.get("options"),
+				unique=field.get("unique"),
+				precision=field.get("precision"),
+				not_nullable=field.get("not_nullable"),
+			)
+		return columns
+
+	def create(self, conn):
 		# create table
-		query = f"""create table \"{self.table_name}\" (
-			{name_column},
-			creation datetime(6),
-			modified datetime(6),
-			modified_by varchar({varchar_len}),
-			owner varchar({varchar_len}),
-			docstatus tinyint not null default '0',
-			idx int not null default '0',
-			{additional_definitions})
-			"""
+		all_columns = ",".join(self.get_all_column_definitions())
+		query = f"""create table \"{self.table_name}\" ({all_columns})"""
 
 		conn.sql(query)
+
+	def get_arrow_schema(self):
+		from frappe.database.duckdb.database import get_pyarrow_type_map
+
+		arrow_typemap = get_pyarrow_type_map()
+		fields = [(v.fieldname, arrow_typemap[v.fieldtype]) for v in self.get_all_columns().values()]
+		return pa.schema(fields)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "Pillow~=12.3.0",
     "PyJWT~=2.13.0",
     "duckdb~=1.4.3",
+    "pyarrow~=25.0.0",
     # We depend on internal attributes,
     # do NOT add loose requirements on PyMySQL versions.
     "PyMySQL==1.1.2",


### PR DESCRIPTION
Use unbuffered cursor on mariadb and generator to batch rows -> convert to apache arrow table (in memory columnar format) -> pass to duckdb. DuckDB is aware of arrow table's in memory representation. So it uses the data as is - zero copy.