### PR TITLE
fix(client): pass parent doctype when fetching child table link values

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -433,7 +433,7 @@ def is_document_amended(doctype: str, docname: str):
 
 
 @frappe.whitelist()
-def validate_link(doctype: str, docname: str, fields=None):
+def validate_link(doctype: str, docname: str, fields: list[str] | str | None = None):
 	if not isinstance(doctype, str):
 		frappe.throw(_("DocType must be a string"))
 

--- a/frappe/client.py
+++ b/frappe/client.py
@@ -440,10 +440,11 @@ def validate_link(doctype: str, docname: str, fields=None):
 	if not isinstance(docname, str):
 		frappe.throw(_("Document Name must be a string"))
 
+	parent_doctype = None
+	if frappe.get_meta(doctype).istable:  # needed for links to child rows
+		parent_doctype = frappe.db.get_value(doctype, docname, "parenttype")
+
 	if doctype != "DocType":
-		parent_doctype = None
-		if frappe.get_meta(doctype).istable:  # needed for links to child rows
-			parent_doctype = frappe.db.get_value(doctype, docname, "parenttype")
 		if not (
 			frappe.has_permission(doctype, "select", parent_doctype=parent_doctype)
 			or frappe.has_permission(doctype, "read", parent_doctype=parent_doctype)
@@ -473,7 +474,7 @@ def validate_link(doctype: str, docname: str, fields=None):
 		return values
 
 	try:
-		values.update(get_value(doctype, fields, docname))
+		values.update(get_value(doctype, fields, docname, parent=parent_doctype))
 	except frappe.PermissionError:
 		frappe.clear_last_message()
 		frappe.msgprint(

--- a/frappe/tests/test_client.py
+++ b/frappe/tests/test_client.py
@@ -177,6 +177,15 @@ class TestClient(FrappeTestCase):
 				validate_link("User", "Guest", fields=["enabled"]), {"name": "Guest", "enabled": 1}
 			)
 
+	def test_validate_link_fetches_child_table_field(self):
+		from frappe.client import validate_link
+
+		role_row = frappe.get_doc("User", "Administrator").roles[0]
+		self.assertEqual(
+			validate_link("Has Role", role_row.name, fields=["role"]),
+			{"name": role_row.name, "role": role_row.role},
+		)
+
 	def test_client_insert(self):
 		from frappe.client import insert
 


### PR DESCRIPTION
Fixes #27357

Fetching a field from a child table row through a Link field fails with "You need Read permission to fetch values from <Child Table>", even when the user can read the parent document.

`validate_link` resolves the child row's `parenttype` and uses it for the read/select permission gate, but then calls `get_value(doctype, fields, docname)` without passing it. `get_value` re-checks permission for the child doctype with `parent_doctype=None`, so `has_child_permission` has no parent to authorize against and raises `PermissionError`, which surfaces as the fetch warning.

This resolves `parent_doctype` before the gate and threads it into the fetch, so the value read authorizes against the parent the same way the gate does. develop and v16 already behave this way after `validate_link` was refactored into `validate_link_and_fetch`; this brings v15 in line.