### PR TITLE
perf!: Derive RTL CSS from compiled LTR CSS

### DIFF
--- a/esbuild/build-cleanup.js
+++ b/esbuild/build-cleanup.js
@@ -2,7 +2,9 @@ const path = require("path");
 const fs = require("fs");
 const glob = require("fast-glob");
 
-module.exports = {
+// esbuild validates plugin objects strictly, so the plugin and the helper
+// (used by derive-rtl.js for outputs that bypass esbuild) are separate exports.
+const plugin = {
 	name: "build_cleanup",
 	setup(build) {
 		build.onEnd((result) => {
@@ -11,6 +13,8 @@ module.exports = {
 		});
 	},
 };
+
+module.exports = { plugin, clean_dist_files };
 
 function clean_dist_files(new_files) {
 	new_files.forEach((file) => {

--- a/esbuild/derive-rtl.js
+++ b/esbuild/derive-rtl.js
@@ -1,0 +1,105 @@
+const path = require("path");
+const fs = require("fs");
+const crypto = require("crypto");
+const postcss = require("postcss");
+const rtlcss = require("rtlcss");
+const { clean_dist_files } = require("./build-cleanup");
+
+// esbuild names hashed outputs with an uppercase base32 alphabet; mimic it so
+// derived RTL files look like every other dist asset.
+const HASH_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+function content_hash(contents) {
+	const digest = crypto.createHash("sha256").update(contents).digest();
+	let hash = "";
+	for (let i = 0; i < 8; i++) {
+		hash += HASH_ALPHABET[digest[i] % HASH_ALPHABET.length];
+	}
+	return hash;
+}
+
+function is_ltr_css_output([output, info]) {
+	return Boolean(info.entryPoint) && output.endsWith(".css") && output.includes("/dist/css/");
+}
+
+// RTL stylesheets are derived by running rtlcss over the compiled LTR CSS
+// instead of compiling every .bundle.scss a second time. Returns a
+// result-shaped object ({ metafile }) consumable by write_assets_json and
+// log_built_assets, or null when the metafile has no stylesheet outputs
+// (e.g. a JS build's rebuild in watch mode).
+async function derive_rtl_styles(metafile) {
+	const css_outputs = Object.entries(metafile.outputs).filter(is_ltr_css_output);
+	if (!css_outputs.length) return null;
+
+	const outputs = {};
+	await Promise.all(
+		css_outputs.map(async ([output, info]) => {
+			const { rtl_path, bytes, map_bytes } = await derive_rtl_file(output);
+			outputs[rtl_path] = { entryPoint: info.entryPoint, bytes };
+			if (map_bytes != null) {
+				outputs[`${rtl_path}.map`] = { bytes: map_bytes };
+			}
+		})
+	);
+	// These files don't flow through an esbuild build, so the build_cleanup
+	// plugin never sees them; delete stale hashed copies here.
+	clean_dist_files(Object.keys(outputs));
+	return { metafile: { outputs } };
+}
+
+async function derive_rtl_file(ltr_path) {
+	// Strip the LTR sourceMappingURL annotation: the map is passed explicitly
+	// via `prev` below, and postcss keeps the comment when `annotation: false`,
+	// which would leave the RTL file pointing at the LTR map.
+	const css = (await fs.promises.readFile(ltr_path, "utf-8")).replace(
+		/\/\*# sourceMappingURL=\S+ \*\/\n?$/,
+		""
+	);
+	let prev_map;
+	try {
+		prev_map = await fs.promises.readFile(`${ltr_path}.map`, "utf-8");
+	} catch {
+		// no LTR source map; emit the RTL css without one
+	}
+
+	const rtl_dir = path.join(path.dirname(path.dirname(ltr_path)), "css-rtl");
+	// "desk.bundle.HASH.css" -> "desk.bundle"
+	const base = path.basename(ltr_path).split(".").slice(0, -2).join(".");
+
+	const result = await postcss([rtlcss]).process(css, {
+		from: ltr_path,
+		to: path.join(rtl_dir, `${base}.css`),
+		map: prev_map ? { prev: prev_map, annotation: false } : false,
+	});
+
+	// The RTL file needs its own content hash for cache busting (its contents
+	// differ from the LTR file). Hash before appending the sourceMappingURL
+	// annotation, like esbuild does.
+	const rtl_name = `${base}.${content_hash(result.css)}.css`;
+	const rtl_path = path.join(rtl_dir, rtl_name);
+
+	await fs.promises.mkdir(rtl_dir, { recursive: true });
+
+	let css_out = result.css;
+	let map_out;
+	if (result.map) {
+		const map = result.map.toJSON();
+		map.file = rtl_name;
+		map_out = JSON.stringify(map);
+		css_out += `\n/*# sourceMappingURL=${rtl_name}.map */\n`;
+	}
+
+	const writes = [fs.promises.writeFile(rtl_path, css_out)];
+	if (map_out) {
+		writes.push(fs.promises.writeFile(`${rtl_path}.map`, map_out));
+	}
+	await Promise.all(writes);
+
+	return {
+		rtl_path,
+		bytes: Buffer.byteLength(css_out),
+		map_bytes: map_out ? Buffer.byteLength(map_out) : null,
+	};
+}
+
+module.exports = { derive_rtl_styles };

--- a/esbuild/esbuild.js
+++ b/esbuild/esbuild.js
@@ -10,11 +10,11 @@ const cliui = require("cliui")();
 const chalk = require("chalk");
 const html_plugin = require("./frappe-html");
 const vue_style_plugin = require("./frappe-vue-style");
-const rtlcss = require("rtlcss");
 const postCssPlugin = require("@frappe/esbuild-plugin-postcss2").default;
+const { derive_rtl_styles } = require("./derive-rtl");
 const ignore_assets = require("./ignore-assets");
 const sass_options = require("./sass_options");
-const build_cleanup_plugin = require("./build-cleanup");
+const build_cleanup_plugin = require("./build-cleanup").plugin;
 
 const {
 	app_list,
@@ -226,7 +226,6 @@ function build_assets_for_apps(apps, files) {
 
 		let file_map = {};
 		let style_file_map = {};
-		let rtl_style_file_map = {};
 		for (let file of files) {
 			let relative_app_path = path.relative(apps_path, file);
 			let app = relative_app_path.split(path.sep)[0];
@@ -248,7 +247,6 @@ function build_assets_for_apps(apps, files) {
 			}
 			if ([".css", ".scss", ".less", ".sass", ".styl"].includes(extension)) {
 				style_file_map[output_name] = file;
-				rtl_style_file_map[output_name.replace("/css/", "/css-rtl/")] = file;
 			} else {
 				file_map[output_name] = file;
 			}
@@ -257,16 +255,20 @@ function build_assets_for_apps(apps, files) {
 			files: file_map,
 			outdir: output_path,
 		});
+		// RTL stylesheets are derived from the compiled LTR CSS instead of
+		// compiling every .bundle.scss a second time. Watch-mode rebuilds derive
+		// again in watch_plugin's onEnd.
 		let style_build = build_style_files({
 			files: style_file_map,
 			outdir: output_path,
+		}).then(async (result) => {
+			let rtl_result = await derive_rtl_styles(result.metafile);
+			return rtl_result ? [result, rtl_result] : [result];
 		});
-		let rtl_style_build = build_style_files({
-			files: rtl_style_file_map,
-			outdir: output_path,
-			rtl_style: true,
-		});
-		return Promise.all([build, style_build, rtl_style_build]);
+		return Promise.all([build, style_build]).then(([build_result, style_results]) => [
+			build_result,
+			...style_results,
+		]);
 	});
 }
 
@@ -318,24 +320,23 @@ function build_files({ files, outdir }) {
 	return build_or_watch(get_build_options(files, outdir, build_plugins));
 }
 
-function build_style_files({ files, outdir, rtl_style = false }) {
-	let plugins = [];
-	if (rtl_style) {
-		plugins.push(rtlcss);
-	}
-
+function build_style_files({ files, outdir }) {
 	let build_plugins = [
 		ignore_assets,
 		build_cleanup_plugin,
 		postCssPlugin({
-			plugins: plugins,
+			plugins: [require("autoprefixer")],
 			sassOptions: sass_options,
 		}),
 	];
 
-	plugins.push(require("autoprefixer"));
 	if (WATCH_MODE) build_plugins.push(watch_plugin);
-	return build_or_watch(get_build_options(files, outdir, build_plugins));
+	let options = get_build_options(files, outdir, build_plugins);
+	// Keep /*!rtl:...*/ control comments (ignore/raw blocks) in place so
+	// derive-rtl.js can honor them; esbuild strips regular comments and moves
+	// legal comments to EOF by default.
+	options.legalComments = "inline";
+	return build_or_watch(options);
 }
 
 // As of esbuild 0.17 the `watch`/`incremental` build options and the
@@ -397,14 +398,26 @@ const watch_plugin = {
 				log(chalk.dim(error.stack));
 				notify_redis({ error });
 			} else {
-				let { new_assets_json, prev_assets_json } = await write_assets_json(
-					result.metafile
-				);
+				let metafiles = [result.metafile];
+				// Style rebuilds must re-derive the RTL variants before
+				// assets-rtl.json is written (no-op for the JS build).
+				let rtl_result = await derive_rtl_styles(result.metafile);
+				if (rtl_result) {
+					metafiles.push(rtl_result.metafile);
+				}
 
 				let changed_files;
-				if (prev_assets_json) {
-					changed_files = get_rebuilt_assets(prev_assets_json, new_assets_json);
+				for (let metafile of metafiles) {
+					let { new_assets_json, prev_assets_json } = await write_assets_json(metafile);
+					if (prev_assets_json) {
+						changed_files = changed_files || [];
+						changed_files.push(
+							...get_rebuilt_assets(prev_assets_json, new_assets_json)
+						);
+					}
+				}
 
+				if (changed_files) {
 					let timestamp = new Date().toLocaleTimeString();
 					let message = `${timestamp}: Compiled ${changed_files.length} files...`;
 					log(chalk.yellow(message));
@@ -485,13 +498,11 @@ function log_built_assets(results) {
 	log(cliui.toString());
 }
 
-// to store previous build's assets.json for comparison
-let prev_assets_json;
-let curr_assets_json;
+// previous build's assets(-rtl).json contents, keyed per file, for comparison
+let assets_json_history = {};
 
 async function write_assets_json(metafile) {
 	let rtl = false;
-	prev_assets_json = curr_assets_json;
 	let out = {};
 	for (let output in metafile.outputs) {
 		let info = metafile.outputs[output];
@@ -509,7 +520,8 @@ async function write_assets_json(metafile) {
 	let { obj: assets_json, path: assets_json_path } = await get_assets_json_path_and_obj(rtl);
 	// update with new values
 	let new_assets_json = Object.assign({}, assets_json, out);
-	curr_assets_json = new_assets_json;
+	let prev_assets_json = assets_json_history[assets_json_path];
+	assets_json_history[assets_json_path] = new_assets_json;
 
 	await fs.promises.writeFile(assets_json_path, JSON.stringify(new_assets_json, null, 4));
 	await update_assets_json_in_cache();

--- a/frappe/public/scss/common/datepicker.scss
+++ b/frappe/public/scss/common/datepicker.scss
@@ -1,6 +1,8 @@
-/*rtl:begin:ignore*/
+// The "datepicker" param keeps this comment textually unique: esbuild's
+// minifier dedupes identical legal comments, which would break begin/end pairing.
+/*!rtl:begin:ignore:datepicker*/
 @import "~air-datepicker/dist/css/datepicker.min";
-/*rtl:end:ignore*/
+/*!rtl:end:ignore:datepicker*/
 
 .datepicker {
 	direction: ltr;

--- a/frappe/public/scss/common/quill.scss
+++ b/frappe/public/scss/common/quill.scss
@@ -7,7 +7,9 @@
 	font-family: inherit;
 }
 
-/*rtl:begin:ignore*/
+// The "quill" param keeps this comment textually unique: esbuild's minifier
+// dedupes identical legal comments, which would break begin/end pairing.
+/*!rtl:begin:ignore:quill*/
 .ql-editor {
 	font-family: var(--font-stack);
 	color: var(--text-color);
@@ -35,7 +37,7 @@
 	}
 }
 
-/*rtl:end:ignore*/
+/*!rtl:end:ignore:quill*/
 
 // Quill doesn't use variables for :(
 .ql-snow.ql-toolbar button:hover,

--- a/frappe/public/scss/desk/global.scss
+++ b/frappe/public/scss/desk/global.scss
@@ -739,7 +739,7 @@ details > summary:focus {
 // 	.img-background();
 // }
 
-/*rtl:raw:
+/*!rtl:raw:
 .dropdown-menu {
 	right: auto;
 }

--- a/frappe/public/scss/website/index.scss
+++ b/frappe/public/scss/website/index.scss
@@ -144,7 +144,7 @@
 		font-size: $font-size-sm;
 
 		&::before {
-			content: #{"/*!rtl:var(--left-arrow-svg);*/"}var(--right-arrow-svg);
+			content: var(--right-arrow-svg);
 			display: inline-block;
 		}
 	}
@@ -160,6 +160,14 @@
 		}
 	}
 }
+
+// rtlcss value directives don't survive esbuild's CSS printer (comments inside
+// declaration values are dropped), so flip the breadcrumb arrow via a raw block.
+/*!rtl:raw:
+.breadcrumb-item + .breadcrumb-item::before {
+	content: var(--left-arrow-svg);
+}
+*/
 
 a.card {
 	text-decoration: none;

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "quill": "2.0.3",
     "quill-magic-url": "^3.0.0",
     "qz-tray": "^2.0.8",
-    "rtlcss": "^4.0.0",
+    "rtlcss": "^4.3.0",
     "sass": "^1.63.0",
     "showdown": "^2.1.0",
     "socket.io": "^4.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -753,9 +753,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001538, caniuse-lite@^1.0.30001541:
-  version "1.0.30001564"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001564.tgz#eaa8bbc58c0cbccdcb7b41186df39dd2ba591889"
-  integrity sha512-DqAOf+rhof+6GVx1y+xzbFPeOumfQnhYzVnZD6LAXijR77yPtm9mfOcqOnT3mpnJiZVT+kwLAFnRlZcIz+c6bg==
+  version "1.0.30001806"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz"
+  integrity sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==
 
 chalk@^1.1.3:
   version "1.1.3"
@@ -2877,10 +2877,10 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rtlcss@^4.0.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/rtlcss/-/rtlcss-4.1.1.tgz#f20409fcc197e47d1925996372be196fee900c0c"
-  integrity sha512-/oVHgBtnPNcggP2aVXQjSy6N1mMAfHg4GSag0QtZBlD5bdDgAHwr4pydqJGd+SUCu9260+Pjqbjwtvu7EMH1KQ==
+rtlcss@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/rtlcss/-/rtlcss-4.3.0.tgz#f8efd4d5b64f640ec4af8fa25b65bacd9e07cc97"
+  integrity sha512-FI+pHEn7Wc4NqKXMXFM+VAYKEj/mRIcW4h24YVwVtyjI+EqGrLc2Hx/Ny0lrZ21cBWU2goLy36eqMcNj3AQJig==
   dependencies:
     escalade "^3.1.1"
     picocolors "^1.0.0"


### PR DESCRIPTION
TLDR: Don't recompile RTL versions; reuse LTR bundle. ~1.6x faster overall build time.


---

LLM summary:

## What

The build compiled every `.bundle.scss` twice: once for LTR, then a second full sass compile (a third esbuild build) with rtlcss as a postcss plugin, just to produce RTL variants. Sass is ~80% of the style-build cost, so RTL doubled the most expensive step.

This PR derives RTL by running rtlcss over the style build's **output** instead: each compiled css bundle is transformed with `postcss([rtlcss])`, gets its own content hash (contents differ, so cache busting must too), a source map chained from the LTR map, and flows through the existing `write_assets_json` — `assets-rtl.json` keys are byte-identical to before. Watch-mode rebuilds re-derive in `watch_plugin`'s `onEnd`; stale hashed copies are cleaned via the now-exported `clean_dist_files`.

**Full `bench build --app frappe`: ~10.4s → ~6.3s** on my machine. No dependency additions (rtlcss bumped 4.1.1 → 4.3.0, see below).

## Fallout handled

- esbuild strips regular CSS comments, which silently ate the rtlcss control directives (ignore blocks around datepicker/quill, the raw block in `global.scss`, the breadcrumb-arrow value directive). They're now in the `/*!rtl:...*/` legal-comment form with `legalComments: "inline"` on style builds.
- esbuild's minifier **dedupes identical legal comments**, which broke begin/end ignore pairing in production builds ← the sneakiest bug here. The ignore blocks now carry unique params (`ignore:quill`, `ignore:datepicker`); rtlcss parses the param and pairs fine.
- Comments inside declaration values don't survive esbuild at all, so the breadcrumb value directive is now a raw block after the rule.
- rtlcss 4.1.1 mangles 8-digit hex colors (`#ffffffe6` → `#fffffferight 6 top 50%`) — esbuild's minifier emits alpha hex for `rgba()`, which the old pre-minify pipeline never exposed rtlcss to. 4.3.0 fixes the hex regex.
- `write_assets_json` shared one prev/curr pair between `assets.json` and `assets-rtl.json`, so watch-mode "changed files" diffed one file against the other. Now tracked per file.

## Why this is safe

- Diffed dev **and** production `desk.bundle` RTL output rule-by-rule against the old pipeline: equivalent except trivial formatting (raw-block indentation, `-.625rem` vs `-0.625rem`, `inset` declaration order) and license comments sitting inline instead of at EOF.
- `assets.json` / `assets-rtl.json` key sets unchanged; `--using-cached` globs `css-rtl/**` as before and needs no change.
- Watch mode verified: scss touch rebuilds LTR + derives RTL + updates both jsons; js touch does no style work.
- rtlcss handles minified CSS fine, so `--production` derives from minified output directly.

## Manual / visual RTL testing checklist

Switch language to Arabic (or any RTL language) and verify with a hard refresh, in both dev and `--production` builds:

- [x] Desk loads with no missing/unstyled elements; `*-rtl.css` bundles load (check Network tab, hashes should match `assets-rtl.json`)
- [x] General mirroring: sidebar, navbar, list view columns, form layout all flipped
- [x] **Datepicker**: opens positioned correctly next to the field, calendar internals stay LTR, range-selection cell rounding looks right (this sits in an `rtl:ignore` block that broke silently before — highest-risk item)
- [x] **Text editor (Quill)**: toolbar and editor render correctly; typing RTL text in a comment/description works; `.ql-editor` styles intact (second `rtl:ignore` block)
- [x] **Dropdowns and popovers** open on the correct side (`.dropdown-menu`/`.popover { right: auto }` comes from the `rtl:raw` block)
- [x] **Charts** (dashboard) stay LTR internally (`.chart-container { direction: ltr }`, same raw block)
- [ ] **Website breadcrumbs** (portal side, e.g. `/me` or any web page with breadcrumbs): separator arrow points left in RTL (rewritten value directive)
- [x] Devtools → Sources: RTL stylesheet source map resolves without errors
- [ ] `bench watch`: edit a `.scss`, confirm RTL page live-reloads with the change
- [x] LTR (English) still renders identically — the LTR pipeline changed too (`legalComments: "inline"` adds license comments inline)