### PR TITLE
fix: preview in print format builder for cancelled documents

### DIFF
--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -437,19 +437,20 @@ $.extend(frappe.model, {
 		return frappe.boot.user.can_print.indexOf(doctype) !== -1;
 	},
 
+	// whether a document in this docstatus is printable at all, per Print Settings
+	// (submitted documents always are; draft/cancelled only if explicitly allowed)
+	can_print_docstatus: function (doctype, docstatus) {
+		if (!frappe.model.is_submittable(doctype) || docstatus == 1) return true;
+
+		const print_settings = frappe.model.get_doc(":Print Settings", "Print Settings") || {};
+		if (docstatus == 2) return !!cint(print_settings.allow_print_for_cancelled);
+		if (docstatus == 0) return !!cint(print_settings.allow_print_for_draft);
+		return false;
+	},
+
 	can_print_doc: function (frm) {
-		const print_settings = frappe.model.get_doc(":Print Settings", "Print Settings");
-		const allow_print_for_draft = cint(print_settings.allow_print_for_draft);
-		const allow_print_for_cancelled = cint(print_settings.allow_print_for_cancelled);
-
-		const docstatus_allows_print =
-			!frappe.model.is_submittable(frm.doc.doctype) ||
-			frm.doc.docstatus == 1 ||
-			(allow_print_for_cancelled && frm.doc.docstatus == 2) ||
-			(allow_print_for_draft && frm.doc.docstatus == 0);
-
 		return !!(
-			docstatus_allows_print &&
+			frappe.model.can_print_docstatus(frm.doc.doctype, frm.doc.docstatus) &&
 			frappe.model.can_print(null, frm) &&
 			!frm.meta.issingle
 		);

--- a/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
@@ -341,11 +341,13 @@ function dismiss_hint() {
 function init_doc_picker() {
 	if (!doc_picker_ref.value) return;
 	const meta = $store.value.meta.value;
-	// cancelled documents can't be printed unless Print Settings allows it, so keep
-	// them out of the picker unless that's turned on (mirrors frappe.model.can_print_doc)
-	const print_settings = frappe.model.get_doc(":Print Settings", "Print Settings") || {};
-	const allow_cancelled = cint(print_settings.allow_print_for_cancelled);
-	const printable_filters = meta?.is_submittable && !allow_cancelled ? { docstatus: ["!=", 2] } : {};
+	// draft/cancelled documents can't be printed unless Print Settings allows it, so
+	// keep them out of the picker unless that's turned on
+	const is_printable_docstatus = (docstatus) =>
+		frappe.model.can_print_docstatus(meta?.name, docstatus);
+	const printable_filters = meta?.is_submittable
+		? { docstatus: ["in", [0, 1, 2].filter(is_printable_docstatus)] }
+		: {};
 	doc_picker_ctrl.value = frappe.ui.form.make_control({
 		parent: doc_picker_ref.value,
 		df: {
@@ -384,7 +386,7 @@ function init_doc_picker() {
 		frappe.db
 			.get_value(meta?.name, saved, ["name", "docstatus"])
 			.then((r) =>
-				r?.message?.name && (allow_cancelled || r.message.docstatus !== 2)
+				r?.message?.name && is_printable_docstatus(r.message.docstatus)
 					? select(saved)
 					: auto_select()
 			);

--- a/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
@@ -341,6 +341,11 @@ function dismiss_hint() {
 function init_doc_picker() {
 	if (!doc_picker_ref.value) return;
 	const meta = $store.value.meta.value;
+	// cancelled documents can't be printed unless Print Settings allows it, so keep
+	// them out of the picker unless that's turned on (mirrors frappe.model.can_print_doc)
+	const print_settings = frappe.model.get_doc(":Print Settings", "Print Settings") || {};
+	const allow_cancelled = cint(print_settings.allow_print_for_cancelled);
+	const printable_filters = meta?.is_submittable && !allow_cancelled ? { docstatus: ["!=", 2] } : {};
 	doc_picker_ctrl.value = frappe.ui.form.make_control({
 		parent: doc_picker_ref.value,
 		df: {
@@ -348,6 +353,7 @@ function init_doc_picker() {
 			fieldtype: "Link",
 			options: meta?.name,
 			placeholder: __("Pick a {0} to preview...", [__(meta?.name || "document")]),
+			get_query: () => ({ filters: printable_filters }),
 			change: () => {
 				const name = doc_picker_ctrl.value.get_value();
 				$store.value.load_preview_doc(name || null);
@@ -363,16 +369,25 @@ function init_doc_picker() {
 		$store.value.load_preview_doc(name);
 	};
 	// Prefer the record chosen last time (persisted across refresh); otherwise
-	// auto-select the most recent record so the preview is ready immediately.
+	// auto-select the most recent printable record so the preview is ready immediately.
 	const saved = $store.value.persisted_preview_doc_name();
 	const auto_select = () =>
 		frappe.db
-			.get_list(meta?.name, { limit: 1, fields: ["name"], order_by: "creation desc" })
+			.get_list(meta?.name, {
+				filters: printable_filters,
+				limit: 1,
+				fields: ["name"],
+				order_by: "creation desc",
+			})
 			.then((rows) => rows?.length && select(rows[0].name));
 	if (saved) {
 		frappe.db
-			.get_value(meta?.name, saved, "name")
-			.then((r) => (r?.message?.name ? select(saved) : auto_select()));
+			.get_value(meta?.name, saved, ["name", "docstatus"])
+			.then((r) =>
+				r?.message?.name && (allow_cancelled || r.message.docstatus !== 2)
+					? select(saved)
+					: auto_select()
+			);
 	} else {
 		auto_select();
 	}

--- a/frappe/public/js/print_format_builder/components/Preview.vue
+++ b/frappe/public/js/print_format_builder/components/Preview.vue
@@ -37,10 +37,17 @@
 		<div v-if="!docname" class="pfb-preview-empty">
 			{{ __("Pick a record in the toolbar above to preview it.") }}
 		</div>
+		<div v-else-if="is_cancelled" class="pfb-preview-empty">
+			{{ __("This document is cancelled and cannot be printed.") }}
+		</div>
 		<div v-else-if="!preview_loaded" class="pfb-preview-empty">
 			{{ __("Generating preview...") }}
 		</div>
-		<div ref="viewport" class="pfb-preview-viewport" v-show="docname && preview_loaded">
+		<div
+			ref="viewport"
+			class="pfb-preview-viewport"
+			v-show="docname && preview_loaded && !is_cancelled"
+		>
 			<!-- the page renders at its true width and is scaled down to fit the rail -->
 			<div class="pfb-preview-stage" :style="stage_style">
 				<iframe
@@ -171,6 +178,20 @@ let docname = computed(() => store.value.preview_doc_name);
 
 let doctype = computed(() => print_format.value.doc_type);
 
+// cancelled documents aren't printable unless Print Settings allows it (see
+// printview.validate_print_for_docstatus) — asking the server for a preview would
+// only bounce back a permission error, so skip the round trip and say so directly
+// instead of rendering a generic "broken" message.
+let allow_print_for_cancelled = computed(() =>
+	cint(frappe.model.get_doc(":Print Settings", "Print Settings")?.allow_print_for_cancelled)
+);
+let is_cancelled = computed(
+	() =>
+		!allow_print_for_cancelled.value &&
+		store.value.preview_doc?.name === docname.value &&
+		store.value.preview_doc?.docstatus === 2
+);
+
 let url = computed(() => {
 	if (!docname.value) return null;
 	// the paged view is a blob of the unsaved format — opening the saved one
@@ -198,6 +219,11 @@ function write_iframe(html) {
 // laid-out heights, keep-together and table splitting, none of which the browser
 // can work out from the flowed HTML. So the paged view asks the print renderer.
 async function render_pages(seq) {
+	if (is_cancelled.value) {
+		set_pdf_url(null);
+		preview_loaded.value = true;
+		return;
+	}
 	preview_loaded.value = false;
 	const params = {
 		print_format: store.value.get_preview_format_doc(),
@@ -241,6 +267,10 @@ function render() {
 	let seq = ++render_seq;
 	if (!docname.value) return;
 	if (type.value === "PDF") return render_pages(seq);
+	if (is_cancelled.value) {
+		preview_loaded.value = true;
+		return;
+	}
 	preview_loaded.value = false;
 	let params = {
 		print_format: store.value.get_preview_format_doc(),
@@ -285,7 +315,9 @@ const auto_render = frappe.utils.debounce(() => {
 }, 1000);
 
 watch(() => layout.value, auto_render, { deep: true });
-watch([docname, type], render, { flush: "post" });
+// preview_doc (and its docstatus) arrives async and can resolve after docname
+// already triggered a render, so re-evaluate once it lands
+watch([docname, type, () => store.value.preview_doc?.docstatus], render, { flush: "post" });
 
 onMounted(() => {
 	render();

--- a/frappe/public/js/print_format_builder/components/Preview.vue
+++ b/frappe/public/js/print_format_builder/components/Preview.vue
@@ -37,8 +37,11 @@
 		<div v-if="!docname" class="pfb-preview-empty">
 			{{ __("Pick a record in the toolbar above to preview it.") }}
 		</div>
-		<div v-else-if="is_cancelled" class="pfb-preview-empty">
+		<div v-else-if="unprintable_reason === 'cancelled'" class="pfb-preview-empty">
 			{{ __("This document is cancelled and cannot be printed.") }}
+		</div>
+		<div v-else-if="unprintable_reason === 'draft'" class="pfb-preview-empty">
+			{{ __("This document is a draft and cannot be printed.") }}
 		</div>
 		<div v-else-if="!preview_loaded" class="pfb-preview-empty">
 			{{ __("Generating preview...") }}
@@ -46,7 +49,7 @@
 		<div
 			ref="viewport"
 			class="pfb-preview-viewport"
-			v-show="docname && preview_loaded && !is_cancelled"
+			v-show="docname && preview_loaded && !unprintable_reason"
 		>
 			<!-- the page renders at its true width and is scaled down to fit the rail -->
 			<div class="pfb-preview-stage" :style="stage_style">
@@ -178,19 +181,20 @@ let docname = computed(() => store.value.preview_doc_name);
 
 let doctype = computed(() => print_format.value.doc_type);
 
-// cancelled documents aren't printable unless Print Settings allows it (see
+// draft/cancelled documents aren't printable unless Print Settings allows it (see
 // printview.validate_print_for_docstatus) — asking the server for a preview would
 // only bounce back a permission error, so skip the round trip and say so directly
 // instead of rendering a generic "broken" message.
-let allow_print_for_cancelled = computed(() =>
-	cint(frappe.model.get_doc(":Print Settings", "Print Settings")?.allow_print_for_cancelled)
+let preview_doc_docstatus = computed(() =>
+	store.value.preview_doc?.name === docname.value ? store.value.preview_doc?.docstatus : null
 );
-let is_cancelled = computed(
-	() =>
-		!allow_print_for_cancelled.value &&
-		store.value.preview_doc?.name === docname.value &&
-		store.value.preview_doc?.docstatus === 2
-);
+
+let unprintable_reason = computed(() => {
+	const docstatus = preview_doc_docstatus.value;
+	if (docstatus == null || frappe.model.can_print_docstatus(doctype.value, docstatus))
+		return null;
+	return docstatus === 2 ? "cancelled" : "draft";
+});
 
 let url = computed(() => {
 	if (!docname.value) return null;
@@ -219,7 +223,7 @@ function write_iframe(html) {
 // laid-out heights, keep-together and table splitting, none of which the browser
 // can work out from the flowed HTML. So the paged view asks the print renderer.
 async function render_pages(seq) {
-	if (is_cancelled.value) {
+	if (unprintable_reason.value) {
 		set_pdf_url(null);
 		preview_loaded.value = true;
 		return;
@@ -267,7 +271,7 @@ function render() {
 	let seq = ++render_seq;
 	if (!docname.value) return;
 	if (type.value === "PDF") return render_pages(seq);
-	if (is_cancelled.value) {
+	if (unprintable_reason.value) {
 		preview_loaded.value = true;
 		return;
 	}


### PR DESCRIPTION
In the print format builder, for the documents having the status as cancelled or draft, the preview tab shows a text - could not generate preview, to fix the ux for this, If the setting is disabled for printing cancelled/draft documents, then we do not show those documents in the filter option 

Before: 

<img width="1438" height="783" alt="Screenshot 2026-07-22 at 4 31 28 PM" src="https://github.com/user-attachments/assets/f39582db-c6bc-4887-83fe-e9a799f032c4" />

After: 

It will not show in the filter list if the setting is disabled