### PR TITLE
perf: Drop autoprefixer

### DIFF
--- a/esbuild/style-plugin.js
+++ b/esbuild/style-plugin.js
@@ -1,10 +1,11 @@
 const path = require("path");
 const fs = require("fs");
 const { fileURLToPath } = require("url");
-const postcss = require("postcss");
-const autoprefixer = require("autoprefixer");
 const { sass, sass_options, app_paths, node_modules_paths } = require("./sass_compiler");
 
+// Plain .css files are not handled here on purpose: esbuild's native CSS
+// loader already resolves @imports (via nodePaths), watches the files, and
+// errors on unresolvable imports.
 module.exports = {
 	name: "frappe-style",
 	setup(build) {
@@ -13,34 +14,12 @@ module.exports = {
 			const watch_files = result.loadedUrls
 				.filter((url) => url.protocol === "file:")
 				.map((url) => fileURLToPath(url));
-			const { contents, warnings } = await postprocess(
-				result.css,
-				args.path,
-				result.sourceMap,
-				watch_files
-			);
 			return {
-				contents,
+				contents: with_inline_sourcemap(result.css, result.sourceMap),
 				loader: "css",
 				resolveDir: path.dirname(args.path),
 				watchFiles: watch_files,
-				warnings,
-			};
-		});
-
-		// Plain CSS — both .bundle.css entries and .css files that sass emitted
-		// as plain-CSS @imports (which esbuild resolves and inlines) — still
-		// goes through autoprefixer, like every stylesheet in the bundle.
-		build.onLoad({ filter: /\.css$/ }, async (args) => {
-			const source = await fs.promises.readFile(args.path, "utf-8");
-			const watch_files = [args.path];
-			const { contents, warnings } = await postprocess(source, args.path, null, watch_files);
-			return {
-				contents,
-				loader: "css",
-				resolveDir: path.dirname(args.path),
-				watchFiles: watch_files,
-				warnings,
+				warnings: find_leftover_imports(result.css, args.path),
 			};
 		});
 
@@ -50,35 +29,27 @@ module.exports = {
 			const less = require("less");
 			const source = await fs.promises.readFile(args.path, "utf-8");
 			const result = await less.render(source, { filename: args.path });
-			const watch_files = [args.path, ...(result.imports || [])];
-			const { contents, warnings } = await postprocess(
-				result.css,
-				args.path,
-				null,
-				watch_files
-			);
 			return {
-				contents,
+				contents: result.css,
 				loader: "css",
 				resolveDir: path.dirname(args.path),
-				watchFiles: watch_files,
-				warnings,
+				watchFiles: [args.path, ...(result.imports || [])],
+				warnings: find_leftover_imports(result.css, args.path),
 			};
 		});
 	},
 };
 
-async function postprocess(css, from, prev_map, watch_files) {
-	const result = await postcss([autoprefixer]).process(css, {
-		from,
-		map: { prev: prev_map || undefined, inline: true, sourcesContent: true },
-	});
-	for (const message of result.messages) {
-		if (message.type === "dependency") {
-			watch_files.push(message.file);
-		}
-	}
-	return { contents: result.css, warnings: find_leftover_imports(css, from) };
+// esbuild picks up inline source maps from loaded contents and chains them
+// into the final .css.map; sources arrive as file: URLs which devtools (and
+// esbuild's relative-path rewriting) expect as plain paths.
+function with_inline_sourcemap(css, map) {
+	if (!map) return css;
+	map.sources = map.sources.map((source) =>
+		source.startsWith("file:") ? fileURLToPath(source) : source
+	);
+	const encoded = Buffer.from(JSON.stringify(map)).toString("base64");
+	return `${css}\n/*# sourceMappingURL=data:application/json;charset=utf-8;base64,${encoded} */\n`;
 }
 
 function is_external_url(url) {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@vueuse/core": "^9.5.0",
     "ace-builds": "^1.4.8",
     "air-datepicker": "git+https://github.com/frappe/air-datepicker",
-    "autoprefixer": "10",
     "awesomplete": "^1.1.5",
     "bootstrap": "4.6.2",
     "chalk": "^2.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,18 +706,6 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-autoprefixer@10:
-  version "10.4.16"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.16.tgz#fad1411024d8670880bdece3970aa72e3572feb8"
-  integrity sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==
-  dependencies:
-    browserslist "^4.21.10"
-    caniuse-lite "^1.0.30001538"
-    fraction.js "^4.3.6"
-    normalize-range "^0.1.2"
-    picocolors "^1.0.0"
-    postcss-value-parser "^4.2.0"
-
 awesomplete@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/awesomplete/-/awesomplete-1.1.5.tgz#1b2b5dd106d3955595619c03da472a1dc0faf0af"
@@ -780,7 +768,7 @@ braces@^3.0.3, braces@~3.0.2:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.0.0, browserslist@^4.21.10, browserslist@^4.21.4:
+browserslist@^4.0.0, browserslist@^4.21.4:
   version "4.22.1"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.22.1.tgz#ba91958d1a59b87dab6fed8dfbcb3da5e2e9c619"
   integrity sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==
@@ -816,7 +804,7 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001538, caniuse-lite@^1.0.30001541:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001541:
   version "1.0.30001806"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz"
   integrity sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==
@@ -1504,11 +1492,6 @@ fill-range@^7.1.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-fraction.js@^4.3.6:
-  version "4.3.7"
-  resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.3.7.tgz#06ca0085157e42fda7f9e726e79fefc4068840f7"
-  integrity sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==
-
 frappe-charts@2.0.0-rc27:
   version "2.0.0-rc27"
   resolved "https://registry.yarnpkg.com/frappe-charts/-/frappe-charts-2.0.0-rc27.tgz#a04737d36bcce5381b25ad48896c43b02eb62852"
@@ -2156,11 +2139,6 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
-
-normalize-range@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
-  integrity sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==
 
 normalize-url@^4.5.0:
   version "4.5.1"


### PR DESCRIPTION
There's no browserslist config anywhere, so autoprefixer only emits prefixes
for long-dead browsers: on the 34k-line desk bundle it adds 19 lines, all
dead (-o-object-fit, -moz-column-*, -moz-placeholder). With the ES2020
baseline it's pure cost, ~0.45s of every style build.

Dropping postcss from the pipeline also means:
- sass sourcemaps get inlined directly for esbuild to chain (postcss was
  doing that before)
- the plain .css onLoad hook is gone entirely; it existed only to
  autoprefix, and esbuild's native CSS loader already does the same
  resolution, watching, and unresolved-import errors

Output diff is vendor-prefix churn in both directions (autoprefixer also
stripped hand-written legacy prefixes from bootstrap-3-era sources, those
now stay) plus whitespace reprinting. Nothing functional.
