### PR TITLE
feat(about-dialog): Add copy apps version button

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/about.js
+++ b/frappe/public/js/frappe/ui/toolbar/about.js
@@ -61,9 +61,15 @@ frappe.ui.misc.about = function () {
 				}
 			</div>
 
-			<div class="about-section-label text-2xs text-ink-gray-6 text-uppercase">${__(
-				"Installed Apps"
-			)}</div>
+			<div class="about-section-header flex items-center justify-between w-full">
+				<div class="about-section-label text-2xs text-ink-gray-6 text-uppercase">${__(
+					"Installed Apps"
+				)}</div>
+				<button class="es-button hidden" data-variant="ghost" data-icon-button="true"
+					id="copy-apps-info" title="${__("Copy Apps Version")}" aria-label="${__("Copy Apps Version")}">
+					${frappe.utils.icon("clipboard", "sm", "", "", "", true)}
+				</button>
+			</div>
 
 			<div id="about-app-versions" class="about-app-list flex flex-col gap-3 w-full"></div>
 		</div>`

--- a/frappe/public/js/frappe/ui/toolbar/about.js
+++ b/frappe/public/js/frappe/ui/toolbar/about.js
@@ -142,7 +142,7 @@ frappe.ui.misc.about = function () {
 			const version_text = get_version_text(app);
 			const title = `${app_name}: ${app.version}`;
 
-			$(`<div class="about-app-row flex items-center gap-3" title="${title}">
+			$(`<div class="about-app-row flex items-center gap-3 cursor-pointer" role="button" title="${title}">
 					${render_app_icon(app_name, app)}
 					<div class="about-app-info flex-1 min-w-0">
 						<div class="about-app-name text-base-semibold text-ink-gray-8">${__(app.title)}</div>

--- a/frappe/public/js/frappe/ui/toolbar/about.js
+++ b/frappe/public/js/frappe/ui/toolbar/about.js
@@ -152,7 +152,33 @@ frappe.ui.misc.about = function () {
 		}
 
 		frappe.versions = versions;
+
+		if (frappe.versions) {
+			$(dialog.body).find("#copy-apps-info").removeClass("hidden");
+		}
 	};
+
+	const code_block = (snippet, lang = "") => "```" + lang + "\n" + snippet + "\n```";
+
+	// Listener for copying installed apps info
+	$(dialog.body).on("click", "#copy-apps-info", function () {
+		if (!frappe.versions) return;
+
+		const versions = Object.entries(frappe.versions).reduce((acc, [key, app]) => {
+			acc[key] = app.branch_version || app.version;
+			return acc;
+		}, {});
+
+		frappe.utils.copy_to_clipboard(code_block(JSON.stringify(versions, null, "\t"), "json"));
+	});
+
+	// Listener for copy app version
+	$(dialog.body).on("click", ".about-app-row", function () {
+		const title = $(this).attr("title");
+		if (title) {
+			frappe.utils.copy_to_clipboard(title);
+		}
+	});
 
 	frappe.ui.misc.about_dialog.show();
 };

--- a/frappe/public/js/frappe/ui/toolbar/about.js
+++ b/frappe/public/js/frappe/ui/toolbar/about.js
@@ -180,5 +180,13 @@ frappe.ui.misc.about = function () {
 		}
 	});
 
+	// Keyboard support for copy app version (Enter / Space)
+	$(dialog.body).on("keydown", ".about-app-row", function (e) {
+		if (e.key === "Enter" || e.key === " ") {
+			e.preventDefault();
+			$(this).trigger("click");
+		}
+	});
+
 	frappe.ui.misc.about_dialog.show();
 };

--- a/frappe/public/js/frappe/ui/toolbar/about.js
+++ b/frappe/public/js/frappe/ui/toolbar/about.js
@@ -142,7 +142,7 @@ frappe.ui.misc.about = function () {
 			const version_text = get_version_text(app);
 			const title = `${app_name}: ${app.version}`;
 
-			$(`<div class="about-app-row flex items-center gap-3 cursor-pointer" role="button" title="${title}">
+			$(`<div class="about-app-row flex items-center gap-3 cursor-pointer" role="button" tabindex="0" title="${title}">
 					${render_app_icon(app_name, app)}
 					<div class="about-app-info flex-1 min-w-0">
 						<div class="about-app-name text-base-semibold text-ink-gray-8">${__(app.title)}</div>


### PR DESCRIPTION
Close: #41173

---

https://github.com/user-attachments/assets/eb614522-b560-4ec0-8731-1dc380edfbd6

**When copy multiple apps**
```json
{
	"frappe": "17.x.x-develop (c97ca94)",
	"erpnext": "17.x.x-develop (a008be7)",
	"hrms": "17.0.0-dev",
	"custom_app": "0.0.1",
	"lms": "2.45.2",
	"telephony": "0.0.1",
	"helpdesk": "1.17.4"
}
```

**when copy single app**
erpnext: 17.0.0-dev

`no-docs`