### PR TITLE
fix: make lazy documents picklable

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -2533,6 +2533,29 @@ def unlock_document(doctype: str, name: str):
 	frappe.msgprint(frappe._("Document Unlocked"), alert=True)
 
 
+def _reduce_lazy_instance(doc):
+	"""Make lazy document instances picklable.
+
+	Lazy controllers are constructed dynamically per doctype (see `get_lazy_controller`)
+	and therefore can't be referenced by a qualified name for pickle to find them. This is
+	the same problem `_reduce_extended_instance` solves for `override_doctype_class` controllers.
+
+	Reconstruct the instance as its non-lazy controller instead: laziness is only a fetch-time
+	optimization and carries no meaning once the document is handed to another process (e.g. a
+	background job serialized by RQ). Reconstruction goes through the base controller's real
+	classes so it never needs database/meta access at unpickle time.
+	"""
+	from frappe.model.base_document import _reconstruct_extended_instance, _reduce_extended_instance
+
+	_lazy_mixin, original_controller = type(doc).__bases__
+	if original_controller.__dict__.get("__reduce__") is _reduce_extended_instance:
+		# `original_controller` is itself a dynamically extended class; use its real bases.
+		bases = original_controller.__bases__
+	else:
+		bases = (original_controller,)
+	return (_reconstruct_extended_instance, (bases,), doc.__getstate__())
+
+
 def get_lazy_controller(doctype):
 	lazy_controllers = frappe.lazy_controllers.setdefault(frappe.local.site, {})
 	if doctype not in lazy_controllers:
@@ -2544,7 +2567,11 @@ def get_lazy_controller(doctype):
 			return original_controller
 
 		# Dynamically construct a class that subclasses LazyDocument and original controller.
-		lazy_controller = type(f"Lazy{original_controller.__name__}", (LazyDocument, original_controller), {})
+		lazy_controller = type(
+			f"Lazy{original_controller.__name__}",
+			(LazyDocument, original_controller),
+			{"__reduce__": _reduce_lazy_instance},
+		)
 		for df in meta.get_table_fields():
 			setattr(lazy_controller, df.fieldname, LazyChildTable(df.fieldname, df.options))
 

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -851,6 +851,7 @@ class TestLazyDocument(IntegrationTestCase):
 		import pickle
 
 		# Both an untouched lazy doc and one whose child tables were loaded must round-trip.
+		eager_doc = frappe.get_doc("User", "Guest")
 		for touch_children in (False, True):
 			guest = frappe.get_lazy_doc("User", "Guest")
 			if touch_children:
@@ -861,6 +862,7 @@ class TestLazyDocument(IntegrationTestCase):
 			self.assertEqual(unpickled.doctype, "User")
 			self.assertEqual(unpickled.name, "Guest")
 			self.assertEqual(unpickled.user_type, guest.user_type)
+			self.assertEqual(unpickled.as_dict(), eager_doc.as_dict())
 			# reduced to the non-lazy controller
 			self.assertIsInstance(unpickled, User)
 			self.assertNotIsInstance(unpickled, LazyDocument)

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -12,7 +12,7 @@ from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.core.doctype.user.user import User
 from frappe.desk.doctype.note.note import Note
 from frappe.desk.doctype.todo.todo import ToDo
-from frappe.model.document import Document, LazyChildTable
+from frappe.model.document import Document, LazyChildTable, LazyDocument
 from frappe.model.naming import make_autoname, parse_naming_series, revert_series_if_last
 from frappe.tests import IntegrationTestCase
 from frappe.utils import cint, now_datetime, set_request
@@ -843,6 +843,27 @@ class TestLazyDocument(IntegrationTestCase):
 	def test_for_update(self):
 		guest = frappe.get_lazy_doc("User", "Guest", for_update=True)
 		self.assertTrue(guest.flags.for_update)
+
+	def test_lazy_doc_is_pickleable(self):
+		# Lazy controllers are built dynamically and can't be referenced by a qualified
+		# name, so pickle used to choke on them (e.g. when a lazy doc was passed to a
+		# background job via frappe.enqueue). It should reduce to its non-lazy controller.
+		import pickle
+
+		# Both an untouched lazy doc and one whose child tables were loaded must round-trip.
+		for touch_children in (False, True):
+			guest = frappe.get_lazy_doc("User", "Guest")
+			if touch_children:
+				_ = guest.roles
+
+			unpickled = pickle.loads(pickle.dumps(guest))
+
+			self.assertEqual(unpickled.doctype, "User")
+			self.assertEqual(unpickled.name, "Guest")
+			self.assertEqual(unpickled.user_type, guest.user_type)
+			# reduced to the non-lazy controller
+			self.assertIsInstance(unpickled, User)
+			self.assertNotIsInstance(unpickled, LazyDocument)
 
 
 class TestGetDocs(IntegrationTestCase):


### PR DESCRIPTION
## Problem

Lazy controllers are constructed dynamically per doctype in `get_lazy_controller` via `type("Lazy<Name>", (LazyDocument, controller), {})`. Such a class reports `__module__ = "frappe.model.document"` but is **not an attribute** of that module, so pickle cannot locate it and raises `PicklingError`.

This surfaced during `bench migrate`. A `Role` patch loads users via `frappe.get_lazy_doc` and saves them; `User.on_update` enqueues `create_contact(user=self)` (the lazy doc) after commit; pickling the RQ job then fails with:

```
_pickle.PicklingError: Can't pickle <class 'frappe.model.document.LazyUser'>: it's not found as frappe.model.document.LazyUser
```

## Fix

Give lazy controllers a `__reduce__` that reduces the instance to its **non-lazy controller**, reusing the exact same `_reconstruct_extended_instance` machinery already used for `override_doctype_class` controllers (which had the identical problem).

Laziness is only a fetch-time optimization and carries no meaning once a document is handed to another process (e.g. a background job serialized by RQ). Reconstruction goes through the base controller's real, importable classes, so it needs **no database/meta access at unpickle time** — important because RQ workers deserialize jobs before a site is initialized.

## Tests

Added `test_lazy_doc_is_pickleable`, covering both an untouched lazy doc and one whose child tables were loaded; both round-trip through `pickle` and reduce to the non-lazy controller.