### PR TITLE
fix: accept dict target_doc in get_mapped_doc

### DIFF
--- a/frappe/model/mapper.py
+++ b/frappe/model/mapper.py
@@ -85,8 +85,8 @@ def get_mapped_doc(
 		else:
 			target_doc = frappe.new_doc(target_doctype)
 			ret_doc = target_doc
-	elif isinstance(target_doc, str):
-		target_doc = frappe.get_doc(json.loads(target_doc))
+	elif isinstance(target_doc, str | dict):
+		target_doc = frappe.get_doc(frappe.parse_json(target_doc))
 		ret_doc = target_doc
 	else:
 		ret_doc = target_doc

--- a/frappe/model/mapper.py
+++ b/frappe/model/mapper.py
@@ -85,8 +85,11 @@ def get_mapped_doc(
 		else:
 			target_doc = frappe.new_doc(target_doctype)
 			ret_doc = target_doc
-	elif isinstance(target_doc, str | dict):
-		target_doc = frappe.get_doc(frappe.parse_json(target_doc))
+	elif isinstance(target_doc, str):
+		target_doc = frappe.get_doc(json.loads(target_doc))
+		ret_doc = target_doc
+	elif isinstance(target_doc, dict):
+		target_doc = frappe.get_doc(target_doc)
 		ret_doc = target_doc
 	else:
 		ret_doc = target_doc

--- a/frappe/tests/test_mapper.py
+++ b/frappe/tests/test_mapper.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
+import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.tests.utils import whitelist_for_tests
 
@@ -29,3 +30,14 @@ class TestMapper(IntegrationTestCase):
 		)
 		self.assertEqual(target["sources"], ["SRC-001", "SRC-002"])
 		self.assertEqual(target["args"], {"key": "val"})
+
+	def test_get_mapped_doc_accepts_dict_target(self):
+		from frappe.model.mapper import get_mapped_doc
+
+		note = frappe.get_doc({"doctype": "Note", "title": "Mapper Source Note"}).insert()
+		target = frappe.new_doc("Note").as_dict()
+
+		doc = get_mapped_doc("Note", note.name, {"Note": {"doctype": "Note"}}, target)
+
+		self.assertEqual(doc.doctype, "Note")
+		self.assertEqual(doc.title, note.title)


### PR DESCRIPTION
With native JSON request bodies (`use_json_request_body`), `map_docs` receives `target_doc` as a parsed dict and passes it through to mapper methods. `get_mapped_doc` only converted `str` targets, so a dict crashed at `target_doc.check_permission`. Convert dict targets the same way as JSON strings.