### PR TITLE
fix(model): use a re-entry flag instead of freezing during mapped doc guard runs

### DIFF
--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -378,15 +378,19 @@ $.extend(frappe.model, {
 					return;
 				}
 				// the request's own freeze lifts as soon as this async callback
-				// yields, so hold our own freeze while guards run; confirmation
-				// dialogs stay usable above the freeze backdrop
-				frappe.dom.freeze(opts.freeze_message || "");
+				// yields; a flag (not a visual freeze, which would cover the
+				// guards' own dialogs) blocks re-entry from a second click
+				// while guards are still deciding
+				if (frappe.model._running_mapped_doc_guards) {
+					return;
+				}
+				frappe.model._running_mapped_doc_guards = true;
 				try {
 					if (!(await frappe.model.should_open_mapped_doc(r.message, opts))) {
 						return;
 					}
 				} finally {
-					frappe.dom.unfreeze();
+					frappe.model._running_mapped_doc_guards = false;
 				}
 				frappe.model.sync(r.message);
 				if (opts.run_link_triggers) {

--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -323,6 +323,7 @@ $.extend(frappe.model, {
 	},
 
 	_mapped_doc_guards: [],
+	_running_mapped_doc_guards: 0,
 
 	add_mapped_doc_guard: function (fn) {
 		// fn(mapped_doc, opts) -> boolean | Promise<boolean>; false blocks opening the doc
@@ -352,6 +353,13 @@ $.extend(frappe.model, {
 	},
 
 	open_mapped_doc: function (opts) {
+		// the request's own freeze lifts while guards are still deciding
+		// (a visual freeze there would cover the guards' own dialogs), so
+		// ignore new invocations until pending guards resolve; responses
+		// already in flight are never discarded
+		if (frappe.model._running_mapped_doc_guards) {
+			return;
+		}
 		if (opts.frm && opts.frm.doc.__unsaved) {
 			frappe.throw(
 				__("You have unsaved changes in this form. Please save before you continue.")
@@ -377,20 +385,13 @@ $.extend(frappe.model, {
 				if (r.exc) {
 					return;
 				}
-				// the request's own freeze lifts as soon as this async callback
-				// yields; a flag (not a visual freeze, which would cover the
-				// guards' own dialogs) blocks re-entry from a second click
-				// while guards are still deciding
-				if (frappe.model._running_mapped_doc_guards) {
-					return;
-				}
-				frappe.model._running_mapped_doc_guards = true;
+				frappe.model._running_mapped_doc_guards++;
 				try {
 					if (!(await frappe.model.should_open_mapped_doc(r.message, opts))) {
 						return;
 					}
 				} finally {
-					frappe.model._running_mapped_doc_guards = false;
+					frappe.model._running_mapped_doc_guards--;
 				}
 				frappe.model.sync(r.message);
 				if (opts.run_link_triggers) {


### PR DESCRIPTION
## Summary

Follow-up to #41079, which holds `frappe.dom.freeze()` while mapped-doc guards run. That was wrong for the current espresso styling: `#freeze` sits at z-index 2000 while modals are at 1140, so the freeze overlay covers any confirmation dialog a guard shows — the dialog renders blurred behind the 0.8-opacity backdrop and its buttons don't receive clicks. It also displays the caller's `freeze_message` (e.g. "Creating Delivery Note ...") while the guard dialog is still asking whether to create anything.

Reproduced on a deployed site (frappe/erpnext#57299's draft-warning dialog); local dev sites can mask it with stale CSS assets.

## Fix

Replace the visual freeze with a re-entry flag. The freeze only ever protected the window where the async callback has yielded (request unfrozen) but no guard dialog is up yet — during a guard's own server call, a second Create click could start a parallel mapping. The flag makes any `open_mapped_doc` invocation a no-op while guards are still deciding; once a guard shows a modal, the modal itself blocks the page. No overlay, no z-index dependency.

## How to test

1. Register a guard that calls a server method and then shows `frappe.confirm` (or use frappe/erpnext#57299: Sales Order with an existing draft Delivery Note → Create → Delivery Note).
2. The dialog must render crisp and clickable — no gray blur, no freeze message behind it.
3. Double-click the Create action rapidly: only one guard flow/dialog appears.

no-docs — behavioral fix to the hook introduced in #41079.