### PR TITLE
feat: add reCAPTCHA verification support for web forms

### DIFF
--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -38,8 +38,39 @@ export default class WebForm extends frappe.ui.FieldGroup {
 		// webform client script
 		frappe.init_client_script && frappe.init_client_script();
 		this.setup_listeners();
+		this.setup_recaptcha();
 		frappe.web_form.events.trigger("after_load");
 		this.after_load && this.after_load();
+	}
+
+	setup_recaptcha() {
+		const el = document.getElementById("web-form-recaptcha-widget");
+		if (!el) return;
+
+		if (window.grecaptcha && typeof grecaptcha.render === "function") {
+			try {
+				grecaptcha.render(el, { sitekey: this.recaptcha_site_key });
+			} catch {
+				// widget already rendered - reset it
+				try {
+					grecaptcha.reset();
+				} catch {
+					// ignore — widget may not be in a renderable state
+				}
+			}
+			return;
+		}
+
+		window.onRecaptchaLoad = () => {
+			grecaptcha.render(el, {
+				sitekey: this.recaptcha_site_key,
+			});
+		};
+
+		const script = document.createElement("script");
+		script.src =
+			"https://www.google.com/recaptcha/api.js?onload=onRecaptchaLoad&render=explicit";
+		document.head.appendChild(script);
 	}
 
 	on(fieldname, handler) {
@@ -406,6 +437,18 @@ export default class WebForm extends frappe.ui.FieldGroup {
 		// TODO: remove this (used for payments app)
 		let for_payment = Boolean(this.accept_payment && !this.doc.paid);
 
+		if (this.enable_recaptcha) {
+			const recaptcha_token = window.grecaptcha?.getResponse();
+			if (!recaptcha_token) {
+				frappe.msgprint({
+					title: __("Verification Required"),
+					message: __("Please complete the reCAPTCHA verification."),
+					indicator: "red",
+				});
+				return false;
+			}
+		}
+
 		Object.assign(this.doc, doc_values);
 		this.doc.doctype = this.doc_type;
 		this.doc.web_form_name = this.name;
@@ -422,6 +465,9 @@ export default class WebForm extends frappe.ui.FieldGroup {
 				web_form: this.name,
 				web_form_request_key: this.web_form_request_key,
 				for_payment,
+				...(this.enable_recaptcha && {
+					recaptcha_token: window.grecaptcha?.getResponse(),
+				}),
 			},
 			btn: $("btn-primary"),
 			freeze: true,
@@ -448,6 +494,7 @@ export default class WebForm extends frappe.ui.FieldGroup {
 			},
 			always: function () {
 				window.saving = false;
+				window.grecaptcha?.reset();
 			},
 		});
 		return false;

--- a/frappe/website/doctype/web_form/templates/web_form.html
+++ b/frappe/website/doctype/web_form/templates/web_form.html
@@ -112,6 +112,11 @@
 					{% include "website/doctype/web_form/templates/web_form_skeleton.html" %}
 				</div>
 			</div>
+			{% if web_form_doc.enable_recaptcha and web_form_doc.recaptcha_site_key and is_new %}
+			<div class="web-form-recaptcha mt-4">
+				<div id="web-form-recaptcha-widget"></div>
+			</div>
+			{% endif %}
 			<div class="web-form-footer">
 				<div class="web-form-actions">
 					{{ action_buttons() }}

--- a/frappe/website/doctype/web_form/web_form.json
+++ b/frappe/website/doctype/web_form/web_form.json
@@ -34,6 +34,9 @@
   "print_format",
   "max_attachment_size",
   "show_attachments",
+  "enable_recaptcha",
+  "recaptcha_site_key",
+  "recaptcha_secret_key",
   "column_break_hhec",
   "hide_navbar",
   "hide_footer",
@@ -416,6 +419,29 @@
    "label": "Allowed embedding domains"
   },
   {
+   "default": "0",
+   "description": "Show a reCAPTCHA v2 challenge at the bottom of this form to prevent spam submissions",
+   "fieldname": "enable_recaptcha",
+   "fieldtype": "Check",
+   "label": "Enable reCAPTCHA"
+  },
+  {
+   "depends_on": "eval:doc.enable_recaptcha == 1",
+   "description": "Public site key from your Google reCAPTCHA v2 registration",
+   "fieldname": "recaptcha_site_key",
+   "fieldtype": "Data",
+   "label": "reCAPTCHA Site Key",
+   "mandatory_depends_on": "eval:doc.enable_recaptcha == 1"
+  },
+  {
+   "depends_on": "eval:doc.enable_recaptcha == 1",
+   "description": "Secret key from your Google reCAPTCHA v2 registration. Used server-side only.",
+   "fieldname": "recaptcha_secret_key",
+   "fieldtype": "Password",
+   "label": "reCAPTCHA Secret Key",
+   "mandatory_depends_on": "eval:doc.enable_recaptcha == 1"
+  },
+  {
    "fieldname": "access_control_section",
    "fieldtype": "Section Break",
    "label": "Access Control"
@@ -455,7 +481,7 @@
    "link_fieldname": "web_form"
   }
  ],
- "modified": "2026-06-18 15:58:18.453845",
+ "modified": "2026-07-23 16:42:55.267948",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Web Form",

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -58,6 +58,7 @@ class WebForm(WebsiteGenerator):
 		custom_css: DF.Code | None
 		doc_type: DF.Link
 		dynamic_filters_json: DF.JSON | None
+		enable_recaptcha: DF.Check
 		hide_footer: DF.Check
 		hide_navbar: DF.Check
 		introduction_text: DF.TextEditor | None
@@ -73,6 +74,8 @@ class WebForm(WebsiteGenerator):
 		module: DF.Link | None
 		print_format: DF.Link | None
 		published: DF.Check
+		recaptcha_secret_key: DF.Password | None
+		recaptcha_site_key: DF.Data | None
 		route: DF.Data | None
 		show_attachments: DF.Check
 		show_list: DF.Check
@@ -325,6 +328,33 @@ def get_context(context):
 
 		context.webform_banner_image = context.get("banner_image") or self.banner_image
 		context.pop("banner_image", None)
+
+	def verify_recaptcha(self, token: str | None) -> None:
+		import requests
+
+		if not token:
+			frappe.throw(_("Please complete the reCAPTCHA verification."), title=_("Verification Required"))
+
+		secret_key = self.get_password("recaptcha_secret_key", raise_exception=False)
+		if not secret_key:
+			return
+
+		try:
+			result = requests.post(
+				"https://www.google.com/recaptcha/api/siteverify",
+				data={"secret": secret_key, "response": token},
+				timeout=10,
+			).json()
+			if not result.get("success"):
+				frappe.throw(
+					_("reCAPTCHA verification failed. Please try again."),
+					title=_("Verification Failed"),
+				)
+		except (requests.exceptions.RequestException, ValueError):
+			frappe.throw(
+				_("Could not reach reCAPTCHA verification service. Please try again."),
+				title=_("Verification Failed"),
+			)
 
 	def add_metatags(self, context):
 		description = self.meta_description
@@ -736,7 +766,12 @@ def get_web_form_module(doc):
 
 @frappe.whitelist(methods=["POST", "PUT"], allow_guest=True)
 @rate_limit(key="web_form", limit=10, seconds=60)
-def accept(web_form: str, data: str | dict, web_form_request_key: str | None = None):
+def accept(
+	web_form: str,
+	data: str | dict,
+	web_form_request_key: str | None = None,
+	recaptcha_token: str | None = None,
+):
 	"""Save the web form"""
 	data = frappe._dict(frappe.parse_json(data))
 
@@ -752,6 +787,9 @@ def accept(web_form: str, data: str | dict, web_form_request_key: str | None = N
 		for_update=True,
 		allow_used=bool(data.name) or bool(web_form.allow_multiple),
 	)
+
+	if web_form.enable_recaptcha:
+		web_form.verify_recaptcha(recaptcha_token)
 
 	if web_form.login_required and frappe.session.user == "Guest":
 		frappe.throw(_("You must login to use this form"))


### PR DESCRIPTION
Adds configurable reCAPTCHA v2 support to Web Forms. Admins can enable it per form via Form Settings, providing site key and secret key from Google reCAPTCHA.
The widget renders on new form submissions and the token is verified server-side before the form is saved.
<img width="2362" height="1120" alt="image" src="https://github.com/user-attachments/assets/4fe3c620-5625-40e9-ac5d-92403f01b8b9" />

https://github.com/user-attachments/assets/c50b50ca-e481-4e2e-9064-a564a21c2b50

