### PR TITLE
feat: Sync doctype using CLI

### DIFF
--- a/frappe/commands/__init__.py
+++ b/frappe/commands/__init__.py
@@ -105,6 +105,7 @@ def call_command(cmd, context):
 
 def get_commands():
 	# prevent circular imports
+	from .doctype import commands as doctype_commands
 	from .gettext import commands as gettext_commands
 	from .microbenchmarks import commands as microbenchmark_commands
 	from .redis_utils import commands as redis_commands
@@ -124,6 +125,7 @@ def get_commands():
 		+ microbenchmark_commands
 		+ utils_commands
 		+ redis_commands
+		+ doctype_commands
 	)
 
 	for command in all_commands:

--- a/frappe/commands/doctype.py
+++ b/frappe/commands/doctype.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+
+import json
+import sys
+
+import click
+
+import frappe
+from frappe.commands import get_site, pass_context
+
+
+@click.group("doctype")
+def doctype_group():
+	"Manage DocTypes from their exported JSON files"
+
+
+@click.command("sync")
+@click.argument("target")
+@pass_context
+def sync_doctype(context, target):
+	"""Sync an edited DocType JSON file through the full validated save pipeline.
+
+	TARGET is a DocType name or a path to its exported .json file (required for new
+	DocTypes). The save runs validation, database schema sync, controller stub and type
+	generation, then re-exports the JSON — renormalizing timestamps, field_order and
+	defaults. The last line of output is a machine-readable JSON result; on validation
+	failure nothing is saved, the file is left as written, and the command exits non-zero.
+	"""
+	from frappe.modules.sync_doctype import sync_doctype_from_file
+	from frappe.utils.messages import get_message_log
+
+	site = get_site(context)
+	try:
+		frappe.init(site)
+		frappe.connect()
+		try:
+			result = sync_doctype_from_file(target)
+			frappe.db.commit()
+		except Exception as e:
+			frappe.db.rollback()
+			output = {
+				"synced": False,
+				"error_type": type(e).__name__,
+				"error": str(e),
+				"messages": [m.get("message") for m in get_message_log()],
+			}
+			click.echo(json.dumps(output, indent=1, default=str))
+			sys.exit(1)
+
+		result["synced"] = True
+		if result["renormalized"]:
+			result["hint"] = (
+				"The exported file was renormalized on save; re-read it before making further edits."
+			)
+		click.echo(json.dumps(result, indent=1, default=str))
+	finally:
+		frappe.destroy()
+
+
+doctype_group.add_command(sync_doctype)
+
+commands = [doctype_group]

--- a/frappe/modules/sync_doctype.py
+++ b/frappe/modules/sync_doctype.py
@@ -1,0 +1,201 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+
+"""Sync a hand-edited DocType JSON file through the validated document lifecycle.
+
+Unlike `frappe.reload_doc` / `import_file` (which intentionally skip validation for
+migrations), this path applies the file's contents onto the DocType document and calls
+`save()`, so validation, schema sync (`updatedb`), controller stubs and type annotations
+all run. The save re-exports the JSON, renormalizing whatever the editor got wrong.
+"""
+
+import os
+from pathlib import Path
+
+import frappe
+from frappe import _
+from frappe.model import no_value_fields
+from frappe.modules.utils import get_doc_path, scrub
+
+
+class DocTypeSyncError(frappe.ValidationError):
+	pass
+
+
+# Framework-managed keys: always taken from the database, never from the edited file.
+IGNORED_KEYS = (
+	"modified",
+	"modified_by",
+	"creation",
+	"owner",
+	"docstatus",
+	"idx",
+	"migration_hash",
+	"__islocal",
+	"__unsaved",
+)
+
+
+def sync_doctype_from_file(target: str) -> dict:
+	"""Push an edited DocType JSON file through the full validated save pipeline.
+
+	:param target: DocType name or path to the exported ``.json`` file.
+	:return: dict with ``doctype``, ``path``, ``renormalized`` and ``warnings``.
+	"""
+	if not frappe.conf.developer_mode:
+		frappe.throw(
+			_("This command requires developer_mode. Enable it with: bench set-config developer_mode 1"),
+			DocTypeSyncError,
+		)
+
+	path, data = _resolve_target(target)
+
+	name = data.get("name")
+	if data.get("doctype") != "DocType" or not name:
+		frappe.throw(
+			_("{0} is not a DocType definition (expected keys 'doctype': 'DocType' and 'name')").format(path),
+			DocTypeSyncError,
+		)
+
+	if data.get("custom"):
+		frappe.throw(
+			_(
+				"{0} is marked custom; custom DocTypes live in the database and are not synced from files"
+			).format(name),
+			DocTypeSyncError,
+		)
+
+	module = data.get("module")
+	if not module:
+		frappe.throw(_("DocType {0} has no 'module' set in the JSON file").format(name), DocTypeSyncError)
+
+	expected_path = _expected_export_path(module, name)
+	if os.path.realpath(path) != os.path.realpath(expected_path):
+		frappe.throw(
+			_(
+				"File is at {0} but DocType {1} (module {2}) exports to {3}. "
+				"Move the file to the canonical location, or fix the 'module'/'name' keys. "
+				"To customize another app's DocType use Custom Fields / Property Setters instead."
+			).format(path, name, module, expected_path),
+			DocTypeSyncError,
+		)
+
+	exists = frappe.db.exists("DocType", name)
+	warnings = []
+
+	if exists:
+		warnings.extend(_detect_possible_renames(name, data))
+
+	original_text = Path(path).read_text()
+
+	doc_data = {key: value for key, value in data.items() if key not in IGNORED_KEYS}
+	doc = frappe.get_doc(doc_data)
+
+	if exists:
+		# the exported JSON omits falsy values; fill defaults for missing keys so an
+		# absent key means "default", not None (save() only sets defaults on new docs)
+		defaults = frappe.new_doc("DocType", as_dict=True)
+		for key in (*IGNORED_KEYS, "name"):
+			defaults.pop(key, None)
+		doc.update_if_missing(defaults)
+		db_values = frappe.db.get_value("DocType", name, ["creation", "owner", "modified"], as_dict=True)
+		doc.name = name
+		doc.creation = db_values.creation
+		doc.owner = db_values.owner
+		doc.modified = db_values.modified
+		doc.save()
+	else:
+		doc.insert()
+
+	new_text = Path(expected_path).read_text()
+
+	return {
+		"doctype": name,
+		"path": str(expected_path),
+		"renormalized": new_text != original_text,
+		"warnings": warnings,
+	}
+
+
+def _resolve_target(target: str) -> tuple[str, dict]:
+	"""Resolve a DocType name or JSON file path to (absolute path, parsed JSON)."""
+	looks_like_path = target.endswith(".json") or os.path.sep in target
+
+	if looks_like_path:
+		path = os.path.abspath(target)
+		if not os.path.isfile(path) and not os.path.isabs(target):
+			# bench runs frappe commands with cwd set to the sites directory;
+			# also try resolving relative to the bench root
+			bench_root_path = os.path.abspath(os.path.join("..", target))
+			if os.path.isfile(bench_root_path):
+				path = bench_root_path
+		if not os.path.isfile(path):
+			frappe.throw(_("File not found: {0}").format(path), DocTypeSyncError)
+	else:
+		module = frappe.db.get_value("DocType", target, "module")
+		if not module:
+			frappe.throw(
+				_(
+					"DocType {0} does not exist on this site. For a new DocType, pass the path to its JSON file."
+				).format(target),
+				DocTypeSyncError,
+			)
+		path = _expected_export_path(module, target)
+		if not os.path.isfile(path):
+			frappe.throw(
+				_("Exported file for DocType {0} not found at {1}").format(target, path), DocTypeSyncError
+			)
+
+	try:
+		data = frappe.get_file_json(path)
+	except ValueError as e:
+		frappe.throw(_("Invalid JSON in {0}: {1}").format(path, e), DocTypeSyncError)
+
+	return path, data
+
+
+def _expected_export_path(module: str, name: str) -> str:
+	try:
+		folder = get_doc_path(module, "DocType", name)
+	except (frappe.DoesNotExistError, ImportError):
+		frappe.throw(
+			_("Module {0} does not belong to any installed app on this site").format(module),
+			DocTypeSyncError,
+		)
+	return os.path.join(folder, f"{scrub(name)}.json")
+
+
+def _detect_possible_renames(name: str, data: dict) -> list[str]:
+	"""Flag removed+added field pairs of the same fieldtype as possible renames.
+
+	A rename done by drop-and-recreate silently loses the column's data; the right tool
+	is a patch using frappe.model.utils.rename_field.
+	"""
+	db_fields = {
+		field.fieldname: field.fieldtype
+		for field in frappe.get_all(
+			"DocField",
+			filters={"parent": name, "parenttype": "DocType"},
+			fields=["fieldname", "fieldtype"],
+		)
+		if field.fieldtype not in no_value_fields
+	}
+	incoming = {
+		field.get("fieldname"): field.get("fieldtype")
+		for field in data.get("fields", [])
+		if field.get("fieldtype") not in no_value_fields
+	}
+
+	removed = set(db_fields) - set(incoming)
+	added = set(incoming) - set(db_fields)
+
+	warnings = []
+	for old_fieldname in sorted(removed):
+		candidates = sorted(a for a in added if incoming[a] == db_fields[old_fieldname])
+		if candidates:
+			warnings.append(
+				f"Field '{old_fieldname}' was removed while '{', '.join(candidates)}' of the same "
+				f"fieldtype was added. If this is a rename, dropping and re-adding loses the column's "
+				f"data — write a patch using frappe.model.utils.rename_field instead."
+			)
+	return warnings

--- a/frappe/tests/test_sync_doctype.py
+++ b/frappe/tests/test_sync_doctype.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+
+import shutil
+import sys
+from pathlib import Path
+
+import frappe
+from frappe.modules.sync_doctype import DocTypeSyncError, sync_doctype_from_file
+from frappe.tests import IntegrationTestCase
+
+DOCTYPE_NAME = "Test Sync Agent DocType"
+SCRUBBED = "test_sync_agent_doctype"
+
+
+def make_definition(**overrides):
+	definition = {
+		"doctype": "DocType",
+		"name": DOCTYPE_NAME,
+		"module": "Core",
+		"custom": 0,
+		"fields": [{"fieldname": "field_1", "fieldtype": "Data", "label": "Field 1"}],
+		"permissions": [{"role": "System Manager", "read": 1, "write": 1, "create": 1, "delete": 1}],
+		"sort_field": "creation",
+		"sort_order": "DESC",
+	}
+	definition.update(overrides)
+	return definition
+
+
+class TestSyncDoctype(IntegrationTestCase):
+	def setUp(self):
+		self._developer_mode = frappe.conf.developer_mode
+		frappe.conf.developer_mode = 1
+		self.folder = Path(frappe.get_app_path("frappe", "core", "doctype", SCRUBBED))
+		self.path = self.folder / f"{SCRUBBED}.json"
+
+	def tearDown(self):
+		frappe.db.rollback()
+		if frappe.db.exists("DocType", DOCTYPE_NAME):
+			frappe.delete_doc("DocType", DOCTYPE_NAME, force=1)
+		frappe.db.commit()
+		frappe.conf.developer_mode = self._developer_mode
+		shutil.rmtree(self.folder, ignore_errors=True)
+
+		# purge module caches so the deleted controller stub isn't found by the next test
+		from frappe.modules.utils import doctype_python_modules
+
+		for key in [k for k in sys.modules if SCRUBBED in k]:
+			del sys.modules[key]
+		for key in [k for k in doctype_python_modules if k[1] == DOCTYPE_NAME]:
+			del doctype_python_modules[key]
+		frappe.controllers.get(frappe.local.site, {}).pop(DOCTYPE_NAME, None)
+
+	def write_definition(self, definition):
+		self.folder.mkdir(parents=True, exist_ok=True)
+		self.path.write_text(frappe.as_json(definition) + "\n")
+
+	def test_requires_developer_mode(self):
+		frappe.conf.developer_mode = 0
+		self.write_definition(make_definition())
+		self.assertRaises(DocTypeSyncError, sync_doctype_from_file, str(self.path))
+
+	def test_creates_new_doctype_and_renormalizes(self):
+		self.write_definition(make_definition())
+		result = sync_doctype_from_file(str(self.path))
+
+		self.assertTrue(frappe.db.exists("DocType", DOCTYPE_NAME))
+		self.assertTrue(frappe.db.has_column(DOCTYPE_NAME, "field_1"))
+
+		# the save re-exported the file, renormalizing the sparse hand-written JSON
+		self.assertTrue(result["renormalized"])
+		exported = frappe.get_file_json(self.path)
+		self.assertEqual(exported["field_order"], ["field_1"])
+		self.assertTrue(exported["modified"])
+
+		# controller stub generated
+		self.assertTrue((self.folder / f"{SCRUBBED}.py").is_file())
+		self.assertTrue((self.folder / "__init__.py").is_file())
+
+	def test_update_by_name_and_rename_warning(self):
+		self.write_definition(make_definition())
+		sync_doctype_from_file(str(self.path))
+
+		exported = frappe.get_file_json(self.path)
+		exported["fields"] = [{"fieldname": "field_one", "fieldtype": "Data", "label": "Field One"}]
+		exported["field_order"] = ["field_one"]
+		self.write_definition(exported)
+
+		# a name (not a path) resolves to the canonical export path
+		result = sync_doctype_from_file(DOCTYPE_NAME)
+
+		self.assertTrue(frappe.db.has_column(DOCTYPE_NAME, "field_one"))
+		self.assertEqual(len(result["warnings"]), 1)
+		self.assertIn("field_1", result["warnings"][0])
+		self.assertIn("field_one", result["warnings"][0])
+
+	def test_validation_failure_saves_nothing(self):
+		definition = make_definition(
+			fields=[
+				{"fieldname": "dup", "fieldtype": "Data", "label": "Dup"},
+				{"fieldname": "dup", "fieldtype": "Data", "label": "Dup 2"},
+			]
+		)
+		self.write_definition(definition)
+
+		self.assertRaises(Exception, sync_doctype_from_file, str(self.path))
+		self.assertFalse(frappe.db.exists("DocType", DOCTYPE_NAME))
+		# file left as written for the agent to fix
+		self.assertEqual(frappe.get_file_json(self.path), definition)
+
+	def test_path_mismatch_guard(self):
+		wrong_folder = Path(frappe.get_app_path("frappe", "core", "doctype", "wrong_location"))
+		wrong_folder.mkdir(parents=True, exist_ok=True)
+		self.addCleanup(shutil.rmtree, wrong_folder, ignore_errors=True)
+		wrong_path = wrong_folder / f"{SCRUBBED}.json"
+		wrong_path.write_text(frappe.as_json(make_definition()) + "\n")
+
+		self.assertRaises(DocTypeSyncError, sync_doctype_from_file, str(wrong_path))
+
+	def test_unknown_module_guard(self):
+		self.write_definition(make_definition(module="No Such Module"))
+		self.assertRaises(Exception, sync_doctype_from_file, str(self.path))
+
+	def test_custom_doctype_refused(self):
+		self.write_definition(make_definition(custom=1))
+		self.assertRaises(DocTypeSyncError, sync_doctype_from_file, str(self.path))


### PR DESCRIPTION
This introduces a new command `bench doctype sync`

This is different from running migrate as this will trigger all
validations and side effects.

Agents should use this after editing file instead of `bench migrate`
