### PR TITLE
fix(build): re-hash vue-style bundle filenames after inlining css

### DIFF
--- a/esbuild/esbuild.js
+++ b/esbuild/esbuild.js
@@ -308,7 +308,9 @@ function get_files_to_build(files) {
 }
 
 function build_files({ files, outdir }) {
-	let build_plugins = [vue(), html_plugin, build_cleanup_plugin, vue_style_plugin];
+	// vue_style before cleanup: it re-hashes bundle filenames after inlining
+	// css, and cleanup must judge staleness against the renamed metafile
+	let build_plugins = [vue(), html_plugin, vue_style_plugin, build_cleanup_plugin];
 	if (WATCH_MODE) build_plugins.push(watch_plugin);
 	return build_or_watch(get_build_options(files, outdir, build_plugins));
 }

--- a/esbuild/frappe-vue-style.js
+++ b/esbuild/frappe-vue-style.js
@@ -1,17 +1,19 @@
 const fs = require("fs");
 const path = require("path");
+const crypto = require("crypto");
 const { sites_path } = require("./utils");
 
 module.exports = {
 	name: "frappe-vue-style",
 	setup(build) {
 		build.initialOptions.write = false;
-		build.onEnd((result) => {
+		build.onEnd(async (result) => {
 			let files = get_files(result.metafile.outputs);
 			let keys = Object.keys(files);
-			for (let out of result.outputFiles) {
+			// process everything before writing anything: the rename below also
+			// touches the sibling .map, which may sit earlier in outputFiles
+			for (let out of [...result.outputFiles]) {
 				let asset_path = "/" + path.relative(sites_path, out.path);
-				let dir = path.dirname(out.path);
 				if (out.path.endsWith(".js") && keys.includes(asset_path)) {
 					let name = out.path.split(".bundle.")[0];
 					name = path.basename(name);
@@ -24,21 +26,82 @@ module.exports = {
 					let modified = `frappe.dom.set_style(${css_data});\n${out.text}`;
 					out.contents = Buffer.from(modified);
 
+					// esbuild hashed the filename from the js alone; the css
+					// inlined above changes the content, so re-hash the name —
+					// otherwise css-only edits ship under an unchanged
+					// (browser-cached) url
+					let new_path = out.path.replace(/\.\w+\.js$/, `.${content_hash(modified)}.js`);
+					if (new_path !== out.path) {
+						let map = result.outputFiles.find((f) => f.path === out.path + ".map");
+						if (map) {
+							out.contents = Buffer.from(
+								modified.replace(
+									`sourceMappingURL=${path.basename(out.path)}.map`,
+									`sourceMappingURL=${path.basename(new_path)}.map`
+								)
+							);
+							rename_metafile_output(result.metafile, map.path, new_path + ".map");
+							map.path = new_path + ".map";
+						}
+						rename_metafile_output(result.metafile, out.path, new_path);
+						out.path = new_path;
+					}
+
+					// the css is inlined and its files never written — drop them
+					// from the metafile too, or assets.json records a phantom
+					// entry and cleanup derives delete patterns from it that
+					// match (and remove) the just-written js
+					delete_metafile_output(result.metafile, result.outputFiles[index].path);
 					result.outputFiles.splice(index, 1);
 					if (result.outputFiles[index - 1].path.endsWith(".css.map")) {
+						delete_metafile_output(
+							result.metafile,
+							result.outputFiles[index - 1].path
+						);
 						result.outputFiles.splice(index - 1, 1);
 					}
 				}
-				if (!fs.existsSync(dir)) {
-					fs.mkdirSync(dir, { recursive: true });
-				}
-				fs.writeFile(out.path, out.contents, (err) => {
-					err && console.error(err);
-				});
 			}
+			// awaited: onEnd resolves before the next plugin (cleanup) globs the
+			// dir, and before the build's process.exit can drop pending writes
+			await Promise.all(
+				result.outputFiles.map((out) => {
+					fs.mkdirSync(path.dirname(out.path), { recursive: true });
+					return fs.promises.writeFile(out.path, out.contents);
+				})
+			);
 		});
 	},
 };
+
+// 8 chars from the same base32 alphabet esbuild uses for [hash]
+function content_hash(text) {
+	const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+	const digest = crypto.createHash("sha256").update(text).digest();
+	return [...digest.subarray(0, 8)].map((byte) => alphabet[byte % 32]).join("");
+}
+
+// metafile keys are cwd-relative; assets.json and build-cleanup read them,
+// so the rename has to land there too
+function rename_metafile_output(metafile, old_path, new_path) {
+	for (let key of Object.keys(metafile.outputs)) {
+		if (path.resolve(key) === old_path) {
+			let new_key = key.slice(0, -path.basename(old_path).length) + path.basename(new_path);
+			metafile.outputs[new_key] = metafile.outputs[key];
+			delete metafile.outputs[key];
+			return;
+		}
+	}
+}
+
+function delete_metafile_output(metafile, abs_path) {
+	for (let key of Object.keys(metafile.outputs)) {
+		if (path.resolve(key) === abs_path) {
+			delete metafile.outputs[key];
+			return;
+		}
+	}
+}
 
 function get_files(files) {
 	let result = {};

--- a/esbuild/frappe-vue-style.js
+++ b/esbuild/frappe-vue-style.js
@@ -51,14 +51,15 @@ module.exports = {
 					// from the metafile too, or assets.json records a phantom
 					// entry and cleanup derives delete patterns from it that
 					// match (and remove) the just-written js
-					delete_metafile_output(result.metafile, result.outputFiles[index].path);
+					let css_path = result.outputFiles[index].path;
+					delete_metafile_output(result.metafile, css_path);
 					result.outputFiles.splice(index, 1);
-					if (result.outputFiles[index - 1].path.endsWith(".css.map")) {
-						delete_metafile_output(
-							result.metafile,
-							result.outputFiles[index - 1].path
-						);
-						result.outputFiles.splice(index - 1, 1);
+					let map_index = result.outputFiles.findIndex(
+						(f) => f.path === css_path + ".map"
+					);
+					if (map_index !== -1) {
+						delete_metafile_output(result.metafile, css_path + ".map");
+						result.outputFiles.splice(map_index, 1);
 					}
 				}
 			}


### PR DESCRIPTION
- re-hash vue-style bundle filenames from the final content after `frappe-vue-style` inlines the css, renaming the js and its sourcemap as a pair — a css-only edit mints a new url instead of shipping under a browser-cached one
- drop the inlined css outputs from the metafile (their phantom entries fed `build-cleanup` delete patterns that removed the just-written js) and locate the css sourcemap by path instead of array position
- run `frappe-vue-style` before `build-cleanup` and await the file writes, so cleanup judges staleness against the renamed metafile instead of racing fire-and-forget writes

Why: esbuild hashes the filename from the js alone, so every css-only change has shipped under an unchanged url since the plugin was introduced.

no-docs
