### PR TITLE
fix: report parent doctype when a child table permission check fails

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -675,12 +675,16 @@ class Document(BaseDocument):
 
 	def raise_no_permission_to(self, perm_type):
 		"""Raise `frappe.PermissionError`."""
+		doctype, name = self.doctype, self.name
+		if self.meta.istable and self.get("parenttype"):
+			doctype, name = self.parenttype, self.parent
+
 		frappe.flags.error_message = _(
 			"You need the '{0}' permission on {1} {2} to perform this action."
 		).format(
 			_(perm_type),
-			frappe.bold(_(self.doctype)),
-			self.name or "",
+			frappe.bold(_(doctype)),
+			name or "",
 		)
 		raise frappe.PermissionError
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -669,7 +669,8 @@ class Document(BaseDocument):
 	def _handle_permission_failure(self, perm_type):
 		from frappe.permissions import check_doctype_permission
 
-		check_doctype_permission(self.doctype, perm_type)
+		parent_doctype = self.get("parenttype") if self.meta.istable else None
+		check_doctype_permission(parent_doctype or self.doctype, perm_type)
 		self.raise_no_permission_to(perm_type)
 
 	def raise_no_permission_to(self, perm_type):

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -733,13 +733,16 @@ class TestPermissions(IntegrationTestCase):
 							"permlevel": 1,
 						}
 					],
-					permissions=[{"role": "System Manager", "read": 1, "write": 1, "delete": 1}],
+					permissions=[{"role": "System Manager", "read": 1, "write": 1, "create": 1, "delete": 1}],
 				)
 				.insert()
 				.name
 			)
+			parent = frappe.new_doc(parent_doctype)
+			parent.append("rows", {})
+			parent.insert()
 
-		row = frappe.new_doc(parent_doctype).append("rows", {})
+		row = parent.rows[0]
 
 		# no access to the parent doctype at all
 		with self.set_user("test@example.com"):
@@ -754,7 +757,9 @@ class TestPermissions(IntegrationTestCase):
 			self.assertRaises(frappe.PermissionError, row.check_permission, "delete")
 
 			self.assertIn(parent_doctype, frappe.flags.error_message)
+			self.assertIn(parent.name, frappe.flags.error_message)
 			self.assertNotIn(child_doctype, frappe.flags.error_message)
+			self.assertNotIn(row.name, frappe.flags.error_message)
 
 	def test_select_user(self):
 		"""If test3@example.com is restricted by a User Permission to see only

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -730,8 +730,10 @@ class TestPermissions(IntegrationTestCase):
 							"fieldname": "rows",
 							"fieldtype": "Table",
 							"options": child_doctype,
+							"permlevel": 1,
 						}
-					]
+					],
+					permissions=[{"role": "System Manager", "read": 1, "write": 1, "delete": 1}],
 				)
 				.insert()
 				.name
@@ -739,12 +741,20 @@ class TestPermissions(IntegrationTestCase):
 
 		row = frappe.new_doc(parent_doctype).append("rows", {})
 
+		# no access to the parent doctype at all
 		with self.set_user("test@example.com"):
 			frappe.local.message_log = []
 			self.assertRaises(frappe.PermissionError, row.check_permission, "delete")
 
 			self.assertIn(parent_doctype, frappe.local.message_log[-1]["message"])
 			self.assertIn(parent_doctype, frappe.flags.error_message)
+
+		# access to the parent doctype, denied on the table's permlevel
+		with self.set_user("test1@example.com"):
+			self.assertRaises(frappe.PermissionError, row.check_permission, "delete")
+
+			self.assertIn(parent_doctype, frappe.flags.error_message)
+			self.assertNotIn(child_doctype, frappe.flags.error_message)
 
 	def test_select_user(self):
 		"""If test3@example.com is restricted by a User Permission to see only

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -719,6 +719,33 @@ class TestPermissions(IntegrationTestCase):
 		doc = user.append("defaults")
 		self.assertRaises(frappe.PermissionError, doc.check_permission)
 
+	def test_child_permission_error_reports_parent_doctype(self):
+		with self.set_user("Administrator"):
+			child_doctype = new_doctype(istable=1).insert().name
+			parent_doctype = (
+				new_doctype(
+					fields=[
+						{
+							"label": "Rows",
+							"fieldname": "rows",
+							"fieldtype": "Table",
+							"options": child_doctype,
+						}
+					]
+				)
+				.insert()
+				.name
+			)
+
+		row = frappe.new_doc(parent_doctype).append("rows", {})
+
+		with self.set_user("test@example.com"):
+			frappe.local.message_log = []
+			self.assertRaises(frappe.PermissionError, row.check_permission, "delete")
+
+			self.assertIn(parent_doctype, frappe.local.message_log[-1]["message"])
+			self.assertIn(parent_doctype, frappe.flags.error_message)
+
 	def test_select_user(self):
 		"""If test3@example.com is restricted by a User Permission to see only
 		users linked to a certain doctype (in this case: Gender "Female"), he


### PR DESCRIPTION
## Summary

Removing a submitted child row without the required permissions on the parent produced confusing errors such as:

- `Please specify a valid parent DocType for Sales Order Item`
- `No permission for Sales Order Item`
- `You need the 'delete' permission on Sales Order Item 10ata2v65u`

None of these point to the actual problem. Permissions are checked on the parent document, not the child doctype, and users don't manage permissions on child doctypes like Sales Order Item.

## Fix

When handling a permission failure for a child row, use its `parenttype` instead of the child doctype. Also report the parent document instead of the child row when the failure falls through to `raise_no_permission_to` (permlevel, user permission, or controller check).

The messages now become:

```text
No permission for Sales Order
You need the 'delete' permission on Sales Order SAL-ORD-2026-00055
```

This doesn't change any permission checks or behavior. 
`_handle_permission_failure` only runs after `has_permission` has already returned `False`, and every path still raises `PermissionError`; only the error message is improved.

Surfaced while working on frappe/erpnext#57419, but the two fixes are independent.