### PR TITLE
feat(print): silent autosave status and lighter builder chrome

### DIFF
--- a/cypress/integration/print_format_builder.js
+++ b/cypress/integration/print_format_builder.js
@@ -136,10 +136,6 @@ context("Print Format Builder — create flow", () => {
 			.trigger("change")
 			.blur();
 
-		cy.get('[data-testid="page-status"]', { timeout: 5000 })
-			.should("be.visible")
-			.and("contain", "Not Saved");
-
 		cy.contains(".page-actions .primary-action", "Save").click({ force: true });
 		cy.wait("@save").then((interception) => {
 			expect(interception.response.statusCode).to.equal(200);
@@ -277,10 +273,6 @@ context("Print Format Builder — create flow", () => {
 			.type("#c0392b")
 			.trigger("change")
 			.blur();
-
-		cy.get('[data-testid="page-status"]', { timeout: 5000 })
-			.should("be.visible")
-			.and("contain", "Not Saved");
 
 		cy.contains(".page-actions .primary-action", "Save").click({ force: true });
 		cy.wait("@save").then((interception) => {

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -88,7 +88,6 @@
 
 		<!-- ── Blocks ─────────────────────────────────────────── -->
 		<div v-else-if="activeTab === 'blocks'" class="pfb-tab-body">
-			<div class="pfb-group-label">{{ __("Content") }}</div>
 			<draggable
 				:list="draggable_blocks"
 				:group="{ name: 'fields', pull: 'clone', put: false }"
@@ -110,8 +109,10 @@
 				</template>
 			</draggable>
 
-			<div class="pfb-group-label mt-3">{{ __("Page") }}</div>
+			<!-- Page Break drops into the sections container, not a column, so it
+			     stays a separate draggable — just without its own heading -->
 			<draggable
+				class="mt-2"
 				:list="page_break_block"
 				:group="{ name: 'sections', pull: 'clone', put: false }"
 				:sort="false"

--- a/frappe/public/js/print_format_builder/print_format_builder.bundle.js
+++ b/frappe/public/js/print_format_builder/print_format_builder.bundle.js
@@ -51,9 +51,7 @@ class PrintFormatBuilder {
 		this.app = app;
 		this.$component = app.mount(this.$wrapper.get(0));
 
-		// autosave persists edits, so the header stays quiet when saved and only
-		// speaks up transiently while saving, or stickily when a save fails —
-		// which the Save button (or Ctrl+S) can retry
+		// quiet when saved; only "Saving…" transiently or a sticky "Save failed"
 		watch(
 			() => this.$component.$store.save_status,
 			(status) => {

--- a/frappe/public/js/print_format_builder/print_format_builder.bundle.js
+++ b/frappe/public/js/print_format_builder/print_format_builder.bundle.js
@@ -24,9 +24,6 @@ class PrintFormatBuilder {
 			description: __("Save Print Format"),
 			page: this.page,
 		});
-		let $reset_changes_btn = this.page.add_button(__("Reset Changes"), () =>
-			this.$component.$store.reset_changes()
-		);
 		let $preview_btn = this.page.add_action_icon(
 			"eye",
 			() => this.$component.toggle_preview(),
@@ -54,18 +51,18 @@ class PrintFormatBuilder {
 		this.app = app;
 		this.$component = app.mount(this.$wrapper.get(0));
 
+		// autosave persists edits, so the header stays quiet when saved and only
+		// speaks up transiently while saving, or stickily when a save fails —
+		// which the Save button (or Ctrl+S) can retry
 		watch(
-			() => this.$component.$store.dirty,
-			(dirty) => {
-				if (dirty.value) {
-					this.page.set_indicator(__("Not Saved"), "orange");
-					$reset_changes_btn.show();
-				} else {
-					this.page.clear_indicator();
-					$reset_changes_btn.hide();
-				}
+			() => this.$component.$store.save_status,
+			(status) => {
+				if (status.value === "saving") this.page.set_indicator(__("Saving…"), "gray");
+				else if (status.value === "failed")
+					this.page.set_indicator(__("Save failed"), "red");
+				else this.page.clear_indicator();
 			},
-			{ deep: true }
+			{ deep: true, immediate: true }
 		);
 
 		watch(

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -150,18 +150,15 @@ export function getStore(print_format_name) {
 			],
 		};
 	}
-	// header status: silent while saved (the norm) — only a brief "saving" while a
-	// request is in flight, and a sticky "failed" after the last save errored
-	let saving = ref(false);
+	// count, not a flag — autosave and a manual save can overlap
+	let saving_count = ref(0);
 	let save_failed = ref(false);
 	let save_status = computed(() =>
-		save_failed.value ? "failed" : saving.value ? "saving" : "saved"
+		save_failed.value ? "failed" : saving_count.value > 0 ? "saving" : "saved"
 	);
-	// Manual save: force-flush now (also the retry after autosave stops). Freezes,
-	// refetches to reconcile with the server, and re-arms autosave.
 	function save_changes() {
 		frappe.dom.freeze(__("Saving…"));
-		saving.value = true;
+		saving_count.value++;
 
 		serialize_layout(layout.value);
 		print_format.value.format_data = JSON.stringify(layout.value);
@@ -187,14 +184,11 @@ export function getStore(print_format_name) {
 			})
 			.catch(() => (save_failed.value = true))
 			.always(() => {
-				saving.value = false;
+				saving_count.value--;
 				frappe.dom.unfreeze();
 			});
 	}
-	// Silent, debounced background save: no freeze, no toast, no refetch — the
-	// canvas keeps its selection and undo history. Stops after a failure (e.g.
-	// a timestamp conflict) so the error dialog doesn't loop; a successful
-	// manual save re-arms it.
+	// stops after a failure so the error dialog doesn't loop; a manual save re-arms it
 	let autosave_stopped = false;
 	function autosave_changes() {
 		if (!dirty.value || autosave_stopped) return;
@@ -203,14 +197,14 @@ export function getStore(print_format_name) {
 			return;
 		}
 		dirty.value = false;
-		saving.value = true;
+		saving_count.value++;
 		frappe
 			.call({
 				method: "frappe.printing.doctype.print_format.print_format.autosave",
 				args: { doc: get_preview_format_doc() },
 			})
 			.then((r) => {
-				// only the stamp — the user may have kept editing during the request
+				// sync only the stamp — the user may have kept editing mid-request
 				const was_dirty = dirty.value;
 				print_format.value.modified = r.message.modified;
 				if (!was_dirty) nextTick(() => (dirty.value = false));
@@ -229,7 +223,7 @@ export function getStore(print_format_name) {
 				dirty.value = true;
 				save_failed.value = true;
 			})
-			.always(() => (saving.value = false));
+			.always(() => saving_count.value--);
 	}
 	const autosave = frappe.utils.debounce(autosave_changes, 3000);
 	function get_preview_format_doc() {

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -150,8 +150,18 @@ export function getStore(print_format_name) {
 			],
 		};
 	}
+	// header status: silent while saved (the norm) — only a brief "saving" while a
+	// request is in flight, and a sticky "failed" after the last save errored
+	let saving = ref(false);
+	let save_failed = ref(false);
+	let save_status = computed(() =>
+		save_failed.value ? "failed" : saving.value ? "saving" : "saved"
+	);
+	// Manual save: force-flush now (also the retry after autosave stops). Freezes,
+	// refetches to reconcile with the server, and re-arms autosave.
 	function save_changes() {
-		frappe.dom.freeze(__("Saving..."));
+		frappe.dom.freeze(__("Saving…"));
+		saving.value = true;
 
 		serialize_layout(layout.value);
 		print_format.value.format_data = JSON.stringify(layout.value);
@@ -172,14 +182,14 @@ export function getStore(print_format_name) {
 			.then(() => fetch())
 			.then(() => {
 				autosave_stopped = false;
+				save_failed.value = false;
 				frappe.show_alert({ message: __("Saved"), indicator: "green" });
 			})
+			.catch(() => (save_failed.value = true))
 			.always(() => {
+				saving.value = false;
 				frappe.dom.unfreeze();
 			});
-	}
-	function reset_changes() {
-		fetch();
 	}
 	// Silent, debounced background save: no freeze, no toast, no refetch — the
 	// canvas keeps its selection and undo history. Stops after a failure (e.g.
@@ -193,6 +203,7 @@ export function getStore(print_format_name) {
 			return;
 		}
 		dirty.value = false;
+		saving.value = true;
 		frappe
 			.call({
 				method: "frappe.printing.doctype.print_format.print_format.autosave",
@@ -212,10 +223,13 @@ export function getStore(print_format_name) {
 						});
 				}
 			})
+			.then(() => (save_failed.value = false))
 			.catch(() => {
 				autosave_stopped = true;
 				dirty.value = true;
-			});
+				save_failed.value = true;
+			})
+			.always(() => (saving.value = false));
 	}
 	const autosave = frappe.utils.debounce(autosave_changes, 3000);
 	function get_preview_format_doc() {
@@ -333,7 +347,7 @@ export function getStore(print_format_name) {
 		persisted_preview_doc_name,
 		fetch,
 		save_changes,
-		reset_changes,
+		save_status,
 		get_preview_format_doc,
 		select_field,
 		select_section,


### PR DESCRIPTION
- replace the builder's "Not Saved" indicator with a save status that stays silent when saved, shows a brief "Saving…" only while a request is in flight, and a sticky red "Save failed" the Save button (or Ctrl+S) can retry
- drop "Reset Changes" — autosave already persists edits, so there is no last-saved state to revert to
- drop the one-item "Content"/"Page" section headers in the Blocks palette; Page Break stays a separate draggable (it drops into the sections container) but without its own heading

Why: with autosave in, a permanent "Saved" badge and a Reset button are noise, and a section header over a single block is over-structuring.

no-docs
