### PR TITLE
revert(perm): drop client-side grant-all rights for Administrator

### DIFF
--- a/frappe/public/js/frappe/model/perm.js
+++ b/frappe/public/js/frappe/model/perm.js
@@ -79,34 +79,11 @@ $.extend(frappe.perm, {
 		const user = frappe.session.user;
 		let meta = frappe.get_meta(doctype);
 
-		// Administrator should get all rights (consistent with Python has_permission/get_role_permissions)
-		if (user === "Administrator" || frappe.user_roles.includes("Administrator")) {
-			// Default permission level
-			let permlevels = [0];
-
-			// Get all unique permission levels from the doctype's permissions
-			// Always include level 0 (default level) and sort in ascending order
-			if (meta && meta.permissions) {
-				const levels = meta.permissions.map((permission) => cint(permission.permlevel));
-				// used Set for "unique" levels
-				permlevels = [...new Set([0, ...levels])].sort();
-			}
-			const rights = frappe.perm.get_rights(doctype);
-			const admin_perm = [];
-			permlevels.forEach((level) => {
-				const p = {
-					permlevel: level,
-					rights_without_if_owner: new Set(rights),
-				};
-				rights.forEach((right) => {
-					p[right] = 1;
-				});
-				admin_perm[level] = p;
-			});
-			return admin_perm;
-		}
-
 		let perm = [{ read: 0, permlevel: 0, rights_without_if_owner: new Set() }];
+
+		if (user === "Administrator" || frappe.user_roles.includes("Administrator")) {
+			perm[0].read = 1;
+		}
 
 		if (!meta) {
 			if (frappe.boot.user?.all_read?.includes(doctype)) {


### PR DESCRIPTION
Reverts the "Administrator gets all rights" branch in `frappe.perm._get_perm` back to `perm[0].read = 1` + normal role-permission computation.

- Removes the client-side blanket grant introduced in #36637 (backported to v16 as #40721) and later reworked in #40994.
- Administrator was being granted every right — including `submit`/`cancel`/`amend` — at all permlevels on every doctype. On non-submittable doctypes like `Bin` this surfaced Submit/Cancel/Update/Amend buttons in the form, and (v16 has no backend guard here) pressing them flipped `docstatus` to 1/2, corrupting stock values on the Stock dashboard.

Why a manual revert: GitHub couldn't revert #40721/#36637 automatically because #40994 rewrote the same lines (swapped `frappe.perm.rights` for `frappe.perm.get_rights(doctype)`). Reverting either PR alone leaves the grant-all behaviour in place, so this restores the pre-#36637 code directly.