### PR TITLE
chore: bump pypdf to 6.14.2 for CVE fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     # We depend on internal attributes,
     # do NOT add loose requirements on PyMySQL versions.
     "PyMySQL==1.1.2",
-    "pypdf==6.13.3",
+    "pypdf==6.14.2",
     "PyPika @ git+https://github.com/frappe/pypika@2c50e6142b2d61d2d243e466fdd5dc03b3d918f2",
     "mysqlclient==2.2.8",
     "PyQRCode~=1.2.1",


### PR DESCRIPTION
Bumps `pypdf` from 6.13.3 to 6.14.2 to clear the failing Vulnerable Dependency Check on `develop`.

- Fixes 4 DoS advisories in pypdf, all requiring a maliciously crafted PDF: CVE-2026-59935, CVE-2026-59936, CVE-2026-59937, CVE-2026-59938.
- 6.14.2 is the smallest release covering all four fixes.

Why: `pip-audit` flags these on every PR since the pin sits in `pyproject.toml`; this unblocks the check tree-wide.