### PR TITLE
fix: percent-encode spaces in document email addresses

### DIFF
--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -4,7 +4,7 @@
 import json
 import typing
 from typing import Any
-from urllib.parse import quote_plus
+from urllib.parse import quote
 
 import frappe
 import frappe.defaults
@@ -451,7 +451,7 @@ def get_document_email(doctype, name):
 		return None
 
 	email = email.split("@")
-	return f"{email[0]}+{quote_plus(doctype)}={quote_plus(cstr(name))}@{email[1]}"
+	return f"{email[0]}+{quote(doctype, safe='')}={quote(cstr(name), safe='')}@{email[1]}"
 
 
 def get_additional_timeline_content(doctype, docname):

--- a/frappe/desk/form/test_load.py
+++ b/frappe/desk/form/test_load.py
@@ -2,9 +2,11 @@
 # License: MIT. See LICENSE
 
 import json
+from unittest.mock import patch
 
 import frappe
-from frappe.desk.form.load import get_filtered_attachments, get_user_info_for_viewers
+from frappe.core.doctype.communication.communication import parse_email
+from frappe.desk.form.load import get_document_email, get_filtered_attachments, get_user_info_for_viewers
 from frappe.tests import IntegrationTestCase
 
 
@@ -54,3 +56,20 @@ class TestLoad(IntegrationTestCase):
 		)
 
 		self.assertEqual([attachment.name for attachment in attachments], [matching_file.name])
+
+	def test_get_document_email(self):
+		with patch(
+			"frappe.email.doctype.email_account.email_account.get_automatic_email_link",
+			return_value="erpnext@example.com",
+		):
+			address = get_document_email("Purchase Order", "PO-26465-002")
+			address_with_separator_in_name = get_document_email("Purchase Order", "PO/2026/002")
+
+		self.assertEqual(address, "erpnext+Purchase%20Order=PO-26465-002@example.com")
+		self.assertEqual(
+			address_with_separator_in_name, "erpnext+Purchase%20Order=PO%2F2026%2F002@example.com"
+		)
+		self.assertEqual([("Purchase Order", "PO-26465-002")], list(parse_email([address])))
+		self.assertEqual(
+			[("Purchase Order", "PO/2026/002")], list(parse_email([address_with_separator_in_name]))
+		)


### PR DESCRIPTION
## Summary

Since #26978, document email addresses have encoded spaces with `+`, producing addresses like:

```text
erpnext+Purchase+Order=PO-26465-002@example.com
```

Under RFC 5233, the first `+` separates the mailbox from the detail, making subsequent `+` characters ambiguous. Our parser works around this, but Exchange Online rejects these addresses with:

```text
550 5.1.10 RecipientNotFound
```

The equivalent v15 address, using `%20` for spaces, is accepted.

## Fix

Use `quote(..., safe="")` instead of `quote_plus` when generating document email addresses.

This changes spaces back to `%20`, while preserving the v16 encoding for other special characters such as `/` and `+`.

Nothing changes on the receiving side. `parse_email` already uses `unquote_plus`, so both existing (`+`) and new (`%20`) addresses continue to resolve correctly.

---

Ref: https://support.frappe.io/helpdesk/tickets/74603?view=VIEW-HD+Ticket-1252