### PR TITLE
fix: resolve doctype from the address before unscrubbing it

### DIFF
--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -411,7 +411,9 @@ class Communication(Document, CommunicationEmailMixin):
 
 		for doctype, docname in parse_email([self.recipients, self.cc, self.bcc]):
 			# Both document and doctype names should be case insensitive in email addresses.
-			doctype = frappe.db.get_value("DocType", doctype)
+			doctype = frappe.db.exists("DocType", doctype, cache=True) or frappe.db.exists(
+				"DocType", frappe.unscrub(doctype), cache=True
+			)
 			if doctype:
 				docname = frappe.db.get_value(doctype, docname, ignore=True)
 			if not (doctype and docname):
@@ -621,7 +623,7 @@ def parse_email(email_strings):
 			if not document_parts or len(document_parts) != 2:
 				continue
 
-			doctype = frappe.unscrub(unquote_plus(document_parts[0]))
+			doctype = unquote_plus(document_parts[0])
 			docname = unquote_plus(document_parts[1])
 			yield doctype, docname
 

--- a/frappe/core/doctype/communication/test_communication.py
+++ b/frappe/core/doctype/communication/test_communication.py
@@ -419,6 +419,38 @@ class TestCommunication(IntegrationTestCase):
 		results = list(parse_email([to, cc, bcc]))
 		self.assertEqual([("A", "Test"), ("Note", "Very important")], results)
 
+	def test_parse_email_keeps_doctype_case(self):
+		results = list(parse_email(["erp+ToDo=TASK-0001@example.org"]))
+		self.assertEqual([("ToDo", "TASK-0001")], results)
+
+	def test_timeline_link_from_doctype_in_address(self):
+		create_email_account()
+
+		todo = frappe.get_doc({"doctype": "ToDo", "description": "Email linking case test"}).insert(
+			ignore_permissions=True
+		)
+		note = frappe.get_doc(
+			{"doctype": "Note", "title": "Email linking case test", "content": "Email linking case test"}
+		).insert(ignore_permissions=True)
+
+		for doctype_in_address, doctype, docname in (
+			("ToDo", "ToDo", todo.name),
+			("note", "Note", note.name),
+		):
+			comm = frappe.get_doc(
+				{
+					"doctype": "Communication",
+					"communication_type": "Communication",
+					"communication_medium": "Email",
+					"content": "Email linking case test",
+					"sender": "sender@example.com",
+					"recipients": f"test_comm+{doctype_in_address}={docname}@example.com",
+				}
+			).insert(ignore_permissions=True)
+
+			self.assertEqual((doctype, docname), (comm.reference_doctype, comm.reference_name))
+			self.assertIn((doctype, docname), [(d.link_doctype, d.link_name) for d in comm.timeline_links])
+
 	def test_get_emails(self):
 		emails = get_emails(
 			[


### PR DESCRIPTION
`parse_email` runs the doctype from an incoming address through `frappe.unscrub()`, which ends in `.title()`. 
That mangles every doctype whose name is not title-case: `ToDo` becomes `Todo`, `UOM` becomes `Uom`. MariaDB hides it, since `tabDocType.name` collates case-insensitively and the lookup matches anyway; Postgres compares case-sensitively, so the email silently loses its timeline link and `reference_doctype`.

`parse_email` now yields the token as sent, and the caller resolves it: exact name first, `unscrub` as fallback for scrubbed forms like `sales_order`. Both probes use `frappe.db.exists(..., cache=True)`, so many addressees no longer mean one uncached query each.