### PR TITLE
fix(image-view): keep load more button pinned while scrolling

### DIFF
--- a/frappe/public/scss/desk/image_view.scss
+++ b/frappe/public/scss/desk/image_view.scss
@@ -2,6 +2,10 @@
 .image-view {
 	.frappe-list {
 		padding: var(--padding-xs);
+
+		.result-container {
+			overflow-y: auto;
+		}
 	}
 
 	.list-header-subject {


### PR DESCRIPTION
Resolve: #40628 

---
**After fix:**

https://github.com/user-attachments/assets/13e92a1f-e1f7-4f51-b669-5e3986d3320d


