### PR TITLE
fix: float fields render as 0 for values below 1e-6

### DIFF
--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -68,11 +68,8 @@ frappe.form.formatters = {
 			return frappe.form.formatters.Currency(value, docfield, options, doc);
 		} else {
 			// show 1.000000 as 1
-			if (!(options || {}).always_show_decimals && !is_null(value)) {
-				var temp = cstr(value).split(".");
-				if (temp[1] == undefined || cint(temp[1]) === 0) {
-					precision = 0;
-				}
+			if (!(options || {}).always_show_decimals && !is_null(value) && flt(value) % 1 === 0) {
+				precision = 0;
 			}
 
 			value = value == null || value === "" ? "" : value;
@@ -95,7 +92,8 @@ frappe.form.formatters = {
 			return "";
 		}
 
-		const valuePrecision = value?.toString().split(".")[1]?.length || 0;
+		const [mantissa, exponent] = cstr(value).toLowerCase().split("e");
+		const valuePrecision = Math.max((mantissa.split(".")[1]?.length || 0) - cint(exponent), 0);
 
 		const precision =
 			docfield.precision ||


### PR DESCRIPTION
## Summary

Float and Percent fields display `0` for values smaller than `1e-6`, regardless of the configured Float Precision. The value stored in the database is correct; only the client-side formatting is wrong.

The issue comes from both formatters inferring decimal places from the value's string representation. JavaScript switches to exponential notation below `1e-6` (`0.0000001` becomes `"1e-7"`), so the formatters incorrectly conclude the value has no decimal places and round it to `0`.

## Fix

- **Float:** Determine whether a value is a whole number using `flt(value) % 1 === 0` instead of inspecting its string representation.
- **Percent:** Continue counting decimal places from the string, but account for exponential notation so values like `1e-7` are treated as having 7 decimal places instead of 0.

## Testing

Verified the change across whole numbers, database strings, grouped strings, floating-point noise, exponential values, empty/undefined inputs, and all `always_show_decimals` callers, with Float Precision set to 9, 6, and unset, both with and without a DocField precision.

The only behavior change is for values smaller than `1e-6`, which now display their actual value instead of `0`.

Closes #41162.