### PR TITLE
fix: msgprint loses its message when a save response follows

### DIFF
--- a/cypress/integration/msgprint.js
+++ b/cypress/integration/msgprint.js
@@ -1,0 +1,41 @@
+context("Msgprint", () => {
+	before(() => {
+		cy.login();
+		cy.visit("/app/todo");
+	});
+
+	it("keeps an open message when the response carries only toasts", () => {
+		cy.window().then((win) => {
+			win.frappe.msgprint({ message: "client message", title: "client title" });
+			win.frappe.request.cleanup(
+				{},
+				{
+					_server_messages: JSON.stringify([
+						JSON.stringify({ message: "Saved", alert: 1 }),
+					]),
+				}
+			);
+		});
+		cy.get(".msgprint-dialog").should("be.visible");
+		cy.get(".msgprint").should("contain", "client message");
+		cy.hide_dialog();
+	});
+
+	it("clears an open message before showing a server message", () => {
+		cy.window().then((win) => {
+			win.frappe.msgprint({ message: "client message", title: "client title" });
+			win.frappe.request.cleanup(
+				{},
+				{
+					_server_messages: JSON.stringify([
+						JSON.stringify({ message: "server message" }),
+					]),
+				}
+			);
+		});
+		cy.get(".msgprint")
+			.should("contain", "server message")
+			.should("not.contain", "client message");
+		cy.hide_dialog();
+	});
+});

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -504,7 +504,13 @@ frappe.request.cleanup = function (opts, r) {
 		if (messages && !opts.silent) {
 			// show server messages if no handlers exist
 			if (handlers.length === 0) {
-				frappe.hide_msgprint();
+				const opens_dialog = messages.some((m) => {
+					const message = typeof m === "string" ? JSON.parse(m) : m;
+					return !(message.alert || message.toast);
+				});
+				if (opens_dialog) {
+					frappe.hide_msgprint();
+				}
 				frappe.msgprint(messages);
 			}
 		}


### PR DESCRIPTION
## Summary

A client-side `frappe.msgprint()` can lose its body if a request completes immediately afterwards, leaving a dialog with only the title.

`frappe.request.cleanup()` always clears the dialog before rendering server messages. If the response only contains an alert (such as the `"Saved"` message), nothing is rendered back into the dialog, so it remains open but empty.

## Fix

Only clear the dialog if the response contains a message that will actually render into it. Alert/toast messages don't use the dialog, so there's nothing to clear. All other cases keep the existing behavior.

<img width="798" height="862" alt="Screenshot 2026-07-26 at 6 40 15 PM" src="https://github.com/user-attachments/assets/a13b25c2-ae6b-43d9-a024-96f264789c1b" />

---

Closes #41090.