### PR TITLE
fix: scheduled job retries forever when its own log write fails

### DIFF
--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
@@ -165,7 +165,14 @@ class ScheduledJobType(Document):
 	def log_status(self, status):
 		# log file
 		frappe.logger("scheduler").info(f"Scheduled Job {status}: {self.method} for {frappe.local.site}")
-		self.update_scheduler_log(status)
+		try:
+			self.update_scheduler_log(status)
+		except Exception:
+			# never fail the job over its own logging
+			frappe.db.rollback()
+			frappe.logger("scheduler").error(
+				f"Could not update Scheduled Job Log for {self.method}", exc_info=True
+			)
 
 	def update_scheduler_log(self, status):
 		if not self.create_log:
@@ -173,6 +180,10 @@ class ScheduledJobType(Document):
 			self.db_set("last_execution", now_datetime(), update_modified=False)
 			frappe.db.commit()
 			return
+		if status == "Start":
+			# commit before logging, its hooks can fail and leave the job due forever
+			self.db_set("last_execution", now_datetime(), update_modified=False, commit=True)
+
 		if not self.scheduler_log:
 			self.scheduler_log = frappe.get_doc(
 				doctype="Scheduled Job Log", scheduled_job_type=self.name
@@ -182,8 +193,6 @@ class ScheduledJobType(Document):
 			self.scheduler_log.db_set("debug_log", "\n".join(frappe.debug_log))
 		if status == "Failed":
 			self.scheduler_log.db_set("details", frappe.get_traceback(with_context=True))
-		if status == "Start":
-			self.db_set("last_execution", now_datetime(), update_modified=False)
 		frappe.db.commit()
 
 	def get_queue_name(self):

--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
@@ -140,7 +140,7 @@ class ScheduledJobType(Document):
 		next_execution = parse_cron(self.cron_format).get_next(datetime, start_time=last_execution)
 		if self.frequency in ("Hourly Maintenance", "Daily Maintenance"):
 			next_execution += timedelta(minutes=maintenance_offset)
-		return parse_cron(self.cron_format).get_next(datetime, start_time=last_execution)
+		return next_execution
 
 	def execute(self):
 		if frappe.job:

--- a/frappe/core/doctype/scheduled_job_type/test_scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/test_scheduled_job_type.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 from datetime import timedelta
+from unittest.mock import patch
 
 import frappe
 from frappe.core.doctype.scheduled_job_type.scheduled_job_type import sync_jobs
@@ -9,12 +10,25 @@ from frappe.utils import get_datetime
 from frappe.utils.data import add_to_date, now_datetime
 
 
+def raise_import_error(doc, method=None):
+	raise ImportError("cannot import name '_follow_document' from 'frappe.desk.form.document_follow'")
+
+
+def record_job_run():
+	frappe.flags.scheduled_job_ran = True
+
+
+def delete_scheduled_job(name):
+	frappe.delete_doc("Scheduled Job Type", name, force=True, ignore_missing=True)
+	frappe.db.commit()  # nosemgrep
+
+
 class TestScheduledJobType(IntegrationTestCase):
 	def setUp(self):
 		frappe.db.rollback()
 		frappe.db.truncate("Scheduled Job Type")
 		sync_jobs()
-		frappe.db.commit()
+		frappe.db.commit()  # nosemgrep
 
 	def test_throws_on_duplicate_job(self):
 		job_config = dict(
@@ -110,13 +124,51 @@ class TestScheduledJobType(IntegrationTestCase):
 			frequency="Hourly Maintenance",
 			last_execution=get_datetime("2019-01-01 23:59:00"),
 		)
+		# "maintenance.test" offset is 38 minutes
+		with patch.object(frappe.local, "site", "maintenance.test"):
+			self.assertEqual(sjt.next_execution, get_datetime("2019-01-02 00:38:00"))
+
 		# Should be within one hour
 		self.assertGreaterEqual(sjt.next_execution, sjt.last_execution)
-		self.assertGreater(add_to_date(sjt.last_execution, hours=1), sjt.next_execution)
+		self.assertGreaterEqual(add_to_date(sjt.last_execution, hours=1), sjt.next_execution)
 
 		# Next should be exactly one hour away
 		sjt.last_execution = sjt.next_execution
 		self.assertEqual(add_to_date(sjt.last_execution, hours=1), sjt.next_execution)
+
+	def test_job_survives_failing_log(self):
+		job = frappe.get_doc(
+			doctype="Scheduled Job Type",
+			method="frappe.core.doctype.scheduled_job_type.test_scheduled_job_type.record_job_run",
+			frequency="Daily",
+			create_log=1,
+			last_execution="2019-01-01 00:00:00",
+		).insert()
+		self.addCleanup(delete_scheduled_job, job.name)
+
+		failing_log_hook = {
+			"doc_events": {
+				"Scheduled Job Log": {
+					"on_update": [
+						"frappe.core.doctype.scheduled_job_type.test_scheduled_job_type.raise_import_error"
+					]
+				}
+			}
+		}
+
+		frappe.flags.scheduled_job_ran = False
+		try:
+			with self.patch_hooks(failing_log_hook):
+				frappe.local.doc_events_hooks = None
+				job.execute()
+		finally:
+			frappe.local.doc_events_hooks = None
+
+		self.assertTrue(frappe.flags.scheduled_job_ran)
+
+		last_execution = frappe.db.get_value("Scheduled Job Type", job.name, "last_execution")
+		self.assertGreater(get_datetime(last_execution), get_datetime("2019-01-01 00:00:00"))
+		self.assertFalse(job.is_event_due())
 
 	def test_cold_start(self):
 		now = now_datetime()


### PR DESCRIPTION
## Summary

`ScheduledJobType.update_scheduler_log` updated `last_execution` *after* inserting the `Scheduled Job Log`. If any `on_update` hook on the log raised, the transaction rolled back before `last_execution` was written, so the scheduler kept treating the job as due and re-enqueuing it on every tick.

A second issue was that a failure while writing the scheduler log could prevent the job itself from running.

The report also uncovered that the per-site maintenance offset has been ineffective since #32661, causing Hourly and Daily Maintenance to run on the exact hour for every site.

## Fix

- Update and commit `last_execution` before inserting the log.
- Don't let scheduler log failures prevent the job from running; log the error and continue.
- Restore the per-site maintenance offset when computing the next execution time.

## Tests

Added tests covering a failing `Scheduled Job Log` hook (ensuring the job still runs and `last_execution` advances) and the maintenance offset calculation.

Closes #41093.