### PR TITLE
fix(search): stop build_index looping forever on an unindexable batch

### DIFF
--- a/frappe/search/sqlite_search.py
+++ b/frappe/search/sqlite_search.py
@@ -404,12 +404,15 @@ class SQLiteSearch(ABC):
 					if documents:
 						self._index_documents(documents)
 
-						# Update progress with last processed document cursor
-						last_doc_modified = docs[-1].get(progress_field) or docs[-1].get("modified")
-						last_doc_name = docs[-1]["name"]
-						self._update_index_progress(doctype, last_doc_name, last_doc_modified, len(documents))
-						last_indexed_modified = last_doc_modified
-						last_indexed_name = last_doc_name
+					# Advance the cursor even when nothing in this batch was indexable: these
+					# rows have been consumed either way. Advancing only when `documents` was
+					# non-empty meant a batch whose documents all failed prepare_document()
+					# was fetched again forever, so build_index() never returned.
+					last_doc_modified = docs[-1].get(progress_field) or docs[-1].get("modified")
+					last_doc_name = docs[-1]["name"]
+					self._update_index_progress(doctype, last_doc_name, last_doc_modified, len(documents))
+					last_indexed_modified = last_doc_modified
+					last_indexed_name = last_doc_name
 
 					batch_count += 1
 

--- a/frappe/tests/test_sqlite_search.py
+++ b/frappe/tests/test_sqlite_search.py
@@ -569,3 +569,48 @@ class TestSQLiteSearchAPI(IntegrationTestCase):
 
 		finally:
 			test_note.delete()
+
+	def test_build_index_terminates_when_a_batch_has_no_indexable_documents(self):
+		"""build_index must advance its cursor even if nothing in a batch can be indexed.
+
+		prepare_document() may legitimately reject every document in a batch (missing text
+		fields, a subclass filtering by its own rules). The cursor used to advance only when
+		at least one document survived, so such a batch was re-fetched forever and
+		build_index() never returned - it spun at full CPU, opening a fresh SQLite connection
+		per iteration, until the process was killed.
+		"""
+		self.search.drop_index()
+
+		real_get_documents_paginated = self.search.get_documents_paginated
+		fetches = []
+
+		def counting_get_documents_paginated(*args, **kwargs):
+			fetches.append(kwargs.get("last_indexed_name"))
+			# Fail the test instead of hanging the suite if the cursor stops advancing.
+			if len(fetches) > 50:
+				raise AssertionError(
+					"build_index() re-fetched batches without advancing its cursor "
+					f"({len(fetches)} fetches for {len(self.search.doc_configs)} doctypes)"
+				)
+			return real_get_documents_paginated(*args, **kwargs)
+
+		with (
+			patch.object(TestSQLiteSearch, "prepare_document", return_value=None),
+			patch.object(self.search, "get_documents_paginated", counting_get_documents_paginated),
+		):
+			self.search.build_index()
+
+		# Every doctype is walked to exhaustion and marked complete, and nothing is indexed.
+		self.assertTrue(self.search.index_exists())
+
+		conn = sqlite3.connect(self.search.db_path)
+		try:
+			indexed_rows = conn.execute("SELECT COUNT(*) FROM search_fts").fetchone()[0]
+			incomplete = conn.execute(
+				"SELECT COUNT(*) FROM search_index_progress WHERE is_complete = 0"
+			).fetchone()[0]
+		finally:
+			conn.close()
+
+		self.assertEqual(indexed_rows, 0)
+		self.assertEqual(incomplete, 0, "every doctype should be marked complete")


### PR DESCRIPTION
## Problem

`SQLiteSearch.build_index` advances its pagination cursor only inside `if documents:` — that is, only when at least one document in the batch survived `prepare_document()`:

```python
documents = []
for doc in docs:
    document = self.prepare_document(doc)
    if document:
        documents.append(document)

if documents:
    self._index_documents(documents)
    last_indexed_modified = docs[-1].get(progress_field) or docs[-1].get("modified")
    last_indexed_name = docs[-1]["name"]        # ← cursor only moves here
```

`prepare_document()` returns `None` whenever `_validate_document_for_indexing()` rejects a document (e.g. missing text fields), and subclasses may reject documents by their own rules.

So when a batch returns rows but yields **no** indexable document, the cursor is left untouched — while the non-empty `docs` means the `break` above is never reached. The identical batch is fetched again, and again, forever.

There is no error and no timeout. The process spins at 100% CPU, opening a fresh SQLite connection per iteration through `_get_indexing_progress()`, with RSS climbing steadily, until something kills it.

## How it showed up

Hit on a Gameplan site during a backend test run. A single `build_index()` call ran for **45 minutes**, read **~35 GB**, and grew to **1 GB RSS** before being stopped. `py-spy` showed the loop plainly:

```
_set_pragmas           (frappe/search/sqlite_search.py:1205)
_get_connection        (frappe/search/sqlite_search.py:1194)
sql                    (frappe/search/sqlite_search.py:1454)
_get_indexing_progress (frappe/search/sqlite_search.py:771)
build_index            (frappe/search/sqlite_search.py:417)
```

The failure is data-dependent — it needs one batch (1000 rows by default) in which nothing is indexable — which makes it intermittent and hard to attribute.

## Fix

Advance the cursor unconditionally. Those rows have been consumed whether or not any of them produced a document.

`_update_index_progress` adds `indexed_count` to `indexed_docs`, so passing `len(documents)` (0 in this case) moves the cursor without inflating reported progress.

## Test

Adds `test_build_index_terminates_when_a_batch_has_no_indexable_documents`, which patches `prepare_document` to reject everything and asserts `build_index()` still terminates, indexes nothing, and marks every doctype complete.

The test caps the number of batch fetches, so a reintroduction of this bug **fails in under a second** rather than hanging the suite — which matters here, since the natural way to write this test would hang CI.

Verified both directions:

| | Result |
|---|---|
| With fix | `Ran 1 test` → `OK` |
| Fix reverted, test kept | `AssertionError: build_index() re-fetched batches without advancing its cursor (51 fetches for 3 doctypes)` |

`develop` carries the same code, so it needs the same fix if this is not forward-ported automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)