### PR TITLE
fix: regional translation overlays lost depending on app install order

### DIFF
--- a/frappe/gettext/translate.py
+++ b/frappe/gettext/translate.py
@@ -1,5 +1,4 @@
 import csv
-import gettext
 import multiprocessing
 import os
 from collections import defaultdict
@@ -346,10 +345,10 @@ def csv_to_po(app: str, locale: str):
 
 
 def get_translations_from_mo(lang, app):
-	"""Get translations from MO files.
+	"""Get translations from the MO file of exactly this locale.
 
-	For dialects (i.e. es_GT), take translations from the base language (i.e. es)
-	and then update with specific translations from the dialect (i.e. es_GT).
+	Dialects (i.e. es_GT) are not resolved here; callers merge the base language
+	(i.e. es) separately so that a dialect catalogue stays an overlay on top of it.
 
 	If we only have a translation with context, also use it as a translation
 	without context. This way we can provide the context for each source string
@@ -361,9 +360,8 @@ def get_translations_from_mo(lang, app):
 	translations = {}
 	lang = lang.replace("-", "_")  # Frappe uses dash, babel uses underscore.
 
-	locale_dir = get_locale_dir()
-	mo_file = gettext.find(app, locale_dir, (lang,))
-	if not mo_file:
+	mo_file = get_mo_path(app, lang)
+	if not mo_file.exists():
 		return translations
 	with open(mo_file, "rb") as f:
 		catalog = read_mo(f)

--- a/frappe/tests/test_translate.py
+++ b/frappe/tests/test_translate.py
@@ -1,14 +1,20 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 import os
+import tempfile
 import textwrap
+from pathlib import Path
 from random import choices
 from unittest.mock import patch
+
+from babel.messages.catalog import Catalog
+from babel.messages.mofile import write_mo
 
 import frappe
 import frappe.translate
 from frappe import N_, _, _lt
 from frappe.gettext.extractors.javascript import extract_javascript
+from frappe.gettext.translate import get_translations_from_mo
 from frappe.tests import IntegrationTestCase
 from frappe.translate import (
 	MERGED_TRANSLATION_KEY,
@@ -33,6 +39,17 @@ first_lang, second_lang, third_lang, fourth_lang, fifth_lang = choices(
 
 _LAZY_SOURCE = "Lazy Translation Source"
 _lazy_translations = _lt(_LAZY_SOURCE)
+
+
+def write_mo_catalogue(locale_dir: str, app: str, locale: str, messages: dict[str, str]):
+	catalog = Catalog(locale=locale)
+	for source, translation in messages.items():
+		catalog.add(source, translation)
+
+	mo_path = Path(locale_dir) / locale / "LC_MESSAGES" / f"{app}.mo"
+	mo_path.parent.mkdir(parents=True, exist_ok=True)
+	with open(mo_path, "wb") as f:
+		write_mo(f, catalog)
 
 
 class TestTranslate(IntegrationTestCase):
@@ -121,6 +138,23 @@ class TestTranslate(IntegrationTestCase):
 			t_pt_br.delete()
 			frappe.local.lang = "en"
 			self.assertEqual(_(source), source)
+
+	def test_regional_catalogue_overrides_parent_language_of_later_app(self):
+		with tempfile.TemporaryDirectory() as locale_dir:
+			write_mo_catalogue(locale_dir, "billing", "es", {"Mobile No": "Móvil"})
+			write_mo_catalogue(locale_dir, "storefront", "es", {"Mobile No": "Móvil"})
+			write_mo_catalogue(locale_dir, "billing", "es_MX", {"Mobile No": "Celular"})
+
+			with (
+				patch("frappe.gettext.translate.get_locale_dir", return_value=Path(locale_dir)),
+				patch("frappe.translate.get_translations_from_csv", return_value={}),
+			):
+				self.assertEqual(get_translations_from_mo("es_MX", "storefront"), {})
+
+				translations = frappe.translate.get_translations_from_apps(
+					"es-MX", apps=["billing", "storefront"]
+				)
+				self.assertEqual(translations["Mobile No"], "Celular")
 
 	def test_translation_with_context(self):
 		t1 = frappe.new_doc("Translation")


### PR DESCRIPTION
## Summary

Apps shipping a regional translation catalogue (for example, `es_MX.po`) couldn't reliably override strings from the base language. Whether an override survived depended on `installed_apps` order, making per-app regional overlays unreliable.

The issue was that `get_translations_from_mo()` used `gettext.find()`, which falls back from `es_MX` to `es`. As a result, apps without an `es_MX.po` still contributed their `es` translations to the regional merge, allowing later-installed apps to overwrite earlier regional overrides.

## Fix

Resolve MO files for the requested locale only.

Base-language fallback already happens in `get_translations_from_apps()` and `get_all_translations()`, so regional languages continue to inherit from their parent language; they just aren't overwritten by it during the per-app merge. 
This also makes MO loading consistent with CSV translations, which already require an exact locale match.

One behavioral change is that an app shipping only `zh_CN.po` will no longer satisfy requests for `zh`. 
Core apps already name their catalogues after the corresponding Language codes, so this doesn't affect frappe/erpnext.

Closes #41231.