### PR TITLE
fix: get_locale_value() crashes when no language is set

### DIFF
--- a/frappe/locale.py
+++ b/frappe/locale.py
@@ -46,7 +46,6 @@ def get_locale_value(key: str, language: str | None = None) -> str | None:
 	:param language: The language code to get the value for. Defaults to the current user's language.
 	"""
 	lang = language or frappe.local.lang
-	if lang:
-		value = frappe.client_cache.get_doc("Language", lang).get(key)
+	value = frappe.client_cache.get_doc("Language", lang).get(key) if lang else None
 
 	return value or frappe.db.get_default(key)

--- a/frappe/tests/test_locale.py
+++ b/frappe/tests/test_locale.py
@@ -1,0 +1,21 @@
+import frappe
+from frappe.locale import get_date_format, get_locale_value
+from frappe.tests import IntegrationTestCase
+
+
+class TestLocale(IntegrationTestCase):
+	def test_locale_value_without_language(self):
+		lang = frappe.local.lang
+		date_format = frappe.db.get_default("date_format")
+		try:
+			frappe.local.lang = None
+
+			frappe.db.set_default("date_format", "dd-mm-yyyy")
+			self.assertEqual(get_locale_value("date_format"), "dd-mm-yyyy")
+
+			frappe.db.set_default("date_format", None)
+			self.assertIsNone(get_locale_value("date_format"))
+			self.assertEqual(get_date_format(), "yyyy-mm-dd")
+		finally:
+			frappe.db.set_default("date_format", date_format)
+			frappe.local.lang = lang


### PR DESCRIPTION
## Summary

`get_locale_value()` only assigns `value` when `lang` is set, but always returns `value or frappe.db.get_default(key)`. If no language is configured, this raises an `UnboundLocalError` instead of falling back to the system default as intended.

This can happen in `bench console`, where `frappe.local.lang` is `None` on sites that have never configured a language. The reported case was `frappe.sendmail()` failing while rendering an email because looking up the date format crashed.

## Fix

Initialize `value` regardless of whether a language is configured, allowing the existing fallback to `frappe.db.get_default(key)` to work as intended.

Sites with a configured language behave exactly as before.

Closes #41229.