### PR TITLE
feat(ui): consolidate view switching to single dropdown

### DIFF
--- a/cypress/integration/kanban.js
+++ b/cypress/integration/kanban.js
@@ -44,10 +44,11 @@ context("Kanban Board", () => {
 			}
 
 			cy.visit("/desk/todo");
+			// the Kanban row hosts the boards submenu (it doesn't act on
+			// click) — creation lives in the submenu's Create Board row
 			cy.get(".page-actions .custom-btn-group button").click();
-			cy.get(".page-actions .custom-btn-group ul.dropdown-menu li")
-				.contains("Kanban")
-				.click();
+			cy.contains(".es-menu__item", "Kanban View").trigger("pointerenter");
+			cy.contains(".es-menu__item", "Create Board").click();
 
 			cy.get(".modal-dialog:visible").should("exist");
 			cy.fill_field("board_name", "ToDo Kanban", "Data");
@@ -56,6 +57,21 @@ context("Kanban Board", () => {
 
 			cy.get(".title-text").should("contain", "ToDo Kanban");
 		});
+	});
+
+	it("Open a board from the view switcher on list view", () => {
+		cy.visit("/desk/todo");
+		cy.get(".page-actions .custom-btn-group button").click();
+		// boards load async at hover — the row appears once the fetch lands
+		cy.contains(".es-menu__item", "Kanban View").trigger("pointerenter");
+		cy.contains(".es-menu__item", "ToDo Kanban").click();
+
+		cy.get(".title-text").should("contain", "ToDo Kanban");
+		cy.window()
+			.its("cur_list")
+			.then((list) => {
+				expect(list.view_name).to.equal("Kanban");
+			});
 	});
 
 	it("Create ToDo from kanban", () => {

--- a/cypress/integration/list_saved_layouts.js
+++ b/cypress/integration/list_saved_layouts.js
@@ -1,18 +1,30 @@
 const LIST_URL = "/desk/todo";
-const LAYOUT_GROUP = encodeURIComponent("Default Layout");
 
-function openSavedLayoutsMenu() {
-	cy.get(`.inner-group-button[data-label="${LAYOUT_GROUP}"] > button`).click({ force: true });
+// saved layouts live in the view switcher now: the current view's row
+// ("List View") carries them as an async submenu
+function openLayoutSubmenu() {
+	cy.get(".custom-btn-group.view-switcher button").click();
+	cy.contains(".es-menu__item", "List View").trigger("pointerenter");
+	// the submenu lazy-loads the layouts bundle — wait for its rows
+	cy.contains(".es-menu__item", "Default Layout").should("exist");
 }
 
-function getLayoutButton() {
-	return cy.get(`.inner-group-button[data-label="${LAYOUT_GROUP}"] > button`);
+function closeMenus() {
+	cy.focused().trigger("keydown", { key: "Escape" });
+	cy.get(".es-menu[data-state='open']").should("not.exist");
 }
 
 function selectLayout(label) {
-	openSavedLayoutsMenu();
-	cy.get(".saved-filter-item .filter-label").contains(label).click();
+	openLayoutSubmenu();
+	cy.contains(".es-menu__item", label).click();
 	cy.wait(500);
+}
+
+// the switcher trigger shows the active layout name (or "List View" when
+// the default layout is active)
+function assertActiveLayout(label) {
+	const trigger_label = label === "Default Layout" ? "List View" : label;
+	cy.get(".custom-btn-group.view-switcher button").should("contain", trigger_label);
 }
 
 function clearTestLayouts() {
@@ -44,10 +56,11 @@ context("List View — Saved Layouts", () => {
 		cy.wait(500);
 		cy.clear_filters();
 
-		openSavedLayoutsMenu();
-		cy.get(".saved-filter-item .filter-label").should("contain", "Default Layout");
-		cy.get(".saved-layout-action-item").contains("Create Layout").should("be.visible");
-		cy.get(".saved-layout-action-item").contains("Manage Layouts").should("be.visible");
+		openLayoutSubmenu();
+		cy.contains(".es-menu__item", "Default Layout").should("be.visible");
+		cy.contains(".es-menu__item", "Create Layout").should("be.visible");
+		cy.contains(".es-menu__item", "Manage Layouts").should("be.visible");
+		closeMenus();
 	});
 
 	it("restores last selected layout on a clean URL when no URL filters exist", () => {
@@ -61,13 +74,13 @@ context("List View — Saved Layouts", () => {
 		cy.clear_filters();
 
 		selectLayout("_cypress_layout_empty");
-		getLayoutButton().should("contain", "_cypress_layout_empty");
+		assertActiveLayout("_cypress_layout_empty");
 
 		cy.visit(LIST_URL);
 		cy.wait(1000);
 		cy.clear_filters();
 
-		getLayoutButton().should("contain", "_cypress_layout_empty");
+		assertActiveLayout("_cypress_layout_empty");
 	});
 
 	it("does not auto-apply empty-filter layout from URL signature alone", () => {
@@ -80,7 +93,7 @@ context("List View — Saved Layouts", () => {
 		cy.wait(1000);
 		cy.clear_filters();
 
-		getLayoutButton().should("contain", "Default Layout");
+		assertActiveLayout("Default Layout");
 	});
 
 	it("auto-applies a layout when the URL matches its route signature", () => {
@@ -93,7 +106,7 @@ context("List View — Saved Layouts", () => {
 		cy.visit(`${LIST_URL}?status=Open`);
 		cy.wait(1000);
 
-		getLayoutButton().should("contain", "_cypress_layout_open");
+		assertActiveLayout("_cypress_layout_open");
 	});
 
 	it("applies a saved layout from the menu and can switch back to default", () => {
@@ -108,10 +121,10 @@ context("List View — Saved Layouts", () => {
 		cy.clear_filters();
 
 		selectLayout("_cypress_layout_switch");
-		getLayoutButton().should("contain", "_cypress_layout_switch");
+		assertActiveLayout("_cypress_layout_switch");
 
 		selectLayout("Default Layout");
-		getLayoutButton().should("contain", "Default Layout");
+		assertActiveLayout("Default Layout");
 	});
 
 	it("opens manage layouts dialog with the saved layout listed", () => {
@@ -122,12 +135,36 @@ context("List View — Saved Layouts", () => {
 		cy.visit(LIST_URL);
 		cy.wait(500);
 
-		openSavedLayoutsMenu();
-		cy.get(".saved-layout-action-item").contains("Manage Layouts").click();
+		openLayoutSubmenu();
+		cy.contains(".es-menu__item", "Manage Layouts").click();
 
 		cy.get(".modal-dialog").should("contain", "Manage Layouts");
 		cy.get(".layout-manage-row").should("contain", "_cypress_layout_manage");
 		cy.get(".layout-manage-row").should("contain", "Personal");
+	});
+
+	it("switches to list view with a layout applied, from another view", () => {
+		createTestLayout({
+			layout_name: "_cypress_layout_jump",
+			filters: JSON.stringify([["ToDo", "status", "=", "Open"]]),
+			route_signature: "status=Open",
+		});
+
+		cy.visit(`${LIST_URL}/view/report`);
+		cy.wait(500);
+
+		// the List row hosts the layouts as an async submenu from other views
+		cy.get(".custom-btn-group.view-switcher button").click();
+		cy.contains(".es-menu__item", "List View").trigger("pointerenter");
+		cy.contains(".es-menu__item", "_cypress_layout_jump").click();
+
+		// one click: switched AND applied (preference + clean route + restore)
+		cy.window()
+			.its("cur_list")
+			.should((list) => {
+				expect(list.view_name).to.equal("List");
+			});
+		assertActiveLayout("_cypress_layout_jump");
 	});
 
 	it("fetches non-in_list_view fields used as saved layout columns", () => {
@@ -156,7 +193,7 @@ context("List View — Saved Layouts", () => {
 		cy.clear_filters();
 
 		selectLayout("_cypress_layout_columns");
-		getLayoutButton().should("contain", "_cypress_layout_columns");
+		assertActiveLayout("_cypress_layout_columns");
 
 		cy.window().then((win) => {
 			const list = win.cur_list;
@@ -173,7 +210,7 @@ context("List View — Saved Layouts", () => {
 
 		// Switching layouts should drop fields that are no longer visible.
 		selectLayout("_cypress_layout_no_role");
-		getLayoutButton().should("contain", "_cypress_layout_no_role");
+		assertActiveLayout("_cypress_layout_no_role");
 
 		cy.window().then((win) => {
 			const fetch_fields = (win.cur_list.fields || []).map((f) => f[0]);

--- a/frappe/public/css/espresso/components/menu.css
+++ b/frappe/public/css/espresso/components/menu.css
@@ -58,6 +58,9 @@
 /* ---- groups ---- */
 .es-menu__group {
     padding: calc(var(--spacing) * 1.5);
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--spacing) * 0.5);
 }
 
 .es-menu__group+.es-menu__group {
@@ -65,7 +68,7 @@
 }
 
 .es-menu__group-label {
-    padding: calc(var(--spacing) * 1.5) calc(var(--spacing) * 2);
+    padding: calc(var(--spacing) * 1.5) calc(var(--spacing) * 1.5);
     font-size: var(--text-sm);
     line-height: calc(var(--spacing) * 4);
     font-weight: var(--font-weight-medium);
@@ -248,7 +251,7 @@
     color: var(--ink-gray-5);
 }
 
-.es-menu__loading > .es-spinner {
+.es-menu__loading>.es-spinner {
     width: calc(var(--spacing) * 3.5);
     height: calc(var(--spacing) * 3.5);
 }

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -213,13 +213,10 @@ frappe.views.BaseList = class BaseList {
 				Map: __("Map View"),
 			};
 
-			this.views_menu = this.page.add_custom_button_group(
-				label_map[this.view_name] || label_map["List"],
-				icon_map[this.view_name] || "list"
-			);
+			// one nested dropdown: view rows + the current view's variants
+			// (saved layouts, kanban boards, ...) as its submenu
 			this.views_list = new frappe.views.ListViewSelect({
 				doctype: this.doctype,
-				parent: this.views_menu,
 				page: this.page,
 				list_view: this,
 				icon_map: icon_map,

--- a/frappe/public/js/frappe/list/list_filter/list_filter_menu.js
+++ b/frappe/public/js/frappe/list/list_filter/list_filter_menu.js
@@ -1,55 +1,70 @@
 import LayoutDialog from "./layout_dialog";
 import ManageLayoutsDialog from "./manage_layouts_dialog";
 
-/** Saved Layout menu rendering and layout dialog actions. */
+/** Saved Layout data + menu items (rendered by the view switcher's submenu). */
 export const ListFilterMenu = {
-	/** Group label shown in page inner button for saved layouts menu. */
-	get saved_layout_group_label() {
-		return __("Default Layout");
-	},
-
-	/** Create the Saved Layouts button and populate the dropdown menu. */
+	/** Fetch layouts and restore the active one. The view switcher renders
+	 *  the menu fresh from get_layout_menu_items() on every open, so no DOM
+	 *  is built or synced here. */
 	setup_layout_menu({ refetch = true, initial_setup = false } = {}) {
-		if (frappe.is_mobile()) return Promise.resolve();
-
-		this.ensure_layout_menu_group();
-
 		const fetch_promise = refetch ? this.get_list_filters() : Promise.resolve();
 
-		return fetch_promise
-			.then(() => {
-				if (!this._default_layout_snapshot) {
-					this.capture_default_layout_state();
-				}
-				if (!initial_setup) {
-					return this.restore_layout_from_route_signature({ refresh: true });
-				}
-			})
-			.then(() => {
-				if (!initial_setup) {
-					this.update_layout_menu_selection({ rerender_menu: true });
-				}
-			});
+		return fetch_promise.then(() => {
+			if (!this._default_layout_snapshot) {
+				this.capture_default_layout_state();
+			}
+			if (!initial_setup) {
+				return this.restore_layout_from_route_signature({ refresh: true });
+			}
+		});
 	},
 
-	/** Create the inner button group once (first item is replaced on render). */
-	ensure_layout_menu_group() {
-		if (this.layout_menu_group) return;
+	/** The saved-layouts submenu, as menu items: Default, then the global and
+	 *  personal layouts (grouped), then the create/manage actions. Called by
+	 *  the view switcher on every open, so active-state is always current. */
+	get_layout_menu_items() {
+		const active = String(this.active_layout_name || "default_layout");
+		const layout_row = (layout) => ({
+			label: __(layout.filter_name),
+			selected: String(layout.name) === active,
+			onclick: () => this.select_layout(layout.name, layout.filter_name),
+		});
 
-		this.list_view.page.add_inner_button(
-			this.default_layout_label,
-			() => {},
-			this.saved_layout_group_label
-		);
-		this.layout_menu_group = this.list_view.page.get_inner_group_button(
-			this.saved_layout_group_label
-		);
-	},
+		const global_layouts = (this.filters || []).filter((f) => !f.for_user).map(layout_row);
+		const user_layouts = (this.filters || [])
+			.filter((f) => f.for_user === frappe.session.user)
+			.map(layout_row);
 
-	/** Live dropdown menu element (do not cache items — menu is re-rendered). */
-	get_layout_menu() {
-		this.ensure_layout_menu_group();
-		return this.layout_menu_group.find(".dropdown-menu");
+		const items = [
+			{
+				label: this.default_layout_label,
+				selected: active === "default_layout",
+				onclick: () => this.select_layout("default_layout", this.default_layout_label),
+			},
+		];
+		if (global_layouts.length) {
+			items.push({ group: __("Global Layouts"), options: global_layouts });
+		}
+		if (user_layouts.length) {
+			items.push({ group: __("Your Layouts"), options: user_layouts });
+		}
+		items.push({
+			group: "",
+			hide_label: true,
+			options: [
+				{
+					label: __("Create Layout"),
+					icon: "plus",
+					onclick: () => this.open_layout_dialog(),
+				},
+				{
+					label: __("Manage Layouts"),
+					icon: "settings",
+					onclick: () => this.open_manage_layouts_dialog(),
+				},
+			],
+		});
+		return items;
 	},
 
 	/** Normalize filter query params into a stable signature (matches list view URL encoding). */
@@ -156,7 +171,8 @@ export const ListFilterMenu = {
 	restore_layout_from_route_signature({ refresh = true } = {}) {
 		const finish = () => {
 			this._initial_layout_restored = true;
-			this.update_layout_menu_selection({ rerender_menu: true });
+			// the view switcher's trigger shows the active layout name
+			this.list_view.views_list?.refresh_trigger?.();
 		};
 
 		if (this._user_selected_layout) {
@@ -192,60 +208,8 @@ export const ListFilterMenu = {
 		return this.apply_saved_layout(matched_layout, { refresh }).then(finish, finish);
 	},
 
-	/** Render default, global, user, and action rows in the dropdown menu. */
-	render_saved_filters() {
-		const $menu = this.get_layout_menu();
-		$menu.empty();
-
-		const $default_item = this.filter_template({
-			name: "default_layout",
-			filter_name: this.default_layout_label,
-		});
-		$default_item.find(".dropdown-item").on("click", (e) => {
-			e.preventDefault();
-			this.select_layout("default_layout", this.default_layout_label);
-		});
-		$menu.append($default_item);
-		$menu.append('<li class="dropdown-divider"></li>');
-
-		const global_filters = (this.filters || []).filter((filter) => !filter.for_user);
-		const user_filters = (this.filters || []).filter(
-			(filter) => filter.for_user === frappe.session.user
-		);
-
-		if (global_filters.length) {
-			$menu.append(`<li class="dropdown-header">${__("Global Layouts")}</li>`);
-			this.append_filter_items($menu, global_filters);
-		}
-
-		if (user_filters.length) {
-			if (global_filters.length) {
-				$menu.append('<li class="dropdown-divider"></li>');
-			}
-			$menu.append(`<li class="dropdown-header">${__("Your Layouts")}</li>`);
-			this.append_filter_items($menu, user_filters);
-		}
-
-		if (global_filters.length || user_filters.length) {
-			$menu.append('<li class="dropdown-divider"></li>');
-		}
-
-		this.append_layout_action_items($menu);
-	},
-
-	/** Append saved layout rows and update button label on selection. */
-	append_filter_items($menu, filters) {
-		(filters || []).forEach((filter) => {
-			const $item = this.filter_template(filter);
-			$item.find(".dropdown-item").on("click", (e) => {
-				e.preventDefault();
-				this.select_layout(filter.name, filter.filter_name);
-			});
-			$menu.append($item);
-		});
-	},
-
-	/** Remember selected layout, apply its state, and reflect it on the button. */
+	/** Remember the selected layout and apply its state. The switcher's menu
+	 *  shows the new selection by itself — it renders fresh on every open. */
 	select_layout(name, label) {
 		if (name === this.active_layout_name) return Promise.resolve();
 
@@ -257,30 +221,15 @@ export const ListFilterMenu = {
 		this.active_layout_label = label;
 		this._user_selected_layout = true;
 		this.save_active_layout_preference(name);
-		this.update_layout_menu_selection();
+		// the view switcher's trigger shows the active layout name
+		this.list_view.views_list?.refresh_trigger?.();
 
 		const apply_promise =
 			name === "default_layout"
 				? this.apply_default_layout()
 				: this.apply_saved_layout((this.filters || []).find((row) => row.name === name));
 
-		return Promise.resolve(apply_promise).then(() => {
-			this.update_active_filter_label();
-			this.update_active_filter_indicators();
-		});
-	},
-
-	/** Sync button label and menu tick with the active layout. */
-	update_layout_menu_selection({ rerender_menu = false } = {}) {
-		if (!this.layout_menu_group) return;
-
-		this.update_active_filter_label();
-
-		if (rerender_menu) {
-			this.render_saved_filters();
-		} else {
-			this.update_active_filter_indicators();
-		}
+		return Promise.resolve(apply_promise);
 	},
 
 	/** Snapshot default layout state from user settings or the live list view. */
@@ -409,28 +358,6 @@ export const ListFilterMenu = {
 			.then(finish, finish);
 	},
 
-	/** Set Saved Layouts button text to the active layout name. */
-	update_active_filter_label() {
-		if (!this.layout_menu_group) return;
-
-		const label = this.active_layout_label || this.default_layout_label;
-		// the group trigger is an es-button now — its text lives in the
-		// label span, not in the button's first text node
-		this.layout_menu_group.find("button .es-button__label").text(label);
-	},
-
-	/** Show tick on the currently selected layout row. */
-	update_active_filter_indicators() {
-		const active_name = String(this.active_layout_name || "default_layout");
-		this.get_layout_menu()
-			.find(".saved-filter-item")
-			.each((_, el) => {
-				const $el = $(el);
-				const is_active = String($el.attr("data-name")) === active_name;
-				$el.find(".filter-check").toggleClass("invisible", !is_active);
-			});
-	},
-
 	/** Build current visible columns state for layout persistence. */
 	get_current_columns_state() {
 		const columns = this.list_view.columns || [];
@@ -458,22 +385,6 @@ export const ListFilterMenu = {
 			.filter(Boolean);
 	},
 
-	/** Append Create / Manage action rows. */
-	append_layout_action_items($menu) {
-		const $create_item = this.layout_action_template(__("Create Layout"), "plus");
-		$create_item.find(".dropdown-item").on("click", (e) => {
-			e.preventDefault();
-			this.open_layout_dialog();
-		});
-		$menu.append($create_item);
-		const $manage_item = this.layout_action_template(__("Manage Layouts"), "settings");
-		$manage_item.find(".dropdown-item").on("click", (e) => {
-			e.preventDefault();
-			this.open_manage_layouts_dialog();
-		});
-		$menu.append($manage_item);
-	},
-
 	open_manage_layouts_dialog() {
 		new ManageLayoutsDialog({ list_filter: this });
 	},
@@ -486,36 +397,5 @@ export const ListFilterMenu = {
 			duplicate_from,
 			on_save: () => this.setup_layout_menu({ refetch: true }),
 		});
-	},
-
-	/** Build one static action menu row. */
-	layout_action_template(label, icon) {
-		return $(`
-			<li class="saved-layout-action-item">
-				<a class="dropdown-item d-flex align-items-center">
-					<span class="mr-2 flex align-items-center">${frappe.utils.icon(icon)}</span>
-					<span>${frappe.utils.escape_html(label)}</span>
-				</a>
-			</li>
-		`);
-	},
-
-	/** Build one saved layout dropdown row. */
-	filter_template(filter) {
-		const is_active = filter.name === (this.active_layout_name || "default_layout");
-		return $(`
-			<li class="saved-filter-item" data-name="${filter.name}">
-				<a class="dropdown-item d-flex justify-content-between align-items-center">
-					<span class="d-flex align-items-center">
-						<span class="filter-check mr-2 ${is_active ? "" : "invisible"}">
-							${frappe.utils.icon("check", "xs")}
-						</span>
-						<span class="filter-label">
-							${frappe.utils.escape_html(__(filter.filter_name))}
-						</span>
-					</span>
-				</a>
-			</li>
-		`);
 	},
 };

--- a/frappe/public/js/frappe/list/list_view_select.js
+++ b/frappe/public/js/frappe/list/list_view_select.js
@@ -1,25 +1,22 @@
 frappe.provide("frappe.views");
 
+/**
+ * The view switcher — one es-dropdown on the page header that lists every
+ * view the doctype supports. Rows with variants carry them as a submenu AT
+ * ALL TIMES (kanban boards, saved layouts, saved reports, calendars, inbox
+ * accounts), so you jump straight to a board or layout from any view instead
+ * of switching first and picking after. Variant lists that need a fetch load
+ * lazily at hover (menu.js async support). The current view's row is marked
+ * selected and shows its active variant as the description line.
+ *
+ * This replaced three separate header dropdowns: the old switcher, the
+ * "Select Kanban" group and the Saved Layouts button.
+ */
 frappe.views.ListViewSelect = class ListViewSelect {
 	constructor(opts) {
 		$.extend(this, opts);
 		this.set_current_view();
-		this.setup_views();
-	}
-
-	add_view_to_menu(view, action) {
-		if (this.doctype == "File" && view == "List") {
-			view = "File";
-		}
-		let $el = this.page.add_custom_menu_item(
-			this.parent,
-			this.label_map[view] || __(view),
-			action,
-			true,
-			null,
-			this.icon_map[view] || "list"
-		);
-		$el.parent().attr("data-view", view);
+		this.make_switcher();
 	}
 
 	set_current_view() {
@@ -37,19 +34,99 @@ frappe.views.ListViewSelect = class ListViewSelect {
 		}
 	}
 
-	set_route(view, calendar_name) {
-		const route = [this.slug(), "view", view];
-		if (calendar_name) route.push(calendar_name);
+	make_switcher() {
+		this.$wrapper = $('<div class="custom-btn-group view-switcher"></div>');
+		this.$trigger = frappe.ui.button({ css_class: "ellipsis" });
+		this.set_trigger_content(this.get_trigger_label());
+		this.$wrapper.append(this.$trigger);
 
-		let search_params = cur_list?.get_search_params();
-		if (search_params) {
-			frappe.route_options = Object.fromEntries(search_params);
-		}
-		frappe.set_route(route);
+		this.dropdown = new frappe.ui.Dropdown({
+			trigger: this.$trigger,
+			options: () => this.get_view_options(),
+		});
+
+		const parent = frappe.is_mobile()
+			? this.page.custom_mobile_actions
+			: this.page.custom_actions;
+		parent.removeClass("hide").append(this.$wrapper);
 	}
 
-	setup_views() {
-		const views = {
+	// the trigger shows WHERE YOU ARE: the view's icon plus the active
+	// variant when one is picked ("Overdue" with the list icon), else the
+	// plain view name ("List View")
+	get_trigger_label() {
+		const route = frappe.get_route();
+		switch (this.current_view) {
+			case "List": {
+				const filter = this.list_view.list_filter;
+				const label = filter?.active_layout_label;
+				return label && label !== filter?.default_layout_label
+					? label
+					: this.label_map["List"];
+			}
+			case "Kanban":
+				return this.kanban_board || this.label_map["Kanban"];
+			case "Calendar":
+				return route[3] && route[3] !== "default" ? route[3] : this.label_map["Calendar"];
+			case "Inbox":
+				return this.email_account || this.label_map["Inbox"];
+			case "Report":
+				return route.length > 3 ? this.get_page_name() : this.label_map["Report"];
+			default:
+				return this.label_map[this.current_view] || this.label_map["List"];
+		}
+	}
+
+	set_trigger_content(label) {
+		frappe.ui.button.dress(this.$trigger, {
+			label,
+			icon: this.icon_map[this.current_view] || "list",
+			icon_right: "chevrons-up-down",
+		});
+		// mobile collapses the trigger to the view icon alone (label and
+		// chevron hide below md; page.scss squares the button)
+		this.$trigger.find(".es-button__label").addClass("hidden-xs custom-btn-group-label");
+		this.$trigger.children("svg").last().addClass("hidden-xs");
+	}
+
+	// called when the active variant changes at runtime (a layout is
+	// selected or restored) so the trigger keeps showing the truth
+	refresh_trigger() {
+		this.set_trigger_content(this.get_trigger_label());
+	}
+
+	get_view_options() {
+		const views = this.get_views();
+		const options = [];
+
+		frappe.views.view_modes.forEach((view) => {
+			const config = views[view];
+			if (!config || !config.condition) return;
+
+			const label =
+				view === "List" && this.doctype === "File"
+					? __("File")
+					: this.label_map[view] || __(view);
+			const item = { label, icon: this.icon_map[view] || "list" };
+
+			// a submenu row doesn't act on click (it opens its panel), so a
+			// view with variants always leads with an entry row inside the
+			// submenu; a view without variants switches on click
+			const submenu = this.get_view_submenu(view, config);
+			if (submenu) item.submenu = submenu;
+			else if (this.current_view !== view) item.onclick = config.action;
+
+			if (this.current_view === view) {
+				item.selected = true;
+			}
+			options.push(item);
+		});
+
+		return options;
+	}
+
+	get_views() {
+		return {
 			List: {
 				condition: true,
 				action: () => this.set_route("list"),
@@ -57,18 +134,6 @@ frappe.views.ListViewSelect = class ListViewSelect {
 			Report: {
 				condition: true,
 				action: () => this.set_route("report"),
-				current_view_handler: () => {
-					const reports = this.get_reports();
-					let default_action = {};
-					// Only add action if current route is not report builder
-					if (frappe.get_route().length > 3) {
-						default_action = {
-							label: __("Report Builder"),
-							action: () => frappe.set_route("report"),
-						};
-					}
-					this.setup_dropdown_in_navbar("Report", reports, default_action);
-				},
 			},
 			Dashboard: {
 				condition: true,
@@ -79,11 +144,6 @@ frappe.views.ListViewSelect = class ListViewSelect {
 					frappe.views.calendar[this.doctype] ||
 					frappe.get_meta(this.doctype).is_calendar_and_gantt,
 				action: () => this.set_route("calendar", "default"),
-				current_view_handler: () => {
-					this.get_calendars().then((calendars) => {
-						this.setup_dropdown_in_navbar("Calendar", calendars);
-					});
-				},
 			},
 			Gantt: {
 				condition:
@@ -94,17 +154,6 @@ frappe.views.ListViewSelect = class ListViewSelect {
 			Inbox: {
 				condition: this.doctype === "Communication" && frappe.boot.email_accounts.length,
 				action: () => this.set_route("inbox"),
-				current_view_handler: () => {
-					const accounts = this.get_email_accounts();
-					let default_action;
-					if (has_common(frappe.user_roles, ["System Manager", "Administrator"])) {
-						default_action = {
-							label: __("New Email Account"),
-							action: () => frappe.new_doc("Email Account"),
-						};
-					}
-					this.setup_dropdown_in_navbar("Inbox", accounts, default_action);
-				},
 			},
 			Image: {
 				condition: this.list_view.meta.image_field,
@@ -119,11 +168,6 @@ frappe.views.ListViewSelect = class ListViewSelect {
 			Kanban: {
 				condition: this.doctype != "File",
 				action: () => this.setup_kanban_boards(),
-				current_view_handler: () => {
-					frappe.views.KanbanView.get_kanbans(this.doctype).then((kanbans) =>
-						this.setup_kanban_switcher(kanbans)
-					);
-				},
 			},
 			Map: {
 				condition:
@@ -136,62 +180,203 @@ frappe.views.ListViewSelect = class ListViewSelect {
 				action: () => this.set_route("map"),
 			},
 		};
-
-		frappe.views.view_modes.forEach((view) => {
-			if (this.current_view !== view && views[view].condition) {
-				this.add_view_to_menu(view, views[view].action);
-			}
-
-			if (this.current_view == view) {
-				views[view].current_view_handler && views[view].current_view_handler();
-			}
-		});
 	}
 
-	setup_dropdown_in_navbar(view, items, default_action) {
-		let placeholder = __("Select {0}", [__(view)]);
+	// a view's variants, as a submenu source (array, or a function for the
+	// lazy ones — menu.js resolves it at hover with a loading state). Present
+	// for every view that HAS variants, whichever view is current.
+	get_view_submenu(view, config) {
+		switch (view) {
+			case "List":
+				return this.get_layout_submenu(config);
+			case "Report":
+				return this.get_report_items();
+			case "Calendar":
+				return () => this.get_calendars().then((c) => this.get_calendar_items(c || []));
+			case "Inbox":
+				return this.get_inbox_items();
+			case "Kanban":
+				return () =>
+					frappe.views.KanbanView.get_kanbans(this.doctype).then((kanbans) =>
+						this.get_kanban_items(kanbans || [])
+					);
+			default:
+				return null;
+		}
+	}
 
-		if (items && items.length) {
-			items.map((item) => {
-				this.page.add_inner_button(
-					item.name,
-					() => location.replace(item.route),
-					placeholder
-				);
+	// Saved layouts under the List row. On the list view itself the rows
+	// apply in place (via the lazily-loaded list_filter bundle). From any
+	// other view, clicking a layout switches to the list view WITH that
+	// layout: the choice is saved as the active-layout preference and the
+	// route is set clean, so the list view's restore logic applies it on
+	// arrival.
+	get_layout_submenu(config) {
+		const lv = this.list_view;
+		if (this.current_view === "List") {
+			if (!lv.show_saved_layout_menu) return null;
+			return () => {
+				const ready = lv.list_filter
+					? Promise.resolve(lv.list_filter.setup_promise)
+					: lv.setup_list_filter_by();
+				return ready.then(() => lv.list_filter.get_layout_menu_items());
+			};
+		}
+
+		if (frappe.session.user === "Guest") return null;
+		return () =>
+			frappe.db
+				.get_list("List Filter", {
+					fields: ["name", "filter_name", "for_user"],
+					filters: { reference_doctype: this.doctype },
+					or_filters: [
+						["for_user", "=", frappe.session.user],
+						["for_user", "=", ""],
+					],
+					order_by: "filter_name asc",
+					limit: 200,
+				})
+				.then((layouts) => this.get_cross_view_layout_items(layouts || []));
+	}
+
+	get_cross_view_layout_items(layouts) {
+		const open_with_layout = (name) => {
+			// remember the choice, then route WITHOUT carrying the current
+			// view's filters — a layout defines its own, and URL filters
+			// would override the restore
+			frappe.model.user_settings.save(this.doctype, "List", {
+				active_layout_name: name === "default_layout" ? "" : name,
+			});
+			frappe.set_route([this.slug(), "view", "list"]);
+		};
+
+		const layout_row = (layout) => ({
+			label: __(layout.filter_name),
+			onclick: () => open_with_layout(layout.name),
+		});
+		const global_layouts = layouts.filter((f) => !f.for_user).map(layout_row);
+		const user_layouts = layouts
+			.filter((f) => f.for_user === frappe.session.user)
+			.map(layout_row);
+
+		const items = [
+			{
+				label: __("Default Layout"),
+				onclick: () => open_with_layout("default_layout"),
+			},
+		];
+		if (global_layouts.length) {
+			items.push({ group: __("Global Layouts"), options: global_layouts });
+		}
+		if (user_layouts.length) {
+			items.push({ group: __("Your Layouts"), options: user_layouts });
+		}
+		return items;
+	}
+
+	get_report_items() {
+		const route = frappe.get_route();
+		const on_report = this.current_view === "Report";
+		const items = [
+			{
+				label: __("Standard Report"),
+				selected: on_report && route.length <= 3,
+				onclick: () => this.set_route("report"),
+			},
+		];
+
+		const report_row = (report) => ({
+			label: report.name,
+			selected: on_report && route.length > 3 && route[3] === report.title,
+			href: report.route,
+		});
+		const reports = this.get_reports();
+		// reports saved from the report builder vs the query/script reports
+		// that developers ship for the doctype
+		const saved = reports.filter((r) => r.report_type === "Report Builder");
+		const related = reports.filter((r) => r.report_type !== "Report Builder");
+
+		if (saved.length) {
+			items.push({ group: __("Saved Reports"), options: saved.map(report_row) });
+		}
+		if (related.length) {
+			items.push({ group: __("Related Reports"), options: related.map(report_row) });
+		}
+		return items;
+	}
+
+	get_calendar_items(calendars) {
+		const current = this.current_view === "Calendar" ? frappe.get_route()[3] : null;
+		const items = [
+			{
+				label: __("Default"),
+				selected: current === "default",
+				onclick: () => this.set_route("calendar", "default"),
+			},
+		];
+		calendars
+			.filter((calendar) => calendar.name !== "Default")
+			.forEach((calendar) => {
+				items.push({
+					label: __(calendar.name),
+					selected: current === calendar.name,
+					href: calendar.route,
+				});
+			});
+		return items;
+	}
+
+	get_inbox_items() {
+		const items = this.get_email_accounts().map((account) => ({
+			label: account.name,
+			selected:
+				this.current_view === "Inbox" &&
+				this.email_account === account.route.split("/").pop(),
+			href: account.route,
+		}));
+		if (has_common(frappe.user_roles, ["System Manager", "Administrator"])) {
+			items.push({
+				label: __("New Email Account"),
+				icon: "plus",
+				onclick: () => frappe.new_doc("Email Account"),
 			});
 		}
-
-		if (default_action && Object.keys(default_action).length) {
-			this.page.add_inner_button(default_action.label, default_action.action, placeholder);
-		}
+		return items;
 	}
 
-	setup_kanban_switcher(kanbans) {
-		const kanban_switcher = this.page.add_custom_button_group(
-			__("Select Kanban"),
-			null,
-			this.list_view.$filter_section
-		);
-
-		kanbans.map((k) => {
-			this.page.add_custom_menu_item(
-				kanban_switcher,
-				k.name,
-				() => this.set_route("kanban", k.name),
-				false
-			);
-		});
-
-		let perms = this.list_view.board_perms;
-		let can_create = perms ? perms.create : true;
-		if (can_create) {
-			this.page.add_custom_menu_item(
-				kanban_switcher,
-				__("Create New Kanban Board"),
-				() => frappe.views.KanbanView.show_kanban_dialog(this.doctype),
-				true
-			);
+	get_kanban_items(kanbans) {
+		const items = kanbans.map((board) => ({
+			label: board.name,
+			selected: board.name === this.kanban_board,
+			onclick: () => this.set_route("kanban", board.name),
+		}));
+		const perms = this.list_view.board_perms;
+		if (perms ? perms.create : true) {
+			// its own group, like the layouts submenu's Create/Manage rows
+			items.push({
+				group: "",
+				hide_label: true,
+				options: [
+					{
+						label: __("Create Board"),
+						icon: "plus",
+						onclick: () => frappe.views.KanbanView.show_kanban_dialog(this.doctype),
+					},
+				],
+			});
 		}
+		return items;
+	}
+
+	set_route(view, calendar_name) {
+		const route = [this.slug(), "view", view];
+		if (calendar_name) route.push(calendar_name);
+
+		let search_params = cur_list?.get_search_params();
+		if (search_params) {
+			frappe.route_options = Object.fromEntries(search_params);
+		}
+		frappe.set_route(route);
 	}
 
 	get_page_name() {
@@ -218,6 +403,10 @@ frappe.views.ListViewSelect = class ListViewSelect {
 						added.push(route);
 						reports_to_add.push({
 							name: __(r.title || r.name),
+							// raw title (route segment) and type, so the menu
+							// can mark the open report and group by kind
+							title: r.title || r.name,
+							report_type: r.report_type,
 							route: route,
 						});
 					}
@@ -328,5 +517,69 @@ frappe.views.ListViewSelect = class ListViewSelect {
 
 	slug() {
 		return frappe.router.slug(frappe.router.doctype_layout || this.doctype);
+	}
+
+	// ─── legacy API (kept for compatibility — the espresso switcher above
+	//     doesn't use these, but apps may call them) ────────────────────────
+
+	add_view_to_menu(view, action) {
+		if (this.doctype == "File" && view == "List") {
+			view = "File";
+		}
+		let $el = this.page.add_custom_menu_item(
+			this.parent,
+			this.label_map[view] || __(view),
+			action,
+			true,
+			null,
+			this.icon_map[view] || "list"
+		);
+		$el.parent().attr("data-view", view);
+	}
+
+	setup_dropdown_in_navbar(view, items, default_action) {
+		let placeholder = __("Select {0}", [__(view)]);
+
+		if (items && items.length) {
+			items.map((item) => {
+				this.page.add_inner_button(
+					item.name,
+					() => location.replace(item.route),
+					placeholder
+				);
+			});
+		}
+
+		if (default_action && Object.keys(default_action).length) {
+			this.page.add_inner_button(default_action.label, default_action.action, placeholder);
+		}
+	}
+
+	setup_kanban_switcher(kanbans) {
+		const kanban_switcher = this.page.add_custom_button_group(
+			__("Select Kanban"),
+			null,
+			this.list_view.$filter_section
+		);
+
+		kanbans.map((k) => {
+			this.page.add_custom_menu_item(
+				kanban_switcher,
+				k.name,
+				() => this.set_route("kanban", k.name),
+				false
+			);
+		});
+
+		let perms = this.list_view.board_perms;
+		let can_create = perms ? perms.create : true;
+		if (can_create) {
+			this.page.add_custom_menu_item(
+				kanban_switcher,
+				__("Create New Kanban Board"),
+				() => frappe.views.KanbanView.show_kanban_dialog(this.doctype),
+				true
+			);
+		}
 	}
 };

--- a/frappe/public/js/frappe/list/list_view_select.js
+++ b/frappe/public/js/frappe/list/list_view_select.js
@@ -243,11 +243,15 @@ frappe.views.ListViewSelect = class ListViewSelect {
 		const open_with_layout = (name) => {
 			// remember the choice, then route WITHOUT carrying the current
 			// view's filters — a layout defines its own, and URL filters
-			// would override the restore
-			frappe.model.user_settings.save(this.doctype, "List", {
-				active_layout_name: name === "default_layout" ? "" : name,
-			});
-			frappe.set_route([this.slug(), "view", "list"]);
+			// would override the restore. The route waits for the save:
+			// user_settings.save only updates the local cache in its server
+			// callback, so routing immediately would let the arriving list
+			// view restore from the stale value.
+			frappe.model.user_settings
+				.save(this.doctype, "List", {
+					active_layout_name: name === "default_layout" ? "" : name,
+				})
+				.then(() => frappe.set_route([this.slug(), "view", "list"]));
 		};
 
 		const layout_row = (layout) => ({

--- a/frappe/public/js/frappe/list/list_view_select.js
+++ b/frappe/public/js/frappe/list/list_view_select.js
@@ -247,11 +247,14 @@ frappe.views.ListViewSelect = class ListViewSelect {
 			// user_settings.save only updates the local cache in its server
 			// callback, so routing immediately would let the arriving list
 			// view restore from the stale value.
+			const go = () => frappe.set_route([this.slug(), "view", "list"]);
 			frappe.model.user_settings
 				.save(this.doctype, "List", {
 					active_layout_name: name === "default_layout" ? "" : name,
 				})
-				.then(() => frappe.set_route([this.slug(), "view", "list"]));
+				// a failed save must not make the click inert — the list
+				// opens either way, just without the chosen layout applied
+				.then(go, go);
 		};
 
 		const layout_row = (layout) => ({

--- a/frappe/public/js/frappe/ui/components/menu.js
+++ b/frappe/public/js/frappe/ui/components/menu.js
@@ -63,6 +63,26 @@ const SUBMENU_OFFSET = 4;
 const SUBMENU_OPEN_DELAY = 150;
 const EXIT_MS = 140;
 const TYPEAHEAD_RESET_MS = 1000;
+// how long the safe-triangle grace lasts after leaving a submenu row —
+// enough to cross the menu diagonally, short enough that a change of mind
+// (parking on a sibling) recovers quickly. Same value radix uses.
+const GRACE_MS = 300;
+// widen the triangle a little around the exit point and the panel corners so
+// pointer paths that hug an edge stay inside it
+const GRACE_PAD = 5;
+
+// ray-casting point-in-polygon; polygon is [[x, y], ...]
+function point_in_polygon(x, y, polygon) {
+	let inside = false;
+	for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+		const [xi, yi] = polygon[i];
+		const [xj, yj] = polygon[j];
+		if (yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi) {
+			inside = !inside;
+		}
+	}
+	return inside;
+}
 
 function is_group(entry) {
 	return entry && typeof entry === "object" && "group" in entry && Array.isArray(entry.options);
@@ -331,6 +351,10 @@ export class MenuTree {
 		// pending promise (see get_submenu_items)
 		this.submenu_cache = new Map();
 		this.submenu_timer = null;
+		// the safe triangle: while the pointer travels from a submenu row
+		// toward its open panel, sibling rows must not steal the highlight or
+		// close the panel. { polygon, expiry } or null.
+		this.grace = null;
 		this.typeahead_buffer = "";
 		this.typeahead_timer = null;
 		this.mnemonics_visible = false; // Alt held → underlines showing
@@ -370,6 +394,11 @@ export class MenuTree {
 		this.onreposition = () => this.reposition();
 		window.addEventListener("resize", this.onreposition);
 		document.addEventListener("scroll", this.onreposition, { capture: true, passive: true });
+
+		// the safe triangle is judged on every pointer move (cheap: a null
+		// check when no grace is active)
+		this.ongracemove = (e) => this.handle_grace_move(e);
+		document.addEventListener("pointermove", this.ongracemove, true);
 
 		if (this.lock_scroll) {
 			// context menus freeze the page: a stray trackpad flick shouldn't
@@ -440,6 +469,15 @@ export class MenuTree {
 	bind_panel(entry) {
 		this.bind_rows(entry);
 
+		// reaching any panel surface — including its padding and group labels,
+		// not just a row — means the pointer arrived at a menu: a close
+		// pending from a previously hovered row must not fire under the
+		// cursor, and any safe-triangle journey is complete
+		entry.panel.addEventListener("pointerenter", () => {
+			clearTimeout(this.submenu_timer);
+			this.grace = null;
+		});
+
 		// whichever row has focus carries the highlight — this is the only
 		// place data-highlighted is ever set. Reads entry.rows live (not a
 		// captured copy) so an async fill's new rows are covered too.
@@ -478,11 +516,78 @@ export class MenuTree {
 			});
 
 			// the highlight follows the pointer; focus follows so keyboard
-			// navigation continues from where the mouse was
-			row.el.addEventListener("pointerenter", () => {
+			// navigation continues from where the mouse was. While the safe
+			// triangle is active the pointer is on its way to an open
+			// submenu — siblings crossed en route must not steal the
+			// highlight or schedule anything.
+			row.el.addEventListener("pointerenter", (e) => {
+				if (this.in_grace(e)) return;
 				row.el.focus({ preventScroll: true });
 				this.schedule_submenu(entry, row);
 			});
+
+			// leaving a row whose submenu is open starts the safe triangle:
+			// exit point + the panel's near corners
+			row.el.addEventListener("pointerleave", (e) => {
+				this.start_grace(entry, row, e);
+			});
+		}
+	}
+
+	// ---- the safe triangle (hover grace toward an open submenu) ----
+
+	start_grace(entry, row, e) {
+		const depth = this.panels.indexOf(entry);
+		const child = this.panels[depth + 1];
+		// only when THIS row's submenu is open
+		if (!child || child.parent_row !== row.el) return;
+
+		const rect = child.panel.getBoundingClientRect();
+		// the triangle spans from the exit point (nudged back so edge-hugging
+		// paths stay inside) to the panel's near edge, padded top and bottom
+		const opens_left = rect.left < e.clientX;
+		const near_x = opens_left ? rect.right : rect.left;
+		const origin_x = e.clientX + (opens_left ? GRACE_PAD : -GRACE_PAD);
+		this.grace = {
+			polygon: [
+				[origin_x, e.clientY],
+				[near_x, rect.top - GRACE_PAD],
+				[near_x, rect.bottom + GRACE_PAD],
+			],
+			expiry: Date.now() + GRACE_MS,
+		};
+	}
+
+	in_grace(e) {
+		if (!this.grace) return false;
+		if (Date.now() > this.grace.expiry) {
+			this.grace = null;
+			return false;
+		}
+		return point_in_polygon(e.clientX, e.clientY, this.grace.polygon);
+	}
+
+	// once the pointer leaves the triangle (or the grace expires), hand
+	// control back to whatever row it is actually on — pointerenter already
+	// fired and was suppressed, so it won't fire again without this
+	handle_grace_move(e) {
+		if (!this.grace) return;
+		if (
+			Date.now() <= this.grace.expiry &&
+			point_in_polygon(e.clientX, e.clientY, this.grace.polygon)
+		) {
+			return;
+		}
+		this.grace = null;
+		const row_el = e.target instanceof Element && e.target.closest(".es-menu__item");
+		if (!row_el) return;
+		for (const entry of this.panels) {
+			const row = entry.rows.find((r) => r.el === row_el);
+			if (row) {
+				row.el.focus({ preventScroll: true });
+				this.schedule_submenu(entry, row);
+				return;
+			}
 		}
 	}
 
@@ -831,6 +936,8 @@ export class MenuTree {
 		document.removeEventListener("pointerdown", this.onpointerdown, true);
 		window.removeEventListener("resize", this.onreposition);
 		document.removeEventListener("scroll", this.onreposition, { capture: true });
+		document.removeEventListener("pointermove", this.ongracemove, true);
+		this.grace = null;
 		if (this.onwheel) {
 			window.removeEventListener("wheel", this.onwheel, { capture: true });
 			window.removeEventListener("touchmove", this.onwheel, { capture: true });

--- a/frappe/public/js/frappe/ui/components/menu.js
+++ b/frappe/public/js/frappe/ui/components/menu.js
@@ -473,7 +473,12 @@ export class MenuTree {
 		// not just a row — means the pointer arrived at a menu: a close
 		// pending from a previously hovered row must not fire under the
 		// cursor, and any safe-triangle journey is complete
-		entry.panel.addEventListener("pointerenter", () => {
+		entry.panel.addEventListener("pointerenter", (e) => {
+			// real pointerenter doesn't bubble — the panel only ever sees
+			// itself as target. Synthetic events (tests) may bubble up from a
+			// row; those are the row's business, and clearing here would kill
+			// the submenu-open timer the row just scheduled.
+			if (e.target !== entry.panel) return;
 			clearTimeout(this.submenu_timer);
 			this.grace = null;
 		});


### PR DESCRIPTION
On list, kanban, and report views - we used to show an additional dropdown to select the corresponding layout. This has now been consolidated to a single dropdown menu - and hence is also available on mobile devices.



https://github.com/user-attachments/assets/b617593b-e548-4e13-80da-17ad07806700




`no-docs`