### PR TITLE
feat: allow scheduled jobs to override their worker queue

### DIFF
--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
@@ -71,7 +71,8 @@
    "read_only": 1
   },
   {
-   "description": "If unset, jobs with a Long or Maintenance frequency run on the long queue and all others on the default queue.",
+   "depends_on": "eval:doc.frequency==='Cron'",
+   "description": "If unset, cron jobs run on the default queue.",
    "fieldname": "queue",
    "fieldtype": "Select",
    "label": "Queue",

--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
@@ -24,6 +24,7 @@
   "scheduler_event",
   "frequency",
   "cron_format",
+  "queue",
   "create_log",
   "status_section",
   "last_execution",
@@ -68,6 +69,14 @@
    "label": "Cron Format",
    "not_nullable": 1,
    "read_only": 1
+  },
+  {
+   "description": "If unset, jobs with a Long or Maintenance frequency run on the long queue and all others on the default queue.",
+   "fieldname": "queue",
+   "fieldtype": "Select",
+   "label": "Queue",
+   "options": "\ndefault\nshort\nlong",
+   "read_only_depends_on": "eval:doc.server_script"
   },
   {
    "fieldname": "frequency",
@@ -118,7 +127,7 @@
    "link_fieldname": "scheduled_job_type"
   }
  ],
- "modified": "2026-08-03 21:30:28.554421",
+ "modified": "2026-08-04 18:13:18.045480",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Scheduled Job Type",

--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
@@ -49,6 +49,7 @@ class ScheduledJobType(Document):
 		]
 		last_execution: DF.Datetime | None
 		method: DF.Data
+		queue: DF.Literal["", "default", "short", "long"]
 		scheduler_event: DF.Link | None
 		server_script: DF.Link | None
 		stopped: DF.Check
@@ -198,6 +199,8 @@ class ScheduledJobType(Document):
 		frappe.db.commit()
 
 	def get_queue_name(self):
+		if self.queue:
+			return self.queue
 		return "long" if ("Long" in self.frequency or "Maintenance" in self.frequency) else "default"
 
 	def on_trash(self):

--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
@@ -70,6 +70,8 @@ class ScheduledJobType(Document):
 					_("{0} is not a valid Cron expression.").format(f"<code>{self.cron_format}</code>"),
 					title=_("Bad Cron Expression"),
 				)
+		else:
+			self.queue = ""
 
 	@property
 	def is_app_disabled(self) -> bool:

--- a/frappe/core/doctype/scheduled_job_type/test_scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/test_scheduled_job_type.py
@@ -114,6 +114,13 @@ class TestScheduledJobType(IntegrationTestCase):
 		long_job = frappe.new_doc("Scheduled Job Type", frequency="Daily Long")
 		self.assertEqual(long_job.get_queue_name(), "long")
 
+		long_job.method = "frappe.desk.notifications.clear_notifications"
+		long_job.queue = "short"
+		long_job.insert()
+		self.assertFalse(long_job.queue)
+		self.assertEqual(long_job.get_queue_name(), "long")
+		frappe.db.rollback()
+
 	def test_maintenance_jobs(self):
 		sjt = frappe.new_doc(
 			"Scheduled Job Type",

--- a/frappe/core/doctype/scheduled_job_type/test_scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/test_scheduled_job_type.py
@@ -104,6 +104,16 @@ class TestScheduledJobType(IntegrationTestCase):
 		self.assertFalse(job.is_event_due(get_datetime("2019-01-01 00:05:06")))
 		self.assertFalse(job.is_event_due(get_datetime("2019-01-01 00:09:59")))
 
+	def test_queue_selection(self):
+		cron_job = frappe.new_doc("Scheduled Job Type", frequency="Cron", cron_format="0 22 * * *")
+		self.assertEqual(cron_job.get_queue_name(), "default")
+
+		cron_job.queue = "long"
+		self.assertEqual(cron_job.get_queue_name(), "long")
+
+		long_job = frappe.new_doc("Scheduled Job Type", frequency="Daily Long")
+		self.assertEqual(long_job.get_queue_name(), "long")
+
 	def test_maintenance_jobs(self):
 		sjt = frappe.new_doc(
 			"Scheduled Job Type",

--- a/frappe/core/doctype/server_script/server_script.json
+++ b/frappe/core/doctype/server_script/server_script.json
@@ -145,8 +145,8 @@
    "label": "Cron Format"
   },
   {
-   "depends_on": "eval:doc.script_type === \"Scheduler Event\"",
-   "description": "If unset, jobs with a Long frequency run on the long queue and all others on the default queue.",
+   "depends_on": "eval:doc.script_type === \"Scheduler Event\" && doc.event_frequency === 'Cron'",
+   "description": "If unset, cron jobs run on the default queue.",
    "fieldname": "queue",
    "fieldtype": "Select",
    "label": "Queue",
@@ -160,7 +160,7 @@
    "link_fieldname": "server_script"
   }
  ],
- "modified": "2026-07-27 14:26:17.061284",
+ "modified": "2026-08-04 18:13:18.243389",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Server Script",

--- a/frappe/core/doctype/server_script/server_script.json
+++ b/frappe/core/doctype/server_script/server_script.json
@@ -10,6 +10,7 @@
   "reference_doctype",
   "event_frequency",
   "cron_format",
+  "queue",
   "doctype_event",
   "api_method",
   "allow_guest",
@@ -142,6 +143,14 @@
    "fieldname": "cron_format",
    "fieldtype": "Data",
    "label": "Cron Format"
+  },
+  {
+   "depends_on": "eval:doc.script_type === \"Scheduler Event\"",
+   "description": "If unset, jobs with a Long frequency run on the long queue and all others on the default queue.",
+   "fieldname": "queue",
+   "fieldtype": "Select",
+   "label": "Queue",
+   "options": "\ndefault\nshort\nlong"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -151,7 +160,7 @@
    "link_fieldname": "server_script"
   }
  ],
- "modified": "2025-09-02 11:11:07.528661",
+ "modified": "2026-07-27 14:26:17.061284",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Server Script",

--- a/frappe/core/doctype/server_script/server_script.py
+++ b/frappe/core/doctype/server_script/server_script.py
@@ -78,6 +78,7 @@ class ServerScript(Document):
 			"Cron",
 		]
 		module: DF.Link | None
+		queue: DF.Literal["", "default", "short", "long"]
 		rate_limit_count: DF.Int
 		rate_limit_seconds: DF.Int
 		reference_doctype: DF.Link | None
@@ -142,6 +143,7 @@ class ServerScript(Document):
 		if self.script_type != "Scheduler Event" or not (
 			self.has_value_changed("event_frequency")
 			or self.has_value_changed("cron_format")
+			or self.has_value_changed("queue")
 			or self.has_value_changed("disabled")
 			or self.has_value_changed("script_type")
 		):
@@ -152,6 +154,7 @@ class ServerScript(Document):
 				"method": frappe.scrub(f"{self.name}-{self.event_frequency}"),
 				"frequency": self.event_frequency,
 				"cron_format": self.cron_format if self.event_frequency == "Cron" else "",
+				"queue": self.queue,
 				"stopped": self.disabled,
 			}
 		).save()

--- a/frappe/core/doctype/server_script/test_server_script.py
+++ b/frappe/core/doctype/server_script/test_server_script.py
@@ -373,6 +373,16 @@ frappe.qb.from_(todo).select(todo.name).where(todo.name == "{todo.name}").run()
 		self.assertEqual(job.reload().frequency, "Cron")
 		self.assertEqual(job.reload().cron_format, script.cron_format)
 
+		script.queue = "long"
+		script.save()
+		self.assertEqual(job.reload().queue, "long")
+		self.assertEqual(job.get_queue_name(), "long")
+
+		script.queue = ""
+		script.save()
+		self.assertFalse(job.reload().queue)
+		self.assertEqual(job.get_queue_name(), "default")
+
 		# manually disable
 
 		script.disabled = 1


### PR DESCRIPTION
## Summary

`ScheduledJobType.get_queue_name` derives the RQ queue from the job frequency: `Long` and `Maintenance` jobs use the `long` queue, while everything else goes to `default`. Since Cron jobs have no long-frequency variant, they're always queued on `default` and inherit its 300s timeout, causing longer-running cron jobs to be terminated by RQ.

A common workaround is to enqueue the real work as a second job with a custom timeout, but that breaks `Scheduled Job Log`, which only tracks the outer scheduling job.

## Fix

Add an optional `queue` field to **Scheduled Job Type** and **Server Script**.

When set, `get_queue_name()` uses the configured queue directly. When left empty, the existing frequency-based behavior is unchanged, so current jobs continue to work as before.

For script-backed jobs, the field is managed from the Server Script and synced to its Scheduled Job Type, just like frequency and cron settings.

The available options are the built-in RQ queues (`default`, `short`, and `long`), matching the **RQ Job** doctype. Sites that need longer timeouts can continue to configure them through the `workers` section of `common_site_config.json`.

`no-docs`

---

Closes #41220.