### PR TITLE
feat(ui): better read-only and impersonation banners

### DIFF
--- a/frappe/public/js/desk.bundle.js
+++ b/frappe/public/js/desk.bundle.js
@@ -51,6 +51,7 @@ import "./frappe/roles_editor.js";
 import "./frappe/module_editor.js";
 import "./frappe/microtemplate.js";
 
+import "./frappe/ui/site_banners.js";
 import "./frappe/ui/page.html";
 import "./frappe/ui/page.js";
 import "./frappe/ui/slides.js";

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -379,6 +379,7 @@ frappe.Application = class Application {
 				"body"
 			);
 			frappe.container = new frappe.views.Container();
+			frappe.ui.setup_site_banners();
 		}
 	}
 	make_nav_bar() {

--- a/frappe/public/js/frappe/ui/page.html
+++ b/frappe/public/js/frappe/ui/page.html
@@ -32,22 +32,6 @@
 				</button>
 				<div class="flex col page-actions justify-content-end {% if frappe.is_mobile() %} pl-0 {% endif %}">
 					<!-- buttons -->
-					{% if (frappe.boot.read_only) { %}
-					{%= frappe.ui.badge.html({
-						label: __("Read Only Mode"),
-						theme: "amber",
-						css_class: "ml-2 read-only-banner",
-						title: __("Your site is undergoing maintenance or being updated."),
-					}) %}
-					{% } %}
-					{% if (frappe.boot.user.impersonated_by) { %}
-					{%= frappe.ui.badge.html({
-						label: __("Impersonating {0}", [frappe.boot.user.name]),
-						theme: "red",
-						css_class: "ml-2",
-						title: __("You are impersonating as another user."),
-					}) %}
-					{% } %}
 					<div class="filters flex"></div>
 					<div class="custom-actions hide hidden-xs hidden-md"></div>
 					<div class="custom-mobile-actions"></div>

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -68,7 +68,6 @@ frappe.ui.Page = class Page {
 	make() {
 		this.wrapper = $(this.parent);
 		this.add_main_section();
-		this.setup_scroll_handler();
 		this.setup_main_sidebar_toggle();
 		this.setup_awesomebar();
 	}
@@ -88,24 +87,6 @@ frappe.ui.Page = class Page {
 				}, __("Background Jobs"));
 			}
 		}
-	}
-
-	setup_scroll_handler() {
-		let last_scroll = 0;
-		$(".main-section").scroll(
-			frappe.utils.throttle(() => {
-				$(".page-head").toggleClass("drop-shadow", !!document.documentElement.scrollTop);
-				let current_scroll = document.documentElement.scrollTop;
-				if (
-					current_scroll > 0 &&
-					last_scroll <= current_scroll &&
-					(frappe.boot.read_only || frappe.boot.user.impersonated_by)
-				) {
-					$(".page-head").css("top", "-15px");
-				}
-				last_scroll = current_scroll;
-			}, 500)
-		);
 	}
 
 	get_empty_state(title, message, primary_action) {

--- a/frappe/public/js/frappe/ui/site_banners.js
+++ b/frappe/public/js/frappe/ui/site_banners.js
@@ -1,0 +1,45 @@
+frappe.provide("frappe.ui");
+
+/**
+ * Site-state banners — read-only mode and impersonation — shown ONCE above
+ * the page header, at the top of the scrollable content column (so they sit
+ * beside the sidebar, not across the whole viewport).
+ *
+ * Deliberately not part of frappe.ui.Page: pages come and go SPA-style while
+ * the site state doesn't, so rendering these in every page header meant every
+ * page duplicated them. The shell mounts this once at startup.
+ *
+ * Composed from utility classes only (the Gameplan ReadOnlyBanner pattern).
+ */
+frappe.ui.setup_site_banners = function () {
+	const banners = [];
+
+	if (frappe.boot.read_only) {
+		banners.push({
+			css_class: "bg-surface-gray-2 text-ink-gray-6",
+			message: __(
+				"This site is in read-only mode - it is undergoing maintenance or being updated."
+			),
+		});
+	}
+
+	if (frappe.boot.user.impersonated_by) {
+		banners.push({
+			css_class: "bg-surface-red-1 text-ink-red-7",
+			message: __("You are impersonating {0}.", [frappe.boot.user.name]),
+		});
+	}
+
+	if (!banners.length) return;
+
+	const $wrapper = $('<div class="site-banners"></div>');
+	banners.forEach((banner) => {
+		const $banner = $(
+			`<div class="${banner.css_class} py-2.5 text-p-sm"><div class="container"></div></div>`
+		);
+		// .container so the text lines up with the page header's content
+		$banner.find(".container").text(banner.message);
+		$wrapper.append($banner);
+	});
+	$wrapper.insertBefore("#body");
+};

--- a/frappe/public/js/frappe/ui/toolbar/toolbar.js
+++ b/frappe/public/js/frappe/ui/toolbar/toolbar.js
@@ -27,7 +27,6 @@ frappe.ui.toolbar.Toolbar = class {
 
 		this.setup_help();
 
-		this.setup_read_only_mode();
 		this.setup_announcement_widget();
 		this.make();
 	}
@@ -151,15 +150,6 @@ frappe.ui.toolbar.Toolbar = class {
 			setTimeout(function () {
 				search_modal.find("#modal-search").focus();
 			}, 300);
-		});
-	}
-
-	setup_read_only_mode() {
-		if (!frappe.boot.read_only) return;
-
-		$("header .read-only-banner").tooltip({
-			delay: { show: 600, hide: 100 },
-			trigger: "hover",
 		});
 	}
 

--- a/frappe/public/scss/common/utilities.scss
+++ b/frappe/public/scss/common/utilities.scss
@@ -113,7 +113,7 @@
 }
 
 /* ---- spacing (1 step = 0.25rem) ----
-   Makes gap-* plus padding/margin classes for steps 0.5 to 4.
+   Makes gap-* plus the full padding/margin family for the steps below.
    ps/pe/ms/me mean start and end — they flip automatically in
    right-to-left languages. Prefer gap on the parent over margins. */
 
@@ -122,6 +122,7 @@ $spacing-steps: (
 	"1": 1,
 	"1\\.5": 1.5,
 	"2": 2,
+	"2\\.5": 2.5,
 	"3": 3,
 	"4": 4,
 	"5": 5,
@@ -143,16 +144,18 @@ $spacing-steps: (
 	}
 }
 
-/* p-*, px-, py-, pt-, pb- and the m- versions are NOT defined here — but you
-   can use them in markup anyway. Bootstrap owns those exact names (with
-   !important), and as of the $spacers remap in desk/variables.scss its scale
-   now matches ours: bootstrap .p-3 = 12px = our .gap-3, .p-4 = 16px, and so on
-   up the 4px grid. So reach for bootstrap's p-* and m-* for physical padding and
-   margin; use ps-*,pe-*,ms-*,me-* below when you need logical (RTL-flipping)
-   sides, or gap on the parent. When bootstrap's utilities are eventually
-   dropped, these names move here — same values, no markup change. */
-
+/* p/m utilities coexist with Bootstrap's identically-named ones. For steps
+   Bootstrap defines (whole numbers), its !important physical declarations
+   still win in devtools — harmless, because the $spacers remap in
+   desk/variables.scss made the values identical. The fractional steps (0.5,
+   1.5, 2.5) exist only here. When Bootstrap's utilities are dropped, these
+   take over with no markup change. Logical properties (padding-inline/-block)
+   on purpose: same result today, RTL-safe forever. */
 @each $name, $n in $spacing-steps {
+	.p-#{$name} {
+		padding: spacing-step($n);
+	}
+
 	.ps-#{$name} {
 		padding-inline-start: spacing-step($n);
 	}
@@ -160,15 +163,51 @@ $spacing-steps: (
 	.pe-#{$name} {
 		padding-inline-end: spacing-step($n);
 	}
+
+	.py-#{$name} {
+		padding-block: spacing-step($n);
+	}
+
+	.px-#{$name} {
+		padding-inline: spacing-step($n);
+	}
+
+	.pt-#{$name} {
+		padding-top: spacing-step($n);
+	}
+
+	.pb-#{$name} {
+		padding-bottom: spacing-step($n);
+	}
 }
 
 @each $name, $n in $spacing-steps {
+	.m-#{$name} {
+		margin: spacing-step($n);
+	}
+
 	.ms-#{$name} {
 		margin-inline-start: spacing-step($n);
 	}
 
 	.me-#{$name} {
 		margin-inline-end: spacing-step($n);
+	}
+
+	.my-#{$name} {
+		margin-block: spacing-step($n);
+	}
+
+	.mx-#{$name} {
+		margin-inline: spacing-step($n);
+	}
+
+	.mt-#{$name} {
+		margin-top: spacing-step($n);
+	}
+
+	.mb-#{$name} {
+		margin-bottom: spacing-step($n);
 	}
 }
 


### PR DESCRIPTION

<img width="3140" height="1838" alt="CleanShot 2026-07-27 at 14 53 30@2x" src="https://github.com/user-attachments/assets/adaa6c2a-d91e-435b-866b-f6447229f012" />

<img width="3140" height="1839" alt="CleanShot 2026-07-27 at 14 54 07@2x" src="https://github.com/user-attachments/assets/fb4211c8-64ef-4ac7-973b-21483aaa480c" />


`no-docs`