### PR TITLE
fix(api): validate HTTP method for document calls (backport)

### DIFF
--- a/frappe/api/v1.py
+++ b/frappe/api/v1.py
@@ -4,6 +4,7 @@ from werkzeug.routing import Rule
 
 import frappe
 from frappe import _
+from frappe.handler import is_valid_http_method
 from frappe.utils import attach_expanded_links
 from frappe.utils.data import sbool
 
@@ -115,6 +116,9 @@ def execute_doc_method(doctype: str, name: str, method: str | None = None):
 	method = method or frappe.form_dict.pop("run_method")
 	doc = frappe.get_doc(doctype, name)
 	doc.is_whitelisted(method)
+	method_obj = getattr(doc, method)
+	fn = getattr(method_obj, "__func__", method_obj)
+	is_valid_http_method(fn)
 
 	if frappe.request.method == "GET":
 		doc.check_permission("read")

--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -228,6 +228,9 @@ def execute_doc_method(doctype: str, name: str, method: str | None = None):
 	method = method or frappe.form_dict.pop("run_method")
 	doc = frappe.get_doc(doctype, name)
 	doc.is_whitelisted(method)
+	method_obj = getattr(doc, method)
+	fn = getattr(method_obj, "__func__", method_obj)
+	is_valid_http_method(fn)
 
 	doc.check_permission(PERMISSION_MAP[frappe.request.method])
 	result = doc.run_method(method, **frappe.form_dict)

--- a/frappe/tests/test_api.py
+++ b/frappe/tests/test_api.py
@@ -295,6 +295,21 @@ class TestResourceAPI(FrappeAPITestCase):
 			self.assertIsInstance(data, list)
 			self.assertIsInstance(data[0], dict)
 
+	def test_run_doc_method_v1_validates_http_method(self):
+		doc = frappe.get_doc("Website Theme", "Standard")
+		method = getattr(doc.get_apps, "__func__", doc.get_apps)
+
+		with (
+			patch.dict(frappe.allowed_http_methods_for_whitelisted_func, {method: ["POST"]}),
+			suppress_stdout(),
+		):
+			response = self.get(
+				self.resource("Website Theme", "Standard"),
+				{"run_method": "get_apps", "sid": self.sid},
+			)
+
+		self.assertEqual(response.status_code, 403)
+
 
 class TestMethodAPI(FrappeAPITestCase):
 	def test_ping(self):

--- a/frappe/tests/test_api_v2.py
+++ b/frappe/tests/test_api_v2.py
@@ -1,5 +1,6 @@
 import typing
 from random import choice
+from unittest.mock import patch
 
 import requests
 
@@ -124,6 +125,20 @@ class TestResourceAPIV2(FrappeAPITestCase):
 	def test_execute_doc_method(self):
 		response = self.get(self.resource("Website Theme", "Standard", "method", "get_apps"))
 		self.assertEqual(response.json["data"][0]["name"], "frappe")
+
+	def test_execute_doc_method_v2_validates_http_method(self):
+		doc = frappe.get_doc("Website Theme", "Standard")
+		method = getattr(doc.get_apps, "__func__", doc.get_apps)
+
+		with (
+			patch.dict(frappe.allowed_http_methods_for_whitelisted_func, {method: ["POST"]}),
+			suppress_stdout(),
+		):
+			response = self.get(
+				self.resource("Website Theme", "Standard", "method", "get_apps"), {"sid": self.sid}
+			)
+
+		self.assertEqual(response.status_code, 403)
 
 	def test_update_document(self):
 		generated_desc = frappe.mock("paragraph")


### PR DESCRIPTION
Backport of 99cf7d98e7 ("fix(api): validate HTTP method for document calls") from `develop`.

## Problem

A whitelisted method's declared `methods=` is enforced on `/api/method/*` (`handle_rpc_call`) and on
`run_doc_method`, but **not** on the document-method routes:

- `/api/v2/document/<doctype>/<name>/method/<method>` — `v2.execute_doc_method`
- `POST /api/resource/<doctype>/<name>/?run_method=<method>` and the `GET ... ?run_method=` fallback
  in `read_doc` — `v1.execute_doc_method`

Both are mounted for GET as well as POST, and neither calls `is_valid_http_method`. So a method
declared `@frappe.whitelist(methods=["POST"])` is still reachable over GET on the route the
frappe-ui SPA actually uses via `useDoc({ methods })`.

That is worse than a missing check, because `frappe/app.py::sync_database` rolls back the
transaction at the end of every GET request. A mutating doc method invoked over GET runs, calls
`save()` without raising, returns a success response — and the write is silently discarded. The
declaration reads as enforced and is documentation-only.

## Change

Three lines in each of `v1.execute_doc_method` and `v2.execute_doc_method`, after the existing
`doc.is_whitelisted(method)`:

```python
method_obj = getattr(doc, method)
fn = getattr(method_obj, "__func__", method_obj)
is_valid_http_method(fn)
```

Plus the two tests from the original commit, one per API version, asserting 403 for a GET against a
method declared `methods=["POST"]`.

## Notes on the backport

`develop` needed no change — all three whitelisted-invoking paths are already guarded there
(`handle_rpc_call`, `run_doc_method` via c290cffc27, and `execute_doc_method` via 99cf7d98e7).
This branch has the first two but not the third, which is why the gap is v16-only.

Two conflicts, both incidental:

- `frappe/api/v1.py` — the upstream hunk carried a `DefaultOrderBy` import that only exists on
  `develop`; dropped, only the `is_valid_http_method` import is kept.
- `frappe/tests/test_api_v2.py` — the hunk anchored on `test_update_document_v2`, which is still
  named `test_update_document` here; anchor restored. `from unittest.mock import patch` added,
  since this branch's `test_api_v2.py` did not already import it.

`is_valid_http_method` is byte-identical on both branches, so behaviour matches `develop` exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBJ9E3nUHQnJTF6mCTfRjW
