### PR TITLE
fix: add order to desktop menu item

### DIFF
--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -1,3 +1,7 @@
+// avatar menu items are sorted by `order` (lower first); anything added via
+// `add_menu_item()` without one lands after the built-ins but before Logout.
+const DEFAULT_MENU_ITEM_ORDER = 50;
+
 frappe.pages["desktop"].on_page_load = function (wrapper) {
 	var page = frappe.ui.make_app_page({
 		parent: wrapper,
@@ -93,6 +97,7 @@ class DesktopPage {
 				icon: "pencil",
 				label: "Edit Profile",
 				url: `/desk/user/${frappe.session.user}`,
+				order: 10,
 			},
 			{
 				icon: is_dark ? "sun" : "moon",
@@ -100,6 +105,7 @@ class DesktopPage {
 				onClick: function () {
 					new frappe.ui.ThemeSwitcher().show();
 				},
+				order: 20,
 			},
 			{
 				icon: "info",
@@ -107,6 +113,7 @@ class DesktopPage {
 				onClick: function () {
 					return frappe.ui.toolbar.show_about();
 				},
+				order: 30,
 			},
 			{
 				icon: "life-buoy",
@@ -114,17 +121,21 @@ class DesktopPage {
 				onClick: function () {
 					window.open("https://support.frappe.io/help", "_blank");
 				},
-			},
-			{
-				icon: "log-out",
-				label: "Logout",
-				onClick: function () {
-					frappe.app.logout();
-				},
+				order: 40,
 			},
 		];
-		if (this.desktop_menu_items && this.desktop_menu_items.length)
-			menu_items = [...menu_items, ...this.desktop_menu_items];
+		// sort() is stable, so items sharing an `order` keep the order they were added in.
+		menu_items = [...menu_items, ...this.desktop_menu_items].sort(
+			(a, b) => (a.order ?? DEFAULT_MENU_ITEM_ORDER) - (b.order ?? DEFAULT_MENU_ITEM_ORDER)
+		);
+		// Logout is appended after sorting so it stays last whatever `order` apps pass in.
+		menu_items.push({
+			icon: "log-out",
+			label: "Logout",
+			onClick: function () {
+				frappe.app.logout();
+			},
+		});
 		frappe.ui.create_menu({
 			parent: $(".desktop-avatar"),
 			menu_items: menu_items,
@@ -133,9 +144,11 @@ class DesktopPage {
 			open_on_left: !frappe.utils.is_rtl(),
 		});
 	}
+	// `item.order` is optional; lower sorts higher up the menu. Built-ins occupy
+	// 10-40, so omitting it drops the item below them (see DEFAULT_MENU_ITEM_ORDER).
+	// Logout is always last and can't be displaced.
 	add_menu_item(item) {
-		if (this.desktop_menu_items && this.desktop_menu_items.find((i) => i.label === item.label))
-			return;
+		if (this.desktop_menu_items.find((i) => i.label === item.label)) return;
 		this.desktop_menu_items.push(item);
 	}
 	setup_navbar() {


### PR DESCRIPTION
Adds order to the add_menu_item api so logout can be last

Before
<img width="266" height="353" alt="Screenshot 2026-07-27 at 6 21 33 PM" src="https://github.com/user-attachments/assets/d30bdecc-3c64-4488-8498-2a4d7431a7a0" />


After
<img width="278" height="330" alt="Screenshot 2026-07-27 at 6 20 38 PM" src="https://github.com/user-attachments/assets/209a0e32-224e-4c74-9c4d-d8d1cfd38d29" />
