### PR TITLE
feat: add reload option to user dropdown menus

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -554,6 +554,14 @@ frappe.ui.Sidebar = class Sidebar {
 						new frappe.ui.DockManager();
 					},
 				},
+				{
+					name: "reload",
+					label: __("Reload"),
+					icon: "rotate-ccw",
+					onClick: function () {
+						frappe.ui.toolbar.clear_cache();
+					},
+				},
 				...frappe.boot.navbar_settings.settings_dropdown.map((item) => ({
 					...item,
 					label: item.item_label,


### PR DESCRIPTION
Re-adds the hard reload option (removed for some reason) to the sidebar user dropdown and the /desk avatar dropdown.

<img width="580" height="289" alt="Screenshot 2026-07-28 at 1 17 07 PM" src="https://github.com/user-attachments/assets/518f9b76-6814-4775-9e7b-87fa00b9e1f1" />

no-docs