### PR TITLE
fix(ui): clean up tab buttons and calendar UI

### DIFF
--- a/cypress/integration/list_paging.js
+++ b/cypress/integration/list_paging.js
@@ -1,3 +1,8 @@
+// the page-size pills are an es TabButtons radio group now — no data-value
+// attribute, so match by exact pill text
+const paging_pill = (value) =>
+	cy.contains(".list-paging-area .es-pill", new RegExp("^\\s*" + value + "\\s*$"));
+
 context("List Paging", () => {
 	before(() => {
 		cy.login();
@@ -20,7 +25,7 @@ context("List Paging", () => {
 		cy.get(".list-paging-area .btn-more").click();
 		cy.get(".list-paging-area .list-count").should("contain.text", "60 of");
 
-		cy.get('.list-paging-area .btn-group .btn-paging[data-value="100"]').click();
+		paging_pill(100).click();
 
 		cy.get(".list-paging-area .list-count").should("contain.text", "100 of");
 		cy.get(".list-paging-area .btn-more").click();
@@ -32,7 +37,7 @@ context("List Paging", () => {
 		cy.get('.page-head .standard-actions [data-original-title="Reload List"]').click();
 		cy.get(".list-paging-area .list-count").should("contain.text", "300 of");
 
-		cy.get('.list-paging-area .btn-group .btn-paging[data-value="500"]').click();
+		paging_pill(500).click();
 
 		cy.get(".list-paging-area .list-count").should("contain.text", "500 of");
 		cy.get(".list-paging-area .btn-more").click();

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -366,65 +366,48 @@ frappe.views.BaseList = class BaseList {
 		const paging_values = [20, 100, 500, 2500];
 		this.$paging_area = $(
 			`<div class="list-paging-area level">
-				<div class="level-left">
-					<div class="btn-group">
-						${paging_values
-							.map(
-								(value) => `
-							<button type="button" class="btn btn-default btn-sm btn-paging"
-								data-value="${value}">
-								${value}
-							</button>
-						`
-							)
-							.join("")}
-					</div>
-				</div>
-				<div class="level-right">
-					<button class="btn btn-default btn-more btn-sm">
-						${__("Load More")}
-					</button>
-				</div>
+				<div class="level-left"></div>
+				<div class="level-right"></div>
 			</div>`
 		).hide();
 		this.$frappe_list.append(this.$paging_area);
 
-		// set default paging btn active
-		this.$paging_area
-			.find(`.btn-paging[data-value="${this.page_length}"]`)
-			.addClass("btn-info")
-			.prop("disabled", true);
-
-		this.$paging_area.on("click", ".btn-paging", (e) => {
-			const $this = $(e.currentTarget);
-			// Set the active button
-			// This is always necessary because the current page length might
-			// have resulted from a previous "load more".
-			this.$paging_area.find(".btn-paging").removeClass("btn-info").prop("disabled", false);
-			$this.addClass("btn-info").prop("disabled", true);
-
-			const old_page_length = this.page_length;
-			const new_page_length = $this.data().value;
-
-			this.selected_page_count = new_page_length;
-			if (this.page_length > new_page_length) {
-				this.start = 0;
-				this.page_length = new_page_length;
-			} else {
-				this.start = this.page_length;
-				this.page_length = new_page_length - this.page_length;
-			}
-
-			if (old_page_length !== new_page_length) {
+		// the page-size choice is a radio group — TabButtons keeps exactly one
+		// pill selected (the old markup hand-rolled this with btn-info +
+		// disabled), and the selection survives "Load More" growing the page
+		this.paging_button_group = new frappe.ui.TabButtons({
+			label: __("Page Size"),
+			options: paging_values.map((value) => ({
+				label: String(value),
+				value: value,
+			})),
+			value: this.selected_page_count,
+			on_change: (value) => {
+				this.selected_page_count = value;
+				if (this.page_length > value) {
+					this.start = 0;
+					this.page_length = value;
+				} else {
+					// growing: fetch only the difference on top of what's loaded
+					this.start = this.page_length;
+					this.page_length = value - this.page_length;
+				}
 				this.refresh();
-			}
+			},
 		});
+		this.$paging_area.find(".level-left").append(this.paging_button_group.$el);
 
-		this.$paging_area.on("click", ".btn-more", (e) => {
-			this.start = this.data.length;
-			this.page_length = this.selected_page_count;
-			this.refresh();
-		});
+		this.$paging_area.find(".level-right").append(
+			frappe.ui.button({
+				label: __("Load More"),
+				css_class: "btn-more",
+				onclick: () => {
+					this.start = this.data.length;
+					this.page_length = this.selected_page_count;
+					this.refresh();
+				},
+			})
+		);
 	}
 
 	setup_resize_handler() {

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -183,9 +183,16 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	setup_page() {
 		this.parent.list_view = this;
 		super.setup_page();
-		// Start loading the virtualization bundle as soon as user picks a large page size.
-		this.$paging_area?.on("click", ".btn-paging", (e) => {
-			if (cint($(e.currentTarget).data("value")) >= this.virtualization_threshold) {
+	}
+
+	setup_paging_area() {
+		super.setup_paging_area();
+		// Start loading the virtualization bundle as soon as the user picks a
+		// large page size. (The old version of this hook bound to $paging_area
+		// from setup_page, which runs BEFORE the paging area exists — the ?.
+		// made it a silent no-op, so the preload never actually happened.)
+		this.paging_button_group.$el.on("click", () => {
+			if (cint(this.paging_button_group.get_value()) >= this.virtualization_threshold) {
 				ensure_list_virtualization_loaded().catch(() => {
 					this._virtualization_bundle_failed = true;
 				});

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -277,7 +277,9 @@ $.extend(frappe.model, {
 			// meta has sugar, like __js and other properties that doc won't have
 			frappe.meta.__doctype_meta = JSON.parse(JSON.stringify(meta));
 		}
-		for (const asset_key of ["__list_js", "__custom_list_js", "__calendar_js", "__tree_js"]) {
+		// custom scripts run last so they can override the standard
+		// definitions for any view, calendar included (#37460)
+		for (const asset_key of ["__list_js", "__calendar_js", "__tree_js", "__custom_list_js"]) {
 			if (meta[asset_key]) {
 				new Function(meta[asset_key])();
 			}

--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -154,32 +154,101 @@ frappe.views.Calendar = class Calendar {
 		});
 
 		$(this.parent).on("show", function () {
-			me.$cal.fullCalendar.refetchEvents();
+			// (this used the FullCalendar v3 jQuery API — me.$cal.fullCalendar
+			// is undefined on v6, so it threw on every page revisit)
+			me.fullCalendar.refetchEvents();
+			me.set_calendar_height();
 		});
 	}
 
 	make() {
 		this.$wrapper = this.parent;
-		this.$cal = $("<div id='fc-calendar-wrapper'>").appendTo(this.$wrapper);
+		this.make_toolbar();
+		// no horizontal padding of its own — the view container's rail is the
+		// alignment edge for the toolbar, the grid and the footnote alike
+		this.$cal = $("<div id='fc-calendar-wrapper' class='pt-3'>").appendTo(this.$wrapper);
 		this.footnote_area = frappe.utils.set_footnote(
 			this.footnote_area,
 			this.$wrapper,
 			__("Select or drag across time slots to create a new event.")
 		);
-		this.footnote_area.addClass("px-4 pb-4").css({
+		this.footnote_area.addClass("pb-4").css({
 			"border-top": "0px",
 		});
 		this.fullCalendar = new frappe.FullCalendar(this.$cal[0], this.cal_options);
 		this.fullCalendar.render();
 
-		this.set_css();
+		this.set_calendar_height();
+		$(window).on(
+			"resize.fc-calendar",
+			frappe.utils.debounce(() => this.set_calendar_height(), 300)
+		);
+	}
+
+	// size the calendar to the space left in the scroll column, so the view
+	// fits the viewport instead of growing past it (FullCalendar's default
+	// aspect-ratio sizing overflows on tall months)
+	set_calendar_height() {
+		if (!this.$cal.is(":visible")) return;
+		const main = document.querySelector(".main-section");
+		if (!main) return;
+		const top = this.$cal[0].getBoundingClientRect().top - main.getBoundingClientRect().top;
+		const footnote_height = this.footnote_area ? this.footnote_area.outerHeight(true) : 0;
+		const available = main.clientHeight - top - footnote_height;
+		this.fullCalendar.setOption("height", Math.max(available, 400));
+	}
+
+	// [prev] [title] [next] ........ [Month|Week|Day] [Today]
+	// Month/Week/Day is a radio group (you are always in exactly one);
+	// Today is an action, so it's a plain button
+	make_toolbar() {
+		this.$toolbar_title = $('<span class="text-lg-semibold text-ink-gray-8"></span>');
+		this.view_button_group = new frappe.ui.TabButtons({
+			label: __("Calendar View"),
+			options: [
+				{ label: __("Month"), value: "dayGridMonth" },
+				{ label: __("Week"), value: "timeGridWeek" },
+				{ label: __("Day"), value: "timeGridDay" },
+			],
+			value: this.cal_options.initialView,
+			on_change: (value) => {
+				this.fullCalendar.changeView(value);
+				this.set_localStorage_option("cal_initialView", value);
+			},
+		});
+
+		this.$toolbar = $('<div class="flex items-center gap-2 pt-4"></div>').append(
+			frappe.ui.button({
+				icon: "chevron-left",
+				variant: "ghost",
+				title: __("Previous"),
+				onclick: () => this.fullCalendar.prev(),
+			}),
+			this.$toolbar_title,
+			frappe.ui.button({
+				icon: "chevron-right",
+				variant: "ghost",
+				title: __("Next"),
+				onclick: () => this.fullCalendar.next(),
+			}),
+			$('<div class="grow"></div>'),
+			this.view_button_group.$el,
+			frappe.ui.button({
+				label: __("Today"),
+				onclick: () => this.fullCalendar.today(),
+			})
+		);
+		this.$wrapper.append(this.$toolbar);
 	}
 	setup_view_mode_button(defaults) {
-		var me = this;
-		$(me.footnote_area).find(".btn-weekend").detach();
-		let btnTitle = defaults.weekends ? __("Hide Weekends") : __("Show Weekends");
-		const btn = `<button class="btn btn-default btn-xs btn-weekend">${btnTitle}</button>`;
-		me.footnote_area.append(btn);
+		$(this.footnote_area).find(".btn-weekend").detach();
+		this.footnote_area.append(
+			frappe.ui.button({
+				label: defaults.weekends ? __("Hide Weekends") : __("Show Weekends"),
+				size: "xs",
+				css_class: "btn-weekend",
+			})
+		);
 	}
 	set_localStorage_option(option, value) {
 		localStorage.removeItem(option);
@@ -187,62 +256,11 @@ frappe.views.Calendar = class Calendar {
 	}
 	bind() {
 		const me = this;
-		let btn_group = me.$wrapper.find(".fc-button-group");
-		btn_group.on("click", ".btn", function () {
-			let value = $(this).hasClass("fc-timeGridWeek-button")
-				? "timeGridWeek"
-				: $(this).hasClass("fc-timeGridDay-button")
-				? "timeGridDay"
-				: "dayGridMonth";
-			me.set_localStorage_option("cal_initialView", value);
-		});
-
 		me.$wrapper.on("click", ".btn-weekend", function () {
 			me.cal_options.weekends = !me.cal_options.weekends;
 			me.fullCalendar.setOption("weekends", me.cal_options.weekends);
 			me.set_localStorage_option("cal_weekends", me.cal_options.weekends);
-			me.set_css();
 			me.setup_view_mode_button(me.cal_options);
-		});
-	}
-	set_css() {
-		const viewButtons =
-			".fc-dayGridMonth-button, .fc-timeGridWeek-button, .fc-timeGridDay-button, .fc-today-button";
-		const fcViewButtonClasses = "fc-button fc-button-primary fc-button-active";
-
-		// remove fc-button styles
-		this.$wrapper
-			.find("button.fc-button")
-			.removeClass(fcViewButtonClasses)
-			.addClass("btn btn-default");
-
-		// group all view buttons
-		this.$wrapper.find(viewButtons).wrapAll('<div class="btn-group" />');
-
-		// add icons
-		this.$wrapper
-			.find(`.fc-prev-button span`)
-			.attr("class", "")
-			.html(frappe.utils.icon("chevron-left"));
-		this.$wrapper
-			.find(`.fc-next-button span`)
-			.attr("class", "")
-			.html(frappe.utils.icon("chevron-right"));
-		if (this.$wrapper.find(".fc-today-button svg").length == 0)
-			this.$wrapper.find(".fc-today-button").prepend(frappe.utils.icon("calendar-days"));
-
-		// v6.x of fc has weird behaviour which removes all the custom classes
-		// on header buttons on click, event below re-adds all the classes
-		var btn_group = this.$wrapper.find(".fc-button-group");
-		btn_group.find(".fc-button-active").addClass("active");
-
-		btn_group.find(".btn").on("click", function () {
-			btn_group
-				.find(viewButtons)
-				.removeClass(`active ${fcViewButtonClasses}`)
-				.addClass("btn btn-default");
-
-			$(this).addClass("active");
 		});
 	}
 
@@ -263,10 +281,12 @@ frappe.views.Calendar = class Calendar {
 			},
 			firstDay: frappe.datetime.get_first_day_of_the_week_index(),
 			eventDisplay: "block",
-			headerToolbar: {
-				left: "prev,title,next",
-				center: "",
-				right: "today,dayGridMonth,timeGridWeek,timeGridDay",
+			// the toolbar is ours (make_toolbar), not FullCalendar's — no
+			// more stripping fc-button classes and re-adding them after every
+			// re-render
+			headerToolbar: false,
+			datesSet: (info) => {
+				this.$toolbar_title && this.$toolbar_title.text(info.view.title);
 			},
 			editable: true,
 			droppable: true,

--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -363,20 +363,14 @@ frappe.views.Calendar = class Calendar {
 						me.fullCalendar.changeView("timeGridDay", info.date);
 						me.$wrapper.find(".date-clicked").removeClass("date-clicked");
 
-						// update "active view" btn
-						me.$wrapper.find(".fc-month-button").removeClass("active");
-						me.$wrapper.find(".fc-agendaDay-button").addClass("active");
+						// keep the view pill in sync with the programmatic view
+						// change. Silent: double-click navigation is a jump, not a
+						// choice of default view, so it isn't persisted.
+						me.view_button_group.set_value("timeGridDay", { silent: true });
 					}
 
 					me.$wrapper.find(".date-clicked").removeClass("date-clicked");
 					$date_cell.addClass("date-clicked");
-
-					// explicitly remove the fc primary button styling that is append on view change
-					// from month -> day
-					$("#fc-calendar-wrapper")
-						.find("button.fc-button")
-						.removeClass("fc-button fc-button-primary fc-button-active")
-						.addClass("btn btn-default");
 				}
 				return false;
 			},

--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -198,11 +198,22 @@ frappe.views.Calendar = class Calendar {
 		this.fullCalendar.setOption("height", Math.max(available, 400));
 	}
 
-	// [prev] [title] [next] ........ [Month|Week|Day] [Today]
+	// [prev] [title ⌄ → jump-to-date picker] [next] ..... [Today] [Month|Week|Day]
 	// Month/Week/Day is a radio group (you are always in exactly one);
 	// Today is an action, so it's a plain button
 	make_toolbar() {
-		this.$toolbar_title = $('<span class="text-lg-semibold text-ink-gray-8"></span>');
+		// the label is filled by the datesSet callback on first render
+		this.$toolbar_title = frappe.ui.button({
+			label: __("Calendar"),
+			variant: "ghost",
+			css_class: "text-lg-medium text-ink-gray-7",
+		});
+		this.date_popover = new frappe.ui.Popover({
+			trigger: this.$toolbar_title,
+			content: () => this.make_date_jumper(),
+			css_class: "calendar-date-jumper",
+		});
+
 		this.view_button_group = new frappe.ui.TabButtons({
 			label: __("Calendar View"),
 			options: [
@@ -232,13 +243,43 @@ frappe.views.Calendar = class Calendar {
 				onclick: () => this.fullCalendar.next(),
 			}),
 			$('<div class="grow"></div>'),
-			this.view_button_group.$el,
 			(this.today_button = frappe.ui.button({
 				label: __("Today"),
 				onclick: () => this.fullCalendar.today(),
-			}))
+			})),
+			this.view_button_group.$el
 		);
 		this.$wrapper.append(this.$toolbar);
+	}
+
+	// inline air-datepicker (the desk-standard picker) inside the title
+	// popover — picking any date jumps the calendar there in the current view
+	make_date_jumper() {
+		const wrapper = document.createElement("div");
+		let lang = (frappe.boot.user && frappe.boot.user.language) || "en";
+		if (!$.fn.datepicker.language[lang]) lang = "en";
+
+		// match the picker to the view: month view jumps by month,
+		// week/day views by day
+		const month_only = this.fullCalendar.view.type === "dayGridMonth";
+
+		let ready = false;
+		$(wrapper).datepicker({
+			language: lang,
+			firstDay: frappe.datetime.get_first_day_of_the_week_index(),
+			...(month_only ? { view: "months", minView: "months" } : {}),
+			onSelect: (fd, date) => {
+				if (!ready || !date) return;
+				this.fullCalendar.gotoDate(date);
+				this.date_popover.close();
+			},
+		});
+		// preselect where the calendar currently is; selectDate fires
+		// onSelect synchronously, so the flag keeps it from immediately
+		// re-navigating and closing the popover
+		$(wrapper).data("datepicker").selectDate(this.fullCalendar.getDate());
+		ready = true;
+		return wrapper;
 	}
 	setup_view_mode_button(defaults) {
 		$(this.footnote_area).find(".btn-weekend").detach();
@@ -286,7 +327,9 @@ frappe.views.Calendar = class Calendar {
 			// re-render
 			headerToolbar: false,
 			datesSet: (info) => {
-				this.$toolbar_title && this.$toolbar_title.text(info.view.title);
+				// the title is an es-button now — swap only its label text
+				this.$toolbar_title &&
+					this.$toolbar_title.find(".es-button__label").text(info.view.title);
 				if (this.today_button) {
 					// no-op when the visible range already contains today
 					// (activeEnd is exclusive)

--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -452,24 +452,52 @@ frappe.views.Calendar = class Calendar {
 		});
 	}
 	prepare_colors(d) {
-		let color, color_name;
+		// espresso color families that have a surface-X-1 / ink-X-7 pair
+		const families = [
+			"red",
+			"green",
+			"blue",
+			"orange",
+			"amber",
+			"yellow",
+			"gray",
+			"purple",
+			"pink",
+			"cyan",
+			"teal",
+			"violet",
+		];
 		if (this.get_css_class) {
-			color_name = this.get_css_class(d);
+			let color_name = this.get_css_class(d);
+			// color_map keeps the old semantic names (danger, success, ...) working
 			color_name = this.color_map[color_name] || color_name || "blue";
 
 			if (color_name.startsWith("#")) {
-				color_name = frappe.ui.color.validate_hex(color_name) ? color_name : "blue";
+				// custom hex straight from the doctype's calendar config
+				if (frappe.ui.color.validate_hex(color_name)) {
+					d.backgroundColor = color_name;
+					d.textColor = frappe.ui.color.get_contrast_color(color_name);
+					return d;
+				}
+				color_name = "blue";
 			}
 
-			d.backgroundColor = frappe.ui.color.get(color_name, "extra-light");
-			d.textColor = frappe.ui.color.get(color_name, "dark");
+			// "dark-green" was a color in the old palette
+			if (color_name === "dark-green") color_name = "green";
+			if (!families.includes(color_name)) color_name = "blue";
+
+			// tokens instead of resolved hexes, so events flip in dark mode
+			d.backgroundColor = `var(--surface-${color_name}-1)`;
+			d.textColor = `var(--ink-${color_name}-7)`;
 		} else {
-			color = d.color;
-			if (!frappe.ui.color.validate_hex(color) || !color) {
-				color = frappe.ui.color.get("blue", "extra-light");
+			let color = d.color;
+			if (color && frappe.ui.color.validate_hex(color)) {
+				d.backgroundColor = color;
+				d.textColor = frappe.ui.color.get_contrast_color(color);
+			} else {
+				d.backgroundColor = "var(--surface-blue-1)";
+				d.textColor = "var(--ink-blue-7)";
 			}
-			d.backgroundColor = color;
-			d.textColor = frappe.ui.color.get_contrast_color(color);
 		}
 		return d;
 	}

--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -444,6 +444,11 @@ frappe.views.Calendar = class Calendar {
 				d.end = frappe.datetime.add_days(d.end, 1);
 			}
 
+			// timed events get the accent bar (see calendar.scss)
+			if (!d.allDay) {
+				d.classNames = (d.classNames || []).concat("timed-event");
+			}
+
 			me.prepare_colors(d);
 
 			d.title = frappe.utils.html2text(d.title);
@@ -467,37 +472,64 @@ frappe.views.Calendar = class Calendar {
 			"teal",
 			"violet",
 		];
+		// the color picker's swatches — saturated hexes stored on existing
+		// documents; render them as their espresso family so old colored
+		// events pick up the soft look instead of a solid block
+		const swatch_families = {
+			"#449cf0": "blue",
+			"#ecad4b": "amber",
+			"#29cd42": "green",
+			"#761acb": "purple",
+			"#cb2929": "red",
+			"#ed6396": "pink",
+			"#4463f0": "violet",
+			"#ec864b": "orange",
+			"#4f9dd9": "cyan",
+			"#39e4a5": "teal",
+			"#b4cd29": "yellow",
+		};
+
+		const apply_family = (name) => {
+			// "dark-green" was a color in the old palette
+			if (name === "dark-green") name = "green";
+			if (!families.includes(name)) name = "blue";
+			// tokens instead of resolved hexes, so events flip in dark mode
+			d.backgroundColor = `var(--surface-${name}-1)`;
+			d.textColor = `var(--ink-${name}-7)`;
+		};
+
+		// known hexes (picker swatches, old standard palette) map to a
+		// family; for hand-picked hexes, synthesize a family-style pair
+		// from the hex itself — a barely-tinted surface and a text color
+		// pulled toward ink. Mixing with tokens keeps them dark-mode aware.
+		const apply_hex = (hex) => {
+			hex = hex.toLowerCase();
+			const family = swatch_families[hex] || frappe.ui.color.get_color_name(hex);
+			if (family) {
+				apply_family(family);
+			} else {
+				d.backgroundColor = `color-mix(in oklab, ${hex} 14%, var(--surface-base))`;
+				d.textColor = `color-mix(in oklab, ${hex} 55%, var(--ink-gray-9))`;
+			}
+		};
+
 		if (this.get_css_class) {
 			let color_name = this.get_css_class(d);
 			// color_map keeps the old semantic names (danger, success, ...) working
 			color_name = this.color_map[color_name] || color_name || "blue";
 
 			if (color_name.startsWith("#")) {
-				// custom hex straight from the doctype's calendar config
 				if (frappe.ui.color.validate_hex(color_name)) {
-					d.backgroundColor = color_name;
-					d.textColor = frappe.ui.color.get_contrast_color(color_name);
+					apply_hex(color_name);
 					return d;
 				}
 				color_name = "blue";
 			}
-
-			// "dark-green" was a color in the old palette
-			if (color_name === "dark-green") color_name = "green";
-			if (!families.includes(color_name)) color_name = "blue";
-
-			// tokens instead of resolved hexes, so events flip in dark mode
-			d.backgroundColor = `var(--surface-${color_name}-1)`;
-			d.textColor = `var(--ink-${color_name}-7)`;
+			apply_family(color_name);
+		} else if (d.color && frappe.ui.color.validate_hex(d.color)) {
+			apply_hex(d.color);
 		} else {
-			let color = d.color;
-			if (color && frappe.ui.color.validate_hex(color)) {
-				d.backgroundColor = color;
-				d.textColor = frappe.ui.color.get_contrast_color(color);
-			} else {
-				d.backgroundColor = "var(--surface-blue-1)";
-				d.textColor = "var(--ink-blue-7)";
-			}
+			apply_family("blue");
 		}
 		return d;
 	}

--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -466,6 +466,15 @@ frappe.views.Calendar = class Calendar {
 				d.allDay = me.field_map.allDay;
 			}
 
+			// date-only events (Date fields, no time part) are all-day by
+			// nature even when the config doesn't say so; without this the
+			// exclusive-end rule below never runs and multi-day events
+			// draw one day short (#25193)
+			const date_only = (v) => v && !String(v).includes(" ");
+			if (!d.allDay && date_only(d.start) && (!d.end || date_only(d.end))) {
+				d.allDay = 1;
+			}
+
 			if (!me.field_map.convertToUserTz) d.convertToUserTz = 1;
 
 			// convert to user tz

--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -233,10 +233,10 @@ frappe.views.Calendar = class Calendar {
 			}),
 			$('<div class="grow"></div>'),
 			this.view_button_group.$el,
-			frappe.ui.button({
+			(this.today_button = frappe.ui.button({
 				label: __("Today"),
 				onclick: () => this.fullCalendar.today(),
-			})
+			}))
 		);
 		this.$wrapper.append(this.$toolbar);
 	}
@@ -287,6 +287,15 @@ frappe.views.Calendar = class Calendar {
 			headerToolbar: false,
 			datesSet: (info) => {
 				this.$toolbar_title && this.$toolbar_title.text(info.view.title);
+				if (this.today_button) {
+					// no-op when the visible range already contains today
+					// (activeEnd is exclusive)
+					const now = new Date();
+					this.today_button.prop(
+						"disabled",
+						info.view.activeStart <= now && now < info.view.activeEnd
+					);
+				}
 			},
 			editable: true,
 			droppable: true,

--- a/frappe/public/js/frappe/views/gantt/gantt_view.js
+++ b/frappe/public/js/frappe/views/gantt/gantt_view.js
@@ -225,37 +225,22 @@ frappe.views.GanttView = class GanttView extends frappe.views.ListView {
 		// view modes (for translation) __("Day"), __("Week"), __("Month"),
 		//__("Half Day"), __("Quarter Day")
 
-		let $btn_group = this.$paging_area.find(".gantt-view-mode");
-		if ($btn_group.length > 0) return;
+		if (this.$paging_area.find(".gantt-view-mode").length > 0) return;
 
 		const view_modes = this.gantt.options.view_modes || [];
-		const active_class = (view_mode) => (this.gantt.view_is(view_mode) ? "btn-info" : "");
-		const html = `<div class="btn-group gantt-view-mode mx-2">
-				${view_modes
-					.map(
-						(value) => `<button type="button"
-						class="btn btn-default btn-sm btn-view-mode ${active_class(value.name)}"
-						data-value="${value.name}">
-						${__(value.name)}
-					</button>`
-					)
-					.join("")}
-			</div>`;
-
-		this.$paging_area.find(".level-left").append(html);
-
-		// change view mode asynchronously
-		const change_view_mode = (value) =>
-			setTimeout(() => this.gantt.change_view_mode(value), 0);
-
-		this.$paging_area.on("click", ".btn-view-mode", (e) => {
-			const $btn = $(e.currentTarget);
-			this.$paging_area.find(".btn-view-mode").removeClass("btn-info");
-			$btn.addClass("btn-info");
-
-			const value = $btn.data().value;
-			change_view_mode(value);
+		const active = view_modes.find((mode) => this.gantt.view_is(mode.name));
+		const view_mode_group = new frappe.ui.TabButtons({
+			label: __("Gantt View Mode"),
+			css_class: "gantt-view-mode ms-2 me-2",
+			options: view_modes.map((mode) => ({
+				label: __(mode.name),
+				value: mode.name,
+			})),
+			value: active && active.name,
+			// change view mode asynchronously
+			on_change: (value) => setTimeout(() => this.gantt.change_view_mode(value), 0),
 		});
+		this.$paging_area.find(".level-left").append(view_mode_group.$el);
 	}
 
 	set_colors() {

--- a/frappe/public/scss/desk/calendar.scss
+++ b/frappe/public/scss/desk/calendar.scss
@@ -1,70 +1,64 @@
+// FullCalendar v6 grid, colored with espresso tokens.
+// Per-event background/text colors are set inline in calendar.js
+// (prepare_colors) — the event colors here are only the fallback.
+
+.fc {
+	// FullCalendar's own theming hooks — set these instead of fighting
+	// its rules with !important
+	--fc-border-color: var(--outline-gray-1);
+	// today is marked on the date number, not by tinting the whole cell
+	--fc-today-bg-color: transparent;
+	--fc-highlight-color: var(--surface-blue-2);
+	--fc-now-indicator-color: var(--ink-red-5);
+	--fc-event-bg-color: var(--surface-blue-1);
+	--fc-event-text-color: var(--ink-blue-7);
+	// background of the "+n more" popover
+	--fc-page-bg-color: var(--surface-elevation-1);
+	--fc-neutral-bg-color: var(--surface-gray-2);
+}
+
 .fc-theme-standard {
-	color: var(--text-light) !important;
+	color: var(--ink-gray-8) !important;
 }
 
 .fc-theme-standard a {
-	color: var(--text-light);
-}
-
-.fc-view-container {
-	margin-left: -1px;
-	margin-right: -1px;
-}
-
-.fc-head-container {
-	border: none !important;
+	color: var(--ink-gray-8);
 }
 
 th.fc-col-header-cell {
-	color: var(--gray-500);
-	font-weight: 600;
-}
-
-.fc-theme-standard td,
-.fc-theme-standard hr,
-.fc-theme-standard thead,
-.fc-theme-standard tbody,
-.fc-theme-standard .fc-row,
-.fc-theme-standard .fc-popover {
-	border-color: var(--gray-300) !important;
+	padding: 10px 12px 10px 0 !important;
+	color: var(--ink-gray-6);
+	font-size: var(--text-base);
+	font-weight: var(--font-weight-regular);
 }
 
 .fc-theme-standard td.fc-day-sun {
-	background: var(--highlight-color);
+	background: var(--surface-gray-1);
 }
 
-.fc-theme-standard .fc-day-today {
-	background-color: var(--fg-color) !important;
+.fc-theme-standard .fc-day-today .fc-daygrid-day-number {
+	background-color: var(--surface-gray-10);
+	border-radius: var(--radius-sm);
+	color: var(--ink-gray-2);
+	height: 25px;
+	width: 25px;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	text-align: center;
+	padding: 0;
+}
 
-	.fc-daygrid-day-number {
-		background-color: var(--gray-700);
-		border-radius: 50%;
-		color: $white;
-		height: 22px;
-		width: 22px;
-		line-height: 22px;
-		display: flex;
-		justify-content: center;
-		text-align: center;
-		padding: 0;
-	}
+.fc-theme-standard .fc-day-other .fc-daygrid-day-number {
+	color: var(--ink-gray-4);
 }
 
 .fc-event {
-	background-color: rgb(237, 246, 253);
 	border: none !important;
 }
 
 .fc-event-main-frame {
 	flex-direction: column;
-}
-
-.fc-time-grid-event {
-	border: none !important;
-}
-
-.fc-day-top {
-	padding: 5px 10px 0 0 !important;
 }
 
 .fc-daygrid-day-top {
@@ -76,18 +70,13 @@ th.fc-col-header-cell {
 	}
 }
 
-th.fc-col-header-cell {
-	padding: 10px 12px 10px 0 !important;
-	text-transform: uppercase;
-	font-size: 12px;
-}
-
 .fc-daygrid-dot-event {
 	padding: 3px;
 	display: flex;
 	flex-direction: column-reverse;
 	align-items: normal;
-	color: rgb(0, 112, 204) !important;
+	// no !important — per-event inline colors should win
+	color: var(--ink-blue-7);
 
 	.fc-event-time {
 		font-weight: normal;
@@ -116,38 +105,13 @@ th.fc-col-header-cell {
 	padding: 1px 5px !important;
 }
 
-.fc-time-grid .fc-slats .fc-minor td {
-	border-top-style: none !important;
+.fc .fc-timegrid-slot-label,
+.fc .fc-timegrid-axis {
+	color: var(--ink-gray-5);
 }
 
-.fc-highlight {
-	background: var(--blue-100) !important;
-}
-
-.fc-time-grid .fc-slats td {
-	height: 2.5em !important;
-}
-
-.fc-day-grid {
-	border-bottom: 1px solid var(--gray-300);
-}
-
-.fc-divider {
+.fc .fc-timegrid-now-indicator-arrow {
 	display: none;
-}
-
-.fc .fc-axis {
-	color: var(--gray-600) !important;
-	text-align: center;
-	width: 60px !important;
-}
-
-.fc-now-indicator {
-	border-color: var(--primary) !important;
-}
-
-.fc-now-indicator-arrow {
-	display: none !important;
 }
 
 #fc-calendar-wrapper .btn {

--- a/frappe/public/scss/desk/calendar.scss
+++ b/frappe/public/scss/desk/calendar.scss
@@ -1,19 +1,9 @@
 .fc-theme-standard {
-	padding: 20px;
 	color: var(--text-light) !important;
 }
 
 .fc-theme-standard a {
 	color: var(--text-light);
-}
-
-.fc-toolbar {
-	padding-bottom: 15px;
-	margin-bottom: 0px !important;
-}
-
-.fc-toolbar-chunk div {
-	display: flex;
 }
 
 .fc-view-container {
@@ -113,66 +103,11 @@ th.fc-col-header-cell {
 	}
 }
 
-.fc-toolbar-title {
-	font-size: $font-size-lg !important;
-	font-weight: 500;
-	line-height: 28px;
-	height: 28px;
-}
-
 .fc button {
 	height: 28px !important;
 	font-size: var(--text-md) !important;
 	outline: none !important;
 	text-transform: capitalize;
-}
-
-.fc-right button {
-	min-width: 64px;
-}
-
-.fc-left button {
-	width: 80px;
-}
-
-.fc-button-active {
-	box-shadow: none !important;
-	background: var(--gray-500) !important;
-	color: var(--fg-color) !important;
-	z-index: 0 !important;
-}
-
-//override default and fc-button styles
-.fc-dayGridMonth-button,
-.fc-dayGridWeek-button,
-.fc-dayGridDay-button {
-	border: none !important;
-	border-radius: 0;
-	background-color: var(--control-bg);
-	color: var(--text-color);
-}
-
-.fc-dayGridMonth-button {
-	border-top-left-radius: var(--radius) !important;
-	border-bottom-left-radius: var(--radius) !important;
-}
-
-.fc-dayGridDay-button {
-	border-top-right-radius: var(--radius) !important;
-	border-bottom-right-radius: var(--radius) !important;
-}
-
-.fc-prev-button {
-	margin-right: 10px !important;
-}
-
-.fc-next-button {
-	margin-left: 10px;
-}
-
-.fc-today-button {
-	margin-right: 10px;
-	border-radius: var(--radius) !important;
 }
 
 .fc-daygrid-event {
@@ -187,23 +122,6 @@ th.fc-col-header-cell {
 
 .fc-highlight {
 	background: var(--blue-100) !important;
-}
-
-.fc-left {
-	.fc-prev-button,
-	.fc-next-button {
-		width: 28px;
-		display: flex;
-		justify-content: center;
-		align-items: center;
-		background: var(--gray-100);
-		box-shadow: none;
-		border: none;
-
-		use {
-			stroke-width: 0.9;
-		}
-	}
 }
 
 .fc-time-grid .fc-slats td {

--- a/frappe/public/scss/desk/calendar.scss
+++ b/frappe/public/scss/desk/calendar.scss
@@ -38,7 +38,7 @@ th.fc-col-header-cell {
 
 .fc-theme-standard .fc-day-today .fc-daygrid-day-number {
 	background-color: var(--surface-gray-10);
-	border-radius: var(--radius-sm);
+	border-radius: var(--radius);
 	color: var(--ink-gray-2);
 	height: 25px;
 	width: 25px;
@@ -63,7 +63,7 @@ th.fc-col-header-cell {
 // that tie with one of fc's need the extra .fc to win the cascade
 .fc .fc-event {
 	border: none !important;
-	border-radius: var(--radius-sm);
+	border-radius: var(--radius);
 }
 
 // title above, time below it
@@ -166,6 +166,18 @@ th.fc-col-header-cell {
 
 .fc .fc-timegrid-now-indicator-arrow {
 	display: none;
+}
+
+// the jump-to-date popover hugs the inline datepicker it contains
+.es-popover.calendar-date-jumper {
+	width: auto;
+	padding: 0;
+
+	.datepicker {
+		border: none;
+		background: transparent;
+		box-shadow: none;
+	}
 }
 
 #fc-calendar-wrapper .btn {

--- a/frappe/public/scss/desk/calendar.scss
+++ b/frappe/public/scss/desk/calendar.scss
@@ -53,12 +53,66 @@ th.fc-col-header-cell {
 	color: var(--ink-gray-4);
 }
 
-.fc-event {
-	border: none !important;
+// fc dims out-of-month cells with opacity — we use ink-gray-4 instead,
+// and the two combined would be too faint
+.fc.fc-theme-standard .fc-day-other .fc-daygrid-day-top {
+	opacity: 1;
 }
 
-.fc-event-main-frame {
-	flex-direction: column;
+// FullCalendar injects its stylesheet at runtime, after ours — rules
+// that tie with one of fc's need the extra .fc to win the cascade
+.fc .fc-event {
+	border: none !important;
+	border-radius: var(--radius-sm);
+}
+
+// title above, time below it
+.fc .fc-daygrid-event .fc-event-main-frame,
+.fc .fc-timegrid-event .fc-event-main-frame {
+	flex-direction: column-reverse;
+	min-width: 0;
+	flex: 1;
+}
+
+// chip anatomy: [accent bar] [title / time]
+.fc-daygrid-event .fc-event-main,
+.fc-timegrid-event .fc-event-main {
+	display: flex;
+	gap: 6px;
+}
+
+.fc .fc-timegrid-event .fc-event-main {
+	padding: 4px 5px;
+}
+
+// currentColor is the event's inline textColor (its ink-X-7 token),
+// so every chip's bar matches its own color without any JS
+.fc-daygrid-event .fc-event-main::before,
+.fc-timegrid-event .fc-event-main::before {
+	content: "";
+	width: 2px;
+	border-radius: 2px;
+	background-color: currentColor;
+	flex-shrink: 0;
+}
+
+// only timed events carry the accent bar (class set in calendar.js)
+.fc-event:not(.timed-event) .fc-event-main::before {
+	display: none;
+}
+
+// titles inherit the event's textColor (its ink-X-7 accent)
+.fc-daygrid-event .fc-event-title {
+	font-weight: var(--font-weight-medium);
+}
+
+// in the timegrid the title keeps the event color; the time goes quiet
+.fc-timegrid-event .fc-event-time {
+	color: var(--ink-gray-6);
+}
+
+.fc-event.fc-event-past {
+	opacity: 0.5;
 }
 
 .fc-daygrid-day-top {
@@ -102,7 +156,7 @@ th.fc-col-header-cell {
 .fc-daygrid-event {
 	border: none !important;
 	margin: 5px 4px 0 !important;
-	padding: 1px 5px !important;
+	padding: 3px 5px !important;
 }
 
 .fc .fc-timegrid-slot-label,

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -344,25 +344,6 @@ $level-margin-right: 8px;
 .list-paging-area,
 .footnote-area {
 	border-top: 1px solid var(--border-color);
-
-	.btn-group {
-		border: 1px solid var(--border-color);
-		border-radius: var(--radius);
-
-		.btn-paging.btn-info {
-			&:not(:first-child) {
-				border-left: 1px solid var(--border-color);
-			}
-
-			background-color: var(--bg-color);
-			color: var(--text-color);
-			font-weight: var(--weight-medium);
-		}
-	}
-
-	.btn-paging {
-		background-color: var(--control-bg);
-	}
 }
 
 .layout-main-list {


### PR DESCRIPTION
### Tab Buttons

Previous:

<img width="1327" height="374" alt="image" src="https://github.com/user-attachments/assets/6e6c363f-f5d2-4d44-8ad8-6d9cad8f572a" />

<img width="1252" height="75" alt="image" src="https://github.com/user-attachments/assets/779d26f6-7e31-4390-a290-6635fc5e04e2" />

New:

<img width="3140" height="1839" alt="CleanShot 2026-07-29 at 13 23 53@2x" src="https://github.com/user-attachments/assets/b373dc49-80f7-4543-bb24-7a05742c2e47" />
<img width="3140" height="1837" alt="CleanShot 2026-07-29 at 13 24 17@2x" src="https://github.com/user-attachments/assets/ba751a17-f93f-458c-a1b8-f6dcaef3a88f" />
<img width="3140" height="1837" alt="CleanShot 2026-07-29 at 13 24 41@2x" src="https://github.com/user-attachments/assets/815f2a83-2eda-4bfd-b0f8-c22fe17c628b" />


Closes https://github.com/frappe/frappe/issues/4608
Closes https://github.com/frappe/frappe/issues/25193
Closes https://github.com/frappe/frappe/issues/37460


`no-docs`