### PR TITLE
feat: let apps run setup through their own UI

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -18,6 +18,7 @@ from frappe.desk.desk_views import DeskViews
 from frappe.desk.doctype.form_tour.form_tour import get_onboarding_ui_tours
 from frappe.desk.doctype.route_history.route_history import frequently_visited_links
 from frappe.desk.form.load import get_meta_bundle
+from frappe.desk.page.setup_wizard.setup_wizard import get_setup_wizard_url
 from frappe.desk.utils import is_item_allowed
 from frappe.email.inbox import get_email_accounts
 from frappe.integrations.frappe_providers.frappecloud_billing import current_site_info, is_fc_site
@@ -45,6 +46,8 @@ def get_bootinfo():
 	bootinfo.sitename = frappe.local.site
 	bootinfo.sysdefaults = frappe.defaults.get_defaults()
 	bootinfo.sysdefaults["setup_complete"] = frappe.is_setup_complete()
+	if not bootinfo.sysdefaults["setup_complete"]:
+		bootinfo.setup_wizard_url = get_setup_wizard_url()
 
 	bootinfo.server_date = frappe.utils.nowdate()
 

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -17,6 +17,22 @@ from frappe.utils.synchronization import LockTimeoutError, filelock
 from . import install_fixtures
 
 
+def site_requires_builtin_wizard() -> bool:
+	for app in frappe.get_installed_apps():
+		hooks = frappe.get_hooks(app_name=app)
+		if hooks.get("setup_wizard_stages") or hooks.get("setup_wizard_complete"):
+			return True
+	return False
+
+
+def get_setup_wizard_url() -> str:
+	"""Setup UI for a fresh site: an app's `setup_wizard_url` hook (last installed wins), else the desk wizard."""
+	urls = frappe.get_hooks("setup_wizard_url")
+	if urls and not site_requires_builtin_wizard():
+		return urls[-1]
+	return "/app/setup-wizard"
+
+
 def get_setup_stages(args):  # nosemgrep
 	# App setup stage functions should not include frappe.db.commit
 	# That is done by frappe after successful completion of all stages

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -33,7 +33,7 @@ def get_setup_wizard_url() -> str:
 	return "/app/setup-wizard"
 
 
-def get_setup_stages(args):  # nosemgrep
+def get_setup_stages(args, include_app_input_stages=True):  # nosemgrep
 	# App setup stage functions should not include frappe.db.commit
 	# That is done by frappe after successful completion of all stages
 	stages = [
@@ -51,7 +51,9 @@ def get_setup_stages(args):  # nosemgrep
 		}
 	]
 
-	stages += get_stages_hooks(args) + get_setup_complete_hooks(args)
+	if include_app_input_stages:
+		stages += get_stages_hooks(args)
+	stages += get_setup_complete_hooks(args)
 
 	stages.append(
 		{
@@ -78,6 +80,27 @@ def setup_complete(args: str | dict[str, Any]):
 
 			kwargs = parse_args(sanitize_input(args))
 			stages = get_setup_stages(kwargs)
+			return process_setup_stages(stages, kwargs)
+	except LockTimeoutError:
+		# Duplicate request
+		return {"status": "ok"}
+
+
+@frappe.whitelist()
+def complete_setup(args: str | dict[str, Any] | None = None):
+	"""Complete setup for an app-provided wizard: the setup engine minus the desk-input stages."""
+	frappe.only_for("System Manager")
+
+	if site_requires_builtin_wizard():
+		frappe.throw(_("This site's setup must run through the built-in wizard."))
+
+	try:
+		with filelock("setup_wizard", timeout=0.5):
+			if frappe.is_setup_complete():
+				return {"status": "ok"}
+
+			kwargs = parse_args(sanitize_input(args or {}))
+			stages = get_setup_stages(kwargs, include_app_input_stages=False)
 			return process_setup_stages(stages, kwargs)
 	except LockTimeoutError:
 		# Duplicate request

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -87,7 +87,14 @@ def setup_complete(args: str | dict[str, Any]):
 
 
 @frappe.whitelist(methods=["POST"])
-def complete_setup(args: str | dict[str, Any] | None = None):
+def complete_setup(
+	country: str | None = None,
+	currency: str | None = None,
+	timezone: str | None = None,
+	language: str | None = None,
+	enable_telemetry: bool | None = None,
+	allow_recording_first_session: bool | None = None,
+):
 	"""Complete setup for an app-provided wizard: the setup engine minus the desk-input stages."""
 	frappe.only_for("System Manager")
 
@@ -99,9 +106,20 @@ def complete_setup(args: str | dict[str, Any] | None = None):
 			if frappe.is_setup_complete():
 				return {"status": "ok"}
 
-			kwargs = parse_args(sanitize_input(args or {}))
-			stages = get_setup_stages(kwargs, include_app_input_stages=False)
-			return process_setup_stages(stages, kwargs)
+			args = parse_args(
+				sanitize_input(
+					{
+						"country": country,
+						"currency": currency,
+						"timezone": timezone,
+						"language": language,
+						"enable_telemetry": enable_telemetry,
+						"allow_recording_first_session": allow_recording_first_session,
+					}
+				)
+			)
+			stages = get_setup_stages(args, include_app_input_stages=False)
+			return process_setup_stages(stages, args)
 	except LockTimeoutError:
 		# Duplicate request
 		return {"status": "ok"}

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -28,14 +28,14 @@ def site_requires_builtin_wizard() -> bool:
 def get_setup_wizard_url() -> str:
 	"""Setup UI for a fresh site: an app's `setup_wizard_url` hook (last installed wins), else the desk wizard.
 
-	`setup_wizard_url` must be a non-desk route (not under `/app`); it redirects the user out of
-	desk to an app-owned setup UI. To customize setup within desk, use the built-in wizard via the
-	`setup_wizard_stages` / `setup_wizard_complete` hooks.
+	`setup_wizard_url` must be a non-desk route (not under `/desk` or `/app`); it redirects the user
+	out of desk to an app-owned setup UI. To customize setup within desk, use the built-in wizard via
+	the `setup_wizard_stages` / `setup_wizard_complete` hooks.
 	"""
 	urls = frappe.get_hooks("setup_wizard_url")
 	if urls and not site_requires_builtin_wizard():
 		return urls[-1]
-	return "/app/setup-wizard"
+	return "/desk/setup-wizard"
 
 
 def get_setup_stages(args, include_app_input_stages=True):  # nosemgrep

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -86,7 +86,7 @@ def setup_complete(args: str | dict[str, Any]):
 		return {"status": "ok"}
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def complete_setup(args: str | dict[str, Any] | None = None):
 	"""Complete setup for an app-provided wizard: the setup engine minus the desk-input stages."""
 	frappe.only_for("System Manager")

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -92,7 +92,7 @@ def setup_complete(args: str | dict[str, Any]):
 
 
 @frappe.whitelist(methods=["POST"])
-def complete_setup(
+def complete_app_setup(
 	country: str | None = None,
 	currency: str | None = None,
 	timezone: str | None = None,

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -26,7 +26,12 @@ def site_requires_builtin_wizard() -> bool:
 
 
 def get_setup_wizard_url() -> str:
-	"""Setup UI for a fresh site: an app's `setup_wizard_url` hook (last installed wins), else the desk wizard."""
+	"""Setup UI for a fresh site: an app's `setup_wizard_url` hook (last installed wins), else the desk wizard.
+
+	`setup_wizard_url` must be a non-desk route (not under `/app`); it redirects the user out of
+	desk to an app-owned setup UI. To customize setup within desk, use the built-in wizard via the
+	`setup_wizard_stages` / `setup_wizard_complete` hooks.
+	"""
 	urls = frappe.get_hooks("setup_wizard_url")
 	if urls and not site_requires_builtin_wizard():
 		return urls[-1]
@@ -121,8 +126,9 @@ def complete_setup(
 			stages = get_setup_stages(args, include_app_input_stages=False)
 			return process_setup_stages(stages, args)
 	except LockTimeoutError:
-		# Duplicate request
-		return {"status": "ok"}
+		if frappe.is_setup_complete():
+			return {"status": "ok"}
+		frappe.throw(_("Setup is already in progress. Please try again in a moment."))
 
 
 @frappe.whitelist()

--- a/frappe/desk/page/setup_wizard/test_setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/test_setup_wizard.py
@@ -32,7 +32,7 @@ class TestSetupWizardUrl(UnitTestCase):
 
 	def test_defaults_to_desk(self):
 		url, builtin = self.resolve({"frappe": {}})
-		self.assertEqual(url, "/app/setup-wizard")
+		self.assertEqual(url, "/desk/setup-wizard")
 		self.assertFalse(builtin)
 
 	def test_uses_app_url(self):
@@ -56,7 +56,7 @@ class TestSetupWizardUrl(UnitTestCase):
 				"erpnext": {"setup_wizard_stages": ["erpnext.setup.get_setup_stages"]},
 			}
 		)
-		self.assertEqual(url, "/app/setup-wizard")
+		self.assertEqual(url, "/desk/setup-wizard")
 		self.assertTrue(builtin)
 
 	def test_complete_hook_forces_desk(self):
@@ -66,7 +66,7 @@ class TestSetupWizardUrl(UnitTestCase):
 				"crm": {"setup_wizard_complete": ["crm.setup.after_complete"]},
 			}
 		)
-		self.assertEqual(url, "/app/setup-wizard")
+		self.assertEqual(url, "/desk/setup-wizard")
 		self.assertTrue(builtin)
 
 

--- a/frappe/desk/page/setup_wizard/test_setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/test_setup_wizard.py
@@ -70,14 +70,14 @@ class TestSetupWizardUrl(UnitTestCase):
 		self.assertTrue(builtin)
 
 
-class TestCompleteSetup(IntegrationTestCase):
+class TestCompleteAppSetup(IntegrationTestCase):
 	def test_needs_system_manager(self):
 		with set_user("Guest"):
-			self.assertRaises(frappe.PermissionError, setup_wizard.complete_setup)
+			self.assertRaises(frappe.PermissionError, setup_wizard.complete_app_setup)
 
 	def test_refuses_builtin_site(self):
 		with patch.object(setup_wizard, "site_requires_builtin_wizard", return_value=True):
-			self.assertRaises(frappe.ValidationError, setup_wizard.complete_setup)
+			self.assertRaises(frappe.ValidationError, setup_wizard.complete_app_setup)
 
 	def test_skips_when_already_complete(self):
 		with (
@@ -85,7 +85,7 @@ class TestCompleteSetup(IntegrationTestCase):
 			patch.object(frappe, "is_setup_complete", return_value=True),
 			patch.object(setup_wizard, "process_setup_stages") as process_stages,
 		):
-			self.assertEqual(setup_wizard.complete_setup(), {"status": "ok"})
+			self.assertEqual(setup_wizard.complete_app_setup(), {"status": "ok"})
 			process_stages.assert_not_called()
 
 	def test_lock_timeout_never_reports_false_success(self):
@@ -96,6 +96,6 @@ class TestCompleteSetup(IntegrationTestCase):
 			patch.object(setup_wizard, "filelock", return_value=lock),
 		):
 			with patch.object(frappe, "is_setup_complete", return_value=False):
-				self.assertRaises(frappe.ValidationError, setup_wizard.complete_setup)
+				self.assertRaises(frappe.ValidationError, setup_wizard.complete_app_setup)
 			with patch.object(frappe, "is_setup_complete", return_value=True):
-				self.assertEqual(setup_wizard.complete_setup(), {"status": "ok"})
+				self.assertEqual(setup_wizard.complete_app_setup(), {"status": "ok"})

--- a/frappe/desk/page/setup_wizard/test_setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/test_setup_wizard.py
@@ -72,11 +72,11 @@ class TestSetupWizardUrl(UnitTestCase):
 class TestCompleteSetup(IntegrationTestCase):
 	def test_needs_system_manager(self):
 		with set_user("Guest"):
-			self.assertRaises(frappe.PermissionError, setup_wizard.complete_setup, {})
+			self.assertRaises(frappe.PermissionError, setup_wizard.complete_setup)
 
 	def test_refuses_builtin_site(self):
 		with patch.object(setup_wizard, "site_requires_builtin_wizard", return_value=True):
-			self.assertRaises(frappe.ValidationError, setup_wizard.complete_setup, {})
+			self.assertRaises(frappe.ValidationError, setup_wizard.complete_setup)
 
 	def test_skips_when_already_complete(self):
 		with (
@@ -84,5 +84,5 @@ class TestCompleteSetup(IntegrationTestCase):
 			patch.object(frappe, "is_setup_complete", return_value=True),
 			patch.object(setup_wizard, "process_setup_stages") as process_stages,
 		):
-			self.assertEqual(setup_wizard.complete_setup({}), {"status": "ok"})
+			self.assertEqual(setup_wizard.complete_setup(), {"status": "ok"})
 			process_stages.assert_not_called()

--- a/frappe/desk/page/setup_wizard/test_setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/test_setup_wizard.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+from unittest.mock import patch
+
+import frappe
+from frappe.desk.page.setup_wizard import setup_wizard
+from frappe.tests import IntegrationTestCase, UnitTestCase, set_user
+
+
+def fake_hooks(apps):
+	def get_hooks(hook=None, default=None, app_name=None):
+		if app_name:
+			return apps.get(app_name, {})
+		merged = []
+		for app_hooks in apps.values():
+			merged += app_hooks.get(hook, [])
+		return merged
+
+	return get_hooks
+
+
+class TestSetupWizardUrl(UnitTestCase):
+	def resolve(self, apps):
+		with (
+			patch.object(frappe, "get_installed_apps", return_value=list(apps)),
+			patch.object(frappe, "get_hooks", side_effect=fake_hooks(apps)),
+		):
+			url = setup_wizard.get_setup_wizard_url()
+			builtin = setup_wizard.site_requires_builtin_wizard()
+			return url, builtin
+
+	def test_defaults_to_desk(self):
+		url, builtin = self.resolve({"frappe": {}})
+		self.assertEqual(url, "/app/setup-wizard")
+		self.assertFalse(builtin)
+
+	def test_uses_app_url(self):
+		url, builtin = self.resolve({"suite": {"setup_wizard_url": ["/suite/setup"]}})
+		self.assertEqual(url, "/suite/setup")
+		self.assertFalse(builtin)
+
+	def test_last_app_wins(self):
+		url, _ = self.resolve(
+			{
+				"suite": {"setup_wizard_url": ["/suite/setup"]},
+				"gameplan": {"setup_wizard_url": ["/gameplan/setup"]},
+			}
+		)
+		self.assertEqual(url, "/gameplan/setup")
+
+	def test_stage_app_forces_desk(self):
+		url, builtin = self.resolve(
+			{
+				"suite": {"setup_wizard_url": ["/suite/setup"]},
+				"erpnext": {"setup_wizard_stages": ["erpnext.setup.get_setup_stages"]},
+			}
+		)
+		self.assertEqual(url, "/app/setup-wizard")
+		self.assertTrue(builtin)
+
+	def test_complete_hook_forces_desk(self):
+		url, builtin = self.resolve(
+			{
+				"suite": {"setup_wizard_url": ["/suite/setup"]},
+				"crm": {"setup_wizard_complete": ["crm.setup.after_complete"]},
+			}
+		)
+		self.assertEqual(url, "/app/setup-wizard")
+		self.assertTrue(builtin)
+
+
+class TestCompleteSetup(IntegrationTestCase):
+	def test_needs_system_manager(self):
+		with set_user("Guest"):
+			self.assertRaises(frappe.PermissionError, setup_wizard.complete_setup, {})
+
+	def test_refuses_builtin_site(self):
+		with patch.object(setup_wizard, "site_requires_builtin_wizard", return_value=True):
+			self.assertRaises(frappe.ValidationError, setup_wizard.complete_setup, {})
+
+	def test_skips_when_already_complete(self):
+		with (
+			patch.object(setup_wizard, "site_requires_builtin_wizard", return_value=False),
+			patch.object(frappe, "is_setup_complete", return_value=True),
+			patch.object(setup_wizard, "process_setup_stages") as process_stages,
+		):
+			self.assertEqual(setup_wizard.complete_setup({}), {"status": "ok"})
+			process_stages.assert_not_called()

--- a/frappe/desk/page/setup_wizard/test_setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/test_setup_wizard.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import frappe
 from frappe.desk.page.setup_wizard import setup_wizard
 from frappe.tests import IntegrationTestCase, UnitTestCase, set_user
+from frappe.utils.synchronization import LockTimeoutError
 
 
 def fake_hooks(apps):
@@ -86,3 +87,15 @@ class TestCompleteSetup(IntegrationTestCase):
 		):
 			self.assertEqual(setup_wizard.complete_setup(), {"status": "ok"})
 			process_stages.assert_not_called()
+
+	def test_lock_timeout_never_reports_false_success(self):
+		lock = MagicMock()
+		lock.__enter__.side_effect = LockTimeoutError
+		with (
+			patch.object(setup_wizard, "site_requires_builtin_wizard", return_value=False),
+			patch.object(setup_wizard, "filelock", return_value=lock),
+		):
+			with patch.object(frappe, "is_setup_complete", return_value=False):
+				self.assertRaises(frappe.ValidationError, setup_wizard.complete_setup)
+			with patch.object(frappe, "is_setup_complete", return_value=True):
+				self.assertEqual(setup_wizard.complete_setup(), {"status": "ok"})

--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -128,6 +128,12 @@ frappe.router = {
 
 		if (frappe.boot.setup_complete) {
 			!frappe.re_route["setup-wizard"] && (frappe.re_route["setup-wizard"] = "app");
+		} else if (
+			frappe.boot.setup_wizard_url &&
+			!frappe.boot.setup_wizard_url.startsWith("/app/")
+		) {
+			window.location.replace(frappe.boot.setup_wizard_url);
+			return;
 		} else if (!sub_path.startsWith("setup-wizard")) {
 			frappe.re_route["setup-wizard"] && delete frappe.re_route["setup-wizard"];
 			frappe.set_route(["setup-wizard"]);

--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -130,7 +130,8 @@ frappe.router = {
 			!frappe.re_route["setup-wizard"] && (frappe.re_route["setup-wizard"] = "app");
 		} else if (
 			frappe.boot.setup_wizard_url &&
-			!frappe.boot.setup_wizard_url.startsWith("/app/")
+			!frappe.boot.setup_wizard_url.startsWith("/app/") &&
+			!frappe.boot.setup_wizard_url.startsWith("/desk/")
 		) {
 			window.location.replace(frappe.boot.setup_wizard_url);
 			return;

--- a/frappe/tests/test_boot.py
+++ b/frappe/tests/test_boot.py
@@ -36,6 +36,21 @@ class TestBootData(IntegrationTestCase):
 		self.assertIsInstance(apps, list)
 		self.assertIn("frappe", apps)
 
+	def test_setup_wizard_url_exposed_until_setup_complete(self):
+		from unittest.mock import patch
+
+		from frappe.boot import get_bootinfo
+
+		frappe.set_user("Administrator")
+		with (
+			patch.object(frappe, "is_setup_complete", return_value=False),
+			patch("frappe.boot.get_setup_wizard_url", return_value="/suite/setup") as resolve,
+		):
+			bootinfo = get_bootinfo()
+
+		resolve.assert_called_once()
+		self.assertEqual(bootinfo.setup_wizard_url, "/suite/setup")
+
 	def test_empty_allowed_views_are_served_from_cache(self):
 		from unittest.mock import patch
 

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -487,7 +487,9 @@ use_json_request_body = True
 # Setup Wizard
 # ------------
 
-# open a fresh site's setup in this app's own UI instead of the desk wizard
+# open a fresh site's setup in this app's own UI instead of the desk wizard.
+# must be a non-desk route (not under /app); to customize setup within desk,
+# use setup_wizard_stages / setup_wizard_complete instead.
 # setup_wizard_url = "/{app_name}/setup"
 
 # Generators

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -484,6 +484,12 @@ use_json_request_body = True
 # 	"Role": "home_page"
 # }}
 
+# Setup Wizard
+# ------------
+
+# open a fresh site's setup in this app's own UI instead of the desk wizard
+# setup_wizard_url = "/{app_name}/setup"
+
 # Generators
 # ----------
 

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -488,8 +488,8 @@ use_json_request_body = True
 # ------------
 
 # open a fresh site's setup in this app's own UI instead of the desk wizard.
-# must be a non-desk route (not under /app); to customize setup within desk,
-# use setup_wizard_stages / setup_wizard_complete instead.
+# must be a non-desk route (not under /desk or /app); to customize setup within
+# desk, use setup_wizard_stages / setup_wizard_complete instead.
 # setup_wizard_url = "/{app_name}/setup"
 
 # Generators


### PR DESCRIPTION
### Problem

On a fresh site, frappe routes every user to the desk setup wizard at `/app/setup-wizard`. The site stays "not ready" until that wizard finishes. The wizard does three separate jobs at once:

- **Data:** collects locale and the first user, derives number/date/time formats, runs the `setup_wizard_complete` hooks.
- **UI:** the desk pages at `/app/setup-wizard`.
- **Gate:** the router redirect that blocks the site, and the `System Settings.setup_complete` flag that everything reads to mean "ready".

The data and the gate are only reachable through the desk UI. There is no public function that just marks a site set up. So an app with its own frontend cannot finish setup on its own screen.

<br>

### Solution

Expose that capability, and let an app point setup at its own UI. Three parts.

#### 1. A public `complete_app_setup(args)`

Ability to mark a site set up without the desk UI. It runs frappe's own engine (`process_setup_stages`), minus the app-input stages that need the desk slides, and fills any arg you skip from frappe's defaults, so a zero-arg call still yields a valid site.

Safe because it reuses the engine, so every guarantee holds (locale, formats, scheduler, flags, completion hooks). It requires `System Manager` (the desk `setup_complete` needs no role, so this is stricter) and is idempotent. Since frappe still fills every default, a custom UI can only match or enrich a default site, never degrade it.

#### 2. A `setup_wizard_url` hook

Routes the fresh-site user to the app's own screen. An app declares `setup_wizard_url = "/suite/setup"` in `hooks.py`; while setup is incomplete, boot exposes it and the desk router redirects there instead of `/app/setup-wizard`. The app's UI collects whatever data it wants (or none) and calls `complete_app_setup(args)`.

### 3. What happens per site

`get_setup_wizard_url()` decides the setup URL in two steps:

1. **Does any app offer a `setup_wizard_url`?** If not -> desk wizard.
2. **If yes, is it safe to use?** `site_requires_builtin_wizard()` is true when any installed app declares `setup_wizard_stages` or `setup_wizard_complete`. If true -> desk wizard (that app's stages need it). If false -> the app's URL.

The cases we ran:

- **frappe only** -> no app offers a URL -> `/app/setup-wizard`. Inert, a plain site is untouched.
- **frappe + suite** -> suite offers `/suite/setup`, nothing forces the desk wizard -> `/suite/setup`. Suite's UI collects its data -> calls `complete_app_setup`.
- **frappe + suite + erpnext** -> suite offers a URL, but erpnext declares `setup_wizard_stages` -> forced to `/app/setup-wizard` -> desk wizard sets the site up. Suite tracks its own onboarding flag separately, so opening `/suite` after -> runs Suite's onboarding UI (no `complete_app_setup`, site is already set up).

<br>

### Tests

`test_setup_wizard.py`: 8 tests, 5 for URL resolution and 3 for `complete_app_setup`.

`no-docs`