### PR TITLE
fix(search): stop build_index looping forever on an unindexable batch (forward-port #41249)

### DIFF
--- a/frappe/search/sqlite_search.py
+++ b/frappe/search/sqlite_search.py
@@ -404,12 +404,15 @@ class SQLiteSearch(ABC):
 					if documents:
 						self._index_documents(documents)
 
-						# Update progress with last processed document cursor
-						last_doc_modified = docs[-1].get(progress_field) or docs[-1].get("modified")
-						last_doc_name = docs[-1]["name"]
-						self._update_index_progress(doctype, last_doc_name, last_doc_modified, len(documents))
-						last_indexed_modified = last_doc_modified
-						last_indexed_name = last_doc_name
+					# Advance the cursor even when nothing in this batch was indexable: these
+					# rows have been consumed either way. Advancing only when `documents` was
+					# non-empty meant a batch whose documents all failed prepare_document()
+					# was fetched again forever, so build_index() never returned.
+					last_doc_modified = docs[-1].get(progress_field) or docs[-1].get("modified")
+					last_doc_name = docs[-1]["name"]
+					self._update_index_progress(doctype, last_doc_name, last_doc_modified, len(documents))
+					last_indexed_modified = last_doc_modified
+					last_indexed_name = last_doc_name
 
 					batch_count += 1
 

--- a/frappe/tests/test_sqlite_search.py
+++ b/frappe/tests/test_sqlite_search.py
@@ -684,3 +684,48 @@ class TestSQLiteSearchAPI(IntegrationTestCase):
 
 		finally:
 			test_note.delete()
+
+	def test_build_index_terminates_when_a_batch_has_no_indexable_documents(self):
+		"""build_index must advance its cursor even if nothing in a batch can be indexed.
+
+		prepare_document() may legitimately reject every document in a batch (missing text
+		fields, a subclass filtering by its own rules). The cursor used to advance only when
+		at least one document survived, so such a batch was re-fetched forever and
+		build_index() never returned - it spun at full CPU, opening a fresh SQLite connection
+		per iteration, until the process was killed.
+		"""
+		self.search.drop_index()
+
+		real_get_documents_paginated = self.search.get_documents_paginated
+		fetches = []
+
+		def counting_get_documents_paginated(*args, **kwargs):
+			fetches.append(kwargs.get("last_indexed_name"))
+			# Fail the test instead of hanging the suite if the cursor stops advancing.
+			if len(fetches) > 50:
+				raise AssertionError(
+					"build_index() re-fetched batches without advancing its cursor "
+					f"({len(fetches)} fetches for {len(self.search.doc_configs)} doctypes)"
+				)
+			return real_get_documents_paginated(*args, **kwargs)
+
+		with (
+			patch.object(TestSQLiteSearch, "prepare_document", return_value=None),
+			patch.object(self.search, "get_documents_paginated", counting_get_documents_paginated),
+		):
+			self.search.build_index()
+
+		# Every doctype is walked to exhaustion and marked complete, and nothing is indexed.
+		self.assertTrue(self.search.index_exists())
+
+		conn = sqlite3.connect(self.search.db_path)
+		try:
+			indexed_rows = conn.execute("SELECT COUNT(*) FROM search_fts").fetchone()[0]
+			incomplete = conn.execute(
+				"SELECT COUNT(*) FROM search_index_progress WHERE is_complete = 0"
+			).fetchone()[0]
+		finally:
+			conn.close()
+
+		self.assertEqual(indexed_rows, 0)
+		self.assertEqual(incomplete, 0, "every doctype should be marked complete")


### PR DESCRIPTION
Forward-port of #41249, which was merged into `version-16-hotfix`. `develop` still has the bug —
it went hotfix-first, so it will not arrive here on its own.

## Problem

`SQLiteSearch.build_index` advances its pagination cursor only inside `if documents:`, i.e. only
when at least one document in the batch survived `prepare_document()`. `prepare_document()` returns
`None` whenever `_validate_document_for_indexing()` rejects a document (no text-field content), and
subclasses may reject documents by their own rules.

A batch that returns rows but produces no indexable document therefore leaves
`last_indexed_modified` / `last_indexed_name` untouched, while the non-empty `docs` prevents the
`break`. The identical batch is fetched again — forever.

There is no error and no timeout. The process spins at 100% CPU, opening a fresh SQLite connection
per iteration via `_get_indexing_progress()`, with RSS climbing, until it is killed. Observed on a
Gameplan site, where one `build_index()` call ran for 45 minutes and read ~35 GB before being
stopped.

## Change

Advance the cursor unconditionally — those rows have been consumed whether or not any of them
produced a document. `_update_index_progress` adds `indexed_count` to `indexed_docs`, so passing 0
moves the cursor without inflating reported progress.

The regression test caps the number of fetches and raises, so a reintroduction fails the suite in
under a second instead of hanging it.

Cherry-picked clean from 474f2d71f2; all symbols the test touches (`drop_index`, `index_exists`,
`doc_configs`, `get_documents_paginated(..., last_indexed_name=)`, `search_fts`,
`search_index_progress`) are unchanged on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBJ9E3nUHQnJTF6mCTfRjW
