### PR TITLE
fix: role permissions manager breaks browser back navigation

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -2494,10 +2494,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		if (frappe.user_roles.includes("System Manager")) {
 			items.push({
 				label: __("Role Permissions Manager", null, "Button in list view menu"),
-				action: () =>
-					frappe.set_route("permission-manager", {
-						doctype,
-					}),
+				action: () => frappe.set_route("permission-manager", doctype),
 				standard: true,
 			});
 		}


### PR DESCRIPTION
## Summary
- When you open Role Permissions Manager from a doctype list view menu and click browser Back, it takes two clicks to leave the page instead of one.
- Cause: the menu action called `frappe.set_route("permission-manager", { doctype })`, passing the doctype wrapped in an object. The router treats object values as route options, not URL parts, so it drops the doctype from the URL and pushes `/permission-manager` first. The page then reads the doctype back from route options and pushes a second URL, `/permission-manager/<doctype>`, to fix itself up. This adds an extra step in browser history that back has to pass through.
- Fix: pass the doctype directly so only one URL gets pushed, matching how the page's own doctype field already navigates.

Before:

[Item.webm](https://github.com/user-attachments/assets/8f2e3a3d-3bff-48b1-8147-9b043da164f1)


After:

[Item (1).webm](https://github.com/user-attachments/assets/bea81176-0304-4d0a-919c-f33721765595)
