### PR TITLE
fix(print): run before_print in builder renderer; guest-only 403 login

### DIFF
--- a/frappe/templates/print_format/print_format_doc.css
+++ b/frappe/templates/print_format/print_format_doc.css
@@ -272,13 +272,6 @@
 	padding: 0;
 	height: 0;
 	border: none !important;
-	border-bottom-left-radius: var(--pfb-radius, 0);
-	border-bottom-right-radius: var(--pfb-radius, 0);
-}
-
-.print-format-doc .child-table--bordered .table .table-foot {
-	height: 0;
-	border-bottom: 1px solid var(--gray-300) !important;
 }
 
 /* plain header: no fill, a single rule under the header row instead */

--- a/frappe/templates/print_format/print_format_doc.css
+++ b/frappe/templates/print_format/print_format_doc.css
@@ -276,6 +276,10 @@
 	border-left: 1px solid var(--gray-300) !important;
 }
 
+.print-format-doc .child-table--bordered .table tbody tr:last-child td {
+	border-bottom: 1px solid var(--gray-300) !important;
+}
+
 /* the cap only has work to do on bordered tables (closing the outline with a
    rounded bottom on every printed page); elsewhere it would just add an empty
    band under the table, so it gets no height */

--- a/frappe/templates/print_format/print_format_doc.css
+++ b/frappe/templates/print_format/print_format_doc.css
@@ -210,23 +210,11 @@
 	border-bottom-right-radius: var(--pfb-radius, 0);
 }
 
-/* bordered tables end in the .table-foot cap instead — rounding the last row
-   too would curve its side borders away from the cap and leave an open notch */
-.print-format-doc
-	.child-table:not(.child-table--bordered)
-	.table
-	tbody
-	tr:last-child
-	td:first-child {
+.print-format-doc .child-table .table tbody tr:last-child td:first-child {
 	border-bottom-left-radius: var(--pfb-radius, 0);
 }
 
-.print-format-doc
-	.child-table:not(.child-table--bordered)
-	.table
-	tbody
-	tr:last-child
-	td:last-child {
+.print-format-doc .child-table .table tbody tr:last-child td:last-child {
 	border-bottom-right-radius: var(--pfb-radius, 0);
 }
 
@@ -280,9 +268,6 @@
 	border-bottom: 1px solid var(--gray-300) !important;
 }
 
-/* the cap only has work to do on bordered tables (closing the outline with a
-   rounded bottom on every printed page); elsewhere it would just add an empty
-   band under the table, so it gets no height */
 .print-format-doc .child-table .table .table-foot {
 	padding: 0;
 	height: 0;
@@ -292,9 +277,7 @@
 }
 
 .print-format-doc .child-table--bordered .table .table-foot {
-	height: var(--pfb-radius, 0);
-	border-left: 1px solid var(--gray-300) !important;
-	border-right: 1px solid var(--gray-300) !important;
+	height: 0;
 	border-bottom: 1px solid var(--gray-300) !important;
 }
 

--- a/frappe/tests/test_printview.py
+++ b/frappe/tests/test_printview.py
@@ -30,3 +30,23 @@ class PrintViewTest(IntegrationTestCase):
 
 		# cancelled doc can't be printed by default
 		self.assertRaises(frappe.PermissionError, frappe.attach_print, doc.doctype, doc.name)
+
+	def test_before_print_runs_in_builder_renderer(self):
+		from frappe.utils.print_format_generator import PrintFormatGenerator
+
+		note = frappe.get_doc(doctype="Note", title=frappe.generate_hash()).insert()
+		print_format = frappe.get_doc(
+			doctype="Print Format",
+			name=frappe.generate_hash(),
+			doc_type="Note",
+			print_format_builder_beta=1,
+			pdf_generator="chrome",
+			format_data="{}",
+		).insert()
+
+		self.assertNotEqual(note.get("print_heading"), note.name)
+
+		PrintFormatGenerator(print_format, note)
+
+		self.assertEqual(note.print_heading, note.name)
+		self.assertTrue(note.flags.in_print)

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -254,6 +254,11 @@ class PrintFormatGenerator:
 			from frappe.www.printview import get_allowed_print_settings_override
 
 			self.print_settings.update(get_allowed_print_settings_override(self.doc, self.settings_override))
+
+		from frappe.www.printview import run_before_print
+
+		run_before_print(self.doc, self.print_settings.as_dict())
+
 		page_width_map = {"A4": 210, "Letter": 216}
 		page_width = page_width_map.get(self.print_settings.pdf_page_size) or 210
 		body_width = page_width - self.print_format.margin_left - self.print_format.margin_right

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -36,10 +36,11 @@ def download_pdf(
 	settings: str | dict | None = None,
 ):
 	from frappe.printing.doctype.print_format.classic_converter import get_default_print_format
-	from frappe.www.printview import validate_print
+	from frappe.www.printview import set_link_titles, validate_print
 
 	doc = frappe.get_doc(doctype, name)
 	validate_print(doc)
+	set_link_titles(doc)
 	if not print_format or print_format == "Standard":
 		print_format = get_default_print_format(doctype)
 	generator = PrintFormatGenerator(print_format, doc, letterhead, settings=frappe.parse_json(settings))

--- a/frappe/website/page_renderers/not_permitted_page.py
+++ b/frappe/website/page_renderers/not_permitted_page.py
@@ -23,6 +23,8 @@ class NotPermittedPage(TemplatePage):
 			if frappe.request.path.startswith("/desk/") or frappe.request.path == "/desk":
 				action = "/login"
 			context.update(primary_action=action, primary_label=_("Login"))
+		else:
+			context.update(primary_action="/app", primary_label=_("Home"))
 		frappe.local.response["context"] = context
 		self.set_standard_path("message")
 		return super().render()

--- a/frappe/website/page_renderers/not_permitted_page.py
+++ b/frappe/website/page_renderers/not_permitted_page.py
@@ -24,7 +24,11 @@ class NotPermittedPage(TemplatePage):
 				action = "/login"
 			context.update(primary_action=action, primary_label=_("Login"))
 		else:
-			context.update(primary_action="/app", primary_label=_("Home"))
+			from frappe.website.utils import get_home_page
+
+			home = get_home_page()
+			home = home if home.startswith("/") else "/" + home
+			context.update(primary_action=home, primary_label=_("Home"))
 		frappe.local.response["context"] = context
 		self.set_standard_path("message")
 		return super().render()

--- a/frappe/website/page_renderers/not_permitted_page.py
+++ b/frappe/website/page_renderers/not_permitted_page.py
@@ -16,12 +16,13 @@ class NotPermittedPage(TemplatePage):
 		return True
 
 	def render(self):
-		action = f"/login?redirect-to={quote_plus(frappe.request.path)}"
-		if frappe.request.path.startswith("/desk/") or frappe.request.path == "/desk":
-			action = "/login"
 		frappe.local.message_title = _("Not Permitted")
-		frappe.local.response["context"] = dict(
-			indicator_color="red", primary_action=action, primary_label=_("Login"), fullpage=True
-		)
+		context = dict(indicator_color="red", fullpage=True)
+		if frappe.session.user == "Guest":
+			action = f"/login?redirect-to={quote_plus(frappe.request.path)}"
+			if frappe.request.path.startswith("/desk/") or frappe.request.path == "/desk":
+				action = "/login"
+			context.update(primary_action=action, primary_label=_("Login"))
+		frappe.local.response["context"] = context
 		self.set_standard_path("message")
 		return super().render()

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -179,12 +179,9 @@ def get_rendered_template(
 	elif no_letterhead is None:
 		no_letterhead = not cint(print_settings.with_letterhead)
 
-	doc.flags.in_print = True
-	doc.flags.print_settings = print_settings
-
 	validate_print_for_docstatus(doc, print_settings)
 
-	doc.run_method("before_print", print_settings)
+	run_before_print(doc, print_settings)
 
 	if not hasattr(doc, "print_heading"):
 		doc.print_heading = None
@@ -440,6 +437,16 @@ def validate_print(doc: "Document", print_settings: dict | None = None) -> None:
 	"""Run both print gates for a document: permission, then draft/cancelled docstatus."""
 	validate_print_permission(doc)
 	validate_print_for_docstatus(doc, print_settings)
+
+
+def run_before_print(doc: "Document", print_settings: dict) -> None:
+	"""Flag the document as printing and fire its ``before_print`` hook.
+
+	Shared by the legacy template renderer and the builder generator so both
+	prepare the document the same way before rendering."""
+	doc.flags.in_print = True
+	doc.flags.print_settings = print_settings
+	doc.run_method("before_print", print_settings)
 
 
 def validate_key(key: str, doc: "Document") -> None:


### PR DESCRIPTION
Print-view correctness fixes:

- **`before_print` not firing in the builder renderer** — the beta renderer never ran the document's `before_print` hook, so controller-computed print fields (e.g. Sales Invoice) were missing. Extracted the legacy flag+hook logic into a shared `run_before_print`, called from both the legacy renderer and `PrintFormatGenerator`. Covered by a new regression test.
- **Link titles missing in beta PDF downloads** — `download_pdf` never called `set_link_titles`, so link fields printed raw IDs instead of their titles. Added it, matching the other print entry points.
- **403 page login button** — the "Not Permitted" page always offered Login, even to an already-authenticated user (e.g. blocked from printing a draft). Now: Login for Guests, a Home link for authenticated users (the fullpage template has no other navigation).
- **Bordered child table last row** — every `--bordered` cell sets `border-bottom: none`, so the last row's box never closed and Chromium clipped its column dividers. Closed the last row's bottom border (kept the foot line at height 0 for multi-page tables), and folded the last-row corner rounding into one rule shared by lined and bordered tables.