### PR TITLE
fix(desk): don't assume frappe.app exists when checking session expiry

### DIFF
--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -149,13 +149,7 @@ frappe.request.call = function (opts) {
 			opts.success_callback && opts.success_callback(data, xhr.responseText);
 		},
 		401: function (xhr) {
-			if (
-				frappe.app.session_expired_dialog ||
-				frappe.request.is_session_expired(xhr.responseJSON)
-			) {
-				frappe.app.handle_session_expired();
-				return;
-			}
+			if (frappe.request.handle_session_expiry(xhr.responseJSON)) return;
 			opts.error_callback && opts.error_callback();
 		},
 		404: function (xhr) {
@@ -168,13 +162,7 @@ frappe.request.call = function (opts) {
 			opts.error_callback && opts.error_callback();
 		},
 		403: function (xhr) {
-			if (
-				frappe.app.session_expired_dialog ||
-				frappe.request.is_session_expired(xhr.responseJSON)
-			) {
-				frappe.app.handle_session_expired();
-				return;
-			}
+			if (frappe.request.handle_session_expiry(xhr.responseJSON)) return;
 			if (xhr.responseJSON && xhr.responseJSON._error_message) {
 				frappe.msgprint({
 					title: __("Not permitted"),
@@ -465,6 +453,20 @@ frappe.request.is_session_expired = function (response) {
 	return !user_id || user_id === "Guest" || frappe.session.user === "Guest";
 };
 
+frappe.request.handle_session_expiry = function (response) {
+	// the dialog and the redirect live on frappe.app, which only exists once
+	// start_app() has run on document ready. Requests fired from top level module
+	// code can land before that, so fall through to the regular handlers instead.
+	if (!frappe.app) return false;
+
+	if (!frappe.app.session_expired_dialog && !frappe.request.is_session_expired(response)) {
+		return false;
+	}
+
+	frappe.app.handle_session_expired();
+	return true;
+};
+
 frappe.request.cleanup = function (opts, r) {
 	// stop button indicator
 	if (opts.btn) {
@@ -477,10 +479,7 @@ frappe.request.cleanup = function (opts, r) {
 	if (opts.freeze) frappe.dom.unfreeze();
 
 	if (r) {
-		if (frappe.app.session_expired_dialog || frappe.request.is_session_expired(r)) {
-			frappe.app.handle_session_expired();
-			return;
-		}
+		if (frappe.request.handle_session_expiry(r)) return;
 
 		// error handlers
 		let global_handlers = frappe.request.error_handlers[r.exc_type] || [];


### PR DESCRIPTION
`frappe.request.cleanup` reads `frappe.app.session_expired_dialog` on every response, but `frappe.app` is only assigned by `start_app()` on document ready. A request fired from top level module code lands before that and throws, skipping the rest of cleanup:

```
Uncaught TypeError: can't access property "session_expired_dialog", frappe.app is undefined
    cleanup request.js:480
```

All three call sites now go through `frappe.request.handle_session_expiry`, which returns `false` when `frappe.app` is missing so the response falls through to the regular handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)