### PR TITLE
revert: non-submittable docstatus guard in ORM

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1119,18 +1119,10 @@ class Document(BaseDocument):
 		- Submit (1) > Cancel (2)
 
 		"""
-		if self.flags.skip_docstatus_validation:
-			return
-
 		if to_docstatus == DocStatus.DRAFT:
 			if self.docstatus.is_draft():
 				self._action = "save"
 			elif self.docstatus.is_submitted():
-				if not getattr(self.meta, "is_submittable", False):
-					frappe.throw(
-						_("Cannot change docstatus of non submittable doctype {0}").format(self.doctype),
-						frappe.DocstatusTransitionError,
-					)
 				self._action = "submit"
 				self.check_permission("submit")
 			elif self.docstatus.is_cancelled():

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -66,22 +66,6 @@ class TestDocument(IntegrationTestCase):
 		self.assertEqual(d.send_reminder, 1)
 		return d
 
-	def test_submittable_insert(self):
-		dt = frappe.get_doc(
-			{
-				"doctype": "DocType",
-				"module": "Core",
-				"name": "Test Submittable Doctype",
-				"custom": 1,
-				"is_submittable": 1,
-				"fields": [{"label": "Field", "fieldname": "test_field", "fieldtype": "Data"}],
-				"permissions": [{"role": "System Manager", "read": 1, "write": 1, "submit": 1, "cancel": 1}],
-			}
-		).insert(ignore_if_duplicate=True)
-
-		d = frappe.get_doc({"doctype": dt.name, "test_field": "test"}).insert()
-		return d
-
 	def test_website_route_default(self):
 		default = frappe.generate_hash()
 		child_table = new_doctype(default=default, istable=1).insert().name
@@ -117,7 +101,7 @@ class TestDocument(IntegrationTestCase):
 		self.assertEqual(frappe.db.get_value(d.doctype, d.name, "subject"), "subject changed")
 
 	def test_discard_transitions(self):
-		d = self.test_submittable_insert()
+		d = self.test_insert()
 		self.assertEqual(d.docstatus, 0)
 
 		# invalid: Submit > Discard, Cancel > Discard
@@ -129,7 +113,7 @@ class TestDocument(IntegrationTestCase):
 		self.assertRaises(frappe.ValidationError, d.discard)
 
 		# valid: Draft > Discard
-		d2 = self.test_submittable_insert()
+		d2 = self.test_insert()
 		d2.discard()
 		self.assertEqual(d2.docstatus, 2)
 

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -108,21 +108,17 @@ class TestWorkflow(IntegrationTestCase):
 		self.assertEqual(workflow_actions[0].status, "Completed")
 
 	def test_if_workflow_set_on_action(self):
-		dt = create_new_submittable_doctype()
-		workflow = create_submittable_workflow(dt.name)
-		doc = frappe.get_doc({"doctype": dt.name, "test_field": "test"}).insert()
+		self.workflow._update_state_docstatus = True
+		self.workflow.states[1].doc_status = 1
+		self.workflow.save()
+		todo = create_new_todo()
+		self.assertEqual(todo.docstatus, 0)
+		todo.submit()
+		self.assertEqual(todo.docstatus, 1)
+		self.assertEqual(todo.workflow_state, "Approved")
 
-		workflow._update_state_docstatus = True
-		workflow.states[1].doc_status = 1
-		workflow.save()
-
-		self.assertEqual(doc.docstatus, 0)
-		doc.submit()
-		self.assertEqual(doc.docstatus, 1)
-		self.assertEqual(doc.workflow_state, "Approved")
-
-		workflow.states[1].doc_status = 0
-		workflow.save()
+		self.workflow.states[1].doc_status = 0
+		self.workflow.save()
 
 	def test_syntax_error_in_transition_rule(self):
 		self.workflow.transitions[0].condition = 'doc.status =! "Closed"'
@@ -352,55 +348,6 @@ def create_domain_workflow():
 
 def create_new_todo():
 	return frappe.get_doc(doctype="ToDo", description="workflow " + random_string(10)).insert()
-
-
-def create_new_submittable_doctype():
-	return frappe.get_doc(
-		{
-			"doctype": "DocType",
-			"module": "Core",
-			"name": "Test Submittable Doc",
-			"custom": 1,
-			"is_submittable": 1,
-			"fields": [
-				{"label": "Field", "fieldname": "test_field", "fieldtype": "Data"},
-				{
-					"label": "Workflow State",
-					"fieldname": "workflow_state",
-					"fieldtype": "Link",
-					"options": "Workflow State",
-				},
-			],
-			"permissions": [{"role": "System Manager", "read": 1, "write": 1, "submit": 1, "cancel": 1}],
-		}
-	).insert(ignore_if_duplicate=True)
-
-
-def create_submittable_workflow(doctype):
-	workflow = frappe.get_doc(
-		{
-			"doctype": "Workflow",
-			"workflow_name": "Submittable Workflow",
-			"document_type": doctype,
-			"workflow_state_field": "workflow_state",
-			"is_active": 1,
-			"states": [
-				{"state": "Pending", "allow_edit": "All"},
-				{"state": "Approved", "allow_edit": "System Manager", "doc_status": 0},
-			],
-			"transitions": [
-				{
-					"state": "Pending",
-					"action": "Approve",
-					"next_state": "Approved",
-					"allowed": "System Manager",
-					"allow_self_approval": 1,
-				}
-			],
-		}
-	).insert(ignore_permissions=True, ignore_if_duplicate=True)
-
-	return workflow
 
 
 def create_new_note(doc):


### PR DESCRIPTION
Reverts the ORM-level docstatus guard added in #41210 (backport #41280) — the `check_docstatus_transition` change in `document.py` and its related test updates in `test_document.py` / `test_workflow.py`.

Why: on version-16 internal submissions of non-submittable doctypes are still supported, so validation cannot live in the ORM / `document.py` — it blocks legitimate internal `.submit()` calls (and broke `test_discard_transitions` and `test_if_workflow_set_on_action`). The guard belongs on the `savedocs` desk endpoint instead, so the user-facing path is blocked while internal submissions keep working.

- Keeps the `perm.js` revert from #41210 (the actual client-side fix) untouched.
- Only removes the backend guard + the test changes it required.

Follow-up: add the equivalent check in `frappe.desk.form.save.savedocs` (not done here).