### PR TITLE
fix: prevent submitting non-submittable doctype from desk

### DIFF
--- a/frappe/desk/form/save.py
+++ b/frappe/desk/form/save.py
@@ -34,6 +34,12 @@ def savedocs(doc, action):
 		"Cancel": DocStatus.CANCELLED,
 	}[action]
 
+	if not doc.docstatus.is_draft() and not doc.meta.is_submittable:
+		frappe.throw(
+			frappe._("Cannot change docstatus of non submittable doctype {0}").format(doc.doctype),
+			frappe.DocstatusTransitionError,
+		)
+
 	if doc.docstatus.is_submitted():
 		if action == "Submit" and doc.meta.queue_in_background and not is_scheduler_inactive():
 			queue_submission(doc, action)


### PR DESCRIPTION
Adds the non-submittable docstatus guard at the `savedocs` desk endpoint (follow-up to #41303, which removed the ORM-level guard).

- `frappe.desk.form.save.savedocs` now throws `DocstatusTransitionError` when a Submit/Update/Cancel action would set `docstatus` to 1/2 on a doctype that isn't submittable.
- Blocks the user-facing corruption path (e.g. Admin seeing Submit/Cancel on a `Bin`) while internal `.submit()`/`.cancel()` calls keep working, since those bypass this endpoint — required on v16.

Blocking Submit/Update here is sufficient to stop the whole chain: the Cancel button only appears once a doc is already `docstatus=1`, which this prevents.

No test changes needed — existing `savedocs` test calls use the `Save` (draft) action and are unaffected.