### PR TITLE
test: isolate msgprint cases on a fresh page

### DIFF
--- a/cypress/integration/msgprint.js
+++ b/cypress/integration/msgprint.js
@@ -1,41 +1,46 @@
 context("Msgprint", () => {
 	before(() => {
 		cy.login();
+	});
+
+	beforeEach(() => {
 		cy.visit("/app/todo");
 	});
 
 	it("keeps an open message when the response carries only toasts", () => {
-		cy.window().then((win) => {
-			win.frappe.msgprint({ message: "client message", title: "client title" });
-			win.frappe.request.cleanup(
-				{},
-				{
-					_server_messages: JSON.stringify([
-						JSON.stringify({ message: "Saved", alert: 1 }),
-					]),
-				}
-			);
-		});
+		cy.window()
+			.its("frappe")
+			.then((frappe) => {
+				frappe.msgprint({ message: "client message", title: "client title" });
+				frappe.request.cleanup(
+					{},
+					{
+						_server_messages: JSON.stringify([
+							JSON.stringify({ message: "Saved", alert: 1 }),
+						]),
+					}
+				);
+			});
 		cy.get(".msgprint-dialog").should("be.visible");
 		cy.get(".msgprint").should("contain", "client message");
-		cy.hide_dialog();
 	});
 
 	it("clears an open message before showing a server message", () => {
-		cy.window().then((win) => {
-			win.frappe.msgprint({ message: "client message", title: "client title" });
-			win.frappe.request.cleanup(
-				{},
-				{
-					_server_messages: JSON.stringify([
-						JSON.stringify({ message: "server message" }),
-					]),
-				}
-			);
-		});
+		cy.window()
+			.its("frappe")
+			.then((frappe) => {
+				frappe.msgprint({ message: "client message", title: "client title" });
+				frappe.request.cleanup(
+					{},
+					{
+						_server_messages: JSON.stringify([
+							JSON.stringify({ message: "server message" }),
+						]),
+					}
+				);
+			});
 		cy.get(".msgprint")
 			.should("contain", "server message")
 			.should("not.contain", "client message");
-		cy.hide_dialog();
 	});
 });


### PR DESCRIPTION
The spec added in #41244 reused the same page across tests, making the second test inherit dialog state and causing CI flakes (e.g. [this run](https://github.com/frappe/frappe/actions/runs/30348392834/job/90239943586), #41293).
This change gives each test a fresh page and uses .its("frappe") so Cypress retries until boot completes instead of failing with a TypeError.