### PR TITLE
fix(quick-list-widget): keep quick-list controls buttons visible without hover

### DIFF
--- a/frappe/public/scss/desk/desktop.scss
+++ b/frappe/public/scss/desk/desktop.scss
@@ -759,12 +759,6 @@ body {
 			.widget-label {
 				padding-left: 6px;
 			}
-
-			.widget-control {
-				width: auto;
-				visibility: visible;
-				opacity: 1;
-			}
 		}
 
 		.widget-body {

--- a/frappe/public/scss/desk/desktop.scss
+++ b/frappe/public/scss/desk/desktop.scss
@@ -755,24 +755,15 @@ body {
 			}
 		}
 
-		&:hover {
-			.widget-head .widget-control {
-				width: auto;
-				visibility: visible;
-				opacity: 1;
-			}
-		}
-
 		.widget-head {
 			.widget-label {
 				padding-left: 6px;
 			}
 
 			.widget-control {
-				width: 0px;
-				visibility: hidden;
-				opacity: 0;
-				transition: visibility 0s, opacity 0.5s ease-in-out;
+				width: auto;
+				visibility: visible;
+				opacity: 1;
 			}
 		}
 


### PR DESCRIPTION
Resolve: #39612

---



https://github.com/user-attachments/assets/050ef008-6d2a-4375-87b6-385a4b920db0


