### PR TITLE
fix(sqlite): publish last_query so assertQueryCount works on SQLite

### DIFF
--- a/frappe/database/sqlite/database.py
+++ b/frappe/database/sqlite/database.py
@@ -482,6 +482,16 @@ class SQLiteDatabase(SQLiteExceptionUtil, Database):
 
 		return self._cursor.execute(query, values or ())
 
+	def log_query(self, query, query_type, values, debug):
+		# sqlite3 cursors expose no equivalent of the executed statement, so the
+		# mogrified query is what `last_query` reports. MariaDB and Postgres both
+		# publish this attribute; without it anything reading `db.last_query`
+		# (e.g. IntegrationTestCase.assertQueryCount) breaks only on SQLite.
+		mogrified_query = self.lazy_mogrify(query, values)
+		self.last_query = mogrified_query
+		self._log_query(mogrified_query, query_type, debug, query)
+		return mogrified_query
+
 	def sql(self, *args, **kwargs):
 		if args:
 			# since tuple is immutable

--- a/frappe/deprecation_dumpster.py
+++ b/frappe/deprecation_dumpster.py
@@ -724,7 +724,10 @@ def get_tests_CompatFrappeTestCase():
 
 			def _sql_with_count(*args, **kwargs):
 				ret = orig_sql(*args, **kwargs)
-				queries.append(args[0].last_query)
+				# `last_query` is a lazy wrapper on every driver except MariaDB
+				# (LazyMogrify on SQLite, LazyDecode on Postgres); the join below
+				# needs real strings. Matches IntegrationTestCase.assertQueryCount.
+				queries.append(str(args[0].last_query))
 				return ret
 
 			try:

--- a/frappe/tests/test_test_utils.py
+++ b/frappe/tests/test_test_utils.py
@@ -65,6 +65,42 @@ class TestTestUtils(IntegrationTestCase):
 		)
 
 
+class TestCompatAssertQueryCount(IntegrationTestCase):
+	"""Cover the `assertQueryCount` copy carried by the deprecated FrappeTestCase.
+
+	`frappe.tests.utils.FrappeTestCase` keeps its own implementation, separate from
+	the one on IntegrationTestCase. Nothing else in-tree exercises it, so a fix
+	applied to one can silently miss the other.
+
+	Deliberately not restricted by db_type: the two copies drift apart on driver
+	details. `last_query` is a plain str only on MariaDB — SQLite hands back a
+	LazyMogrify and Postgres a LazyDecode — so a MariaDB-only test cannot catch a
+	regression here.
+	"""
+
+	def compat_case(self):
+		from frappe.tests.utils import FrappeTestCase
+
+		class _Case(FrappeTestCase):
+			def runTest(self):
+				pass
+
+		return _Case()
+
+	def test_query_under_the_budget_passes(self):
+		with self.compat_case().assertQueryCount(5):
+			frappe.db.sql("select 1")
+
+	def test_going_over_the_budget_reports_the_executed_queries(self):
+		# The failure message is built by joining the collected queries, and it is an
+		# eagerly evaluated argument — so this path runs even when the count fits.
+		with self.assertRaises(AssertionError) as raised:
+			with self.compat_case().assertQueryCount(0):
+				frappe.db.sql("select 1")
+
+		self.assertIn("Queries executed:", str(raised.exception))
+
+
 def tearDownModule():
 	"""assertions for ensuring tests didn't leave state behind"""
 	assert "temp_flag_to_be_discarded" not in frappe.flags


### PR DESCRIPTION
Two small fixes that together make `assertQueryCount` work on SQLite. Both are SQLite/Postgres-only paths; MariaDB behaviour is unchanged.

## 1. The SQLite driver never publishes `last_query`

MariaDB sets `last_query` inside its own `log_query` override. Postgres exposes it as a property. The SQLite driver does neither, so it falls back to the base `Database.log_query`, which builds the mogrified query but never publishes it.

Any code that reads `db.last_query` then fails on SQLite alone:

```
AttributeError: 'SQLiteDatabase' object has no attribute 'last_query'
  File "frappe/tests/classes/integration_test_case.py", line 127, in _sql_with_count
    queries.append(str(args[0].last_query))
```

The fix is a driver-local override that mirrors MariaDB.

It cannot go in the base `Database.log_query`, even though that is where the duplication sits: Postgres declares `last_query` as a read-only property, so assigning to it there would raise on every Postgres query.

## 2. The legacy `assertQueryCount` does not stringify the query

With the above fixed, the next error is:

```
TypeError: sequence item 0: expected str instance, LazyMogrify found
  File "frappe/deprecation_dumpster.py", line 734, in assertQueryCount
    self.assertLessEqual(len(queries), count, msg="Queries executed: \n" + "\n\n".join(queries))
```

`last_query` is a lazy wrapper on every driver except MariaDB — `LazyMogrify` on SQLite, `LazyDecode` on Postgres — so the join needs real strings. MariaDB works only by accident, because its `last_query` is `cursor._executed`, a plain `str`.

Worth noting `msg=` is an eagerly evaluated argument, so this raises even when the assertion would have passed.

`IntegrationTestCase.assertQueryCount` already calls `str()`. This applies the same to the deprecated copy, so apps still on `FrappeTestCase` are not left behind.

## Testing

Found this through an app whose CI runs its suite against both databases. The query-count test errored on SQLite and passed on MariaDB.

- App suite, 545 tests: green on MariaDB and on SQLite (was 1 error on SQLite).
- `frappe.tests.test_perf` (the main in-tree user of `assertQueryCount`): 19 pass, 2 errors. Both errors are present without this change too — they need a running bench server.
