### PR TITLE
fix: initialize value in get_locale_value to avoid UnboundLocalError

### DIFF
--- a/frappe/locale.py
+++ b/frappe/locale.py
@@ -46,6 +46,7 @@ def get_locale_value(key: str, language: str | None = None) -> str | None:
 	:param language: The language code to get the value for. Defaults to the current user's language.
 	"""
 	lang = language or frappe.local.lang
+	value = None
 	if lang:
 		value = frappe.client_cache.get_doc("Language", lang).get(key)
 


### PR DESCRIPTION
## Problem

`frappe.locale.get_locale_value()` raises `UnboundLocalError: cannot access local variable 'value'` whenever `lang` is falsy.

```python
def get_locale_value(key: str, language: str | None = None) -> str | None:
    lang = language or frappe.local.lang
    if lang:
        value = frappe.client_cache.get_doc("Language", lang).get(key)
    return value or frappe.db.get_default(key)   # `value` unbound when lang is empty
```

`value` is only assigned inside `if lang:`, but the `return` references it unconditionally.

## Impact

Any request where `frappe.local.lang` is unset hits this — most notably **anonymous (Guest) requests rendering published website pages** on a cold cache, which then return a `500`. `get_date_format`, `get_time_format`, and `get_first_day_of_the_week` all route through this helper, and the fallback error page renders through it too, so it fails the same way.

It's easily masked in normal use because logged-in users always have a language set and rendered pages get cached.

### Reproduce
1. Clear cache.
2. As a logged-out user, load any published Website/Web Page route (e.g. `curl` it).
3. → `500 / Server Error` (`UnboundLocalError` in the traceback).

## Fix

Initialize `value = None` before the branch so the fallback to `frappe.db.get_default(key)` works when there is no language.