### PR TITLE
fix: typeerror on cancel if doctype has int name (autoincrement)

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1071,7 +1071,7 @@ frappe.ui.form.Form = class FrappeForm {
 				method: "frappe.desk.form.linked_with.get_submitted_linked_docs",
 				args: {
 					doctype: me.doc.doctype,
-					name: me.doc.name,
+					name: cstr(me.doc.name),
 					ignore_doctypes_on_cancel_all: me.ignore_doctypes_on_cancel_all,
 				},
 				freeze: true,


### PR DESCRIPTION
```
10:55:45 web.1         | Traceback (most recent call last):
10:55:45 web.1         |   File "apps/frappe/frappe/utils/typing_validations.py", line 184, in transform_parameter_types
10:55:45 web.1         |     current_arg_value_after = TypeAdapter(current_arg_type).validate_python(current_arg_value)
10:55:45 web.1         |   File "env/lib/python3.14/site-packages/pydantic/type_adapter.py", line 441, in validate_python
10:55:45 web.1         |     return self.validator.validate_python(
10:55:45 web.1         |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
10:55:45 web.1         |         object,
10:55:45 web.1         |         ^^^^^^^
10:55:45 web.1         |     ...<6 lines>...
10:55:45 web.1         |         by_name=by_name,
10:55:45 web.1         |         ^^^^^^^^^^^^^^^^
10:55:45 web.1         |     )
10:55:45 web.1         |     ^
10:55:45 web.1         | pydantic_core._pydantic_core.ValidationError: 1 validation error for str
10:55:45 web.1         |   Input should be a valid string [type=string_type, input_value=4, input_type=int]
10:55:45 web.1         |     For further information visit https://errors.pydantic.dev/2.13/v/string_type
10:55:45 web.1         | 
10:55:45 web.1         | The above exception was the direct cause of the following exception:
10:55:45 web.1         | 
10:55:45 web.1         | Traceback (most recent call last):
10:55:45 web.1         |   File "apps/frappe/frappe/app.py", line 126, in application
10:55:45 web.1         |     response = frappe.api.handle(request)
10:55:45 web.1         |   File "apps/frappe/frappe/api/__init__.py", line 64, in handle
10:55:45 web.1         |     data = endpoint(**arguments)
10:55:45 web.1         |   File "apps/frappe/frappe/api/v1.py", line 44, in handle_rpc_call
10:55:45 web.1         |     return frappe.handler.handle()
10:55:45 web.1         |            ~~~~~~~~~~~~~~~~~~~~~^^
10:55:45 web.1         |   File "apps/frappe/frappe/handler.py", line 54, in handle
10:55:45 web.1         |     data = execute_cmd(cmd)
10:55:45 web.1         |   File "apps/frappe/frappe/handler.py", line 87, in execute_cmd
10:55:45 web.1         |     return frappe.call(method, **frappe.form_dict)
10:55:45 web.1         |            ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
10:55:45 web.1         |   File "apps/frappe/frappe/__init__.py", line 1145, in call
10:55:45 web.1         |     return fn(*args, **newargs)
10:55:45 web.1         |   File "apps/frappe/frappe/utils/typing_validations.py", line 47, in wrapper
10:55:45 web.1         |     args, kwargs = transform_parameter_types(func, args, kwargs, force_types)
10:55:45 web.1         |                    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
10:55:45 web.1         |   File "apps/frappe/frappe/utils/typing_validations.py", line 186, in transform_parameter_types
10:55:45 web.1         |     raise_type_error(func, current_arg, current_arg_type, current_arg_value, current_exception=e)
10:55:45 web.1         |     ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
10:55:45 web.1         |   File "apps/frappe/frappe/utils/typing_validations.py", line 86, in raise_type_error
10:55:45 web.1         |     raise FrappeTypeError(
10:55:45 web.1         |     ...<2 lines>...
10:55:45 web.1         |     ) from current_exception
10:55:45 web.1         | frappe.exceptions.FrappeTypeError: Argument 'name' in 'frappe.desk.form.linked_with.get_submitted_linked_docs' should be of type 'str' but got 'int' instead.
```