### PR TITLE
fix: resolve inline email image paths inside the assets and site files directories

### DIFF
--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -638,15 +638,21 @@ def get_filecontent_from_path(path):
 
 	if path.startswith("assets/"):
 		# from public folder
+		base_path = os.path.abspath("assets")
 		full_path = os.path.abspath(path)
 	elif path.startswith("files/"):
 		# public file
-		full_path = frappe.get_site_path("public", path)
+		base_path = os.path.abspath(frappe.get_site_path("public", "files"))
+		full_path = os.path.abspath(frappe.get_site_path("public", path))
 	elif path.startswith("private/files/"):
 		# private file
-		full_path = frappe.get_site_path(path)
+		base_path = os.path.abspath(frappe.get_site_path("private", "files"))
+		full_path = os.path.abspath(frappe.get_site_path(path))
 	else:
-		full_path = path
+		return None
+
+	if os.path.commonpath((base_path, full_path)) != base_path:
+		return None
 
 	if os.path.exists(full_path):
 		with open(full_path, "rb") as f:


### PR DESCRIPTION
Inline image paths in outgoing email now resolve only inside the assets directory and the site public and private files directories.

Paths that fall outside those directories no longer resolve to file content, and the embed attribute is dropped from the message.