### PR TITLE
fix: limit cross-user event lookups to System Manager

### DIFF
--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -353,8 +353,7 @@ def get_events(
 	target_user = user or caller
 
 	if user and user != caller:
-		if not frappe.has_permission("Event", ptype="read"):
-			frappe.throw(_("You are not allowed to view events for another user."), frappe.PermissionError)
+		frappe.only_for("System Manager")
 	type EventLikeDict = Event | frappe._dict
 	resolved_events: list[EventLikeDict] = []
 


### PR DESCRIPTION
The `user` parameter of `get_events` now requires the System Manager role. Callers without that role only see their own events.

No UI caller sends the parameter, and the scheduled event digest runs as Administrator, so both keep working.