### PR TITLE
fix: check permissions before returning a contact number for SMS

### DIFF
--- a/frappe/core/doctype/sms_settings/sms_settings.py
+++ b/frappe/core/doctype/sms_settings/sms_settings.py
@@ -50,17 +50,24 @@ def validate_receiver_nos(receiver_list):
 @frappe.whitelist()
 def get_contact_number(contact_name: str, ref_doctype: str, ref_name: str):
 	"Return mobile number of the given contact."
-	number = frappe.db.sql(
-		"""select mobile_no, phone from tabContact
-		where name=%s
-			and exists(
-				select name from `tabDynamic Link` where link_doctype=%s and link_name=%s
-			)
-	""",
-		(contact_name, ref_doctype, ref_name),
-	)
+	frappe.has_permission("Contact", doc=contact_name, throw=True)
+	frappe.has_permission(ref_doctype, doc=ref_name, throw=True)
 
-	return (number and (number[0][0] or number[0][1])) or ""
+	is_linked = frappe.db.exists(
+		"Dynamic Link",
+		{
+			"parenttype": "Contact",
+			"parent": contact_name,
+			"link_doctype": ref_doctype,
+			"link_name": ref_name,
+		},
+	)
+	if not is_linked:
+		return ""
+
+	contact = frappe.db.get_value("Contact", contact_name, ["mobile_no", "phone"], as_dict=True)
+
+	return (contact and (contact.mobile_no or contact.phone)) or ""
 
 
 @frappe.whitelist()


### PR DESCRIPTION
The contact number lookup now requires read access on both the contact and the reference document. It returns a number only when the contact is actually linked to that reference document.