### PR TITLE
fix: require read access on the prepared report before queuing its CSV export

### DIFF
--- a/frappe/core/doctype/prepared_report/prepared_report.py
+++ b/frappe/core/doctype/prepared_report/prepared_report.py
@@ -143,7 +143,7 @@ def generate_report(prepared_report):
 		create_json_gz_file(result, instance.doctype, instance.name, instance.report_name)
 
 		if report.generate_csv:
-			enqueue_json_to_csv_conversion(prepared_report)
+			_enqueue_json_to_csv_conversion(prepared_report)
 
 		instance.status = "Completed"
 
@@ -371,6 +371,11 @@ def has_permission(doc, user):
 @frappe.whitelist()
 def enqueue_json_to_csv_conversion(prepared_report_name: str):
 	"""Call this to enqueue the conversion in background."""
+	frappe.get_doc("Prepared Report", prepared_report_name).check_permission("read")
+	_enqueue_json_to_csv_conversion(prepared_report_name)
+
+
+def _enqueue_json_to_csv_conversion(prepared_report_name: str):
 	enqueue(method=convert_json_to_csv, queue="long", prepared_report_name=prepared_report_name)
 
 


### PR DESCRIPTION
The whitelisted `enqueue_json_to_csv_conversion` endpoint now checks the caller's read permission on the Prepared Report before it queues the conversion.

Report generation calls the internal helper directly, so automatic CSV generation is unchanged.
