### PR TITLE
fix(pfb): keep the selection ring above field content

### DIFF
--- a/frappe/public/js/frappe/model/perm.js
+++ b/frappe/public/js/frappe/model/perm.js
@@ -3,7 +3,7 @@
 
 frappe.provide("frappe.perm");
 
-const boot_backed_rights = ["select", "delete", "submit", "cancel"];
+const boot_backed_rights = ["select", "write", "delete", "submit", "cancel"];
 
 // backward compatibilty
 Object.assign(window, {

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -1013,13 +1013,7 @@ function handle_slash_key(e) {
 	user-select: none;
 }
 
-.pfb-tree-row:hover {
-	background: var(--gray-100);
-}
-
-/* mirrors the canvas hover back into the tree — an outline in the same accent
-   as the canvas ring, so it reads as "this is the block you're pointing at"
-   rather than as another selectable/active row */
+.pfb-tree-row:hover,
 .pfb-tree-row.pfb-tree-hover {
 	outline: 1px solid var(--pfb-accent);
 	outline-offset: -1px;

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -650,6 +650,7 @@ watch(
 
 <style scoped>
 .field--chip {
+	position: relative;
 	display: flex;
 	flex-direction: column;
 	gap: 0;
@@ -827,18 +828,19 @@ watch(
 	opacity: 0.35;
 }
 
-/* One ring for every active field state — selected, hover, layer-hover all
-   look identical. Inset (never changes previewed geometry, never bleeds past
-   the page or a grid cell); 2px survives the canvas zoom (1px → sub-pixel). */
-.field--preview.field--selected,
-.field--preview:hover,
-.field--preview.field--layer-hover,
-.field--chip.field--selected,
-.field--chip:hover,
-.field--chip.field--layer-hover {
-	outline: var(--pfb-ring);
-	outline-offset: -2px;
-	box-shadow: none;
+.field--preview.field--selected::after,
+.field--preview:hover::after,
+.field--preview.field--layer-hover::after,
+.field--chip.field--selected::after,
+.field--chip:hover::after,
+.field--chip.field--layer-hover::after {
+	content: "";
+	position: absolute;
+	inset: 0;
+	z-index: 1;
+	border: var(--pfb-ring);
+	border-radius: inherit;
+	pointer-events: none;
 }
 
 .field-preview-actions {


### PR DESCRIPTION
- Draw the field selection/hover ring as an inset overlay instead of an `outline`, so it paints above the field's own content — a child table's full-bleed header no longer spills past the ring
- Layer rows use the same accent outline on hover as the canvas ring, instead of a gray fill
- `frappe.perm.has_perm(dt, 0, "write")` now falls back to `boot.user.can_write` when the doctype meta isn't loaded yet — it previously always returned false, so the builder's gear icon told even Administrator "You are not permitted to change Print Settings"

Why: an `outline` with a negative offset sits below descendant backgrounds, so full-bleed content leaked over it. And the boot-backed rights list covered only select/delete/submit/cancel, leaving `write` un-grantable before the meta loads even though boot already ships `can_write`.

no-docs
