### PR TITLE
fix(attach): Skip auto-save when attaching files on unsaved documents

### DIFF
--- a/cypress/integration/control_attach.js
+++ b/cypress/integration/control_attach.js
@@ -214,15 +214,18 @@ context("Attach Control with Failed Document Save", () => {
 		cy.intercept("POST", "/api/method/upload_file").as("upload_image");
 		cy.get(".modal-footer").findByRole("button", { name: "Upload" }).click({ delay: 500 });
 		cy.wait("@upload_image");
-		cy.get(".msgprint-dialog .modal-title").contains("Missing Fields").should("be.visible");
-		cy.hide_dialog();
-		cy.fill_field("text_field", "Random value", "Text Editor").wait(500);
-		cy.findByRole("button", { name: "Save" }).click().wait(500);
+
+		// After fix for #39480: uploading on a new doc should NOT trigger save/validation
+		cy.get(".msgprint-dialog").should("not.exist");
 
 		//Checking if the URL of the attached image is getting displayed in the field of the newly created doctype
 		cy.get(".attached-file > .ellipsis > .attached-file-link")
 			.should("have.attr", "href")
 			.and("equal", "https://wallpaperplay.com/walls/full/8/2/b/72402.jpg");
+
+		// Now fill mandatory field and save manually
+		cy.fill_field("text_field", "Random value", "Text Editor").wait(500);
+		cy.findByRole("button", { name: "Save" }).click().wait(500);
 
 		cy.get(".title-text-form").then(($value) => {
 			docname = $value.text();

--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -40,7 +40,9 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 				me.frm.attachments.remove_attachment_by_filename(me.value, async () => {
 					await me.parse_validate_and_set_in_model(null);
 					me.refresh();
-					me.frm.doc.docstatus == 1 ? me.frm.save("Update") : me.frm.save();
+					if (!me.frm.is_new()) {
+						me.frm.doc.docstatus == 1 ? me.frm.save("Update") : me.frm.save();
+					}
 				});
 			} else {
 				me.dataurl = null;
@@ -139,7 +141,9 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 		if (this.frm) {
 			await this.parse_validate_and_set_in_model(attachment.file_url);
 			this.frm.attachments.update_attachment(attachment);
-			this.frm.doc.docstatus == 1 ? this.frm.save("Update") : this.frm.save();
+			if (!this.frm.is_new()) {
+				this.frm.doc.docstatus == 1 ? this.frm.save("Update") : this.frm.save();
+			}
 		}
 		this.set_value(attachment.file_url);
 	}


### PR DESCRIPTION
Guard `frm.save()` calls in `on_upload_complete` and `clear_attachment` with `!frm.is_new()` so that uploading or clearing an attachment on a new (unsaved) document does not trigger the full save pipeline and mandatory field validation.

Fixes #39480

Credits to: @musabaku 

