### PR TITLE
fix(ui): mobile list scrolling, large-list performance, and virtual skeletons

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -430,6 +430,16 @@ frappe.views.BaseList = class BaseList {
 		// place it at the footer of the page
 
 		let $result_container = this.$result.parent(".result-container");
+
+		// On mobile a fixed height makes the container a second scroller and
+		// the page double-scrolls (the browser bar resizing the viewport
+		// leaves the pixel height stale). Let rows flow instead — except in
+		// virtual mode, which needs a scrollbox to window rows.
+		if (frappe.is_mobile() && !this.virtualization_state?.enabled) {
+			$result_container.css("height", "");
+			return;
+		}
+
 		let main_rect = $(".main-section").get(0).getBoundingClientRect();
 		let result_top = $result_container.get(0).getBoundingClientRect().top - main_rect.top;
 		let resultContainerHeight = Math.floor(

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1051,6 +1051,10 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		if (this.should_use_virtualization()) {
 			this.sync_virtualization_viewport_mode();
 			this.setup_virtualization_scroll_handler();
+			// restore the fixed container height (mobile drops it for small
+			// lists) BEFORE the first window render — otherwise the window
+			// math reads the container's own content as the viewport
+			this.set_result_height();
 			this.render_virtual_rows(true);
 		} else {
 			// Small list path: original behaviour — render every row into the DOM.
@@ -1058,11 +1062,17 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 				this.teardown_virtualization_scroll_handler();
 			}
 			if (this.data.length > 0) {
+				// build all rows, insert once — per-row appends turn any
+				// geometry read in the loop into a re-layout of the growing
+				// list (quadratic on big pages)
 				let idx = 0;
-				for (let doc of this.data) {
-					doc._idx = idx++;
-					this.$result.append(this.get_list_row_html(doc));
-				}
+				const rows_html = this.data
+					.map((doc) => {
+						doc._idx = idx++;
+						return this.get_list_row_html(doc);
+					})
+					.join("");
+				this.$result.append(rows_html);
 			}
 		}
 

--- a/frappe/public/js/frappe/list/list_view_virtualization.js
+++ b/frappe/public/js/frappe/list/list_view_virtualization.js
@@ -139,8 +139,9 @@ export const list_view_virtualization = {
 	},
 
 	get_virtualization_row_buffer() {
-		// Keep more rows rendered off-screen so fast scrolls are less likely to hit a blank gap.
-		return frappe.is_mobile() ? 24 : this.virtualization_row_buffer;
+		// Keep more rows rendered off-screen so fast scrolls are less likely to hit
+		// a blank gap. Touch flings outrun the window sooner, so mobile gets more.
+		return frappe.is_mobile() ? 40 : this.virtualization_row_buffer;
 	},
 
 	uses_accumulated_row_heights() {
@@ -361,7 +362,10 @@ export const list_view_virtualization = {
 		// Step 1: compute visible window from scroll position
 		const row_buffer = this.get_virtualization_row_buffer();
 		const scroll_top = $container.scrollTop() || 0;
-		const viewport_height = $container.innerHeight() || 0;
+		// clamped: an auto-height container reports its own content (spacers
+		// included) as innerHeight, which would inflate the row window until
+		// the whole list is in the DOM
+		const viewport_height = Math.min($container.innerHeight() || 0, window.innerHeight);
 		const start = this.find_virtual_start_index(scroll_top, row_buffer, total_rows);
 		const end = this.find_virtual_end_index(start, viewport_height, row_buffer, total_rows);
 
@@ -381,27 +385,24 @@ export const list_view_virtualization = {
 		$container.find(".list-virtual-spacer").remove();
 		this.$result.find('.list-row-container[data-virtual-row="1"]').remove();
 
-		// Steps 4–6: spacers + rows + spacers
+		// Steps 4–6: spacers + rows + spacers, built as one string and
+		// inserted once — this runs on every window shift while scrolling
 		const top_spacer_height = this.get_virtual_spacer_height(0, start);
 		const bottom_spacer_height = this.get_virtual_spacer_height(end, total_rows);
 
+		let window_html = "";
 		if (top_spacer_height > 0) {
-			this.$result.append(
-				`<div class="list-virtual-spacer" style="height:${top_spacer_height}px"></div>`
-			);
+			window_html += `<div class="list-virtual-spacer" style="height:${top_spacer_height}px"></div>`;
 		}
-
 		for (let i = start; i < end; i++) {
 			const doc = this.data[i];
 			doc._idx = i;
-			this.$result.append(this.get_list_row_html(doc, { virtual: true }));
+			window_html += this.get_list_row_html(doc, { virtual: true });
 		}
-
 		if (bottom_spacer_height > 0) {
-			this.$result.append(
-				`<div class="list-virtual-spacer" style="height:${bottom_spacer_height}px"></div>`
-			);
+			window_html += `<div class="list-virtual-spacer" style="height:${bottom_spacer_height}px"></div>`;
 		}
+		this.$result.append(window_html);
 
 		if (!frappe.is_mobile()) {
 			this.apply_column_widths();

--- a/frappe/public/js/frappe/utils/common.js
+++ b/frappe/public/js/frappe/utils/common.js
@@ -270,8 +270,18 @@ frappe.get_cookies = function getCookies() {
 	return cookies;
 };
 
+// Memoized: window.innerWidth forces layout, and is_mobile runs in tight
+// render loops where DOM writes keep layout dirty — reading it per call
+// made large list renders quadratic.
+let _is_mobile_cache = null;
+$(window).on("resize", () => {
+	_is_mobile_cache = null;
+});
 frappe.is_mobile = function () {
-	return window.innerWidth < 768;
+	if (_is_mobile_cache === null) {
+		_is_mobile_cache = window.innerWidth < 768;
+	}
+	return _is_mobile_cache;
 };
 
 frappe.is_large_screen = function () {

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -10,6 +10,49 @@
 				.list-virtual-spacer {
 					width: 100%;
 					pointer-events: none;
+					position: relative;
+
+					// Fast flings outrun the rendered row window — paint the gap
+					// as breathing skeleton rows. The paint sits on a bounded
+					// pseudo-element because iOS won't rasterize an animated
+					// layer the size of the full spacer (~100k+px). The SVG is
+					// a mask so the color stays a theme token; surface-gray-3
+					// because the breathe animation would dim --skeleton-bg to
+					// invisibility in light mode. Cadence matches the row
+					// height estimates in list_view.js (44px rows, 72px cards).
+					&::before {
+						content: "";
+						position: absolute;
+						left: 0;
+						right: 0;
+						height: min(100%, 4096px);
+						background-color: var(--surface-gray-3);
+						-webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='1%25' y='16' width='24%25' height='12' rx='6' fill='black'/%3E%3Crect x='46%25' y='16' width='12%25' height='12' rx='6' fill='black'/%3E%3Crect x='63%25' y='16' width='9%25' height='12' rx='6' fill='black'/%3E%3Crect x='79%25' y='16' width='7%25' height='12' rx='6' fill='black'/%3E%3Crect x='95%25' y='16' width='4%25' height='12' rx='6' fill='black'/%3E%3C/svg%3E");
+						mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='1%25' y='16' width='24%25' height='12' rx='6' fill='black'/%3E%3Crect x='46%25' y='16' width='12%25' height='12' rx='6' fill='black'/%3E%3Crect x='63%25' y='16' width='9%25' height='12' rx='6' fill='black'/%3E%3Crect x='79%25' y='16' width='7%25' height='12' rx='6' fill='black'/%3E%3Crect x='95%25' y='16' width='4%25' height='12' rx='6' fill='black'/%3E%3C/svg%3E");
+						-webkit-mask-size: 100% 44px;
+						mask-size: 100% 44px;
+						-webkit-mask-repeat: repeat-y;
+						mask-repeat: repeat-y;
+						animation: 2s breathe infinite;
+
+						// mobile cards: a title line over a shorter meta line
+						@media (max-width: 767.98px) {
+							-webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='3%25' y='16' width='58%25' height='13' rx='6' fill='black'/%3E%3Crect x='3%25' y='42' width='34%25' height='11' rx='5' fill='black'/%3E%3C/svg%3E");
+							mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='3%25' y='16' width='58%25' height='13' rx='6' fill='black'/%3E%3Crect x='3%25' y='42' width='34%25' height='11' rx='5' fill='black'/%3E%3C/svg%3E");
+							-webkit-mask-size: 100% 72px;
+							mask-size: 100% 72px;
+						}
+					}
+
+					// the bottom spacer's gap appears at its top edge (just
+					// past the rendered rows); the top spacer's at its bottom
+					&:last-child::before {
+						top: 0;
+					}
+
+					&:not(:last-child)::before {
+						bottom: 0;
+					}
 				}
 
 				.list-row-container {
@@ -338,6 +381,18 @@ $level-margin-right: 8px;
 
 	&.seen {
 		font-weight: normal;
+	}
+}
+
+// On mobile the rows flow in the page scroll (see set_result_height), so
+// pin the paging controls to the bottom edge; opaque background because
+// rows pass underneath
+@media (max-width: 767.98px) {
+	.frappe-list .list-paging-area {
+		position: sticky;
+		bottom: 0;
+		background-color: var(--fg-color);
+		z-index: 3;
 	}
 }
 
@@ -717,6 +772,10 @@ input.list-header-checkbox {
 
 @media (max-width: map-get($grid-breakpoints, "sm")) {
 	.layout-main-section .frappe-list .result-container {
+		// rows are stacked cards at this width — nothing needs horizontal
+		// scroll, and iOS turns any transient overflow into a sideways wiggle
+		overflow-x: hidden;
+
 		.result {
 			overflow: hidden;
 			display: block;
@@ -726,6 +785,18 @@ input.list-header-checkbox {
 				width: 15px !important;
 				height: 15px;
 			}
+		}
+
+		// the desktop column split (level-left 80% + level-right 130px) sums
+		// past the card-width viewport and pushed the list count and the
+		// header's rounded corner over the clipped right edge
+		.list-row .level-right {
+			flex: 0 0 auto;
+			width: auto;
+		}
+
+		.list-row-head .level-left {
+			min-width: 0;
 		}
 
 		.list-row-container:not(:has(.list-row-head)) {

--- a/frappe/public/scss/desk/main.scss
+++ b/frappe/public/scss/desk/main.scss
@@ -36,12 +36,14 @@ body {
 
 .main-section {
 	width: 100%;
-	height: 100vh;
+	height: 100vh; // fallback for engines without dvh
+	height: 100dvh; // tracks the mobile browser bar
 	overflow: scroll;
 	overflow-x: hidden;
 	overflow-y: visible;
 	scrollbar-gutter: stable;
 }
+
 .sticky-top {
 	z-index: 1019;
 }

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -34,7 +34,8 @@
 		// reserves the panel's width in-flow so the main section glides across as the panel animates
 		// in/out; the panel itself is absolutely positioned over this
 		width: var(--sidebar-width);
-		height: 100vh;
+		height: 100vh; // fallback for engines without dvh
+		height: 100dvh;
 		transition: width 0.25s cubic-bezier(0.4, 0, 0.2, 1);
 	}
 }
@@ -58,7 +59,8 @@
 	display: flex;
 	flex-direction: column;
 	gap: 12px;
-	height: 100vh;
+	height: 100vh; // fallback for engines without dvh
+	height: 100dvh;
 	z-index: 1020;
 	padding: 8px 8px 10px 8px;
 
@@ -447,6 +449,7 @@
 .indent + .nested-container {
 	margin-left: calc(var(--margin-sm) + 1px);
 	border-left: 1px solid var(--border-color);
+
 	.sidebar-item-container {
 		margin-left: var(--margin-xs);
 	}


### PR DESCRIPTION
Fixes a set of mobile list view issues found while testing on a phone, plus two performance bugs that affect all screen sizes.

### Scrolling

1. Fix double scroll on mobile: the desk shell now uses 100dvh (with vh fallback), and list rows flow in the page scroll instead of a nested fixed-height container
2. Pin the pagination controls to the bottom of the screen on mobile (sticky)
3. Remove horizontal scroll on mobile card layout — it only existed because the list header overflowed
4. Fix the list header overflowing on mobile (page count and rounded corner were cut off)

### Performance

1. Fix a freeze when loading 2000+ rows on mobile: virtual mode now gets its fixed-height scrollbox back before the first render, and the viewport is clamped so the row window can't grow unbounded
2. Fix a hang on "Load More" with large pages: frappe.is_mobile() read window.innerWidth (a forced-layout trigger) once per row, making renders quadratic — it's now memoized, and rows are inserted in one batch instead of one by one
3. Batch virtual scroll window renders the same way (~90 inserts → 1 per scroll step)

### Virtual scroll UX

1. Show skeleton rows in the gap when a fast fling outruns the rendered window (pure CSS, per-column bars, theme-aware)
2. Paint the skeleton on a bounded pseudo-element — iOS silently drops animated layers the size of the full spacer, which made it invisible on iPhones
3. Larger row buffer on mobile (24 → 40) since touch flings outrun the window faster