### PR TITLE
fix: persist google oauth callback method in state so callback routes across workers

### DIFF
--- a/frappe/integrations/google_oauth.py
+++ b/frappe/integrations/google_oauth.py
@@ -130,7 +130,8 @@ class GoogleOAuth:
 		:param state: dict of values which you need on callback (for calling methods, redirection back to the form, doc name, etc)
 		"""
 
-		state.update({"domain": self.domain})
+		# Persist the callback method in the (server-side) state so the callback can route without relying on _DOMAIN_CALLBACK_METHODS, which only lives in current worker's memory.
+		state.update({"domain": self.domain, "callback_method": _DOMAIN_CALLBACK_METHODS[self.domain]})
 		state_token = create_google_oauth_state(state)
 		callback_url = get_request_site_address(True) + CALLBACK_METHOD
 
@@ -209,9 +210,11 @@ def callback(state: str, code: str | None = None, error: str | None = None) -> N
 	failure_query_param = state.pop("failure_query_param", "")
 
 	if not error:
-		if (domain := state.pop("domain")) in _DOMAIN_CALLBACK_METHODS:
+		domain = state.pop("domain", None)
+		callback_method = state.pop("callback_method", None) or _DOMAIN_CALLBACK_METHODS.get(domain)
+		if callback_method:
 			state.update({"code": code})
-			frappe.get_attr(_DOMAIN_CALLBACK_METHODS[domain])(**state)
+			frappe.get_attr(callback_method)(**state)
 
 			# GET request, hence using commit to persist changes
 			frappe.db.commit()  # nosemgrep

--- a/frappe/integrations/test_google_oauth.py
+++ b/frappe/integrations/test_google_oauth.py
@@ -46,6 +46,23 @@ class TestGoogleOAuth(IntegrationTestCase):
 		self.assertEqual(frappe.local.response["type"], "redirect")
 		self.assertEqual(frappe.local.response["location"], "/app/todo?connected=1")
 
+	def test_callback_dispatches_via_state_callback_method(self):
+		_dispatched_calls.clear()
+		frappe.local.response = frappe._dict()
+		state_token = create_google_oauth_state(
+			{
+				"domain": "drive",
+				"callback_method": "frappe.integrations.test_google_oauth._fake_domain_callback",
+				"redirect": "/app/todo",
+				"success_query_param": "connected=1",
+			}
+		)
+		# "drive" is deliberately absent from _DOMAIN_CALLBACK_METHODS here
+		callback(state=state_token, code="real-auth-code")
+
+		self.assertEqual(_dispatched_calls, [{"code": "real-auth-code"}])
+		self.assertEqual(frappe.local.response["location"], "/app/todo?connected=1")
+
 	def test_callback_rejects_unknown_state(self):
 		frappe.local.response = frappe._dict()
 		callback(state="not-a-real-token", error="access_denied")


### PR DESCRIPTION
_DOMAIN_CALLBACK_METHODS is a process-local global dict. The registration only lives in the memory of the gunicorn worker that handled the "Authorize" click. The Google callback is a separate HTTP request that lands on whichever worker gunicorn picks — that's almost always a different worker, which never registered "drive". So the lookup fails in prod.

The OAuth state (which carries domain: "drive") does survive the round-trip because it's stored in Redis — but the domain→callback-method mapping is not, so the callback can't route it.

Fix: Persist the callback method in the Redis-backed state at authorize time so the callback no longer depends on per-worker global state

https://support.frappe.io/helpdesk/tickets/74983?view=VIEW-HD+Ticket-70178