### PR TITLE
fix: page header actions get clipped when the title is long

### DIFF
--- a/frappe/public/scss/desk/breadcrumb.scss
+++ b/frappe/public/scss/desk/breadcrumb.scss
@@ -32,6 +32,16 @@
 		}
 	}
 
+	li {
+		min-width: 0;
+	}
+
+	li:last-child > a {
+		display: block;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
 	&.mobile-no-divider {
 		a:before {
 			display: none;

--- a/frappe/public/scss/desk/page.scss
+++ b/frappe/public/scss/desk/page.scss
@@ -2,6 +2,7 @@
 	display: flex;
 	align-items: center;
 	padding: 0 15px;
+	min-width: 0;
 
 	.sidebar-toggle-btn {
 		display: flex;


### PR DESCRIPTION
The header was `flex-nowrap`, and `.page-title` lacked `min-width: 0`, so long breadcrumb titles couldn't shrink and pushed the actions off-screen, clipping the primary action.

Allowing the title to shrink exposed another issue: `.navbar-breadcrumbs` is a flex container, so the inherited `text-overflow` from `.ellipsis` never applied. The current breadcrumb now truncates with an ellipsis instead of being clipped mid-word.

### Before/After


https://github.com/user-attachments/assets/d6ebf018-4af8-4ba7-a4a7-3a4ba3066496



https://github.com/user-attachments/assets/68e73122-a218-4aa6-b874-838be109ea1c

---

Ref: https://support.frappe.io/helpdesk/tickets/75027?view=VIEW-HD+Ticket-1252


