### PR TITLE
fix(print): blank Desk preview for standard Jinja print formats

### DIFF
--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -76,7 +76,9 @@ class PrintFormat(Document):
 		if self.print_format_for == "Report":
 			self.custom_format = 1
 
-		if self.is_new() and not self.custom_format:
+		# standard formats render from their app's .html template or a classic layout,
+		# neither of which the beta renderer can read
+		if self.is_new() and not self.custom_format and self.standard != "Yes":
 			self.print_format_builder_beta = 1
 
 		if self.print_format_builder_beta and not self.custom_format:

--- a/frappe/printing/doctype/print_format/test_print_format.py
+++ b/frappe/printing/doctype/print_format/test_print_format.py
@@ -374,6 +374,22 @@ class TestClassicConverter(IntegrationTestCase):
 		self.assertTrue(uses_beta_renderer(classic))
 		self.assertTrue(uses_beta_renderer(beta))
 
+	def test_standard_jinja_format_stays_off_the_beta_renderer(self):
+		from frappe.printing.doctype.print_format.classic_converter import uses_beta_renderer
+
+		# app-shipped Jinja format: html lives in the module's .html file, so there is
+		# no format_data for the beta renderer to read
+		doc = frappe.new_doc("Print Format")
+		doc.name = "_Test Standard Jinja Format"
+		doc.doc_type = "User"
+		doc.module = "Core"
+		doc.standard = "Yes"
+		doc.custom_format = 0
+		doc.before_save()
+
+		self.assertEqual(doc.print_format_builder_beta, 0)
+		self.assertFalse(uses_beta_renderer(doc))
+
 	def test_convert_print_format_document(self):
 		from frappe.printing.doctype.print_format.classic_converter import convert_print_format
 


### PR DESCRIPTION
Fixes #41302

- `before_save` no longer flips `print_format_builder_beta` on standard formats, so app-shipped Jinja formats keep rendering from their `.html` template instead of an empty `format_data`
- Clearing the print format selector now falls back to the doctype's default, matching what the server already does when no format is passed
- Adds a regression test

Why:

"not custom_format" is also true of a standard format whose HTML lives in `<module>/print_format/<name>/<name>.html`. On first insert it was marked beta, `uses_beta_renderer` then returned true, and the Desk preview rendered it through `PrintFormatGenerator` with no `format_data` — a blank page. Full Page, Print and `download_pdf` were unaffected because they go through `get_rendered_template`.

Separately, `selected_format()` collapsed an empty selector to `"Standard"`, which isn't a real Print Format — so `get_print_format()` returned `{}` and every decision derived from it was made against a format that wasn't the one being rendered: which renderer to use, whether raw printing is on, the format's letterhead and default print language, and whether Customize is offered. The server meanwhile resolved `meta.default_print_format`, so the two disagreed and the preview came out blank whenever that default was a custom format.

Standard classic-builder formats are unaffected: `uses_beta_renderer` still detects them from their layout, so the render-time conversion applies as before.
