### PR TITLE
fix(print): clearing the print format falls back to the standard format

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -106,7 +106,7 @@ frappe.ui.form.PrintView = class {
 	setup_sidebar() {
 		this.sidebar = this.page.sidebar.addClass("print-preview-sidebar");
 
-		this.print_format_selector = this.add_sidebar_item({
+		this.print_format_field = this.add_sidebar_item({
 			fieldtype: "Link",
 			fieldname: "print_format",
 			options: "Print Format",
@@ -120,7 +120,8 @@ frappe.ui.form.PrintView = class {
 				};
 			},
 			change: () => this.refresh_print_format(),
-		}).$input;
+		});
+		this.print_format_selector = this.print_format_field.$input;
 
 		this.language_selector = this.add_sidebar_item({
 			fieldtype: "Link",
@@ -312,7 +313,7 @@ frappe.ui.form.PrintView = class {
 					callback: (r) => {
 						if (r.message) {
 							frappe.set_route("print-format-builder", r.message.name);
-							this.print_format_selector.val(data.print_format_name);
+							this.print_format_field.set_input(data.print_format_name);
 						}
 					},
 				});
@@ -495,15 +496,12 @@ frappe.ui.form.PrintView = class {
 	}
 
 	preview_beta() {
-		let print_format = this.get_print_format();
 		const iframe = this.print_wrapper.find(".preview-beta-wrapper iframe");
 		let params = new URLSearchParams({
 			doctype: this.frm.doc.doctype,
 			name: this.frm.doc.name,
+			print_format: this.selected_format(),
 		});
-		if (print_format.name) {
-			params.append("print_format", print_format.name);
-		}
 		let letterhead = this.get_letterhead();
 		if (letterhead) {
 			params.append("letterhead", letterhead);
@@ -881,7 +879,7 @@ frappe.ui.form.PrintView = class {
 	set_default_print_format() {
 		const default_format =
 			this.frm._layout_print_format || this.frm.meta.default_print_format || "";
-		this.print_format_selector.val(default_format);
+		this.print_format_field.set_input(default_format);
 	}
 
 	selected_format() {

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -288,10 +288,8 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			}
 			let value = me.get_input_value();
 			let label = me.get_label_value();
-			let last_value = me.last_value || "";
-			let last_label = me.label || "";
 
-			if (value !== last_value) {
+			if (value !== (me.value || "")) {
 				me.parse_validate_and_set_in_model(value, null, label);
 			}
 		});


### PR DESCRIPTION
Clearing the Print Format field in the print view left the previous format on screen, and once it did re-render it showed the doctype's default instead of the standard format.

- Set the default format through the control instead of writing `$input.val()` directly, so the control's own value stays in sync
- Compare the Link field's blur value against the control's current value rather than `last_value`, which holds the *previous* value and made an out-of-band write look like "unchanged"
- Send the resolved format to `/printpreview` explicitly, so an empty selector means the standard format instead of letting the server fall back to `meta.default_print_format`

Why: `set_default_print_format()` wrote the input directly, so the control's `value` stayed `null`. On clearing, the blur guard compared `"" !== (last_value || "")` — both empty — and never fired `change`, so `refresh_print_format()` never ran. With the value in sync the change fires, and passing the format explicitly keeps the client and server agreeing on what "nothing selected" means.

no-docs
