### PR TITLE
fix: require POST for bulk document and title update endpoints

### DIFF
--- a/frappe/desk/doctype/bulk_update/bulk_update.py
+++ b/frappe/desk/doctype/bulk_update/bulk_update.py
@@ -50,7 +50,7 @@ class BulkUpdate(Document):
 		)
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def submit_cancel_or_update_docs(
 	doctype: str,
 	docnames: str | list[str],

--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 	from frappe.model.meta import Meta
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def update_document_title(
 	*,
 	doctype: str,

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -314,7 +314,7 @@ def get_workflow_field_value(workflow_name, field):
 	return frappe.get_cached_value("Workflow", workflow_name, field)
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def bulk_workflow_approval(docnames: str | list, doctype: str, action: str):
 	docnames = frappe.parse_json(docnames)
 	if len(docnames) < 20:


### PR DESCRIPTION
The bulk submit/cancel/update, bulk workflow approval, and document title
update endpoints now reject requests made with safe HTTP methods.