### PR TITLE
fix: serve boot translations only for enabled languages

### DIFF
--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -138,6 +138,9 @@ def get_messages_for_boot():
 @http_cache(max_age=31536000)
 def get_boot_translations(lang: str | None = None) -> dict[str, str]:
 	"""Return all translations for the current user's language."""
+	if lang and lang not in get_all_languages():
+		lang = None
+
 	return get_all_translations(lang or frappe.local.lang)
 
 


### PR DESCRIPTION
An unknown language code now falls back to the language of the current
session instead of being used as given.