### PR TITLE
fix: limit notification log document access to its recipient

### DIFF
--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -111,6 +111,12 @@ def get_permission_query_conditions(for_user):
 	return f"""(`tabNotification Log`.for_user = {frappe.db.escape(for_user)})"""
 
 
+def has_permission(doc, ptype="read", user=None):
+	user = user or frappe.session.user
+
+	return user == "Administrator" or doc.for_user == user
+
+
 def get_title(doctype, docname, title_field=None):
 	if not title_field:
 		title_field = frappe.get_meta(doctype).get_title_field()

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -141,6 +141,7 @@ has_permission = {
 	"File": "frappe.core.doctype.file.file.has_permission",
 	"Prepared Report": "frappe.core.doctype.prepared_report.prepared_report.has_permission",
 	"Notification Settings": "frappe.desk.doctype.notification_settings.notification_settings.has_permission",
+	"Notification Log": "frappe.desk.doctype.notification_log.notification_log.has_permission",
 	"User Invitation": "frappe.core.doctype.user_invitation.user_invitation.has_permission",
 	"Document Template": "frappe.desk.doctype.document_template.document_template.has_permission",
 }


### PR DESCRIPTION
A notification log document is now readable only by the user it is
addressed to, matching the list view filter.