### PR TITLE
fix: limit Dashboard Settings access to the matching user

### DIFF
--- a/frappe/desk/doctype/dashboard_settings/dashboard_settings.py
+++ b/frappe/desk/doctype/dashboard_settings/dashboard_settings.py
@@ -45,6 +45,12 @@ def get_permission_query_conditions(user):
 	return f"""(`tabDashboard Settings`.name = {frappe.db.escape(user)})"""
 
 
+def has_permission(doc, ptype="read", user=None):
+	user = user or frappe.session.user
+
+	return user == "Administrator" or doc.name == user
+
+
 @frappe.whitelist()
 def save_chart_config(reset: int | str | bool, config: str | dict[str, Any], chart_name: str):
 	reset = frappe.parse_json(reset)

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -141,6 +141,7 @@ has_permission = {
 	"File": "frappe.core.doctype.file.file.has_permission",
 	"Prepared Report": "frappe.core.doctype.prepared_report.prepared_report.has_permission",
 	"Notification Settings": "frappe.desk.doctype.notification_settings.notification_settings.has_permission",
+	"Dashboard Settings": "frappe.desk.doctype.dashboard_settings.dashboard_settings.has_permission",
 	"User Invitation": "frappe.core.doctype.user_invitation.user_invitation.has_permission",
 	"Document Template": "frappe.desk.doctype.document_template.document_template.has_permission",
 }


### PR DESCRIPTION
Document level permission now requires the record name to match the
session user, with Administrator retained as an exception.