### PR TITLE
fix: limit Tag Link queries to doctypes the user can read

### DIFF
--- a/frappe/desk/doctype/tag_link/tag_link.py
+++ b/frappe/desk/doctype/tag_link/tag_link.py
@@ -3,6 +3,7 @@
 
 import frappe
 from frappe.model.document import Document
+from frappe.permissions import get_doctypes_with_read
 
 
 class TagLink(Document):
@@ -31,6 +32,19 @@ class TagLink(Document):
 
 def on_doctype_update():
 	frappe.db.add_index("Tag Link", ["document_type", "document_name"])
+
+
+def get_permission_query_conditions(user: str | None = None) -> str:
+	user = user or frappe.session.user
+
+	if user == "Administrator":
+		return ""
+
+	readable_doctypes = ", ".join(repr(dt) for dt in get_doctypes_with_read(user))
+	if not readable_doctypes:
+		return " 1 = 0 "
+
+	return f""" `tabTag Link`.`document_type` in ({readable_doctypes}) """
 
 
 def has_tags(doctype: str):

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -123,6 +123,7 @@ permission_query_conditions = {
 	"File": "frappe.core.doctype.file.file.get_permission_query_conditions",
 	"User Invitation": "frappe.core.doctype.user_invitation.user_invitation.get_permission_query_conditions",
 	"Document Template": "frappe.desk.doctype.document_template.document_template.get_permission_query_conditions",
+	"Tag Link": "frappe.desk.doctype.tag_link.tag_link.get_permission_query_conditions",
 }
 
 has_permission = {


### PR DESCRIPTION
Tag Link now applies a permission query condition, so list and report
results only include tags on doctypes readable by the current user.