### PR TITLE
fix: scope follow and unfollow endpoints to the session user

### DIFF
--- a/frappe/desk/form/document_follow.py
+++ b/frappe/desk/form/document_follow.py
@@ -19,16 +19,16 @@ if TYPE_CHECKING:
 def update_follow(doctype: str, doc_name: str, following: bool | str):
 	following = frappe.utils.sbool(following)
 	if following:
-		is_following = follow_document(doctype, doc_name, frappe.session.user)
+		is_following = follow_document(doctype, doc_name)
 		return bool(is_following)
 	else:
-		unfollow_document(doctype, doc_name, frappe.session.user)
+		unfollow_document(doctype, doc_name)
 		return False
 
 
 @frappe.whitelist()
-def follow_document(doctype: str, doc_name: str, user: str) -> Document | bool:
-	return _follow_document(doctype, doc_name, user, ignore_permissions=False)
+def follow_document(doctype: str, doc_name: str) -> Document | bool:
+	return _follow_document(doctype, doc_name, frappe.session.user, ignore_permissions=False)
 
 
 def _follow_document(
@@ -67,13 +67,6 @@ def _follow_document(
 		frappe.toast(_("Administrator can't follow"))
 		return False
 
-	if (
-		not ignore_permissions
-		and user != frappe.session.user
-		and not frappe.has_permission("Document Follow", "write")
-	):
-		frappe.throw(_("You can only follow documents for yourself."), frappe.PermissionError)
-
 	if not frappe.has_permission(doctype, "read", doc=doc_name, user=user):
 		return False
 
@@ -92,9 +85,12 @@ def _follow_document(
 
 
 @frappe.whitelist()
-def unfollow_document(doctype: str, doc_name: str, user: str) -> bool:
-	if user != frappe.session.user and not frappe.has_permission("Document Follow", "write"):
-		frappe.throw(_("You can only unfollow documents for yourself."), frappe.PermissionError)
+def unfollow_document(doctype: str, doc_name: str) -> bool:
+	return _unfollow_document(doctype, doc_name, frappe.session.user)
+
+
+def _unfollow_document(doctype: str, doc_name: str, user: str) -> bool:
+	"""Same as unfollow_document but hides param `user` from API"""
 
 	doc = frappe.get_all(
 		"Document Follow",

--- a/frappe/desk/form/utils.py
+++ b/frappe/desk/form/utils.py
@@ -9,7 +9,7 @@ import frappe.desk.form.load
 import frappe.desk.form.meta
 from frappe import _
 from frappe.core.doctype.file.utils import extract_images_from_html
-from frappe.desk.form.document_follow import follow_document
+from frappe.desk.form.document_follow import _follow_document
 from frappe.query_builder.functions import IfNull
 
 if TYPE_CHECKING:
@@ -44,7 +44,7 @@ def add_comment(
 	comment.insert(ignore_permissions=True)
 
 	if frappe.get_cached_value("User", frappe.session.user, "follow_commented_documents"):
-		follow_document(comment.reference_doctype, comment.reference_name, frappe.session.user)
+		_follow_document(comment.reference_doctype, comment.reference_name, frappe.session.user)
 
 	return comment
 

--- a/frappe/desk/like.py
+++ b/frappe/desk/like.py
@@ -8,7 +8,7 @@ import json
 import frappe
 from frappe import _
 from frappe.database.schema import add_column
-from frappe.desk.form.document_follow import follow_document
+from frappe.desk.form.document_follow import _follow_document
 from frappe.utils import get_link_to_form
 from frappe.utils.data import sbool
 
@@ -50,7 +50,7 @@ def _toggle_like(doctype, name, add, user=None):
 				liked_by.append(user)
 				add_comment(doctype, name)
 				if frappe.get_cached_value("User", user, "follow_liked_documents"):
-					follow_document(doctype, name, user)
+					_follow_document(doctype, name, user)
 		else:
 			if user in liked_by:
 				liked_by.remove(user)

--- a/frappe/email/doctype/document_follow/test_document_follow.py
+++ b/frappe/email/doctype/document_follow/test_document_follow.py
@@ -22,8 +22,8 @@ class TestDocumentFollow(IntegrationTestCase):
 		event_doc.description = "This is a test description for sending mail"
 		event_doc.save(ignore_version=False)
 
-		document_follow.unfollow_document("Event", event_doc.name, user.name)
-		doc = document_follow.follow_document("Event", event_doc.name, user.name)
+		document_follow._unfollow_document("Event", event_doc.name, user.name)
+		doc = document_follow._follow_document("Event", event_doc.name, user.name)
 		self.assertEqual(doc.user, user.name)
 
 		document_follow.send_hourly_updates()
@@ -38,8 +38,8 @@ class TestDocumentFollow(IntegrationTestCase):
 			event_doc.doctype, event_doc.name, "This is a test comment", "Administrator@example.com", "Bosh"
 		)
 
-		document_follow.unfollow_document("Event", event_doc.name, user.name)
-		doc = document_follow.follow_document("Event", event_doc.name, user.name)
+		document_follow._unfollow_document("Event", event_doc.name, user.name)
+		doc = document_follow._follow_document("Event", event_doc.name, user.name)
 		self.assertEqual(doc.user, user.name)
 
 		document_follow.send_hourly_updates()
@@ -50,8 +50,8 @@ class TestDocumentFollow(IntegrationTestCase):
 		user = get_user()
 		for _ in range(25):
 			event_doc = get_event()
-			document_follow.unfollow_document("Event", event_doc.name, user.name)
-			doc = document_follow.follow_document("Event", event_doc.name, user.name)
+			document_follow._unfollow_document("Event", event_doc.name, user.name)
+			doc = document_follow._follow_document("Event", event_doc.name, user.name)
 			self.assertEqual(doc.user, user.name)
 		self.assertEqual(len(get_document_followed_by_user(user.name)), 20)
 
@@ -186,14 +186,14 @@ class TestDocumentFollow(IntegrationTestCase):
 		frappe.share.remove("Event", event_doc.name, user.name)
 
 		frappe.set_user(user.name)
-		result = document_follow.follow_document("Event", event_doc.name, user.name)
+		result = document_follow._follow_document("Event", event_doc.name, user.name)
 		self.assertFalse(result)
 		frappe.set_user("Administrator")
 
 	def test_revoked_access_cleans_up_follow(self):
 		user = get_user()
 		event_doc = get_event()
-		document_follow.follow_document("Event", event_doc.name, user.name)
+		document_follow._follow_document("Event", event_doc.name, user.name)
 
 		self.assertTrue(
 			frappe.db.exists(

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -20,7 +20,7 @@ from frappe import _, is_whitelisted, msgprint
 from frappe.core.doctype.file.utils import relink_mismatched_files
 from frappe.core.doctype.server_script.server_script_utils import run_server_script_for_doc_event
 from frappe.database.utils import commit_after_response
-from frappe.desk.form.document_follow import follow_document
+from frappe.desk.form.document_follow import _follow_document
 from frappe.integrations.doctype.webhook import run_webhooks
 from frappe.model import optional_fields, table_fields
 from frappe.model.base_document import BaseDocument, D, get_controller
@@ -771,7 +771,7 @@ class Document(BaseDocument):
 
 		if not (frappe.flags.in_migrate or frappe.local.flags.in_install or frappe.flags.in_setup_wizard):
 			if frappe.get_cached_value("User", frappe.session.user, "follow_created_documents"):
-				follow_document(self.doctype, self.name, frappe.session.user)
+				_follow_document(self.doctype, self.name, frappe.session.user)
 		return self
 
 	def check_if_locked(self):

--- a/frappe/public/js/frappe/form/sidebar/document_follow.js
+++ b/frappe/public/js/frappe/form/sidebar/document_follow.js
@@ -57,8 +57,6 @@ frappe.ui.form.DocumentFollow = class DocumentFollow {
 				args: {
 					doctype: this.frm.doctype,
 					doc_name: this.frm.doc.name,
-					user: frappe.session.user,
-					force: true,
 				},
 				callback: (r) => {
 					if (r.message) {
@@ -75,7 +73,6 @@ frappe.ui.form.DocumentFollow = class DocumentFollow {
 				args: {
 					doctype: this.frm.doctype,
 					doc_name: this.frm.doc.name,
-					user: frappe.session.user,
 				},
 				callback: (r) => {
 					if (r.message) {

--- a/frappe/share.py
+++ b/frappe/share.py
@@ -11,7 +11,7 @@ from frappe.desk.doctype.notification_log.notification_log import (
 	get_title,
 	get_title_html,
 )
-from frappe.desk.form.document_follow import follow_document
+from frappe.desk.form.document_follow import _follow_document
 from frappe.utils import cint
 
 if TYPE_CHECKING:
@@ -85,7 +85,7 @@ def add_docshare(
 	if (user != name or doctype != "User") and frappe.get_cached_value(
 		"User", user, "follow_shared_documents"
 	):
-		follow_document(doctype, name, user)
+		_follow_document(doctype, name, user)
 
 	return doc
 


### PR DESCRIPTION
The whitelisted follow and unfollow endpoints no longer accept a user
parameter and always act on the current session user. Internal callers
use the private helpers to follow a document on behalf of another user.