### PR TITLE
feat(ui): migrate dropdown menus to Espresso

### DIFF
--- a/cypress/integration/control_attach.js
+++ b/cypress/integration/control_attach.js
@@ -53,8 +53,7 @@ context("Attach Control", () => {
 		//Deleting the doc
 		cy.go_to_list("Test Attach Control");
 		cy.get(".list-row-checkbox").eq(0).click();
-		cy.get(".actions-btn-group > button").contains("Actions").click();
-		cy.get('.actions-btn-group > .dropdown-menu [data-label="Delete"]').click();
+		cy.click_action_button("Delete");
 		cy.click_modal_primary_button("Yes");
 	});
 
@@ -109,8 +108,7 @@ context("Attach Control", () => {
 		cy.go_to_list("Test Attach Control");
 		cy.get(".list-row-checkbox").eq(0).click();
 		cy.get(".list-row-checkbox").eq(1).click();
-		cy.get(".actions-btn-group > button").contains("Actions").click();
-		cy.get('.actions-btn-group > .dropdown-menu [data-label="Delete"]').click();
+		cy.click_action_button("Delete");
 		cy.click_modal_primary_button("Yes");
 	});
 

--- a/cypress/integration/control_data.js
+++ b/cypress/integration/control_data.js
@@ -144,8 +144,7 @@ context("Data Control", () => {
 		//Deleting the inserted document
 		cy.go_to_list("Test Data Control");
 		cy.get(".list-row-checkbox").eq(0).click({ force: true });
-		cy.get(".actions-btn-group > button").contains("Actions").click();
-		cy.get('.actions-btn-group > .dropdown-menu [data-label="Delete"]').click();
+		cy.click_action_button("Delete");
 		cy.click_modal_primary_button("Yes");
 	});
 });

--- a/cypress/integration/custom_buttons.js
+++ b/cypress/integration/custom_buttons.js
@@ -25,7 +25,9 @@ const check_button_count = (label, group = "TestGroup") => {
 		.should("have.length", 1)
 		.should("be.visible")
 		.first()
-		.type("{esc}");
+		// buttons aren't typeable — keyboard goes through trigger (see
+		// the es_components spec convention)
+		.trigger("keydown", { key: "Escape" });
 
 	// Mobile: the ... menu shows the group as a nested submenu row
 	cy.viewport(420, 900);

--- a/cypress/integration/custom_buttons.js
+++ b/cypress/integration/custom_buttons.js
@@ -16,19 +16,31 @@ const add_button = (label, group = "TestGroup") => {
 };
 
 const check_button_count = (label, group = "TestGroup") => {
-	// Verify main buttons
+	// the group opens an espresso menu; the hidden item store keeps one
+	// element per label (the dedupe contract)
+	cy.get(`[data-label="${encodeURIComponent(label)}"]`).should("have.length", 1);
 	cy.findByRole("button", { name: group }).click();
-	cy.get(`[data-label="${encodeURIComponent(label)}"]`)
+	cy.get('.es-menu [role="menuitem"]')
+		.filter((_, el) => el.textContent.trim() === label)
 		.should("have.length", 1)
-		.should("be.visible");
+		.should("be.visible")
+		.first()
+		.type("{esc}");
 
-	// Verify dropdown buttons in mobile view
+	// Mobile: the ... menu shows the group as a nested submenu row
 	cy.viewport(420, 900);
 	const dropdown_btn_label = `${group} > ${label}`;
+	cy.get(`[data-label="${encodeURIComponent(dropdown_btn_label)}"]`).should("have.length", 1);
 	cy.get(".menu-btn-group > button").click();
-	cy.get(`[data-label="${encodeURIComponent(dropdown_btn_label)}"]`)
+	cy.get('.es-menu [role="menuitem"]')
+		.filter((_, el) => el.textContent.trim() === group)
+		.should("have.length", 1)
+		.click();
+	cy.get('.es-menu [role="menuitem"]')
+		.filter((_, el) => el.textContent.trim() === label)
 		.should("have.length", 1)
 		.should("be.visible");
+	cy.get("body").type("{esc}");
 
 	//reset viewport
 	cy.viewport(Cypress.config("viewportWidth"), Cypress.config("viewportHeight"));

--- a/cypress/integration/dashboard_links.js
+++ b/cypress/integration/dashboard_links.js
@@ -50,8 +50,7 @@ context("Dashboard links", () => {
 		//Deleting the newly created contact
 		cy.visit("/desk/contact");
 		cy.get(".list-subject > .select-like > .list-row-checkbox").eq(0).click({ force: true });
-		cy.findByRole("button", { name: "Actions" }).click();
-		cy.get('.actions-btn-group [data-label="Delete"]').click();
+		cy.click_action_button("Delete");
 		cy.findByRole("button", { name: "Yes" }).click({ delay: 700 });
 
 		//To check if the counter from the "Contact" doc link is removed

--- a/cypress/integration/list_view.js
+++ b/cypress/integration/list_view.js
@@ -50,15 +50,13 @@ context("List View", () => {
 		];
 		cy.go_to_list("ToDo");
 		cy.clear_filters();
-		cy.intercept({
-			method: "POST",
-			url: "api/method/frappe.model.workflow.get_common_transition_actions",
-		}).as("common-actions");
+		cy.intercept("POST", "/api/method/frappe.model.workflow.get_common_transition_actions").as(
+			"common-actions"
+		);
 		cy.get(".list-header-subject .list-subject .list-check-all").click();
-		// the menu snapshots its items at open — wait for the workflow toggle
-		// round-trip to hide "Review" (not common to the selected docs) first;
-		// the old bootstrap menu was live DOM, so the count could converge
-		// after opening, but a snapshot can't
+		// selecting rows triggers the workflow-actions refresh (debounced);
+		// wait for it to hide "Review" (not common to the selected docs)
+		// before opening — the menu snapshots its items at open
 		cy.wait("@common-actions");
 		cy.get('.actions-btn-group [data-label="Review"]')
 			.closest("li")

--- a/cypress/integration/list_view.js
+++ b/cypress/integration/list_view.js
@@ -50,7 +50,19 @@ context("List View", () => {
 		];
 		cy.go_to_list("ToDo");
 		cy.clear_filters();
+		cy.intercept({
+			method: "POST",
+			url: "api/method/frappe.model.workflow.get_common_transition_actions",
+		}).as("common-actions");
 		cy.get(".list-header-subject .list-subject .list-check-all").click();
+		// the menu snapshots its items at open — wait for the workflow toggle
+		// round-trip to hide "Review" (not common to the selected docs) first;
+		// the old bootstrap menu was live DOM, so the count could converge
+		// after opening, but a snapshot can't
+		cy.wait("@common-actions");
+		cy.get('.actions-btn-group [data-label="Review"]')
+			.closest("li")
+			.should("have.css", "display", "none");
 		cy.findByRole("button", { name: "Actions" }).click();
 		cy.get('.es-menu [role="menuitem"]')
 			.should("have.length", 9)

--- a/cypress/integration/list_view.js
+++ b/cypress/integration/list_view.js
@@ -52,7 +52,7 @@ context("List View", () => {
 		cy.clear_filters();
 		cy.get(".list-header-subject .list-subject .list-check-all").click();
 		cy.findByRole("button", { name: "Actions" }).click();
-		cy.get(".dropdown-menu li:visible .dropdown-item")
+		cy.get('.es-menu [role="menuitem"]')
 			.should("have.length", 9)
 			.each((el, index) => {
 				cy.wrap(el).contains(actions[index]);

--- a/cypress/integration/list_view_column_width.js
+++ b/cypress/integration/list_view_column_width.js
@@ -11,7 +11,7 @@ const BASE_FIELDS = JSON.stringify([
 // Helper — open List View Settings modal for the current list
 function openListSettings() {
 	cy.get(".menu-btn-group button").click({ force: true });
-	cy.get(".dropdown-menu li").filter(":visible").contains("List Settings").click();
+	cy.get(".es-menu").contains('[role="menuitem"]', "List Settings").click();
 	cy.get(".modal-dialog").should("contain", `${DOCTYPE} List View Settings`);
 }
 

--- a/cypress/integration/list_view_settings.js
+++ b/cypress/integration/list_view_settings.js
@@ -7,7 +7,7 @@ context("List View Settings", () => {
 		cy.clear_filters();
 		cy.wait(300);
 		cy.get(".menu-btn-group button").click({ force: true });
-		cy.get(".dropdown-menu li").filter(":visible").contains("List Settings").click();
+		cy.get(".es-menu").contains('[role="menuitem"]', "List Settings").click();
 		cy.get(".modal-dialog").should("contain", "DocType List View Settings");
 		cy.findByLabelText("Disable Count").uncheck({ force: true });
 		cy.findByLabelText("Disable Comment Count").uncheck({ force: true });
@@ -22,7 +22,7 @@ context("List View Settings", () => {
 		cy.get(".list-count").should("contain", "20 of");
 		cy.get(".frappe-list .comment-count svg.icon").should("be.visible");
 		cy.get(".menu-btn-group button").click();
-		cy.get(".dropdown-menu li").filter(":visible").contains("List Settings").click();
+		cy.get(".es-menu").contains('[role="menuitem"]', "List Settings").click();
 		cy.get(".modal-dialog").should("contain", "DocType List View Settings");
 
 		cy.findByLabelText("Disable Count").check({ force: true });
@@ -37,7 +37,7 @@ context("List View Settings", () => {
 		cy.get(".frappe-list .comment-count").should("not.exist");
 
 		cy.get(".menu-btn-group button").click({ force: true });
-		cy.get(".dropdown-menu li").filter(":visible").contains("List Settings").click();
+		cy.get(".es-menu").contains('[role="menuitem"]', "List Settings").click();
 		cy.get(".modal-dialog").should("contain", "DocType List View Settings");
 		cy.findByLabelText("Disable Count").uncheck({ force: true });
 		cy.findByLabelText("Disable Comment Count").uncheck({ force: true });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -454,14 +454,16 @@ Cypress.Commands.add("click_custom_action_button", (name) => {
 	cy.get(`.custom-actions [data-label="${encodeURIComponent(name)}"]`).click();
 });
 
+// the page header dropdowns are espresso menus now — the panel body-portals,
+// so rows are matched inside .es-menu, not inside the btn-group
 Cypress.Commands.add("click_action_button", (name) => {
 	cy.findByRole("button", { name: "Actions" }).click();
-	cy.get(`.actions-btn-group [data-label="${encodeURIComponent(name)}"]`).click();
+	cy.get(".es-menu").contains('[role="menuitem"]', name).click();
 });
 
 Cypress.Commands.add("click_menu_button", (name) => {
 	cy.get(".standard-actions .menu-btn-group > button").click();
-	cy.get(`.menu-btn-group [data-label="${encodeURIComponent(name)}"]`).click();
+	cy.get(".es-menu").contains('[role="menuitem"]', name).click();
 });
 
 Cypress.Commands.add("clear_filters", () => {

--- a/frappe/public/css/espresso/components/menu.css
+++ b/frappe/public/css/espresso/components/menu.css
@@ -218,6 +218,14 @@
     box-shadow: none;
 }
 
+/* mobile layouts have no keyboard — the combo hints are noise there
+   (the bindings themselves stay active for attached keyboards) */
+@media (max-width: 767.98px) {
+    .es-menu__shortcut {
+        display: none;
+    }
+}
+
 /* ---- submenu chevron ---- */
 .es-menu__chevron {
     margin-inline-start: auto;

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -2207,11 +2207,20 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 			this.update_checkbox($target);
 		});
+	}
 
-		let me = this;
-		this.page.actions_btn_group.on("show.bs.dropdown", () => {
-			me.toggle_workflow_actions();
-		});
+	// Workflow actions refresh when the SELECTION changes
+	// instead — the store is settled before the menu is ever opened, rather
+	// than mutating under an open menu. Lazily built so ReportView (which
+	// overrides setup_events) inherits it too.
+	debounced_toggle_workflow_actions() {
+		if (!this._debounced_toggle_workflow_actions) {
+			this._debounced_toggle_workflow_actions = frappe.utils.debounce(
+				() => this.toggle_workflow_actions(),
+				300
+			);
+		}
+		this._debounced_toggle_workflow_actions();
 	}
 
 	setup_like() {
@@ -2424,6 +2433,9 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		}
 		this.update_checkbox();
 		this.toggle_actions_menu_button(checked_count > 0);
+		if (checked_count > 0) {
+			this.debounced_toggle_workflow_actions();
+		}
 	}
 
 	get_checked_items(only_docnames) {
@@ -2704,6 +2716,8 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			this.workflow_action_items[key].addClass("disabled");
 		});
 		const checked_items = this.get_checked_items();
+		// the debounced call can land after a quick select-then-deselect
+		if (!checked_items.length) return;
 
 		frappe
 			.xcall("frappe.model.workflow.get_common_transition_actions", {

--- a/frappe/public/js/frappe/ui/components/menu.js
+++ b/frappe/public/js/frappe/ui/components/menu.js
@@ -43,6 +43,7 @@ import { place } from "./position.js";
  * @property {function} [onclick] Called with the click event. The menu closes after.
  * @property {string} [href] Renders the row as a link. Code-running schemes are refused.
  * @property {function} [condition] Checked on every open; return false to hide the row.
+ * @property {string} [css_class] Extra classes on the row element (responsive visibility hooks like visible-xs).
  * @property {MenuItem[]|function} [submenu] Nested rows — the row opens a side panel instead of acting. A function runs at hover-start (once per menu open, result cached) and may return the rows or a Promise of them; the panel shows a loading state until it settles.
  */
 
@@ -183,6 +184,7 @@ function build_item(item, { reserve_icon_space, component, taken }) {
 	const href = item.submenu || item.disabled ? null : safe_href(item.href, component);
 	const el = document.createElement(href ? "a" : "button");
 	el.className = "es-menu__item";
+	if (item.css_class) el.className += ` ${item.css_class}`;
 	el.setAttribute("role", "menuitem");
 	el.setAttribute("tabindex", "-1");
 	if (href) el.href = href;

--- a/frappe/public/js/frappe/ui/components/menu.js
+++ b/frappe/public/js/frappe/ui/components/menu.js
@@ -212,9 +212,11 @@ function build_item(item, { reserve_icon_space, component, taken }) {
 	const label = document.createElement("span");
 	label.className = "es-menu__label";
 	const label_text = item.label || "";
-	// disabled rows can't be activated, so they get no mnemonic
+	// disabled rows can't be activated, so they get no mnemonic; rows with
+	// an accelerator keep it as their only key path (the legacy desk rule —
+	// it also leaves the letter pool for shortcut-less rows)
 	let mnemonic = null;
-	if (taken && label_text && !item.disabled) {
+	if (taken && label_text && !item.disabled && !item.shortcut) {
 		mnemonic = assign_mnemonic(label, label_text, taken);
 	} else {
 		label.textContent = label_text;

--- a/frappe/public/js/frappe/ui/page.html
+++ b/frappe/public/js/frappe/ui/page.html
@@ -42,9 +42,11 @@
 								icon: "ellipsis",
 								title: __("Menu"),
 								css_class: "icon-btn menu-more-button",
-								attrs: { "data-toggle": "dropdown", "aria-expanded": "false" },
 							}) %}
-							<ul class="dropdown-menu dropdown-menu-right" role="menu"></ul>
+							<!-- hidden item store, not UI: add_dropdown_item writes <li><a> here
+							(the returned jQuery is public API); frappe.ui.Dropdown snapshots it
+							into menu rows on every open — see page.js build_dropdown_options -->
+							<ul class="dropdown-menu dropdown-menu-right" role="presentation"></ul>
 						</div>
 						{%= frappe.ui.button.html({ css_class: "secondary-action hide" }) %}
 						<div class="actions-btn-group hide">
@@ -52,9 +54,8 @@
 								label: __("Actions"),
 								icon_right: "chevrons-up-down",
 								variant: "solid",
-								attrs: { "data-toggle": "dropdown", "aria-expanded": "false" },
 							}) %}
-							<ul class="dropdown-menu dropdown-menu-right" role="menu">
+							<ul class="dropdown-menu dropdown-menu-right" role="presentation">
 							</ul>
 						</div>
 						{%= frappe.ui.button.html({ variant: "solid", css_class: "primary-action hide" }) %}

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -605,6 +605,8 @@ frappe.ui.Page = class Page {
 			(el.classList.contains("hidden-xl") &&
 				window.matchMedia("(min-width: 992px)").matches);
 		const segments = [[]];
+		// one submenu row per inner-button group, keyed by group label
+		const nested_groups = new Map();
 
 		$parent.children("li").each((_, li) => {
 			if (li.classList.contains("dropdown-divider")) {
@@ -628,6 +630,37 @@ frappe.ui.Page = class Page {
 				.filter((c) => !internal.includes(c))
 				.join(" ");
 			const click = $li.data("menu_click");
+			const onclick = (e) => {
+				if (e && (e.ctrlKey || e.metaKey)) {
+					frappe.open_in_new_tab = true;
+				}
+				// raw <li>s appended by apps have no stashed handler —
+				// clicking their own link keeps them working
+				return click ? click() : a.click();
+			};
+
+			// grouped inner buttons mirror into this menu on mobile as flat
+			// "Group > Label" store items (see add_inner_button) — render
+			// them as one "Group" row with a submenu instead
+			const nested = $li.data("menu_submenu");
+			if (nested) {
+				let submenu = nested_groups.get(nested.group);
+				if (!submenu) {
+					submenu = [];
+					nested_groups.set(nested.group, submenu);
+					segments[segments.length - 1].push({
+						label: nested.group,
+						css_class: css_class || undefined,
+						submenu,
+					});
+				}
+				submenu.push({
+					label: nested.label,
+					disabled: a.classList.contains("disabled"),
+					onclick,
+				});
+				return;
+			}
 
 			segments[segments.length - 1].push({
 				label,
@@ -635,14 +668,7 @@ frappe.ui.Page = class Page {
 				shortcut: $li.data("menu_shortcut") || undefined,
 				disabled: a.classList.contains("disabled"),
 				css_class: css_class || undefined,
-				onclick: (e) => {
-					if (e && (e.ctrlKey || e.metaKey)) {
-						frappe.open_in_new_tab = true;
-					}
-					// raw <li>s appended by apps have no stashed handler —
-					// clicking their own link keeps them working
-					return click ? click() : a.click();
-				},
+				onclick,
 			});
 		});
 
@@ -780,9 +806,15 @@ frappe.ui.Page = class Page {
 			me.btn_disable_enable(btn, response);
 		};
 
-		// Add actions as menu item in Mobile View
+		// Add actions as menu item in Mobile View. The store keeps the flat
+		// "Group > Label" item (dedupe and remove_custom_button look it up by
+		// that label) — the snapshot renders stamped items as a nested
+		// "Group" row with a submenu instead.
 		let menu_item_label = group ? `${group} > ${label}` : label;
 		let menu_item = this.add_menu_item(menu_item_label, _action, false, false, false);
+		if (group) {
+			menu_item.closest("li").data("menu_submenu", { group, label });
+		}
 		menu_item.parent().addClass("hidden-xl");
 		if (this.menu_btn_group.hasClass("hide")) {
 			this.menu_btn_group.removeClass("hide").addClass("hidden-xl");

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -195,6 +195,28 @@ frappe.ui.Page = class Page {
 			});
 		frappe.ui.keys.get_shortcut_group(this.page_actions[0]).add(menu_btn);
 
+		// The Menu / Actions dropdowns are espresso menus. The old bootstrap
+		// ULs stay in the DOM as hidden item stores: add_dropdown_item keeps
+		// writing <li><a> markup there (the returned jQuery is public API and
+		// callers mutate it), and every open snapshots the store into rows —
+		// so .text() / .toggle() / .addClass("disabled") all keep working.
+		this.menu_dropdown = new frappe.ui.Dropdown({
+			trigger: menu_btn,
+			align: "end",
+			options: () => this.build_dropdown_options(this.menu),
+		});
+		this.actions_dropdown = new frappe.ui.Dropdown({
+			trigger: this.actions_btn_group.find("button"),
+			align: "end",
+			options: () => this.build_dropdown_options(this.actions),
+		});
+		// the menus body-portal, so one left open would float over the next
+		// page — the container fires "hide" on the page element on switch
+		this.wrapper.on("hide", () => {
+			this.menu_dropdown.close("owner");
+			this.actions_dropdown.close("owner");
+		});
+
 		// desktop shows "Actions" + chevron; mobile keeps just the chevron.
 		// actions-btn-group-label stays as the legacy hook name for the span.
 		let action_btn = this.actions_btn_group.find("button");
@@ -507,28 +529,35 @@ frappe.ui.Page = class Page {
 			)}</span>`;
 		}
 
+		const data_label = encodeURIComponent(label);
 		if (shortcut) {
 			let shortcut_obj = this.prepare_shortcut_obj(shortcut, click, label);
 			$li = $(`
 				<li>
 					<a class="grey-link dropdown-item" href="#" onClick="return false;">
 						${$icon}
-						<span class="menu-item-label">${label}</span>
+						<span class="menu-item-label" data-label="${data_label}">${label}</span>
 						<span class="menu-item-shortcut">${shortcut_obj.shortcut_label}</span>
 					</a>
 				</li>
 			`);
+			// binding stays here — the menu rows only display the combo
 			frappe.ui.keys.add_shortcut(shortcut_obj);
+			$li.data("menu_shortcut", shortcut_obj.shortcut);
 		} else {
 			$li = $(`
 				<li>
 					<a class="grey-link dropdown-item" href="#" onClick="return false;">
 						${$icon}
-						<span class="menu-item-label">${label}</span>
+						<span class="menu-item-label" data-label="${data_label}">${label}</span>
 					</a>
 				</li>
 			`);
 		}
+
+		// the snapshot (build_dropdown_options) reads these back
+		$li.data("menu_click", click);
+		if (icon) $li.data("menu_icon", icon);
 
 		$link = $li.find("a").on("click", (e) => {
 			if (e.ctrlKey || e.metaKey) {
@@ -557,6 +586,69 @@ frappe.ui.Page = class Page {
 				.add($link, $link.find(".menu-item-label"));
 		}
 		return $link;
+	}
+
+	// Snapshot a hidden item store (this.menu / this.actions) into menu rows.
+	// Reading the live elements on every open is what keeps the legacy jQuery
+	// contract alive: .text(), .toggle(), .addClass("disabled") on a held item
+	// all show up the next time the menu opens. Divider <li>s split groups.
+	build_dropdown_options($parent) {
+		// classes internal to the legacy markup; everything else (visible-xs,
+		// hidden-xl, caller classes) is carried onto the rendered row
+		const internal = ["grey-link", "dropdown-item", "disabled", "user-action"];
+		// the responsive utilities, evaluated at open time — a group whose
+		// rows are all CSS-hidden would still paint its separator, and the
+		// legacy divider was itself visible-xs (desktop menus had none)
+		const responsive_hidden = (el) =>
+			(el.classList.contains("visible-xs") &&
+				window.matchMedia("(min-width: 576px)").matches) ||
+			(el.classList.contains("hidden-xl") &&
+				window.matchMedia("(min-width: 992px)").matches);
+		const segments = [[]];
+
+		$parent.children("li").each((_, li) => {
+			if (li.classList.contains("dropdown-divider")) {
+				if (!responsive_hidden(li) && segments[segments.length - 1].length) {
+					segments.push([]);
+				}
+				return;
+			}
+			const $li = $(li);
+			const a = $li.children("a").get(0);
+			if (!a) return;
+			// .toggle(false) / .hide() by callers
+			if (li.style.display === "none" || a.style.display === "none") return;
+			if (responsive_hidden(li) || responsive_hidden(a)) return;
+
+			// .text(label) on the held <a> replaces its children, so fall back
+			const label = ($li.find(".menu-item-label").text() || $(a).text()).trim();
+			if (!label) return;
+
+			const css_class = [...li.classList, ...a.classList]
+				.filter((c) => !internal.includes(c))
+				.join(" ");
+			const click = $li.data("menu_click");
+
+			segments[segments.length - 1].push({
+				label,
+				icon: $li.data("menu_icon") || undefined,
+				shortcut: $li.data("menu_shortcut") || undefined,
+				disabled: a.classList.contains("disabled"),
+				css_class: css_class || undefined,
+				onclick: (e) => {
+					if (e && (e.ctrlKey || e.metaKey)) {
+						frappe.open_in_new_tab = true;
+					}
+					// raw <li>s appended by apps have no stashed handler —
+					// clicking their own link keeps them working
+					return click ? click() : a.click();
+				},
+			});
+		});
+
+		const groups = segments.filter((segment) => segment.length);
+		if (groups.length <= 1) return groups[0] || [];
+		return groups.map((options) => ({ group: "", hide_label: true, options }));
 	}
 
 	prepare_shortcut_obj(shortcut, click, label) {

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -799,12 +799,18 @@ frappe.ui.Page = class Page {
 			if (el.tagName !== "A" || el.style.display === "none") return;
 			const label = $(el).text().trim();
 			if (!label) return;
+			const internal = ["dropdown-item", "disabled", "btn", "btn-danger", "text-danger"];
+			const css_class = [...el.classList].filter((c) => !internal.includes(c)).join(" ");
 			segments[segments.length - 1].push({
 				label,
 				disabled: el.classList.contains("disabled"),
-				// change_inner_button_type(label, group, "danger") pokes
-				// btn-danger onto the store item
-				theme: el.classList.contains("btn-danger") ? "red" : undefined,
+				// btn-danger comes from change_inner_button_type(label, group,
+				// "danger"); text-danger is how apps mark risky rows
+				theme:
+					el.classList.contains("btn-danger") || el.classList.contains("text-danger")
+						? "red"
+						: undefined,
+				css_class: css_class || undefined,
 				// clicking the store element runs every handler callers bound
 				onclick: () => $(el).trigger("click"),
 			});

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -215,7 +215,7 @@ frappe.ui.Page = class Page {
 		this.wrapper.on("hide", () => {
 			this.menu_dropdown.close("owner");
 			this.actions_dropdown.close("owner");
-			this.inner_toolbar.find(".inner-group-button").each((_, group) => {
+			this.wrapper.find(".inner-group-button, .custom-btn-group").each((_, group) => {
 				$(group).data("es_dropdown")?.close("owner");
 			});
 		});
@@ -581,13 +581,6 @@ frappe.ui.Page = class Page {
 			$li.addClass("user-action").insertBefore(this.divider);
 		}
 
-		// if an shortcut is already set, dont set an alt Shortcut
-		if (!shortcut) {
-			// alt shortcut
-			frappe.ui.keys
-				.get_shortcut_group(parent.get(0))
-				.add($link, $link.find(".menu-item-label"));
-		}
 		return $link;
 	}
 
@@ -1018,9 +1011,12 @@ frappe.ui.Page = class Page {
 	}
 
 	add_custom_button_group(label, icon, parent) {
+		// same bridge as the header menus: the UL is a hidden item store
+		// (add_custom_menu_item writes li > a there and returns the link),
+		// rendered as an espresso menu per open
 		let custom_btn_group = $(`
 			<div class="custom-btn-group">
-				<ul class="dropdown-menu" role="menu"></ul>
+				<ul class="dropdown-menu" role="presentation"></ul>
 			</div>
 		`);
 
@@ -1029,7 +1025,6 @@ frappe.ui.Page = class Page {
 			icon: icon,
 			icon_right: "chevrons-up-down",
 			css_class: "ellipsis",
-			attrs: { "data-toggle": "dropdown", "aria-expanded": "false" },
 		});
 		$button.find(".es-button__label").addClass("custom-btn-group-label");
 		if (icon) {
@@ -1045,7 +1040,16 @@ frappe.ui.Page = class Page {
 			parent = frappe.is_mobile() ? this.custom_mobile_actions : this.custom_actions;
 		parent.removeClass("hide").append(custom_btn_group);
 
-		return custom_btn_group.find(".dropdown-menu");
+		const $store = custom_btn_group.find(".dropdown-menu");
+		custom_btn_group.data(
+			"es_dropdown",
+			new frappe.ui.Dropdown({
+				trigger: $button,
+				options: () => this.build_dropdown_options($store),
+			})
+		);
+
+		return $store;
 	}
 
 	add_dropdown_button(parent, label, click, icon) {

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -215,6 +215,9 @@ frappe.ui.Page = class Page {
 		this.wrapper.on("hide", () => {
 			this.menu_dropdown.close("owner");
 			this.actions_dropdown.close("owner");
+			this.inner_toolbar.find(".inner-group-button").each((_, group) => {
+				$(group).data("es_dropdown")?.close("owner");
+			});
 		});
 
 		// desktop shows "Actions" + chevron; mobile keeps just the chevron.
@@ -733,25 +736,63 @@ frappe.ui.Page = class Page {
 			`.inner-group-button[data-label="${encodeURIComponent(label)}"]`
 		);
 		if (!$group.length) {
+			// same bridge as the header menus: the .dropdown-menu div stays in
+			// the DOM as a hidden item store (add_inner_button returns its
+			// <a>s to callers, who mutate them), and the espresso dropdown
+			// snapshots it on every open
 			$group = $(
 				`<div class="inner-group-button" data-label="${encodeURIComponent(label)}">
-					<div role="menu" class="dropdown-menu ${align_right ? "dropdown-menu-right" : ""}"></div>
+					<div role="presentation" class="dropdown-menu ${align_right ? "dropdown-menu-right" : ""}"></div>
 				</div>`
 			).appendTo(this.inner_toolbar);
-			frappe.ui
+			const $btn = frappe.ui
 				.button({
 					label: label,
 					icon_right: "chevrons-up-down",
 					css_class: "ellipsis",
-					attrs: {
-						"data-toggle": "dropdown",
-						"aria-haspopup": "true",
-						"aria-expanded": "false",
-					},
 				})
 				.prependTo($group);
+			$group.data(
+				"es_dropdown",
+				new frappe.ui.Dropdown({
+					trigger: $btn,
+					align: align_right ? "end" : "start",
+					options: () =>
+						this.build_inner_group_options($group.children(".dropdown-menu")),
+				})
+			);
 		}
 		return $group;
+	}
+
+	// Snapshot an inner group's item store — bare <a.dropdown-item> children
+	// plus divider <li>s — into menu rows; same live-read contract as
+	// build_dropdown_options, so held-reference mutations show on next open.
+	build_inner_group_options($store) {
+		const segments = [[]];
+		$store.children().each((_, el) => {
+			if (el.classList.contains("dropdown-divider")) {
+				if (segments[segments.length - 1].length) segments.push([]);
+				return;
+			}
+			// match by tag, not .dropdown-item — change_inner_button_type's
+			// legacy removeClass() strips ALL classes off the store item
+			if (el.tagName !== "A" || el.style.display === "none") return;
+			const label = $(el).text().trim();
+			if (!label) return;
+			segments[segments.length - 1].push({
+				label,
+				disabled: el.classList.contains("disabled"),
+				// change_inner_button_type(label, group, "danger") pokes
+				// btn-danger onto the store item
+				theme: el.classList.contains("btn-danger") ? "red" : undefined,
+				// clicking the store element runs every handler callers bound
+				onclick: () => $(el).trigger("click"),
+			});
+		});
+		const groups = segments.filter((segment) => segment.length);
+		if (groups.length <= 1) return groups[0] || [];
+		return groups.map((options) => ({ group: "", hide_label: true, options }));
 	}
 
 	get_inner_group_button(label) {
@@ -873,8 +914,9 @@ frappe.ui.Page = class Page {
 		let btn;
 
 		if (group) {
-			// dropdown items keep the legacy class treatment until the menu
-			// wave; note this strips any extra classes (pre-existing behavior)
+			// the class poke lands on the store item; the snapshot maps
+			// btn-danger to the red row theme. Strips extra classes
+			// (pre-existing behavior).
 			var $group = this.get_inner_group_button(__(group));
 			if ($group.length) {
 				btn = $group.find(`.dropdown-item[data-label="${encodeURIComponent(label)}"]`);

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -409,8 +409,30 @@ frappe.ui.Page = class Page {
 		this.clear_secondary_action();
 	}
 
+	// Close and tear down the espresso dropdowns of button groups inside
+	// $scope before their elements are discarded — an open menu body-portals,
+	// so removing its group would otherwise leave the panel floating over
+	// the page with its listeners live.
+	destroy_group_dropdowns($scope) {
+		$scope
+			.find(".inner-group-button, .custom-btn-group")
+			.addBack(".inner-group-button, .custom-btn-group")
+			.each((_, group) => {
+				$(group).data("es_dropdown")?.destroy();
+			});
+	}
+
 	clear_custom_actions() {
+		this.destroy_group_dropdowns(this.custom_actions);
 		this.custom_actions.addClass("hide").empty();
+		this.clear_mobile_custom_groups();
+	}
+	clear_mobile_custom_groups() {
+		const $groups = this.custom_mobile_actions.children(
+			".custom-btn-group:not(.view-switcher)"
+		);
+		this.destroy_group_dropdowns($groups);
+		$groups.remove();
 	}
 
 	clear_icons() {
@@ -716,6 +738,10 @@ frappe.ui.Page = class Page {
 	}
 
 	clear_btn_group(parent) {
+		// a refresh can clear the store while its menu is open — close it so
+		// the portaled panel doesn't float on with stale rows
+		if (parent.is(this.menu)) this.menu_dropdown?.close("owner");
+		if (parent.is(this.actions)) this.actions_dropdown?.close("owner");
 		parent.empty();
 		parent.parent().addClass("hide");
 	}
@@ -897,7 +923,10 @@ frappe.ui.Page = class Page {
 			if ($group.length) {
 				$group.find(`.dropdown-item[data-label="${encodeURIComponent(label)}"]`).remove();
 			}
-			if ($group.find(".dropdown-item").length === 0) $group.remove();
+			if ($group.find(".dropdown-item").length === 0) {
+				this.destroy_group_dropdowns($group);
+				$group.remove();
+			}
 		} else {
 			this.inner_toolbar.find(`button[data-label="${encodeURIComponent(label)}"]`).remove();
 		}
@@ -939,7 +968,9 @@ frappe.ui.Page = class Page {
 	}
 
 	clear_inner_toolbar() {
-		this.inner_toolbar.empty().addClass("hide");
+		// inner_toolbar IS custom_actions (see setup_page) — delegate so the
+		// dropdown teardown and the mobile-container clear live in one place
+		this.clear_custom_actions();
 	}
 
 	clear_user_actions() {

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -67,15 +67,11 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 	}
 
 	setup_events() {
-		const me = this;
 		if (this.list_view_settings?.disable_auto_refresh) {
 			return;
 		}
 		frappe.realtime.doctype_subscribe(this.doctype);
 		frappe.realtime.on("list_update", (data) => this.on_update(data));
-		this.page.actions_btn_group.on("show.bs.dropdown", () => {
-			me.toggle_workflow_actions();
-		});
 	}
 
 	setup_page() {
@@ -361,6 +357,11 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 				onCheckRow: () => {
 					const checked_items = this.get_checked_items();
 					this.toggle_actions_menu_button(checked_items.length > 0);
+					// refresh workflow actions on selection, not on menu open —
+					// see the matching note in list_view.js
+					if (checked_items.length > 0) {
+						this.debounced_toggle_workflow_actions();
+					}
 				},
 			},
 			hooks: {

--- a/frappe/public/scss/desk/calendar.scss
+++ b/frappe/public/scss/desk/calendar.scss
@@ -146,13 +146,6 @@ th.fc-col-header-cell {
 	}
 }
 
-.fc button {
-	height: 28px !important;
-	font-size: var(--text-md) !important;
-	outline: none !important;
-	text-transform: capitalize;
-}
-
 .fc-daygrid-event {
 	border: none !important;
 	margin: 5px 4px 0 !important;
@@ -177,17 +170,5 @@ th.fc-col-header-cell {
 		border: none;
 		background: transparent;
 		box-shadow: none;
-	}
-}
-
-#fc-calendar-wrapper .btn {
-	display: inline-flex;
-	align-items: center;
-	gap: 6px;
-	line-height: 1.4;
-
-	svg {
-		width: 14px;
-		height: 14px;
 	}
 }

--- a/frappe/public/scss/desk/page.scss
+++ b/frappe/public/scss/desk/page.scss
@@ -201,38 +201,13 @@ body[data-route^="Form"] {
 	}
 }
 
+// these groups hold only the trigger button and a hidden item store now —
+// the visible menus are es-menu panels portaled to <body> (see page.js)
 .menu-btn-group,
 .custom-btn-group,
 .actions-btn-group,
 .page-icon-group {
 	display: flex;
-
-	.dropdown-menu {
-		width: max-content;
-	}
-
-	.dropdown-item {
-		display: flex;
-		align-items: center;
-	}
-
-	.menu-item-label {
-		margin-right: var(--margin-md);
-	}
-
-	.menu-item-shortcut {
-		margin-left: auto;
-		color: var(--ink-gray-4, #999999);
-		font-size: var(--text-sm);
-		font-weight: 420;
-		line-height: 1.15;
-		letter-spacing: 0.02em;
-		white-space: nowrap;
-	}
-
-	.menu-item-icon {
-		margin-right: var(--margin-sm);
-	}
 }
 
 .layout-main {


### PR DESCRIPTION
Migrates all three dropdown families in the page header — the ••• Menu, the Actions menu, and the custom button groups (form "View ⌄"/"Create ⌄" groups and add_custom_button_group) — from bootstrap dropdowns to frappe.ui.Dropdown. No bootstrap dropdown JS runs in the page header anymore.

### How compatibility is kept

1. The public API (add_menu_item, add_actions_menu_item, add_custom_button, etc.) is unchanged, including return values: callers still get the same jQuery elements and can keep mutating them (.text(), .toggle(), .addClass("disabled"), extra click handlers)
2. The old dropdown ULs stay in the DOM as hidden item stores; the espresso menu re-reads them on every open, so held-reference mutations show up on the next open
3. Keyboard shortcut binding stays with the caller; menus display the combo

### Improvements that come with it

1. Nested submenus on mobile: grouped buttons in the ••• menu show as "Group →" with a submenu instead of flat "Group > Option" labels
2. Shortcut hints are hidden on mobile (no keyboard); bindings stay active
3. Alt mnemonics follow the old desk rule: items with a real shortcut don't get an Alt letter
4. Proper accessibility: real disabled buttons, menu-button ARIA pattern, keyboard navigation, collision-aware positioning (no more clipped dropdowns)
5. Fixes two silently broken things: menu label dedupe and remove_custom_button's lookup (both depended on a data-label attribute that was never written)
6. Open menus close on route change (they portal to <body> now, so they no longer die with the page container)
7. Removes the dead legacy Alt-shortcut registrations for menu items


#### Notes for developers

1. HTML in menu item labels now renders as plain text (labels are hardened by default)
2. The hidden store markup is internal — per the "DOM is not API" policy, scripts should use the public methods, not the dropdown DOM

<img width="483" height="555" alt="image" src="https://github.com/user-attachments/assets/19fb7b9d-0b89-49c2-8fda-2b2340674da8" />

<img width="483" height="555" alt="image" src="https://github.com/user-attachments/assets/ad23f322-3e66-42ab-9ed5-6390b93d2185" />

<img width="483" height="806" alt="image" src="https://github.com/user-attachments/assets/89398180-91ce-4388-a3f1-9654edb4fd2a" />

`no-docs`


