### PR TITLE
fix: accept only POST requests on the api login endpoint

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -129,6 +129,8 @@ class LoginManager:
 		self.user_type = None
 
 		if frappe.local.request.path == "/api/method/login":
+			if frappe.local.request.method != "POST":
+				frappe.throw_permission_error()
 			if self.login() is False:
 				return
 			self.resume = False


### PR DESCRIPTION
Requests to /api/method/login that use any other HTTP method now get a
permission error instead of establishing a session.