### PR TITLE
fix!: apply the sid request parameter to the current request only

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -402,6 +402,12 @@ class CookieManager:
 		if not frappe.local.session.get("sid"):
 			return
 
+		# A session id supplied as a request parameter is only honoured for that request. Callers
+		# that intentionally hand a session over to a browser set the cookie themselves.
+		session_obj = getattr(frappe.local, "session_obj", None)
+		if session_obj and session_obj.sid_from_params:
+			return
+
 		if frappe.session.sid:
 			self.set_cookie("sid", frappe.session.sid, max_age=get_expiry_in_seconds(), httponly=True)
 

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -1280,7 +1280,9 @@ def browse(
 			frappe.local.login_manager = LoginManager()
 			frappe.local.login_manager.login_as(user, session_end, user_for_audit)
 			sid = frappe.session.sid
-			login_path = f"/app?sid={sid}"
+			login_token = frappe.generate_hash(length=32)
+			frappe.cache.set_value(f"login_token:{login_token}", sid, expires_in_sec=120)
+			login_path = f"/api/method/frappe.www.login.login_via_token?login_token={login_token}"
 		else:
 			click.echo("Please enable developer mode to login as a user")
 

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -208,7 +208,16 @@ def generate_csrf_token():
 
 
 class Session:
-	__slots__ = ("_update_in_cache", "data", "full_name", "sid", "time_diff", "user", "user_type")
+	__slots__ = (
+		"_update_in_cache",
+		"data",
+		"full_name",
+		"sid",
+		"sid_from_params",
+		"time_diff",
+		"user",
+		"user_type",
+	)
 
 	def __init__(
 		self,
@@ -219,9 +228,9 @@ class Session:
 		session_end: str | None = None,
 		audit_user: str | None = None,
 	):
-		self.sid = cstr(
-			frappe.form_dict.pop("sid", None) or unquote(frappe.request.cookies.get("sid", "Guest"))
-		)
+		params_sid = frappe.form_dict.pop("sid", None)
+		self.sid_from_params = bool(params_sid)
+		self.sid = cstr(params_sid or unquote(frappe.request.cookies.get("sid", "Guest")))
 		assert isinstance(self.sid, str), "sid must be a string after cstr normalization"
 		self.user = user
 		self.user_type = user_type
@@ -258,6 +267,7 @@ class Session:
 
 		self.data.user = self.user
 		self.sid = self.data.sid = sid
+		self.sid_from_params = False
 		self.data.data.user = self.user
 		self.data.data.session_ip = frappe.local.request_ip
 

--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -11,6 +11,7 @@ from frappe.apps import get_default_path
 from frappe.auth import LoginManager
 from frappe.core.doctype.navbar_settings.navbar_settings import get_app_logo
 from frappe.rate_limiter import rate_limit
+from frappe.sessions import get_expiry_in_seconds
 from frappe.utils import cint, get_url
 from frappe.utils.data import escape_html
 from frappe.utils.html_utils import get_icon_html
@@ -122,6 +123,7 @@ def login_via_token(login_token: str):
 
 	frappe.local.form_dict.sid = sid
 	frappe.local.login_manager = LoginManager()
+	frappe.local.cookie_manager.set_cookie("sid", sid, max_age=get_expiry_in_seconds(), httponly=True)
 
 	redirect_post_login(
 		desk_user=frappe.db.get_value("User", frappe.session.user, "user_type") == "System User"


### PR DESCRIPTION
A session id sent as a request parameter no longer becomes a browser
cookie. Callers that hand a session to a browser now use the one-time
login token route and set the cookie themselves.