### PR TITLE
fix(realtime): Use urlsplit for parsing hostname

### DIFF
--- a/frappe/realtime/util.py
+++ b/frappe/realtime/util.py
@@ -14,12 +14,12 @@ def read_header(environ: dict, name: str) -> str | None:
 
 
 def get_hostname(url: str | None) -> str | None:
-	"""hostname without scheme or port. Port of node_utils get_hostname."""
+	"""hostname without scheme, userinfo, or port."""
 	if not url:
 		return None
-	if "://" in url:
-		url = url.split("/")[2]
-	return url.split(":")[0] if ":" in url else url
+	if "://" not in url:
+		url = f"//{url}"
+	return urlsplit(url).hostname
 
 
 def resolve_site_name(environ: dict, config: RealtimeConfig) -> str | None:

--- a/frappe/tests/test_realtime_py.py
+++ b/frappe/tests/test_realtime_py.py
@@ -150,6 +150,9 @@ class TestAuthHelpers(unittest.TestCase):
 		self.assertEqual(auth_mod.get_hostname("site.local:9000"), "site.local")
 		self.assertEqual(auth_mod.get_hostname("site.local"), "site.local")
 		self.assertIsNone(auth_mod.get_hostname(None))
+		# userinfo (user:pass@host) must resolve to the real host, not the userinfo
+		self.assertEqual(auth_mod.get_hostname("https://victim.com:1@evil.com"), "evil.com")
+		self.assertEqual(auth_mod.get_hostname("victim.com:1@evil.com"), "evil.com")
 
 	def test_site_resolution_order(self):
 		cfg = make_config(default_site="default.local")

--- a/realtime/utils.js
+++ b/realtime/utils.js
@@ -3,10 +3,11 @@ const conf = get_conf();
 
 function get_hostname(url) {
 	if (!url) return undefined;
-	if (url.indexOf("://") > -1) {
-		url = url.split("/")[2];
+	try {
+		return new URL(url.indexOf("://") > -1 ? url : `http://${url}`).hostname;
+	} catch (e) {
+		return undefined;
 	}
-	return url.match(/:/g) ? url.slice(0, url.indexOf(":")) : url;
 }
 
 function get_url(socket, path) {


### PR DESCRIPTION
It's better to use urlsplit instead of manually parsing the hostname