### PR TITLE
fix(telemetry): apply opt-out at setup completion, not mid-wizard

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -151,8 +151,8 @@ frappe.setup.SetupWizard = class SetupWizard extends frappe.ui.Slides {
 	sync_telemetry_preference() {
 		// Apply the opt-out from the final committed values, not on each checkbox
 		// change, so toggling within a slide stays reversible — disable() is one-way.
-		// Called from action_on_complete *after* initated_client_side is captured,
-		// so the funnel event still fires for users who opted out.
+		// Server-side the preference lands only at wizard completion, so setup
+		// events (funnel, persona) are captured regardless of the choice.
 		if (frappe.telemetry.enabled && !this.values.enable_telemetry) {
 			frappe.telemetry.disable();
 		}
@@ -213,7 +213,6 @@ frappe.setup.SetupWizard = class SetupWizard extends frappe.ui.Slides {
 	}
 
 	action_on_complete() {
-		frappe.telemetry.capture("initated_client_side", "setup");
 		if (!this.current_slide.set_values()) return;
 		this.update_values();
 		this.sync_telemetry_preference();
@@ -371,7 +370,6 @@ frappe.setup.SetupWizardSlide = class SetupWizardSlide extends frappe.ui.Slide {
 	make() {
 		super.make();
 		this.set_init_values();
-		this.setup_telemetry_events();
 		this.reset_action_button_state();
 	}
 
@@ -386,16 +384,6 @@ frappe.setup.SetupWizardSlide = class SetupWizardSlide extends frappe.ui.Slide {
 				}
 			});
 		}
-	}
-
-	setup_telemetry_events() {
-		let me = this;
-		this.fields.filter(frappe.model.is_value_type).forEach((field) => {
-			field.fieldname &&
-				me.get_input(field.fieldname)?.on?.("change", function () {
-					frappe.telemetry.capture(`${field.fieldname}_set`, "setup");
-				});
-		});
 	}
 };
 

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -98,7 +98,7 @@ def process_setup_stages(stages, user_input, is_background_task=False):
 	setup_wizard_completed_apps = get_setup_wizard_completed_apps()
 	telemetry_enabled = bool(cint(user_input.get("enable_telemetry")))
 
-	capture("initated_server_side", "setup")
+	capture("initiated_server_side", "setup")
 	try:
 		frappe.flags.in_setup_wizard = True
 		current_task = None

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -152,6 +152,7 @@ def process_setup_stages(stages, user_input, is_background_task=False):
 				"telemetry_enabled": telemetry_enabled,
 			},
 		)
+		apply_telemetry_preference(telemetry_enabled)
 		if not is_background_task:
 			return {"status": "ok"}
 		frappe.publish_realtime("setup_task", {"status": "ok"}, user=frappe.session.user)
@@ -185,6 +186,12 @@ def update_global_settings(args):  # nosemgrep
 	update_system_settings(args)
 	create_or_update_user(args)
 	frappe.enqueue(set_timezone, timezone=args.get("timezone"))
+
+
+def apply_telemetry_preference(telemetry_enabled):
+	# Applied only after the wizard's own completion event: setup events (funnel,
+	# persona) are always captured — this checkbox governs tracking after setup.
+	frappe.db.set_single_value("System Settings", "enable_telemetry", cint(telemetry_enabled))
 
 
 def run_post_setup_complete(args):  # nosemgrep
@@ -291,7 +298,6 @@ def update_system_settings(args):  # nosemgrep
 			"number_format": number_format,
 			"enable_scheduler": 1 if not frappe.in_test else 0,
 			"backup_limit": 3,  # Default for downloadable backups
-			"enable_telemetry": cint(args.get("enable_telemetry")),
 		}
 	)
 	system_settings.save()

--- a/frappe/utils/install.py
+++ b/frappe/utils/install.py
@@ -163,7 +163,7 @@ def complete_setup_wizard():
 			"country": "United States",
 			"timezone": "America/New_York",
 			"currency": "USD",
-			"enable_telemtry": 1,
+			"enable_telemetry": 1,
 		}
 	)
 

--- a/frappe/utils/telemetry/pulse/client.py
+++ b/frappe/utils/telemetry/pulse/client.py
@@ -10,7 +10,7 @@ from .utils import anonymize_user, pulse_host, utc_iso
 def is_enabled() -> bool:
 	# Not cached: the underlying reads are conf lookups (in-memory) and System Settings
 	# (already request- and redis-cached by frappe), so a local cache here buys nothing
-	# but staleness — notably during the setup wizard, where enable_telemetry flips on.
+	# but staleness — notably at setup wizard completion, where the opt-out lands.
 	if not frappe.conf.get("pulse_api_key"):
 		return False
 
@@ -141,7 +141,10 @@ def alias(previous_id: str):
 
 
 def send_queued_events():
-	if not is_enabled():
+	# Consent gates capture, not delivery: events queued while telemetry was on
+	# (e.g. setup wizard events, before an opt-out lands at wizard completion)
+	# must still be sent. Delivery only needs the ingest credentials.
+	if not frappe.conf.get("pulse_api_key"):
 		return
 
 	http = PulseHTTP()


### PR DESCRIPTION
The setup wizard wrote `enable_telemetry=0` in its first stage. For opt-out users, the consent gate then dropped every later capture. This included app stage events such as ERPNext's `user_persona_submitted`, and `completed_server_side` — the one event that records the opt-out. `send_queued_events` also checked consent, so the scheduler never delivered events queued before the flip. In the signup → setup funnel, opt-outs and abandoned setups looked the same.

Changes:

- Apply the telemetry preference after the completion event. The wizard always captures setup events. The checkbox controls tracking after setup. This matches the client side, which applies the opt-out only on complete.
- Gate `send_queued_events` on `pulse_api_key` only. Consent decides what the client captures. Delivery sends what the queue holds.
- Remove the per-field `<fieldname>_set` events and `initated_client_side`. Pageviews already record slide progress, because each slide sets the route. `initiated_server_side` covers the complete click.
- Fix the event name typo: `initated_server_side` → `initiated_server_side`. Funnel queries that match the old name need an update.
- Fix the `enable_telemtry` key typo in the test setup args.

ERPNext needs no change. Its persona stage flows through the fixed pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)