### PR TITLE
fix(print): don't route layout-less standard formats to the beta renderer

### DIFF
--- a/frappe/printing/doctype/print_format/classic_converter.py
+++ b/frappe/printing/doctype/print_format/classic_converter.py
@@ -34,7 +34,9 @@ def uses_beta_renderer(print_format) -> bool:
 	if print_format.get("custom_format") or print_format.get("raw_printing"):
 		return False
 	if print_format.get("print_format_builder_beta"):
-		return True
+		# a standard format with no layout is a file-based Jinja format whose
+		# flag was set wrongly on insert — the beta renderer has nothing to draw
+		return print_format.get("standard") != "Yes" or bool(print_format.get("format_data"))
 	return is_classic_layout(print_format.get("format_data"))
 
 

--- a/frappe/printing/doctype/print_format/test_print_format.py
+++ b/frappe/printing/doctype/print_format/test_print_format.py
@@ -390,6 +390,13 @@ class TestClassicConverter(IntegrationTestCase):
 		self.assertEqual(doc.print_format_builder_beta, 0)
 		self.assertFalse(uses_beta_renderer(doc))
 
+		# rows flipped before the before_save fix are still in the wild — the flag
+		# alone must not route a layout-less standard format to the beta renderer
+		doc.print_format_builder_beta = 1
+		self.assertFalse(uses_beta_renderer(doc))
+		doc.format_data = '{"sections": []}'
+		self.assertTrue(uses_beta_renderer(doc))
+
 	def test_convert_print_format_document(self):
 		from frappe.printing.doctype.print_format.classic_converter import convert_print_format
 

--- a/frappe/www/printpreview.py
+++ b/frappe/www/printpreview.py
@@ -3,7 +3,8 @@ no_cache = 1
 
 def get_context(context):
 	import frappe
-	from frappe.www.printview import resolve_print_format
+	from frappe.utils.jinja_globals import is_rtl
+	from frappe.www.printview import get_print_style, get_rendered_template, resolve_print_format
 
 	doctype = frappe.form_dict.doctype
 	docname = frappe.form_dict.name
@@ -18,4 +19,22 @@ def get_context(context):
 
 		context.body = get_html(doctype, docname, pf, letterhead, settings=settings)
 	else:
-		context.body = pf.get_html(docname, letterhead)
+		# Jinja formats render through the legacy pipeline, wrapped in the same
+		# page shell /printview uses — PrintFormat.get_html is the beta generator
+		# and has nothing to draw for them
+		body = get_rendered_template(
+			doc, print_format=pf, meta=doc.meta, letterhead=letterhead, settings=settings
+		)
+		context.body = frappe.render_template(
+			"www/printview.html",
+			{
+				"standalone": False,
+				"no_action_banner": True,
+				"body": body,
+				"print_style": get_print_style(print_format=pf),
+				"lang": frappe.local.lang,
+				"layout_direction": "rtl" if is_rtl() else "ltr",
+				"title": doc.get_title() or doc.name,
+				"comment": None,
+			},
+		)

--- a/frappe/www/printview.html
+++ b/frappe/www/printview.html
@@ -17,7 +17,7 @@
 	{% endif %}
 </head>
 <body>
-	{% include "templates/print_formats/print_action_banner.html" %}
+	{% if not no_action_banner %}{% include "templates/print_formats/print_action_banner.html" %}{% endif %}
 	<div class="print-format-gutter">
 		<div class="print-format">
 			{{ body }}


### PR DESCRIPTION
Fixes #41302 for existing sites

- `uses_beta_renderer` no longer trusts the `print_format_builder_beta` flag on a standard format that has no `format_data` — it routes to the Jinja path, restoring the old file-first precedence
- `/printpreview` renders non-beta formats through `get_rendered_template` wrapped in the `/printview` page shell — its else-branch called `PrintFormat.get_html`, which is the beta generator, so any Jinja format reaching the route crashed on `page_number` (or rendered blank)
- Extends the regression test to cover the flipped-flag state

Why: #41340 stopped `before_save` from flipping the flag on new inserts, but rows flipped before that fix are still in the wild (the GST3B report in the issue), and the Desk preview sends every non-custom format to `/printpreview` regardless. Both halves are needed: the guard fixes wrongly-flagged rows, the route fix covers correctly-flagged Jinja formats (e.g. erpnext's Sales Invoice Return) that the preview routes there anyway. No data migration required.

no-docs
