### PR TITLE
fix: gate tree rebuild and user permission reads behind dedicated endpoints

### DIFF
--- a/frappe/core/doctype/user_permission/user_permission.py
+++ b/frappe/core/doctype/user_permission/user_permission.py
@@ -88,13 +88,13 @@ def send_user_permissions(bootinfo):
 
 
 @frappe.whitelist()
+def get_current_user_permissions():
+	"""Return the permissions of the logged in user."""
+	return get_user_permissions(frappe.session.user)
+
+
 def get_user_permissions(user: str | None = None):
 	"""Get all users permissions for the user as a dict of doctype"""
-	# if this is called from client-side,
-	# user can access only his/her user permissions
-	if frappe.request and frappe.local.form_dict.cmd == "get_user_permissions":
-		user = frappe.session.user
-
 	if not user:
 		user = frappe.session.user
 

--- a/frappe/public/js/frappe/defaults.js
+++ b/frappe/public/js/frappe/defaults.js
@@ -118,7 +118,8 @@ frappe.defaults = {
 	},
 
 	update_user_permissions: function () {
-		const method = "frappe.core.doctype.user_permission.user_permission.get_user_permissions";
+		const method =
+			"frappe.core.doctype.user_permission.user_permission.get_current_user_permissions";
 		frappe.call(method).then((r) => {
 			if (r.message) {
 				this._user_permissions = Object.assign({}, r.message);

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -270,7 +270,7 @@ frappe.views.TreeView = class TreeView {
 	rebuild_tree() {
 		let me = this;
 		frappe.call({
-			method: "frappe.utils.nestedset.rebuild_tree",
+			method: "frappe.utils.nestedset.rebuild_tree_for_doctype",
 			args: {
 				doctype: me.doctype,
 			},

--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -168,12 +168,14 @@ def update_move_node(doc: Document, parent_field: str):
 
 
 @frappe.whitelist()
+def rebuild_tree_for_doctype(doctype: str) -> None:
+	"""Rebuild the nested set of a tree doctype on request."""
+	frappe.only_for("System Manager")
+	rebuild_tree(doctype)
+
+
 def rebuild_tree(doctype: str) -> None:
 	"""Call rebuild_node for all root nodes."""
-	# Check for perm if called from client-side
-	if frappe.request and frappe.local.form_dict.cmd == "rebuild_tree":
-		frappe.only_for("System Manager")
-
 	meta = frappe.get_meta(doctype)
 	if not meta.has_field("lft") or not meta.has_field("rgt"):
 		frappe.throw(


### PR DESCRIPTION
The internal helpers are no longer callable over HTTP. A tree rebuild now runs
only for a System Manager, and the permission endpoint returns the permissions
of the logged in user.