### PR TITLE
fix: compare API and socket secrets in constant time

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -2,6 +2,7 @@
 # MIT License. See LICENSE
 import base64
 import binascii
+import hmac
 from urllib.parse import quote, unquote, urlencode, urlparse
 
 from werkzeug.wrappers import Response
@@ -748,7 +749,7 @@ def validate_api_key_secret(api_key, api_secret, frappe_authorization_source=Non
 		raise frappe.AuthenticationError
 	form_dict = frappe.local.form_dict
 	doc_secret = get_decrypted_password(doctype, docname, fieldname="api_secret", raise_exception=False)
-	if doc_secret and api_secret == doc_secret:
+	if doc_secret and hmac.compare_digest(api_secret.encode(), doc_secret.encode()):
 		if doctype == "User":
 			user = frappe.db.get_value(doctype="User", filters={"api_key": api_key}, fieldname=["name"])
 		else:

--- a/frappe/realtime/__init__.py
+++ b/frappe/realtime/__init__.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 
 
+import hmac
 from contextlib import suppress
 from typing import TYPE_CHECKING
 
@@ -150,7 +151,7 @@ def get_user_info():
 	user_type = frappe.session.data.user_type
 	trusted_secret = get_socketio_secret()
 	provided_secret = frappe.get_request_header("X-Frappe-Socket-Secret")
-	if trusted_secret != provided_secret:
+	if not provided_secret or not hmac.compare_digest(trusted_secret.encode(), provided_secret.encode()):
 		return {}
 	# For requests with Bearer tokens, user_type is not set in the session data
 	if not user_type:


### PR DESCRIPTION
Both checks now use hmac.compare_digest instead of a short-circuiting equality test.