### PR TITLE
fix: set the desk comment author from the session user

### DIFF
--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -996,8 +996,6 @@ class TestFileUtils(IntegrationTestCase):
 			"ToDo",
 			test_doc.name,
 			'<div class="ql-editor read-mode"><img src="data:image/png;filename=pix.png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="></div>',
-			frappe.session.user,
-			frappe.session.user,
 		)
 
 		self.assertTrue(

--- a/frappe/desk/form/utils.py
+++ b/frappe/desk/form/utils.py
@@ -11,6 +11,7 @@ from frappe import _
 from frappe.core.doctype.file.utils import extract_images_from_html
 from frappe.desk.form.document_follow import follow_document
 from frappe.query_builder.functions import IfNull
+from frappe.utils import get_fullname
 
 if TYPE_CHECKING:
 	from frappe.core.doctype.comment.comment import Comment
@@ -24,9 +25,7 @@ def remove_attach():
 
 
 @frappe.whitelist(methods=["POST", "PUT"])
-def add_comment(
-	reference_doctype: str, reference_name: str, content: str, comment_email: str, comment_by: str
-) -> "Comment":
+def add_comment(reference_doctype: str, reference_name: str, content: str) -> "Comment":
 	"""Allow logged user with permission to read document to add a comment"""
 	reference_doc = frappe.get_lazy_doc(reference_doctype, reference_name, check_permission=True)
 
@@ -36,8 +35,8 @@ def add_comment(
 			"comment_type": "Comment",
 			"reference_doctype": reference_doctype,
 			"reference_name": reference_name,
-			"comment_email": comment_email,
-			"comment_by": comment_by,
+			"comment_email": frappe.session.user,
+			"comment_by": get_fullname(frappe.session.user),
 			"content": extract_images_from_html(reference_doc, content, is_private=True),
 		}
 	)

--- a/frappe/email/doctype/document_follow/test_document_follow.py
+++ b/frappe/email/doctype/document_follow/test_document_follow.py
@@ -34,9 +34,7 @@ class TestDocumentFollow(IntegrationTestCase):
 		user = get_user()
 		event_doc = get_event()
 
-		add_comment(
-			event_doc.doctype, event_doc.name, "This is a test comment", "Administrator@example.com", "Bosh"
-		)
+		add_comment(event_doc.doctype, event_doc.name, "This is a test comment")
 
 		document_follow.unfollow_document("Event", event_doc.name, user.name)
 		doc = document_follow.follow_document("Event", event_doc.name, user.name)
@@ -91,7 +89,7 @@ class TestDocumentFollow(IntegrationTestCase):
 		frappe.set_user(user.name)
 		event = get_event()
 
-		add_comment(event.doctype, event.name, "This is a test comment", "Administrator@example.com", "Bosh")
+		add_comment(event.doctype, event.name, "This is a test comment")
 
 		documents_followed = get_events_followed_by_user(event.name, user.name)
 		self.assertTrue(documents_followed)
@@ -101,7 +99,7 @@ class TestDocumentFollow(IntegrationTestCase):
 		frappe.set_user(user.name)
 		event = get_event()
 
-		add_comment(event.doctype, event.name, "This is a test comment", "Administrator@example.com", "Bosh")
+		add_comment(event.doctype, event.name, "This is a test comment")
 
 		documents_followed = get_events_followed_by_user(event.name, user.name)
 		self.assertFalse(documents_followed)

--- a/frappe/public/js/frappe/form/footer/footer.js
+++ b/frappe/public/js/frappe/form/footer/footer.js
@@ -60,8 +60,6 @@ frappe.ui.form.Footer = class FormFooter {
 							reference_doctype: this.frm.doctype,
 							reference_name: this.frm.docname,
 							content: comment,
-							comment_email: frappe.session.user,
-							comment_by: frappe.session.user_fullname,
 						})
 						.then(() => {
 							this.frm.comment_box.set_value("");


### PR DESCRIPTION
The add_comment endpoint no longer accepts comment_email and comment_by.
It stores the session user and the full name of that user instead.