### PR TITLE
fix: record query report exports in the access log on the server

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -419,6 +419,7 @@ def run_export_query_job(user_email: str, form_params, csv_params):
 
 
 def _export_query(form_params, csv_params, populate_response=True):
+	from frappe.core.doctype.access_log.access_log import make_access_log
 	from frappe.desk.utils import get_csv_bytes, provide_binary_file
 
 	report_name = form_params.report_name
@@ -434,6 +435,13 @@ def _export_query(form_params, csv_params, populate_response=True):
 		visible_idx = json.loads(visible_idx)
 	elif not isinstance(visible_idx, list):
 		visible_idx = []
+
+	make_access_log(
+		report_name=report_name,
+		file_type=file_format_type,
+		filters=form_params.filters,
+		method="Export",
+	)
 
 	data = run(
 		report_name,

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1806,8 +1806,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				csv_quoting,
 				csv_decimal_sep,
 			}) => {
-				this.make_access_log("Export", file_format);
-
 				const filters = this.get_filter_values(true);
 				const applied_filters = this.get_applied_filters(filters);
 


### PR DESCRIPTION
The export endpoint now writes the Access Log row itself, so exports made
outside the desk UI are also recorded.