### PR TITLE
feat: capture document lifecycle timeline in Recorder

### DIFF
--- a/frappe/core/doctype/recorder/recorder.js
+++ b/frappe/core/doctype/recorder/recorder.js
@@ -82,10 +82,6 @@ frappe.ui.form.on("Recorder", {
 			const max_queries = Math.max(1, ...frm.doc.timeline.map((d) => d.queries));
 			heatmap("timeline", "duration", max_event);
 			heatmap("timeline", "queries", max_queries);
-			// preserve the depth indentation baked into the label
-			frm.fields_dict.timeline.grid.grid_rows.forEach((row) => {
-				$(row.columns.label).css("white-space", "pre");
-			});
 		}
 	},
 });

--- a/frappe/core/doctype/recorder/recorder.js
+++ b/frappe/core/doctype/recorder/recorder.js
@@ -4,6 +4,7 @@
 frappe.ui.form.on("Recorder", {
 	onload: function (frm) {
 		frm.fields_dict.sql_queries.grid.only_sortable();
+		frm.fields_dict.timeline.grid.only_sortable();
 	},
 	refresh: function (frm) {
 		frm.disable_save();
@@ -11,6 +12,8 @@ frappe.ui.form.on("Recorder", {
 		frm.trigger("setup_sort");
 		frm.fields_dict.sql_queries.grid.grid_pagination.page_length = 500;
 		refresh_field("sql_queries");
+		frm.fields_dict.timeline.grid.grid_pagination.page_length = 500;
+		refresh_field("timeline");
 		frm.trigger("format_grid");
 		frm.add_custom_button(__("Suggest Optimizations"), () => {
 			frappe.xcall("frappe.core.doctype.recorder.recorder.optimize", {
@@ -73,6 +76,17 @@ frappe.ui.form.on("Recorder", {
 			});
 		};
 		heatmap("sql_queries", "duration", max_duration);
+
+		if (frm.doc.timeline && frm.doc.timeline.length) {
+			const max_event = Math.max(20, ...frm.doc.timeline.map((d) => d.duration));
+			const max_queries = Math.max(1, ...frm.doc.timeline.map((d) => d.queries));
+			heatmap("timeline", "duration", max_event);
+			heatmap("timeline", "queries", max_queries);
+			// preserve the depth indentation baked into the label
+			frm.fields_dict.timeline.grid.grid_rows.forEach((row) => {
+				$(row.columns.label).css("white-space", "pre");
+			});
+		}
 	},
 });
 

--- a/frappe/core/doctype/recorder/recorder.json
+++ b/frappe/core/doctype/recorder/recorder.json
@@ -9,12 +9,16 @@
   "path",
   "number_of_queries",
   "time_in_queries",
+  "number_of_events",
   "method",
   "column_break_qo53",
   "cmd",
   "time",
   "duration",
   "event_type",
+  "apps_involved",
+  "section_break_timeline",
+  "timeline",
   "section_break_1skt",
   "request_headers",
   "section_break_sgro",
@@ -62,6 +66,12 @@
    "fieldname": "time_in_queries",
    "fieldtype": "Float",
    "label": "Time in Queries"
+  },
+  {
+   "fieldname": "number_of_events",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Number of Events"
   },
   {
    "fieldname": "column_break_qo53",
@@ -112,6 +122,26 @@
    "label": "Event Type"
   },
   {
+   "fieldname": "apps_involved",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Apps Involved",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_timeline",
+   "fieldtype": "Section Break",
+   "label": "Timeline"
+  },
+  {
+   "description": "Ordered timeline of document lifecycle methods and doc_events handlers that ran during this request, attributed to the app(s) that hook them.",
+   "fieldname": "timeline",
+   "fieldtype": "Table",
+   "label": "Timeline",
+   "options": "Recorder Event",
+   "read_only": 1
+  },
+  {
    "fieldname": "section_break_optn",
    "fieldtype": "Section Break"
   },
@@ -134,7 +164,7 @@
  "index_web_pages_for_search": 1,
  "is_virtual": 1,
  "links": [],
- "modified": "2024-05-14 15:16:55.626656",
+ "modified": "2026-07-30 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Recorder",

--- a/frappe/core/doctype/recorder/recorder.py
+++ b/frappe/core/doctype/recorder/recorder.py
@@ -23,17 +23,20 @@ class Recorder(Document):
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
+		from frappe.core.doctype.recorder_event.recorder_event import RecorderEvent
 		from frappe.core.doctype.recorder_query.recorder_query import RecorderQuery
 		from frappe.core.doctype.recorder_suggested_index.recorder_suggested_index import (
 			RecorderSuggestedIndex,
 		)
 		from frappe.types import DF
 
+		apps_involved: DF.Data | None
 		cmd: DF.Data | None
 		duration: DF.Float
 		event_type: DF.Data | None
 		form_dict: DF.Code | None
 		method: DF.Literal["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]
+		number_of_events: DF.Int
 		number_of_queries: DF.Int
 		path: DF.Data | None
 		profile: DF.Code | None
@@ -42,6 +45,7 @@ class Recorder(Document):
 		suggested_indexes: DF.Table[RecorderSuggestedIndex]
 		time: DF.Datetime | None
 		time_in_queries: DF.Float
+		timeline: DF.Table[RecorderEvent]
 	# end: auto-generated types
 
 	def load_from_db(self):
@@ -101,13 +105,26 @@ def serialize_request(request):
 		for i in request.calls:
 			i["stack"] = frappe.as_json(i["stack"])
 			i["explain_result"] = frappe.as_json(i["explain_result"])
+
+	events = request.get("events") or []
+	for event in events:
+		# indent the method by its nesting depth so the grid reads as a call tree
+		event["label"] = ("    " * event.get("depth", 0)) + (event.get("method") or "")
+		if isinstance(event.get("apps"), list):
+			event["apps"] = ", ".join(event["apps"])
+		if isinstance(event.get("handlers"), list):
+			event["handlers"] = "\n".join(event["handlers"])
+
 	request.update(
 		name=request.get("uuid"),
 		number_of_queries=request.get("queries"),
 		time_in_queries=request.get("time_queries"),
+		number_of_events=request.get("number_of_events") or len(events),
+		apps_involved=request.get("apps_involved"),
 		request_headers=frappe.as_json(request.get("headers", {}), indent=4),
 		form_dict=frappe.as_json(request.get("form_dict", {}), indent=4),
 		sql_queries=request.get("calls"),
+		timeline=events,
 		suggested_indexes=request.get("suggested_indexes"),
 		modified=request.get("time"),
 		creation=request.get("time"),

--- a/frappe/core/doctype/recorder/recorder.py
+++ b/frappe/core/doctype/recorder/recorder.py
@@ -108,8 +108,10 @@ def serialize_request(request):
 
 	events = request.get("events") or []
 	for event in events:
-		# indent the method by its nesting depth so the grid reads as a call tree
-		event["label"] = ("    " * event.get("depth", 0)) + (event.get("method") or "")
+		# indent the method by its nesting depth so the grid reads as a call tree.
+		# non-breaking spaces render the indentation without depending on CSS white-space.
+		indent = "\u00a0\u00a0\u00a0\u00a0" * event.get("depth", 0)
+		event["label"] = indent + (event.get("method") or "")
 		if isinstance(event.get("apps"), list):
 			event["apps"] = ", ".join(event["apps"])
 		if isinstance(event.get("handlers"), list):

--- a/frappe/core/doctype/recorder/recorder_list.js
+++ b/frappe/core/doctype/recorder/recorder_list.js
@@ -178,6 +178,19 @@ frappe.listview_settings["Recorder"] = {
 				},
 				{
 					fieldtype: "Section Break",
+					fieldname: "doc_events_section",
+					label: "Document Events",
+				},
+				{
+					fieldname: "capture_doc_events",
+					fieldtype: "Check",
+					label: "Capture document lifecycle timeline",
+					default: 1,
+					description: `Records each document lifecycle method / <code>doc_events</code> handler
+						that runs during the request, timed and attributed to the app that hooks it.`,
+				},
+				{
+					fieldtype: "Section Break",
 					fieldname: "python_section",
 					label: "Python",
 				},

--- a/frappe/core/doctype/recorder/test_recorder.py
+++ b/frappe/core/doctype/recorder/test_recorder.py
@@ -2,6 +2,7 @@
 # See license.txt
 
 import re
+from unittest.mock import patch
 
 import frappe
 import frappe.recorder
@@ -81,6 +82,8 @@ class TestRecorder(IntegrationTestCase):
 	def test_recorder_doc_events_timeline(self):
 		# saving a document runs its lifecycle methods through Document.run_method,
 		# which the recorder should capture as a timeline of events.
+		# stop() -> post_process() left a read-only transaction open; end it before writing.
+		frappe.db.rollback()
 		frappe.get_doc(doctype="ToDo", description="recorder timeline test").insert()
 		self.stop_recorder()
 
@@ -109,6 +112,7 @@ class TestRecorder(IntegrationTestCase):
 		set_request(path="/api/method/ping")
 		frappe.recorder.start(capture_doc_events=False)
 		frappe.recorder.record()
+		frappe.db.rollback()  # end the read-only transaction left open by the previous stop()
 		frappe.get_doc(doctype="ToDo", description="no timeline").insert()
 		self.stop_recorder()
 
@@ -119,6 +123,13 @@ class TestRecorder(IntegrationTestCase):
 		# run_method also runs DocType Event server scripts and webhooks; both should be
 		# attributed in the timeline, not just app doc_events hooks.
 		from frappe.recorder import _doc_event_contributors
+
+		# "*" (all doctypes) hooks are flagged so it's clear why an unrelated app ran
+		with patch.object(
+			frappe, "get_doc_hooks", return_value={"*": {"validate": ["demo_app.always_runs"]}}
+		):
+			_, handlers = _doc_event_contributors("ToDo", "validate")
+			self.assertIn("demo_app.always_runs  (all doctypes)", handlers)
 
 		frappe.client_cache.set_value("server_script_map", {"ToDo": {"Before Save": ["Demo Script"]}})
 		frappe.client_cache.set_value(
@@ -132,6 +143,38 @@ class TestRecorder(IntegrationTestCase):
 			apps, handlers = _doc_event_contributors("ToDo", "on_update")
 			self.assertIn("webhook", apps)
 			self.assertIn("Webhook: Demo Webhook", handlers)
+
+			# a webhook whose condition is false for this doc won't run, so don't attribute it
+			frappe.client_cache.set_value(
+				"webhooks",
+				{
+					"ToDo": [
+						frappe._dict(
+							name="Cond Webhook",
+							webhook_docevent="on_update",
+							condition="doc.status == 'Cancelled'",
+						)
+					]
+				},
+			)
+			doc = frappe.new_doc("ToDo", description="cond")  # status defaults to Open -> condition false
+			apps, handlers = _doc_event_contributors("ToDo", "on_update", doc=doc)
+			self.assertNotIn("Webhook: Cond Webhook", handlers)
+
+			# on_change / before_update_after_submit don't fire during insert
+			frappe.client_cache.set_value(
+				"webhooks", {"ToDo": [frappe._dict(name="Change Webhook", webhook_docevent="on_change")]}
+			)
+			doc.flags.in_insert = True
+			apps, handlers = _doc_event_contributors("ToDo", "on_change", doc=doc)
+			self.assertNotIn("Webhook: Change Webhook", handlers)
+			doc.flags.in_insert = False
+			apps, handlers = _doc_event_contributors("ToDo", "on_change", doc=doc)
+			self.assertIn("Webhook: Change Webhook", handlers)
+
+			frappe.client_cache.set_value(
+				"webhooks", {"ToDo": [frappe._dict(name="Demo Webhook", webhook_docevent="on_update")]}
+			)
 
 			# during migrate/install/etc. the dispatch paths skip these, so don't attribute them
 			frappe.flags.in_migrate = True

--- a/frappe/core/doctype/recorder/test_recorder.py
+++ b/frappe/core/doctype/recorder/test_recorder.py
@@ -78,6 +78,43 @@ class TestRecorder(IntegrationTestCase):
 		request_doc = get_recorder_data(requests[0].name)
 		self.assertIsInstance(serialize_request(request_doc), dict)
 
+	def test_recorder_doc_events_timeline(self):
+		# saving a document runs its lifecycle methods through Document.run_method,
+		# which the recorder should capture as a timeline of events.
+		frappe.get_doc(doctype="ToDo", description="recorder timeline test").insert()
+		self.stop_recorder()
+
+		requests = frappe.get_all("Recorder")
+		self.assertGreaterEqual(len(requests), 1)
+		request = frappe.get_doc("Recorder", requests[0].name)
+
+		self.assertGreaterEqual(len(request.timeline), 1)
+		self.assertEqual(request.number_of_events, len(request.timeline))
+
+		methods = {event.method for event in request.timeline}
+		lifecycle = {"before_insert", "validate", "before_save", "after_insert", "on_update"}
+		self.assertTrue(
+			methods & lifecycle,
+			msg=f"expected lifecycle methods in timeline, got: {methods}",
+		)
+
+		event = request.timeline[0]
+		self.assertTrue(event.method)
+		self.assertGreaterEqual(event.duration, 0)
+		self.assertGreaterEqual(event.queries, 0)
+
+	def test_timeline_can_be_disabled(self):
+		frappe.recorder.stop()
+		frappe.recorder.delete()
+		set_request(path="/api/method/ping")
+		frappe.recorder.start(capture_doc_events=False)
+		frappe.recorder.record()
+		frappe.get_doc(doctype="ToDo", description="no timeline").insert()
+		self.stop_recorder()
+
+		request = frappe.get_doc("Recorder", frappe.get_all("Recorder")[0].name)
+		self.assertEqual(len(request.timeline), 0)
+
 
 class TestQueryOptimization(IntegrationTestCase):
 	@run_only_if(db_type_is.MARIADB)

--- a/frappe/core/doctype/recorder/test_recorder.py
+++ b/frappe/core/doctype/recorder/test_recorder.py
@@ -115,6 +115,27 @@ class TestRecorder(IntegrationTestCase):
 		request = frappe.get_doc("Recorder", frappe.get_all("Recorder")[0].name)
 		self.assertEqual(len(request.timeline), 0)
 
+	def test_timeline_attributes_server_scripts_and_webhooks(self):
+		# run_method also runs DocType Event server scripts and webhooks; both should be
+		# attributed in the timeline, not just app doc_events hooks.
+		from frappe.recorder import _doc_event_contributors
+
+		frappe.client_cache.set_value("server_script_map", {"ToDo": {"Before Save": ["Demo Script"]}})
+		frappe.client_cache.set_value(
+			"webhooks", {"ToDo": [frappe._dict(name="Demo Webhook", webhook_docevent="on_update")]}
+		)
+		try:
+			apps, handlers = _doc_event_contributors("ToDo", "validate")  # -> "Before Save"
+			self.assertIn("server_script", apps)
+			self.assertIn("Server Script: Demo Script", handlers)
+
+			apps, handlers = _doc_event_contributors("ToDo", "on_update")
+			self.assertIn("webhook", apps)
+			self.assertIn("Webhook: Demo Webhook", handlers)
+		finally:
+			frappe.client_cache.delete_value("server_script_map")
+			frappe.client_cache.delete_value("webhooks")
+
 
 class TestQueryOptimization(IntegrationTestCase):
 	@run_only_if(db_type_is.MARIADB)

--- a/frappe/core/doctype/recorder/test_recorder.py
+++ b/frappe/core/doctype/recorder/test_recorder.py
@@ -161,7 +161,7 @@ class TestRecorder(IntegrationTestCase):
 			apps, handlers = _doc_event_contributors("ToDo", "on_update", doc=doc)
 			self.assertNotIn("Webhook: Cond Webhook", handlers)
 
-			# on_change / before_update_after_submit don't fire during insert
+			# on_change doesn't fire during insert
 			frappe.client_cache.set_value(
 				"webhooks", {"ToDo": [frappe._dict(name="Change Webhook", webhook_docevent="on_change")]}
 			)
@@ -171,6 +171,18 @@ class TestRecorder(IntegrationTestCase):
 			doc.flags.in_insert = False
 			apps, handlers = _doc_event_contributors("ToDo", "on_change", doc=doc)
 			self.assertIn("Webhook: Change Webhook", handlers)
+
+			# run_webhooks rejects events outside supported_events, so don't attribute them
+			frappe.client_cache.set_value(
+				"webhooks",
+				{
+					"ToDo": [
+						frappe._dict(name="Submit Webhook", webhook_docevent="before_update_after_submit")
+					]
+				},
+			)
+			apps, handlers = _doc_event_contributors("ToDo", "before_update_after_submit", doc=doc)
+			self.assertNotIn("Webhook: Submit Webhook", handlers)
 
 			frappe.client_cache.set_value(
 				"webhooks", {"ToDo": [frappe._dict(name="Demo Webhook", webhook_docevent="on_update")]}

--- a/frappe/core/doctype/recorder/test_recorder.py
+++ b/frappe/core/doctype/recorder/test_recorder.py
@@ -132,6 +132,16 @@ class TestRecorder(IntegrationTestCase):
 			apps, handlers = _doc_event_contributors("ToDo", "on_update")
 			self.assertIn("webhook", apps)
 			self.assertIn("Webhook: Demo Webhook", handlers)
+
+			# during migrate/install/etc. the dispatch paths skip these, so don't attribute them
+			frappe.flags.in_migrate = True
+			try:
+				apps, _ = _doc_event_contributors("ToDo", "validate")
+				self.assertNotIn("server_script", apps)
+				apps, _ = _doc_event_contributors("ToDo", "on_update")
+				self.assertNotIn("webhook", apps)
+			finally:
+				frappe.flags.in_migrate = False
 		finally:
 			frappe.client_cache.delete_value("server_script_map")
 			frappe.client_cache.delete_value("webhooks")

--- a/frappe/core/doctype/recorder_event/recorder_event.json
+++ b/frappe/core/doctype/recorder_event/recorder_event.json
@@ -1,0 +1,102 @@
+{
+ "actions": [],
+ "creation": "2026-07-30 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "label",
+  "ref_doctype",
+  "ref_name",
+  "apps",
+  "queries",
+  "duration",
+  "method",
+  "depth",
+  "seq",
+  "handlers"
+ ],
+ "fields": [
+  {
+   "columns": 4,
+   "fieldname": "label",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Method",
+   "read_only": 1
+  },
+  {
+   "columns": 2,
+   "fieldname": "ref_doctype",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "DocType",
+   "read_only": 1
+  },
+  {
+   "fieldname": "ref_name",
+   "fieldtype": "Data",
+   "label": "Document",
+   "read_only": 1
+  },
+  {
+   "columns": 2,
+   "fieldname": "apps",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Apps",
+   "read_only": 1
+  },
+  {
+   "columns": 1,
+   "fieldname": "queries",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Queries",
+   "read_only": 1
+  },
+  {
+   "columns": 1,
+   "fieldname": "duration",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "Duration (ms)",
+   "read_only": 1
+  },
+  {
+   "fieldname": "method",
+   "fieldtype": "Data",
+   "label": "Raw Method",
+   "read_only": 1
+  },
+  {
+   "fieldname": "depth",
+   "fieldtype": "Int",
+   "label": "Depth",
+   "read_only": 1
+  },
+  {
+   "fieldname": "seq",
+   "fieldtype": "Int",
+   "label": "Sequence",
+   "read_only": 1
+  },
+  {
+   "fieldname": "handlers",
+   "fieldtype": "Small Text",
+   "label": "Handlers",
+   "read_only": 1
+  }
+ ],
+ "istable": 1,
+ "links": [],
+ "modified": "2026-07-30 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Core",
+ "name": "Recorder Event",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/frappe/core/doctype/recorder_event/recorder_event.py
+++ b/frappe/core/doctype/recorder_event/recorder_event.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2026, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class RecorderEvent(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		apps: DF.Data | None
+		depth: DF.Int
+		duration: DF.Float
+		handlers: DF.SmallText | None
+		label: DF.Data | None
+		method: DF.Data | None
+		queries: DF.Int
+		ref_doctype: DF.Data | None
+		ref_name: DF.Data | None
+		seq: DF.Int
+	# end: auto-generated types
+
+	pass

--- a/frappe/recorder.py
+++ b/frappe/recorder.py
@@ -103,7 +103,7 @@ def get_current_stack_frames():
 		pass
 
 
-def _doc_event_contributors(doctype: str, method: str) -> tuple[list[str], list[str]]:
+def _doc_event_contributors(doctype: str, method: str, doc=None) -> tuple[list[str], list[str]]:
 	"""Everything Document.run_method runs for (doctype, method): app `doc_events` hooks,
 	DocType Event server scripts, and webhooks. Returns (apps, handler_labels), where `apps`
 	tags the source (app name, "server_script", or "webhook"). All lookups are cached, and
@@ -113,8 +113,13 @@ def _doc_event_contributors(doctype: str, method: str) -> tuple[list[str], list[
 
 	try:
 		doc_hooks = frappe.get_doc_hooks()
-		for handler in doc_hooks.get(doctype, {}).get(method, []) + doc_hooks.get("*", {}).get(method, []):
+		for handler in doc_hooks.get(doctype, {}).get(method, []):
 			handlers.append(handler)
+			apps.add(handler.split(".")[0])
+		# "*" hooks fire on every doctype, so flag them — otherwise it's unclear why an
+		# unrelated app's handler ran on this document.
+		for handler in doc_hooks.get("*", {}).get(method, []):
+			handlers.append(f"{handler}  (all doctypes)")
 			apps.add(handler.split(".")[0])
 	except Exception:
 		pass
@@ -132,16 +137,29 @@ def _doc_event_contributors(doctype: str, method: str) -> tuple[list[str], list[
 	except Exception:
 		pass
 
-	# webhooks are skipped by run_webhooks during import/patch/install/migrate
+	# webhooks are skipped by run_webhooks during import/patch/install/migrate; on insert,
+	# on_change/before_update_after_submit don't fire; and each webhook's condition is
+	# evaluated per-document. Mirror all three so we don't attribute one that wouldn't run.
 	try:
 		from frappe.integrations.doctype.webhook import get_all_webhooks
+		from frappe.integrations.doctype.webhook.webhook import get_context
 
 		if not (flags.in_import or flags.in_patch or flags.in_install or flags.in_migrate):
+			skip_on_insert = (
+				doc is not None
+				and getattr(doc.flags, "in_insert", False)
+				and method in ("on_change", "before_update_after_submit")
+			)
 			webhooks = frappe.client_cache.get_value("webhooks", generator=get_all_webhooks)
 			for webhook in webhooks.get(doctype, None) or []:
-				if webhook.get("webhook_docevent") == method:
-					handlers.append(f"Webhook: {webhook.get('name')}")
-					apps.add("webhook")
+				if webhook.get("webhook_docevent") != method or skip_on_insert:
+					continue
+				condition = webhook.get("condition")
+				if condition and doc is not None:
+					if not frappe.safe_eval(condition, eval_locals=get_context(doc)):
+						continue
+				handlers.append(f"Webhook: {webhook.get('name')}")
+				apps.add("webhook")
 	except Exception:
 		pass
 
@@ -181,7 +199,7 @@ def _install_run_method_tracer():
 		recorder._depth += 1
 		queries_before = len(recorder.calls)
 		start_time = time.monotonic()
-		apps, handlers = _doc_event_contributors(doc.doctype, method)
+		apps, handlers = _doc_event_contributors(doc.doctype, method, doc=doc)
 		try:
 			return original_run_method(doc, method, *args, **kwargs)
 		finally:

--- a/frappe/recorder.py
+++ b/frappe/recorder.py
@@ -119,24 +119,29 @@ def _doc_event_contributors(doctype: str, method: str) -> tuple[list[str], list[
 	except Exception:
 		pass
 
+	flags = frappe.flags
+
+	# server scripts are skipped by run_server_script_for_doc_event during install/migrate
 	try:
 		from frappe.core.doctype.server_script.server_script_utils import EVENT_MAP, get_server_script_map
 
-		if event := EVENT_MAP.get(method):
+		if not (flags.in_install or flags.in_migrate) and (event := EVENT_MAP.get(method)):
 			for name in get_server_script_map().get(doctype, {}).get(event, None) or []:
 				handlers.append(f"Server Script: {name}")
 				apps.add("server_script")
 	except Exception:
 		pass
 
+	# webhooks are skipped by run_webhooks during import/patch/install/migrate
 	try:
 		from frappe.integrations.doctype.webhook import get_all_webhooks
 
-		webhooks = frappe.client_cache.get_value("webhooks", generator=get_all_webhooks)
-		for webhook in webhooks.get(doctype, None) or []:
-			if webhook.get("webhook_docevent") == method:
-				handlers.append(f"Webhook: {webhook.get('name')}")
-				apps.add("webhook")
+		if not (flags.in_import or flags.in_patch or flags.in_install or flags.in_migrate):
+			webhooks = frappe.client_cache.get_value("webhooks", generator=get_all_webhooks)
+			for webhook in webhooks.get(doctype, None) or []:
+				if webhook.get("webhook_docevent") == method:
+					handlers.append(f"Webhook: {webhook.get('name')}")
+					apps.add("webhook")
 	except Exception:
 		pass
 

--- a/frappe/recorder.py
+++ b/frappe/recorder.py
@@ -38,6 +38,7 @@ class RecorderConfig:
 	record_jobs: bool = True  # record background jobs
 	record_sql: bool = True  # Record SQL queries
 	capture_stack: bool = True  # Recod call stack of SQL queries
+	capture_doc_events: bool = True  # Record document lifecycle / doc_events timeline
 	profile: bool = False  # Run cProfile
 	explain: bool = True  # Provide explain output of SQL queries
 	request_filter: str = "/"  # Filter request paths
@@ -100,6 +101,71 @@ def get_current_stack_frames():
 				}
 	except Exception:
 		pass
+
+
+def _doc_event_handlers(doctype: str, method: str) -> list[str]:
+	"""Return the dotted paths of doc_events hooked on (doctype, method), across all apps."""
+	try:
+		doc_hooks = frappe.get_doc_hooks()
+	except Exception:
+		return []
+	return list(doc_hooks.get(doctype, {}).get(method, [])) + list(doc_hooks.get("*", {}).get(method, []))
+
+
+_run_method_traced = False
+
+
+def _install_run_method_tracer():
+	"""Wrap Document.run_method once per process so every lifecycle phase / doc_events
+	handler is recorded as a timed, nested span on the active recorder — attributed to
+	the app(s) that hook it. The wrapper is a cheap no-op unless recording is active with
+	`capture_doc_events`, so it is safe to leave installed."""
+	global _run_method_traced
+	if _run_method_traced:
+		return
+
+	from frappe.model.document import Document
+
+	original_run_method = Document.run_method
+
+	@functools.wraps(original_run_method)
+	def run_method(doc, method, *args, **kwargs):
+		recorder = getattr(frappe.local, "_recorder", None)
+		if (
+			recorder is None
+			or not getattr(recorder, "_recording", False)
+			or not recorder.config.capture_doc_events
+			or method.startswith("__")
+		):
+			return original_run_method(doc, method, *args, **kwargs)
+
+		seq = recorder._seq
+		depth = recorder._depth
+		recorder._seq += 1
+		recorder._depth += 1
+		queries_before = len(recorder.calls)
+		start_time = time.monotonic()
+		handlers = _doc_event_handlers(doc.doctype, method)
+		try:
+			return original_run_method(doc, method, *args, **kwargs)
+		finally:
+			recorder._depth -= 1
+			recorder.register_event(
+				{
+					"seq": seq,
+					"depth": depth,
+					"method": method,
+					"ref_doctype": doc.doctype,
+					"ref_name": doc.name or "",
+					"duration": float(f"{(time.monotonic() - start_time) * 1000:.3f}"),
+					"queries": len(recorder.calls) - queries_before,
+					"apps": sorted({handler.split(".")[0] for handler in handlers}),
+					"handlers": handlers,
+				}
+			)
+
+	Document.run_method = run_method
+	_run_method_traced = True
 
 
 def post_process():
@@ -206,6 +272,9 @@ class Recorder:
 		self.headers = None
 		self.form_dict = None
 		self.patched_databases = []
+		self.events = []
+		self._depth = 0
+		self._seq = 0
 
 		if (
 			self.config.record_requests
@@ -235,6 +304,8 @@ class Recorder:
 		self.time = now_datetime()
 
 		self._patch_sql(frappe.db)
+		if self.config.capture_doc_events:
+			_install_run_method_tracer()
 
 		if self.config.profile:
 			self.profiler = cProfile.Profile()
@@ -242,6 +313,9 @@ class Recorder:
 
 	def register(self, data):
 		self.calls.append(data)
+
+	def register_event(self, data):
+		self.events.append(data)
 
 	def cleanup(self):
 		if self.profiler:
@@ -277,10 +351,13 @@ class Recorder:
 			"duration": float(f"{(now_datetime() - self.time).total_seconds() * 1000:0.3f}"),
 			"method": self.method,
 			"event_type": self.event_type,
+			"number_of_events": len(self.events),
+			"apps_involved": ", ".join(sorted({app for event in self.events for app in event["apps"]})),
 		}
 		frappe.cache.hset(RECORDER_REQUEST_SPARSE_HASH, self.uuid, request_data)
 
 		request_data["calls"] = self.calls
+		request_data["events"] = sorted(self.events, key=lambda event: event["seq"])
 		request_data["headers"] = self.headers
 		request_data["form_dict"] = self.form_dict
 		request_data["profile"] = profiler_output
@@ -338,6 +415,7 @@ def start(
 	record_sql: bool = True,
 	profile: bool = False,
 	capture_stack: bool = True,
+	capture_doc_events: bool = True,
 	explain: bool = True,
 	request_filter: str = "/",
 	jobs_filter: str = "",
@@ -350,6 +428,7 @@ def start(
 		record_sql=int(record_sql),
 		profile=int(profile),
 		capture_stack=int(capture_stack),
+		capture_doc_events=int(capture_doc_events),
 		explain=int(explain),
 		request_filter=request_filter,
 		jobs_filter=jobs_filter,

--- a/frappe/recorder.py
+++ b/frappe/recorder.py
@@ -137,18 +137,18 @@ def _doc_event_contributors(doctype: str, method: str, doc=None) -> tuple[list[s
 	except Exception:
 		pass
 
-	# webhooks are skipped by run_webhooks during import/patch/install/migrate; on insert,
-	# on_change/before_update_after_submit don't fire; and each webhook's condition is
-	# evaluated per-document. Mirror all three so we don't attribute one that wouldn't run.
+	# Mirror every gate run_webhooks applies so we don't attribute a webhook that wouldn't
+	# run: the event must be webhook-supported; skipped during import/patch/install/migrate;
+	# on_change doesn't fire on insert; and each webhook's condition is evaluated per-document.
 	try:
-		from frappe.integrations.doctype.webhook import get_all_webhooks
+		from frappe.integrations.doctype.webhook import get_all_webhooks, supported_events
 		from frappe.integrations.doctype.webhook.webhook import get_context
 
-		if not (flags.in_import or flags.in_patch or flags.in_install or flags.in_migrate):
+		if method in supported_events and not (
+			flags.in_import or flags.in_patch or flags.in_install or flags.in_migrate
+		):
 			skip_on_insert = (
-				doc is not None
-				and getattr(doc.flags, "in_insert", False)
-				and method in ("on_change", "before_update_after_submit")
+				doc is not None and getattr(doc.flags, "in_insert", False) and method == "on_change"
 			)
 			webhooks = frappe.client_cache.get_value("webhooks", generator=get_all_webhooks)
 			for webhook in webhooks.get(doctype, None) or []:

--- a/frappe/recorder.py
+++ b/frappe/recorder.py
@@ -103,13 +103,44 @@ def get_current_stack_frames():
 		pass
 
 
-def _doc_event_handlers(doctype: str, method: str) -> list[str]:
-	"""Return the dotted paths of doc_events hooked on (doctype, method), across all apps."""
+def _doc_event_contributors(doctype: str, method: str) -> tuple[list[str], list[str]]:
+	"""Everything Document.run_method runs for (doctype, method): app `doc_events` hooks,
+	DocType Event server scripts, and webhooks. Returns (apps, handler_labels), where `apps`
+	tags the source (app name, "server_script", or "webhook"). All lookups are cached, and
+	any failure is swallowed so tracing can never break the actual request."""
+	handlers: list[str] = []
+	apps: set[str] = set()
+
 	try:
 		doc_hooks = frappe.get_doc_hooks()
+		for handler in doc_hooks.get(doctype, {}).get(method, []) + doc_hooks.get("*", {}).get(method, []):
+			handlers.append(handler)
+			apps.add(handler.split(".")[0])
 	except Exception:
-		return []
-	return list(doc_hooks.get(doctype, {}).get(method, [])) + list(doc_hooks.get("*", {}).get(method, []))
+		pass
+
+	try:
+		from frappe.core.doctype.server_script.server_script_utils import EVENT_MAP, get_server_script_map
+
+		if event := EVENT_MAP.get(method):
+			for name in get_server_script_map().get(doctype, {}).get(event, None) or []:
+				handlers.append(f"Server Script: {name}")
+				apps.add("server_script")
+	except Exception:
+		pass
+
+	try:
+		from frappe.integrations.doctype.webhook import get_all_webhooks
+
+		webhooks = frappe.client_cache.get_value("webhooks", generator=get_all_webhooks)
+		for webhook in webhooks.get(doctype, None) or []:
+			if webhook.get("webhook_docevent") == method:
+				handlers.append(f"Webhook: {webhook.get('name')}")
+				apps.add("webhook")
+	except Exception:
+		pass
+
+	return sorted(apps), handlers
 
 
 _run_method_traced = False
@@ -145,7 +176,7 @@ def _install_run_method_tracer():
 		recorder._depth += 1
 		queries_before = len(recorder.calls)
 		start_time = time.monotonic()
-		handlers = _doc_event_handlers(doc.doctype, method)
+		apps, handlers = _doc_event_contributors(doc.doctype, method)
 		try:
 			return original_run_method(doc, method, *args, **kwargs)
 		finally:
@@ -159,7 +190,7 @@ def _install_run_method_tracer():
 					"ref_name": doc.name or "",
 					"duration": float(f"{(time.monotonic() - start_time) * 1000:.3f}"),
 					"queries": len(recorder.calls) - queries_before,
-					"apps": sorted({handler.split(".")[0] for handler in handlers}),
+					"apps": apps,
 					"handlers": handlers,
 				}
 			)

--- a/frappe/recorder.py
+++ b/frappe/recorder.py
@@ -199,11 +199,15 @@ def _install_run_method_tracer():
 		recorder._depth += 1
 		queries_before = len(recorder.calls)
 		start_time = time.monotonic()
-		apps, handlers = _doc_event_contributors(doc.doctype, method, doc=doc)
 		try:
 			return original_run_method(doc, method, *args, **kwargs)
 		finally:
 			recorder._depth -= 1
+			duration = float(f"{(time.monotonic() - start_time) * 1000:.3f}")
+			queries = len(recorder.calls) - queries_before
+			# compute contributors after the method ran: run_webhooks evaluates each
+			# webhook's condition against the post-execution doc, so we must too.
+			apps, handlers = _doc_event_contributors(doc.doctype, method, doc=doc)
 			recorder.register_event(
 				{
 					"seq": seq,
@@ -211,8 +215,8 @@ def _install_run_method_tracer():
 					"method": method,
 					"ref_doctype": doc.doctype,
 					"ref_name": doc.name or "",
-					"duration": float(f"{(time.monotonic() - start_time) * 1000:.3f}"),
-					"queries": len(recorder.calls) - queries_before,
+					"duration": duration,
+					"queries": queries,
 					"apps": apps,
 					"handlers": handlers,
 				}


### PR DESCRIPTION
- Recorder now captures each document lifecycle method / `doc_events` handler that runs during a request as a timed, nested **Timeline**, attributed to the app(s) that hook it
- New Timeline grid on the Recorder (per-step duration, query count, apps) + `number_of_events` / `apps_involved` summary + a "Capture document lifecycle timeline" toggle in Configure Recorder
- `Document.run_method` is wrapped once per process and is a no-op unless recording with the option on; `document.py` is untouched. Administrator-only, like the rest of Recorder




https://github.com/user-attachments/assets/a9b51dca-9c78-48b2-a137-243d38660ce9


`no-docs`