### PR TITLE
fix(auth): verify OTP through LDAP flow instead of local password check

### DIFF
--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.py
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.py
@@ -413,15 +413,17 @@ def login():
 	# LDAP LOGIN LOGIC
 	args = frappe.form_dict
 
+	ldap: LDAPSettings = frappe.get_doc("LDAP Settings")
+
 	if args.get("otp") and args.get("tmp_id"):
-		cached_user, _cached_pwd = get_cached_user_pass()
-		if not cached_user:
+		cached_user, cached_pwd = get_cached_user_pass()
+		if not cached_user or not cached_pwd:
 			frappe.throw(_("Invalid or expired login attempt."), frappe.AuthenticationError)
-		frappe.local.login_manager.user = cached_user
+		user = ldap.authenticate(frappe.as_unicode(cached_user), frappe.as_unicode(cached_pwd))
 	else:
-		ldap: LDAPSettings = frappe.get_doc("LDAP Settings")
 		user = ldap.authenticate(frappe.as_unicode(args.usr), frappe.as_unicode(args.pwd))
-		frappe.local.login_manager.user = user.name
+
+	frappe.local.login_manager.user = user.name
 
 	if should_run_2fa(frappe.local.login_manager.user):
 		authenticate_for_2factor(frappe.local.login_manager.user)

--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.py
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.py
@@ -414,9 +414,6 @@ def login():
 	args = frappe.form_dict
 
 	if args.get("otp") and args.get("tmp_id"):
-		# Second round-trip of the 2FA challenge: user was already bound via LDAP
-		# in step 1, so resolve identity from the tmp_id cache instead of
-		# re-authenticating (that would wrongly fall back to the local password).
 		cached_user, _cached_pwd = get_cached_user_pass()
 		if not cached_user:
 			frappe.throw(_("Invalid or expired login attempt."), frappe.AuthenticationError)

--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.py
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.py
@@ -19,7 +19,12 @@ from ldap3.utils.hashed import hashed
 import frappe
 from frappe import _, safe_encode
 from frappe.model.document import Document
-from frappe.twofactor import authenticate_for_2factor, confirm_otp_token, should_run_2fa
+from frappe.twofactor import (
+	authenticate_for_2factor,
+	confirm_otp_token,
+	get_cached_user_pass,
+	should_run_2fa,
+)
 
 if TYPE_CHECKING:
 	from frappe.core.doctype.user.user import User
@@ -407,13 +412,22 @@ class LDAPSettings(Document):
 def login():
 	# LDAP LOGIN LOGIC
 	args = frappe.form_dict
-	ldap: LDAPSettings = frappe.get_doc("LDAP Settings")
 
-	user = ldap.authenticate(frappe.as_unicode(args.usr), frappe.as_unicode(args.pwd))
+	if args.get("otp") and args.get("tmp_id"):
+		# Second round-trip of the 2FA challenge: user was already bound via LDAP
+		# in step 1, so resolve identity from the tmp_id cache instead of
+		# re-authenticating (that would wrongly fall back to the local password).
+		cached_user, _cached_pwd = get_cached_user_pass()
+		if not cached_user:
+			frappe.throw(_("Invalid or expired login attempt."), frappe.AuthenticationError)
+		frappe.local.login_manager.user = cached_user
+	else:
+		ldap: LDAPSettings = frappe.get_doc("LDAP Settings")
+		user = ldap.authenticate(frappe.as_unicode(args.usr), frappe.as_unicode(args.pwd))
+		frappe.local.login_manager.user = user.name
 
-	frappe.local.login_manager.user = user.name
-	if should_run_2fa(user.name):
-		authenticate_for_2factor(user.name)
+	if should_run_2fa(frappe.local.login_manager.user):
+		authenticate_for_2factor(frappe.local.login_manager.user)
 		if not confirm_otp_token(frappe.local.login_manager):
 			return False
 

--- a/frappe/integrations/doctype/ldap_settings/test_ldap_settings.py
+++ b/frappe/integrations/doctype/ldap_settings/test_ldap_settings.py
@@ -674,6 +674,133 @@ class LDAP_TestCase:
 			restore_2fa()
 
 	@mock_ldap_connection
+	def test_login_with_2fa_rejects_tampered_cached_password_on_otp_step(self):
+		system_settings = frappe.get_doc("System Settings")
+		original_2fa_state = system_settings.enable_two_factor_auth
+		original_2fa_method = system_settings.two_factor_method
+		all_role = frappe.get_doc("Role", "All")
+		original_role_2fa = all_role.two_factor_auth
+
+		def enable_2fa():
+			settings = frappe.get_doc("System Settings")
+			settings.enable_two_factor_auth = 1
+			settings.two_factor_method = "OTP App"
+			settings.flags.ignore_mandatory = True
+			settings.save(ignore_permissions=True)
+
+			role = frappe.get_doc("Role", "All")
+			role.two_factor_auth = 1
+			role.save(ignore_permissions=True)
+
+		def restore_2fa():
+			settings = frappe.get_doc("System Settings")
+			settings.enable_two_factor_auth = original_2fa_state
+			settings.two_factor_method = original_2fa_method
+			settings.flags.ignore_mandatory = True
+			settings.save(ignore_permissions=True)
+
+			role = frappe.get_doc("Role", "All")
+			role.two_factor_auth = original_role_2fa
+			role.save(ignore_permissions=True)
+
+		ldap_login_path = "/api/method/frappe.integrations.doctype.ldap_settings.ldap_settings.login"
+
+		enable_2fa()
+		try:
+			set_request(method="POST", path=ldap_login_path)
+			frappe.form_dict.usr = "posix.user"
+			frappe.form_dict.pwd = "posix_user_password"
+			HTTPRequest()
+
+			with mock.patch(
+				"frappe.integrations.doctype.ldap_settings.ldap_settings.LDAPSettings.fetch_ldap_groups"
+			):
+				ldap_settings_module.login()
+
+			tmp_id = frappe.local.response.get("tmp_id")
+			self.assertTrue(tmp_id)
+
+			otp_secret = frappe.safe_decode(frappe.cache.get(f"{tmp_id}_otp_secret"))
+			otp = pyotp.TOTP(otp_secret).now()
+
+			frappe.cache.set(f"{tmp_id}_pwd", "wrong-password")
+
+			set_request(method="POST", path=ldap_login_path)
+			frappe.form_dict.otp = otp
+			frappe.form_dict.tmp_id = tmp_id
+			HTTPRequest()
+
+			with self.assertRaises(ValidationError):
+				ldap_settings_module.login()
+		finally:
+			restore_2fa()
+
+	@mock_ldap_connection
+	def test_login_with_2fa_blocked_when_ldap_disabled_mid_flow(self):
+		system_settings = frappe.get_doc("System Settings")
+		original_2fa_state = system_settings.enable_two_factor_auth
+		original_2fa_method = system_settings.two_factor_method
+		all_role = frappe.get_doc("Role", "All")
+		original_role_2fa = all_role.two_factor_auth
+
+		def enable_2fa():
+			settings = frappe.get_doc("System Settings")
+			settings.enable_two_factor_auth = 1
+			settings.two_factor_method = "OTP App"
+			settings.flags.ignore_mandatory = True
+			settings.save(ignore_permissions=True)
+
+			role = frappe.get_doc("Role", "All")
+			role.two_factor_auth = 1
+			role.save(ignore_permissions=True)
+
+		def restore_2fa():
+			settings = frappe.get_doc("System Settings")
+			settings.enable_two_factor_auth = original_2fa_state
+			settings.two_factor_method = original_2fa_method
+			settings.flags.ignore_mandatory = True
+			settings.save(ignore_permissions=True)
+
+			role = frappe.get_doc("Role", "All")
+			role.two_factor_auth = original_role_2fa
+			role.save(ignore_permissions=True)
+
+		ldap_login_path = "/api/method/frappe.integrations.doctype.ldap_settings.ldap_settings.login"
+
+		enable_2fa()
+		try:
+			set_request(method="POST", path=ldap_login_path)
+			frappe.form_dict.usr = "posix.user"
+			frappe.form_dict.pwd = "posix_user_password"
+			HTTPRequest()
+
+			with mock.patch(
+				"frappe.integrations.doctype.ldap_settings.ldap_settings.LDAPSettings.fetch_ldap_groups"
+			):
+				ldap_settings_module.login()
+
+			tmp_id = frappe.local.response.get("tmp_id")
+			self.assertTrue(tmp_id)
+
+			otp_secret = frappe.safe_decode(frappe.cache.get(f"{tmp_id}_otp_secret"))
+			otp = pyotp.TOTP(otp_secret).now()
+
+			ldap_settings = frappe.get_doc("LDAP Settings")
+			ldap_settings.enabled = 0
+			ldap_settings.flags.ignore_mandatory = True
+			ldap_settings.save(ignore_permissions=True)
+
+			set_request(method="POST", path=ldap_login_path)
+			frappe.form_dict.otp = otp
+			frappe.form_dict.tmp_id = tmp_id
+			HTTPRequest()
+
+			with self.assertRaises(ValidationError):
+				ldap_settings_module.login()
+		finally:
+			restore_2fa()
+
+	@mock_ldap_connection
 	def test_convert_ldap_entry_to_dict(self):
 		self.connection.search(
 			search_base=self.ldap_user_path,

--- a/frappe/integrations/doctype/ldap_settings/test_ldap_settings.py
+++ b/frappe/integrations/doctype/ldap_settings/test_ldap_settings.py
@@ -8,11 +8,15 @@ import typing
 from unittest import TestCase, mock
 
 import ldap3
+import pyotp
 from ldap3 import MOCK_SYNC, OFFLINE_AD_2012_R2, OFFLINE_SLAPD_2_4, Connection, Server
 
 import frappe
+from frappe.auth import HTTPRequest
 from frappe.exceptions import MandatoryError, ValidationError
+from frappe.integrations.doctype.ldap_settings import ldap_settings as ldap_settings_module
 from frappe.integrations.doctype.ldap_settings.ldap_settings import LDAPSettings
+from frappe.utils import set_request
 
 
 class LDAP_TestCase:
@@ -589,6 +593,85 @@ class LDAP_TestCase:
 					"posix.user1@unit.testing", "posix_user_password"
 				)  # Change Password
 			connect_to_ldap.assert_called_with(self.base_dn, self.base_password, read_only=False)
+
+	@mock_ldap_connection
+	def test_login_with_2fa_completes_via_cached_ldap_identity(self):
+		user_name = "posix.user1@unit.testing"
+		original_session_user = frappe.session.user
+
+		system_settings = frappe.get_doc("System Settings")
+		original_2fa_state = system_settings.enable_two_factor_auth
+		original_2fa_method = system_settings.two_factor_method
+		all_role = frappe.get_doc("Role", "All")
+		original_role_2fa = all_role.two_factor_auth
+
+		def enable_2fa():
+			settings = frappe.get_doc("System Settings")
+			settings.enable_two_factor_auth = 1
+			settings.two_factor_method = "OTP App"
+			settings.flags.ignore_mandatory = True
+			settings.save(ignore_permissions=True)
+
+			role = frappe.get_doc("Role", "All")
+			role.two_factor_auth = 1
+			role.save(ignore_permissions=True)
+
+		def restore_2fa():
+			settings = frappe.get_doc("System Settings")
+			settings.enable_two_factor_auth = original_2fa_state
+			settings.two_factor_method = original_2fa_method
+			settings.flags.ignore_mandatory = True
+			settings.save(ignore_permissions=True)
+
+			role = frappe.get_doc("Role", "All")
+			role.two_factor_auth = original_role_2fa
+			role.save(ignore_permissions=True)
+
+		ldap_login_path = "/api/method/frappe.integrations.doctype.ldap_settings.ldap_settings.login"
+
+		enable_2fa()
+		try:
+			# Local password intentionally does not match the LDAP password, so the
+			# test fails loudly if the OTP step ever falls back to local auth.
+			user_doc = frappe.get_doc("User", user_name)
+			user_doc.new_password = "not-the-ldap-password-!@#123"
+			user_doc.save(ignore_permissions=True)
+			frappe.db.commit()
+
+			# Step 1: LDAP bind + password, triggers the OTP challenge.
+			set_request(method="POST", path=ldap_login_path)
+			frappe.form_dict.usr = "posix.user"
+			frappe.form_dict.pwd = "posix_user_password"
+			HTTPRequest()
+
+			with mock.patch(
+				"frappe.integrations.doctype.ldap_settings.ldap_settings.LDAPSettings.fetch_ldap_groups"
+			):
+				first_step_result = ldap_settings_module.login()
+
+			self.assertFalse(first_step_result)
+			self.assertEqual(frappe.local.login_manager.user, user_name)
+			tmp_id = frappe.local.response.get("tmp_id")
+			self.assertTrue(tmp_id)
+
+			otp_secret = frappe.safe_decode(frappe.cache.get(f"{tmp_id}_otp_secret"))
+			otp = pyotp.TOTP(otp_secret).now()
+
+			# Step 2: OTP submission only, no usr/pwd resubmitted.
+			set_request(method="POST", path=ldap_login_path)
+			frappe.form_dict.otp = otp
+			frappe.form_dict.tmp_id = tmp_id
+			HTTPRequest()
+
+			with mock.patch("frappe.core.doctype.user.user.User.find_by_credentials") as find_by_credentials:
+				ldap_settings_module.login()
+
+			find_by_credentials.assert_not_called()
+			self.assertEqual(frappe.local.login_manager.user, user_name)
+			self.assertEqual(frappe.session.user, user_name)
+		finally:
+			frappe.set_user(original_session_user)
+			restore_2fa()
 
 	@mock_ldap_connection
 	def test_convert_ldap_entry_to_dict(self):

--- a/frappe/templates/includes/login/login.js
+++ b/frappe/templates/includes/login/login.js
@@ -28,7 +28,8 @@ login.bind_events = function () {
 			hasError = true;
 		}
 		if (hasError) return false;
-		login.call(args, null, "/api/method/login");
+		login.verify_url = "/api/method/login";
+		login.call(args, null, login.verify_url);
 		return false;
 	});
 
@@ -127,7 +128,8 @@ login.bind_events = function () {
 			login.set_status({{ _("Both login and password required") | tojson }}, 'red');
 			return false;
 		}
-		login.call(args, null, "/api/method/{{ ldap_settings.method }}");
+		login.verify_url = "/api/method/{{ ldap_settings.method }}";
+		login.call(args, null, login.verify_url);
 		return false;
 	});
 	{% endif %}
@@ -406,7 +408,7 @@ var verify_token = function (event) {
 			frappe.msgprint("{{ _('Login token required') | striptags | e }}");
 			return false;
 		}
-		login.call(args, null, "/api/method/login");
+		login.call(args, null, login.verify_url || "/api/method/login");
 		return false;
 	});
 }


### PR DESCRIPTION
**Resolve:** #41341

---
Two-factor OTP submission always posted to the generic `/api/method/login` endpoint, which re-authenticates cached credentials against the local password hash via `find_by_credentials`, bypassing LDAP entirely for the second factor. The OTP step now resubmits to the same endpoint that issued the challenge, and the LDAP `login()` view resolves the user from the `tmp_id` cache on that second round-trip instead of re-binding.

> [!NOTE]
> Fixed with the help of AI

