### PR TITLE
fix: populate footer parent_label options on page load (#20918)

### DIFF
--- a/cypress/integration/grid_configuration.js
+++ b/cypress/integration/grid_configuration.js
@@ -20,4 +20,42 @@ context("Grid Configuration", () => {
 		cy.findByRole("button", { name: "Update" }).click();
 		cy.get('[title="Align Right"').should("be.visible");
 	});
+
+	it("Populates footer parent label options on page load (#20918)", () => {
+		cy.findByRole("tab", { name: "Footer" }).click();
+		cy.window()
+			.its("cur_frm")
+			.then((frm) => {
+				frm.clear_table("footer_items");
+				frm.add_child("footer_items", { label: "Products" });
+				frm.add_child("footer_items", { label: "Phones" });
+				frm.refresh_field("footer_items");
+			});
+		cy.save();
+
+		// reload the page so onload_post_render actually runs; asserting in the
+		// same session would go through the reactive (field-change) path instead
+		// and mask the bug where options stayed empty on a fresh load
+		cy.reload();
+		cy.findByRole("tab", { name: "Footer" }).click();
+		cy.wait(200);
+
+		cy.window()
+			.its("cur_frm")
+			.then((frm) => {
+				let parent_label_field = frm
+					.get_field("footer_items")
+					.grid.docfields.find((df) => df.fieldname === "parent_label");
+				expect(parent_label_field.options).to.include("Products");
+				expect(parent_label_field.options).to.include("Phones");
+			});
+
+		cy.window()
+			.its("cur_frm")
+			.then((frm) => {
+				frm.clear_table("footer_items");
+				frm.refresh_field("footer_items");
+			});
+		cy.save();
+	});
 });

--- a/cypress/integration/grid_configuration.js
+++ b/cypress/integration/grid_configuration.js
@@ -47,13 +47,16 @@ context("Grid Configuration", () => {
 		cy.window()
 			.its("cur_frm")
 			.then((frm) => {
-				// snapshot only the editable fields, not full rows (name/idx/etc
-				// belong to the rows being deleted and shouldn't be reused below)
+				// snapshot every real data field on Top Bar Item (label, url,
+				// parent_label, right, open_in_new_tab) — not full rows, since
+				// name/idx/etc belong to the rows being deleted and shouldn't
+				// be reused below
 				saved_footer_items = (frm.doc.footer_items || []).map((row) => ({
 					label: row.label,
 					url: row.url,
 					parent_label: row.parent_label,
 					right: row.right,
+					open_in_new_tab: row.open_in_new_tab,
 				}));
 
 				frm.clear_table("footer_items");

--- a/cypress/integration/grid_configuration.js
+++ b/cypress/integration/grid_configuration.js
@@ -1,8 +1,29 @@
 context("Grid Configuration", () => {
+	// set by the footer test below; restored in afterEach so a failed
+	// assertion never leaves the shared Website Settings singleton with the
+	// test's rows instead of whatever was actually configured for the site.
+	let saved_footer_items;
+
 	beforeEach(() => {
 		cy.login();
 		cy.visit("/desk/website-settings");
 	});
+
+	afterEach(() => {
+		if (!saved_footer_items) return;
+		let footer_items_to_restore = saved_footer_items;
+		saved_footer_items = undefined;
+
+		cy.window()
+			.its("cur_frm")
+			.then((frm) => {
+				frm.clear_table("footer_items");
+				footer_items_to_restore.forEach((row) => frm.add_child("footer_items", row));
+				frm.refresh_field("footer_items");
+			});
+		cy.save();
+	});
+
 	it("Set user wise grid settings", () => {
 		cy.findByRole("tab", { name: "Navbar" }).click();
 		cy.wait(100);
@@ -26,6 +47,15 @@ context("Grid Configuration", () => {
 		cy.window()
 			.its("cur_frm")
 			.then((frm) => {
+				// snapshot only the editable fields, not full rows (name/idx/etc
+				// belong to the rows being deleted and shouldn't be reused below)
+				saved_footer_items = (frm.doc.footer_items || []).map((row) => ({
+					label: row.label,
+					url: row.url,
+					parent_label: row.parent_label,
+					right: row.right,
+				}));
+
 				frm.clear_table("footer_items");
 				frm.add_child("footer_items", { label: "Products" });
 				frm.add_child("footer_items", { label: "Phones" });
@@ -38,24 +68,18 @@ context("Grid Configuration", () => {
 		// and mask the bug where options stayed empty on a fresh load
 		cy.reload();
 		cy.findByRole("tab", { name: "Footer" }).click();
-		cy.wait(200);
 
+		// .should() re-queries cur_frm and retries the assertion until it
+		// passes or the command timeout elapses, instead of a fixed cy.wait()
+		// racing onload_post_render on slower (CI) runs
 		cy.window()
 			.its("cur_frm")
-			.then((frm) => {
+			.should((frm) => {
 				let parent_label_field = frm
 					.get_field("footer_items")
 					.grid.docfields.find((df) => df.fieldname === "parent_label");
 				expect(parent_label_field.options).to.include("Products");
 				expect(parent_label_field.options).to.include("Phones");
 			});
-
-		cy.window()
-			.its("cur_frm")
-			.then((frm) => {
-				frm.clear_table("footer_items");
-				frm.refresh_field("footer_items");
-			});
-		cy.save();
 	});
 });

--- a/cypress/integration/grid_configuration.js
+++ b/cypress/integration/grid_configuration.js
@@ -1,7 +1,5 @@
 context("Grid Configuration", () => {
-	// set by the footer test below; restored in afterEach so a failed
-	// assertion never leaves the shared Website Settings singleton with the
-	// test's rows instead of whatever was actually configured for the site.
+	// restored in afterEach(), even on failure, so the shared Website Settings singleton isn't left mutated
 	let saved_footer_items;
 
 	beforeEach(() => {
@@ -42,15 +40,11 @@ context("Grid Configuration", () => {
 		cy.get('[title="Align Right"').should("be.visible");
 	});
 
-	it("Populates footer parent label options on page load (#20918)", () => {
+	it("Populates footer parent label options on page load", () => {
 		cy.findByRole("tab", { name: "Footer" }).click();
 		cy.window()
 			.its("cur_frm")
 			.then((frm) => {
-				// snapshot every real data field on Top Bar Item (label, url,
-				// parent_label, right, open_in_new_tab) — not full rows, since
-				// name/idx/etc belong to the rows being deleted and shouldn't
-				// be reused below
 				saved_footer_items = (frm.doc.footer_items || []).map((row) => ({
 					label: row.label,
 					url: row.url,
@@ -66,15 +60,9 @@ context("Grid Configuration", () => {
 			});
 		cy.save();
 
-		// reload the page so onload_post_render actually runs; asserting in the
-		// same session would go through the reactive (field-change) path instead
-		// and mask the bug where options stayed empty on a fresh load
 		cy.reload();
 		cy.findByRole("tab", { name: "Footer" }).click();
 
-		// .should() re-queries cur_frm and retries the assertion until it
-		// passes or the command timeout elapses, instead of a fixed cy.wait()
-		// racing onload_post_render on slower (CI) runs
 		cy.window()
 			.its("cur_frm")
 			.should((frm) => {

--- a/cypress/integration/grid_configuration.js
+++ b/cypress/integration/grid_configuration.js
@@ -21,4 +21,42 @@ context("Grid Configuration", () => {
 		cy.wait(200);
 		cy.get('[title="Align Right"').should("be.visible");
 	});
+
+	it("Populates footer parent label options on page load (#20918)", () => {
+		cy.findByRole("tab", { name: "Footer" }).click();
+		cy.window()
+			.its("cur_frm")
+			.then((frm) => {
+				frm.clear_table("footer_items");
+				frm.add_child("footer_items", { label: "Products" });
+				frm.add_child("footer_items", { label: "Phones" });
+				frm.refresh_field("footer_items");
+			});
+		cy.save();
+
+		// reload the page so onload_post_render actually runs; asserting in the
+		// same session would go through the reactive (field-change) path instead
+		// and mask the bug where options stayed empty on a fresh load
+		cy.reload();
+		cy.findByRole("tab", { name: "Footer" }).click();
+		cy.wait(200);
+
+		cy.window()
+			.its("cur_frm")
+			.then((frm) => {
+				let parent_label_field = frm
+					.get_field("footer_items")
+					.grid.docfields.find((df) => df.fieldname === "parent_label");
+				expect(parent_label_field.options).to.include("Products");
+				expect(parent_label_field.options).to.include("Phones");
+			});
+
+		cy.window()
+			.its("cur_frm")
+			.then((frm) => {
+				frm.clear_table("footer_items");
+				frm.refresh_field("footer_items");
+			});
+		cy.save();
+	});
 });

--- a/frappe/website/doctype/website_settings/website_settings.js
+++ b/frappe/website/doctype/website_settings/website_settings.js
@@ -31,6 +31,7 @@ frappe.ui.form.on("Website Settings", {
 
 	onload_post_render: function (frm) {
 		frm.trigger("set_parent_label_options");
+		frm.trigger("set_parent_label_options_footer");
 	},
 
 	set_parent_label_options: function (frm) {


### PR DESCRIPTION
Authored by @g-sowani - opening this on her behalf as she doesn't have PR access on this repo yet.

onload_post_render only triggered set_parent_label_options (Top Bar Items), never set_parent_label_options_footer (Footer Items), so the footer grid's Parent Label select stayed empty on a fresh page load and only populated reactively once a label/url/parent_label field was edited in the same session. This mirrors the footer half of #11710 that was never fixed alongside the Top Bar Items fix.

Add a Cypress regression test that saves footer items, reloads the page, and asserts the parent_label options are populated without any prior in-session field edits.

fixes: https://github.com/frappe/frappe/issues/20918

