### PR TITLE
fix(installer): Re-load the module map if newly installed app not there

### DIFF
--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -321,6 +321,10 @@ def install_app(name, verbose=False, set_as_patched=True, force=False):
 	if name != "frappe":
 		add_module_defs(name, ignore_if_duplicate=force)
 
+	if name not in (frappe.local.app_modules or {}):
+		frappe.cache.delete_value("app_modules")
+		frappe.setup_module_map(include_all_apps=True)
+
 	sync_for(name, force=force, reset_permissions=True)
 
 	add_to_installed_apps(name)


### PR DESCRIPTION
**Issue -**

In pilot, while installing erpnext sometimes, we get this error -

```
No module named 'frappe.core.doctype.currency_exchange_settings' 
```

The issue was reported previously also - https://github.com/frappe/erpnext/issues/39628

It happens due to some stale module map.

Re-producable steps (with frappe/bench):
1. Create a new bench
2. Create a new site - `bench new-site test1.local`
3. Now do some activity on site, so that it loads app modules - `bench --site test1.local list-apps`
4. Install erpnext without trigerring assets build - `bench get-app https://github.com/frappe/erpnext --skip-assets`
5. Install app on the site - `bench --site test1.local install-app erpnext`
6. That will throw module not found.

**Fix -**
Before syncing fixtures, if the app name isn't in module map, then load it.

Related https://github.com/frappe/pilot/issues/276