### PR TITLE
fix: Raise error while export fixtures for Page, Doctype

### DIFF
--- a/frappe/tests/test_hooks.py
+++ b/frappe/tests/test_hooks.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+from unittest.mock import patch
+
 import frappe
 from frappe.cache_manager import clear_controller_cache
 from frappe.desk.doctype.todo.todo import ToDo
@@ -185,6 +187,25 @@ class TestHooks(IntegrationTestCase):
 			["1_my_prefix_user.json", "2_contact.json", "3_role.json"],
 			os.listdir(frappe.get_app_path(app, "fixtures")),
 		)
+
+	def test_disallowed_fixture_doctypes(self):
+		import click
+
+		from frappe import hooks
+		from frappe.utils.fixtures import DISALLOWED_FIXTURE_DOCTYPES, export_fixtures
+
+		app = "frappe"
+		for doctype in DISALLOWED_FIXTURE_DOCTYPES:
+			hooks.fixtures = [{"dt": doctype}]
+			if frappe._load_app_hooks in frappe.local.request_cache.keys():
+				del frappe.local.request_cache[frappe._load_app_hooks]
+
+			with patch("frappe.utils.fixtures.click.secho") as secho:
+				self.assertRaises(click.exceptions.Exit, export_fixtures, app)
+
+			message = secho.call_args.args[0]
+			self.assertIn(f'Cannot export "{doctype}" doctype', message)
+			self.assertIn("it can only be created in developer mode from desk", message)
 
 
 class TestDocEventHandlerSignature(UnitTestCase):

--- a/frappe/utils/fixtures.py
+++ b/frappe/utils/fixtures.py
@@ -8,6 +8,10 @@ import click
 import frappe
 from frappe.core.doctype.data_import.data_import import export_json, import_doc
 
+# these doctypes are only meant to be created
+# via desk in developer mode
+DISALLOWED_FIXTURE_DOCTYPES = ["DocType", "Page"]
+
 
 def sync_fixtures(app=None):
 	"""Import, overwrite fixtures from `[app]/fixtures`"""
@@ -78,6 +82,16 @@ def export_fixtures(app=None):
 				or_filters = fixture.get("or_filters")
 				prefix = fixture.get("prefix")
 				fixture = fixture.get("doctype") or fixture.get("dt")
+
+			if fixture in DISALLOWED_FIXTURE_DOCTYPES:
+				click.secho(
+					f'Cannot export "{fixture}" doctype as a fixture, since it can only be created in developer mode from desk.\n'
+					f'Remove the fixture for "{fixture}" doctype with {(filters if filters else or_filters)} filters from {app}/hooks.py.',
+					fg="red",
+					err=True,
+				)
+				raise click.exceptions.Exit(1)
+
 			print(f"Exporting {fixture} app {app} filters {(filters if filters else or_filters)}")
 			if not os.path.exists(frappe.get_app_path(app, "fixtures")):
 				os.mkdir(frappe.get_app_path(app, "fixtures"))


### PR DESCRIPTION
**Issue -**

`Page` and `Doctype` fixtures can't be imported due to added checks .

https://github.com/frappe/frappe/blob/ca568e11092ee9fd39a28d7eed62543f05e96e2c/frappe/core/doctype/page/page.py#L60-L65
https://github.com/frappe/frappe/blob/ca568e11092ee9fd39a28d7eed62543f05e96e2c/frappe/core/doctype/doctype/doctype.py#L188-L199

This one later cause issue in migration's sync fixture stage.

**Fix -**
Don't allow users to export it.