### PR TITLE
feat(ui): migrate modal footer buttons to espresso

### DIFF
--- a/cypress/integration/control_attach.js
+++ b/cypress/integration/control_attach.js
@@ -54,7 +54,7 @@ context("Attach Control", () => {
 		cy.go_to_list("Test Attach Control");
 		cy.get(".list-row-checkbox").eq(0).click();
 		cy.click_action_button("Delete");
-		cy.click_modal_primary_button("Yes");
+		cy.click_modal_primary_button("Delete");
 	});
 
 	it('Checking functionality for "Library" button in the "Attach" fieldtype', () => {
@@ -109,7 +109,7 @@ context("Attach Control", () => {
 		cy.get(".list-row-checkbox").eq(0).click();
 		cy.get(".list-row-checkbox").eq(1).click();
 		cy.click_action_button("Delete");
-		cy.click_modal_primary_button("Yes");
+		cy.click_modal_primary_button("Delete");
 	});
 
 	it('Checking that "Camera" button in the "Attach" fieldtype does show if camera is available', () => {

--- a/cypress/integration/control_data.js
+++ b/cypress/integration/control_data.js
@@ -145,6 +145,6 @@ context("Data Control", () => {
 		cy.go_to_list("Test Data Control");
 		cy.get(".list-row-checkbox").eq(0).click({ force: true });
 		cy.click_action_button("Delete");
-		cy.click_modal_primary_button("Yes");
+		cy.click_modal_primary_button("Delete");
 	});
 });

--- a/cypress/integration/dashboard_links.js
+++ b/cypress/integration/dashboard_links.js
@@ -51,7 +51,7 @@ context("Dashboard links", () => {
 		cy.visit("/desk/contact");
 		cy.get(".list-subject > .select-like > .list-row-checkbox").eq(0).click({ force: true });
 		cy.click_action_button("Delete");
-		cy.findByRole("button", { name: "Yes" }).click({ delay: 700 });
+		cy.findByRole("button", { name: "Delete" }).click({ delay: 700 });
 
 		//To check if the counter from the "Contact" doc link is removed
 		cy.wait(700);

--- a/cypress/integration/file_uploader.js
+++ b/cypress/integration/file_uploader.js
@@ -115,7 +115,7 @@ context("FileUploader", () => {
 
 			// Toggle button should be visible (secondary action button)
 			cy.get_open_dialog()
-				.find(".modal-footer .btn-secondary")
+				.find(".modal-footer .btn-modal-secondary")
 				.should("be.visible")
 				.and("contain", "Set all");
 
@@ -165,7 +165,7 @@ context("FileUploader", () => {
 
 			// Toggle button should be visible (secondary action button)
 			cy.get_open_dialog()
-				.find(".modal-footer .btn-secondary")
+				.find(".modal-footer .btn-modal-secondary")
 				.should("be.visible")
 				.and("contain", "Set all");
 
@@ -210,7 +210,7 @@ context("FileUploader", () => {
 
 			// Toggle button should be visible (secondary action button)
 			cy.get_open_dialog()
-				.find(".modal-footer .btn-secondary")
+				.find(".modal-footer .btn-modal-secondary")
 				.should("be.visible")
 				.and("contain", "Set all");
 
@@ -257,7 +257,9 @@ context("FileUploader", () => {
 			cy.get_open_dialog().find("#uploader-private-checkbox input").should("be.disabled");
 
 			// Toggle button should not be visible (secondary action button should be hidden)
-			cy.get_open_dialog().find(".modal-footer .btn-secondary").should("not.be.visible");
+			cy.get_open_dialog()
+				.find(".modal-footer .btn-modal-secondary")
+				.should("not.be.visible");
 
 			cy.hide_dialog();
 		});

--- a/cypress/integration/global_search_settings.js
+++ b/cypress/integration/global_search_settings.js
@@ -111,7 +111,7 @@ context("Global Search Settings — configure search fields", () => {
 			.should("exist");
 
 		cy.get_open_dialog()
-			.find(".modal-footer .standard-actions .btn-primary")
+			.find(".modal-footer .standard-actions .btn-modal-primary")
 			.contains("Save")
 			.click({ force: true });
 

--- a/cypress/integration/kanban.js
+++ b/cypress/integration/kanban.js
@@ -83,7 +83,7 @@ context("Kanban Board", () => {
 		cy.click_listview_primary_button("Add ToDo");
 
 		cy.fill_field("description", "Test Kanban ToDo", "Text Editor").wait(300);
-		cy.get(".modal-footer .btn-primary").last().click();
+		cy.get(".modal-footer .btn-modal-primary").last().click();
 
 		cy.wait("@save-todo");
 	});

--- a/cypress/integration/print_format_builder.js
+++ b/cypress/integration/print_format_builder.js
@@ -69,7 +69,7 @@ context("Print Format Builder — create flow", () => {
 	it("shows the Create or Edit Print Format dialog", () => {
 		cy.visit("/app/print-format-builder");
 		cy.get_open_dialog().should("contain", "Create or Edit Print Format");
-		cy.get_open_dialog().find(".btn-primary").should("contain", "Create");
+		cy.get_open_dialog().find(".btn-modal-primary").should("contain", "Create");
 	});
 
 	// 2. Filling the dialog and clicking Create inserts a builder format
@@ -93,7 +93,7 @@ context("Print Format Builder — create flow", () => {
 			.trigger("input")
 			.trigger("change");
 
-		cy.get_open_dialog().find(".btn-primary").contains("Create").click();
+		cy.get_open_dialog().find(".btn-modal-primary").contains("Create").click();
 
 		cy.wait("@insert").then((interception) => {
 			expect(interception.response.statusCode).to.equal(200);

--- a/cypress/integration/workspace.js
+++ b/cypress/integration/workspace.js
@@ -25,7 +25,7 @@ context("Workspace 2.0", () => {
 		cy.wait(300);
 
 		cy.get_open_dialog().find(".modal-header").click();
-		cy.get_open_dialog().find(".btn-primary").click();
+		cy.get_open_dialog().find(".btn-modal-primary").click();
 
 		// check if sidebar item is added in pubic section
 		cy.get('.sidebar-item-container[item-name="Test Private Page"]');

--- a/cypress/integration/workspace_blocks.js
+++ b/cypress/integration/workspace_blocks.js
@@ -23,7 +23,7 @@ context("Workspace Blocks", () => {
 		cy.fill_field("title", "Test Block Page", "Data");
 		cy.fill_field("type", "Workspace", "Select");
 		cy.get_open_dialog().find(".modal-header").click();
-		cy.get_open_dialog().find(".btn-primary").click();
+		cy.get_open_dialog().find(".btn-modal-primary").click();
 
 		// check if sidebar item is added in private section
 		cy.get('.sidebar-item-container[item-name="Test Block Page"]');
@@ -85,7 +85,7 @@ context("Workspace Blocks", () => {
 		cy.get_open_dialog().find(".filter-field .input-with-feedback").type("Pending");
 
 		cy.get_open_dialog().find(".modal-header").click();
-		cy.get_open_dialog().find(".btn-primary").click();
+		cy.get_open_dialog().find(".btn-modal-primary").click();
 
 		cy.get('.standard-actions .primary-action[data-label="Save"]').click();
 
@@ -115,7 +115,7 @@ context("Workspace Blocks", () => {
 			.focus()
 			.type("{selectall}Approved");
 		cy.get_open_dialog().find(".modal-header").click();
-		cy.get_open_dialog().find(".btn-primary").click();
+		cy.get_open_dialog().find(".btn-modal-primary").click();
 
 		cy.get("@todo-quick-list").find(".quick-list-item .status").should("contain", "Approved");
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -473,7 +473,7 @@ Cypress.Commands.add("clear_filters", () => {
 
 Cypress.Commands.add("click_modal_primary_button", (btn_name) => {
 	cy.wait(400);
-	cy.get(".modal-footer > .standard-actions > .btn-primary")
+	cy.get(".modal-footer > .standard-actions > .btn-modal-primary")
 		.contains(btn_name)
 		.click({ force: true });
 });

--- a/frappe/public/css/espresso/components/button.css
+++ b/frappe/public/css/espresso/components/button.css
@@ -243,3 +243,22 @@
     width: var(--es-bt-icon);
     height: var(--es-bt-icon);
 }
+/* ---- legacy compat shims (remove in v17 with the bootstrap button CSS) ----
+   External desk apps poke bootstrap-era classes onto held dialog-button
+   references (found by the selector gate): india_compliance adds .disabled
+   to guard double submits, erpnext adds .btn-danger for destructive
+   primaries. Map both onto the es contract so the behavior survives until
+   those call sites migrate. */
+.es-button.disabled {
+    pointer-events: none;
+    background: var(--bt-disabled-bg);
+    color: var(--bt-disabled-fg);
+    border-color: var(--bt-disabled-border);
+}
+
+.es-button.btn-danger {
+    --bt-bg: var(--surface-red-5);
+    --bt-fg: var(--ink-white);
+    --bt-hover-bg: var(--surface-red-6);
+    --bt-active-bg: var(--surface-red-7);
+}

--- a/frappe/public/js/frappe/dom.js
+++ b/frappe/public/js/frappe/dom.js
@@ -348,23 +348,34 @@ frappe.get_modal = function (title, content) {
 						<h4 class="modal-title">${title}</h4>
 					</div>
 					<div class="modal-actions d-flex">
-						<button class="btn btn-ghost btn-modal-minimize icon-btn hide">
-							${frappe.utils.icon("minimize-2")}
-						</button>
-						<button class="btn btn-ghost btn-modal-close icon-btn" data-dismiss="modal">
-							${frappe.utils.icon("x", "sm")}
-						</button>
+						${frappe.ui.button.html({
+							icon: "minimize-2",
+							variant: "ghost",
+							title: __("Minimize"),
+							css_class: "btn-modal-minimize icon-btn hide",
+						})}
+						${frappe.ui.button.html({
+							icon: "x",
+							variant: "ghost",
+							title: __("Close"),
+							css_class: "btn-modal-close icon-btn",
+							attrs: { "data-dismiss": "modal" },
+						})}
 					</div>
 				</div>
 				<div class="modal-body ui-front">${content}</div>
 				<div class="modal-footer hide">
 					<div class="custom-actions"></div>
 					<div class="standard-actions">
-						<button type="button" class="btn btn-secondary btn-sm hide btn-modal-secondary">
-						</button>
-						<button type="button" class="btn btn-primary btn-sm hide btn-modal-primary">
-							${__("Confirm")}
-						</button>
+						${frappe.ui.button.html({
+							label: "",
+							css_class: "btn-modal-secondary hide",
+						})}
+						${frappe.ui.button.html({
+							label: __("Confirm"),
+							variant: "solid",
+							css_class: "btn-modal-primary hide",
+						})}
 					</div>
 				</div>
 			</div>

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1188,7 +1188,8 @@ frappe.ui.form.Form = class FrappeForm {
 		if (skip_confirm) {
 			cancel_doc();
 		} else {
-			frappe.warn(
+			// destructive: red primary via frappe.warn
+			const d = frappe.warn(
 				__("Confirm"),
 				__("Permanently Cancel {0}?", [this.docname]),
 				cancel_doc,
@@ -1196,7 +1197,14 @@ frappe.ui.form.Form = class FrappeForm {
 				false,
 				__("No")
 			);
-			me.handle_save_fail(btn, on_error);
+			// declined (No / Escape / close): re-enable the button. A
+			// confirmed-but-failed cancellation calls handle_save_fail from
+			// inside cancel_doc — this must not double up with that.
+			d.onhide = () => {
+				if (!d.primary_action_fulfilled) {
+					me.handle_save_fail(btn, on_error);
+				}
+			};
 		}
 	}
 

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1188,11 +1188,15 @@ frappe.ui.form.Form = class FrappeForm {
 		if (skip_confirm) {
 			cancel_doc();
 		} else {
-			frappe.confirm(
+			frappe.warn(
+				__("Confirm"),
 				__("Permanently Cancel {0}?", [this.docname]),
 				cancel_doc,
-				me.handle_save_fail(btn, on_error)
+				__("Yes"),
+				false,
+				__("No")
 			);
+			me.handle_save_fail(btn, on_error);
 		}
 	}
 

--- a/frappe/public/js/frappe/form/workflow.js
+++ b/frappe/public/js/frappe/form/workflow.js
@@ -59,6 +59,11 @@ frappe.ui.form.States = class FormStates {
 	}
 
 	refresh() {
+		// always drop the previous doc's actions first — a doc with no
+		// workflow_state (it predates the workflow) never reaches
+		// show_actions, and would otherwise keep showing them
+		this.frm.page.clear_actions_menu();
+
 		// hide if its not yet saved
 		if (this.frm.doc.__islocal) {
 			this.set_default_state();
@@ -96,8 +101,11 @@ frappe.ui.form.States = class FormStates {
 			return approval_access;
 		}
 
+		// refresh() already cleared the menu synchronously; guard the async
+		// re-fill against the user having navigated to another doc meanwhile
+		const docname = this.frm.doc.name;
 		frappe.workflow.get_transitions(this.frm.doc).then((transitions) => {
-			this.frm.page.clear_actions_menu();
+			if (this.frm.doc.name !== docname) return;
 			transitions.forEach((d) => {
 				if (frappe.user_roles.includes(d.allowed) && has_approval_access(d)) {
 					added = true;

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -2859,14 +2859,20 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 							"Title of confirmation dialog"
 						);
 					}
-					frappe.confirm(message, () => {
-						this.disable_list_update = true;
-						bulk_operations.delete(docnames, () => {
-							this.disable_list_update = false;
-							this.clear_checked_items();
-							this.refresh();
-						});
-					});
+					// destructive: red primary via frappe.warn
+					frappe.warn(
+						__("Confirm"),
+						message,
+						() => {
+							this.disable_list_update = true;
+							bulk_operations.delete(docnames, () => {
+								this.disable_list_update = false;
+								this.clear_checked_items();
+								this.refresh();
+							});
+						},
+						__("Delete")
+					);
 				},
 				standard: true,
 			};
@@ -2878,7 +2884,9 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 				action: () => {
 					const docnames = this.get_checked_items(true);
 					if (docnames.length > 0) {
-						frappe.confirm(
+						// destructive: red primary via frappe.warn
+						frappe.warn(
+							__("Confirm"),
 							__(
 								"Cancel {0} documents?",
 								[docnames.length],
@@ -2891,7 +2899,10 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 									this.clear_checked_items();
 									this.refresh();
 								});
-							}
+							},
+							__("Yes"),
+							false,
+							__("No")
 						);
 					}
 				},

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -741,24 +741,30 @@ $.extend(frappe.model, {
 				title = `${value} (${docname})`;
 			}
 		}
-		frappe.confirm(__("Permanently delete {0}?", [title.bold()]), function () {
-			return frappe.call({
-				method: "frappe.client.delete",
-				args: {
-					doctype: doctype,
-					name: docname,
-				},
-				freeze: true,
-				freeze_message: __("Deleting {0}...", [title]),
-				callback: function (r, rt) {
-					if (!r.exc) {
-						frappe.utils.play_sound("delete");
-						frappe.model.clear_doc(doctype, docname);
-						if (callback) callback(r, rt);
-					}
-				},
-			});
-		});
+		// destructive: red primary via frappe.warn, not a neutral confirm
+		frappe.warn(
+			__("Confirm"),
+			__("Permanently delete {0}?", [title.bold()]),
+			function () {
+				return frappe.call({
+					method: "frappe.client.delete",
+					args: {
+						doctype: doctype,
+						name: docname,
+					},
+					freeze: true,
+					freeze_message: __("Deleting {0}...", [title]),
+					callback: function (r, rt) {
+						if (!r.exc) {
+							frappe.utils.play_sound("delete");
+							frappe.model.clear_doc(doctype, docname);
+							if (callback) callback(r, rt);
+						}
+					},
+				});
+			},
+			__("Delete")
+		);
 	},
 
 	rename_doc: function (doctype, docname, callback) {

--- a/frappe/public/js/frappe/ui/dialog.js
+++ b/frappe/public/js/frappe/ui/dialog.js
@@ -193,7 +193,20 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 	}
 
 	get_primary_btn() {
-		return this.standard_actions.find(".btn-primary");
+		return this.standard_actions.find(".btn-modal-primary");
+	}
+
+	// the footer buttons are es-buttons — swap only the label text so the
+	// spinner/loading-label structure survives; when there's no label span
+	// (empty initial label, or an external caller .html()'d the structure
+	// away) rebuild it via dress, which leaves the other attributes alone
+	set_btn_label($btn, label) {
+		const $label = $btn.find(".es-button__label");
+		if ($label.length) {
+			$label.text(label);
+		} else {
+			frappe.ui.button.dress($btn, { label });
+		}
 	}
 
 	get_minimize_btn() {
@@ -234,8 +247,15 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 		this.footer.removeClass("hide");
 		this.has_primary_action = true;
 		var me = this;
-		const primary_btn = this.get_primary_btn().removeClass("hide").html(label);
-		const spinner = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" style="width: 13px; height: 13px; animation: spin 1s linear infinite;"><circle opacity=".25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path opacity=".25" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/></svg>`;
+		// rebuild the es-button content so the spinner + loading-label
+		// structure matches this action (replaces the old hand-rolled
+		// spinner html; the busy visuals are pure CSS on aria-busy)
+		const primary_btn = this.get_primary_btn().removeClass("hide");
+		frappe.ui.button.dress(primary_btn, {
+			label,
+			loading_label: this.primary_action_loading_label || undefined,
+			variant: "solid",
+		});
 		if (typeof click == "function") {
 			primary_btn.off("click").on("click", function () {
 				me.primary_action_fulfilled = true;
@@ -246,31 +266,9 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 				if (!values) return;
 				const action = click.apply(me, [values]);
 				if (action && typeof action.then === "function") {
-					const loading_label = me.primary_action_loading_label;
-					primary_btn
-						.css({
-							"min-width": primary_btn.outerWidth(),
-							"min-height": primary_btn.outerHeight(),
-						})
-						.prop("disabled", true)
-						.addClass("btn-primary-dark")
-						.html(
-							`<div class="d-flex align-items-center justify-content-center" style="gap: 0.45rem;">
-									${spinner}
-								${
-									loading_label
-										? `<span class="text-muted" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${loading_label}</span>`
-										: ""
-								}
-							</div>`
-						);
-
+					primary_btn.attr("aria-busy", "true");
 					Promise.resolve(action).finally(() => {
-						primary_btn
-							.css({ "min-width": "", "min-height": "" })
-							.prop("disabled", false)
-							.removeClass("btn-primary-dark")
-							.html(label);
+						primary_btn.removeAttr("aria-busy");
 					});
 				}
 			});
@@ -284,15 +282,16 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 	}
 
 	set_secondary_action_label(label) {
-		this.get_secondary_btn().removeClass("hide").html(label);
+		this.set_btn_label(this.get_secondary_btn().removeClass("hide"), label);
 	}
 
 	disable_primary_action() {
-		this.get_primary_btn().addClass("disabled");
+		// class kept in sync for callers that read .hasClass("disabled")
+		this.get_primary_btn().prop("disabled", true).addClass("disabled");
 	}
 
 	enable_primary_action() {
-		this.get_primary_btn().removeClass("disabled");
+		this.get_primary_btn().prop("disabled", false).removeClass("disabled");
 	}
 
 	make_head() {
@@ -394,11 +393,10 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 
 	add_custom_action(label, action, css_class = null) {
 		this.footer.removeClass("hide");
-		let action_button = $(`
-			<button class="btn btn-secondary btn-sm ${css_class || ""}">
-				${label}
-			</button>
-		`);
+		let action_button = frappe.ui.button({
+			label,
+			css_class: css_class || "",
+		});
 		this.custom_actions.append(action_button);
 
 		action && action_button.click(action);

--- a/frappe/public/js/frappe/ui/messages.js
+++ b/frappe/public/js/frappe/ui/messages.js
@@ -63,7 +63,14 @@ frappe.confirm = function (
 	return d;
 };
 
-frappe.warn = function (title, message_html, proceed_action, primary_label, is_minimizable) {
+frappe.warn = function (
+	title,
+	message_html,
+	proceed_action,
+	primary_label,
+	is_minimizable,
+	secondary_label
+) {
 	const d = new frappe.ui.Dialog({
 		title: title,
 		indicator: "red",
@@ -72,13 +79,18 @@ frappe.warn = function (title, message_html, proceed_action, primary_label, is_m
 			if (proceed_action) proceed_action();
 			d.hide();
 		},
-		secondary_action_label: __("Cancel", null, "Secondary button in warning dialog"),
+		// "Cancel" reads wrong when the ACTION is cancelling something —
+		// those callers pass "No" instead
+		secondary_action_label:
+			secondary_label || __("Cancel", null, "Secondary button in warning dialog"),
 		secondary_action: () => d.hide(),
 		minimizable: is_minimizable,
 	});
 
 	d.$body.append(`<div class="frappe-confirm-message">${message_html}</div>`);
-	d.standard_actions.find(".btn-primary").removeClass("btn-primary").addClass("btn-danger");
+	// destructive confirm: the es-button red theme replaces the old
+	// btn-primary → btn-danger class swap
+	d.get_primary_btn().attr("data-theme", "red");
 
 	d.show();
 	return d;

--- a/frappe/public/scss/common/modal.scss
+++ b/frappe/public/scss/common/modal.scss
@@ -115,11 +115,6 @@ body.modal-open[style^="padding-right"] {
 			button:not(:last-child) {
 				margin-right: var(--margin-xs);
 			}
-
-			.btn-primary-dark {
-				min-width: 80px;
-				max-width: 200px;
-			}
 		}
 
 		& > * {


### PR DESCRIPTION
Destructive actions like Delete and cancel now have a danger button and use frappe.warn instead.

<img width="1505" height="327" alt="image" src="https://github.com/user-attachments/assets/19edf3df-f460-46d6-a0a4-9944862d6f51" />


Also fixes an unrelated bug on workflows when workflow actions were shown on documents created before enabling a workflow.

`no-docs`