### PR TITLE
fix(print): tolerate sidebar overrides that don't create print_format_field

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -313,7 +313,7 @@ frappe.ui.form.PrintView = class {
 					callback: (r) => {
 						if (r.message) {
 							frappe.set_route("print-format-builder", r.message.name);
-							this.print_format_field.set_input(data.print_format_name);
+							this.set_print_format_value(data.print_format_name);
 						}
 					},
 				});
@@ -879,7 +879,17 @@ frappe.ui.form.PrintView = class {
 	set_default_print_format() {
 		const default_format =
 			this.frm._layout_print_format || this.frm.meta.default_print_format || "";
-		this.print_format_field.set_input(default_format);
+		this.set_print_format_value(default_format);
+	}
+
+	// apps like Print Designer replace setup_sidebar and only provide
+	// print_format_selector, not the whole control
+	set_print_format_value(value) {
+		if (this.print_format_field) {
+			this.print_format_field.set_input(value);
+		} else {
+			this.print_format_selector.val(value);
+		}
 	}
 
 	selected_format() {


### PR DESCRIPTION
- Route print-format value writes through `set_print_format_value`, which falls back to `print_format_selector.val()` when `print_format_field` doesn't exist

Why: Print Designer replaces `setup_sidebar` and only creates `print_format_selector`, so `set_default_print_format` crashed with "Cannot read properties of undefined (reading 'set_input')" on sites with it installed (regression from #41358). Overriding apps get the pre-#41358 behavior; the core sidebar keeps the control-synced path.

no-docs
