### PR TITLE
fix(print): route jinja formats to the legacy pipeline in generator pdf download

### DIFF
--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -35,7 +35,10 @@ def download_pdf(
 	letterhead: str | None = None,
 	settings: str | dict | None = None,
 ):
-	from frappe.printing.doctype.print_format.classic_converter import get_default_print_format
+	from frappe.printing.doctype.print_format.classic_converter import (
+		get_default_print_format,
+		uses_beta_renderer,
+	)
 	from frappe.www.printview import set_link_titles, validate_print
 
 	doc = frappe.get_doc(doctype, name)
@@ -43,6 +46,14 @@ def download_pdf(
 	set_link_titles(doc)
 	if not print_format or print_format == "Standard":
 		print_format = get_default_print_format(doctype)
+	else:
+		pf_doc = frappe.get_doc("Print Format", print_format)
+		if not uses_beta_renderer(pf_doc):
+			# jinja formats have no layout for the generator — hand off to the
+			# legacy pipeline, which reads the format's template
+			from frappe.utils.print_format import download_pdf as download_jinja_pdf
+
+			return download_jinja_pdf(doctype, name, format=print_format, letterhead=letterhead)
 	generator = PrintFormatGenerator(print_format, doc, letterhead, settings=frappe.parse_json(settings))
 	pdf = generator.render_pdf()
 


### PR DESCRIPTION
Fixes the remaining PDF half of #41302

- `print_format_generator.download_pdf` hands non-beta formats to `frappe.utils.print_format.download_pdf`, which renders the format's Jinja template and resolves the PDF engine from the format → Print Settings chain

Why: the Desk PDF button sends every non-custom format to the generator endpoint, which renders `format_data` — a standard Jinja format has none, so the PDF came out blank even after the preview fix (#41413 covered `/printpreview` but not this endpoint). Same server-side division of labor as the preview: beta layouts through the generator, Jinja templates through the legacy pipeline.

no-docs
