### PR TITLE
fix(print): keep print designer formats off the beta renderer

### DIFF
--- a/frappe/printing/doctype/print_format/classic_converter.py
+++ b/frappe/printing/doctype/print_format/classic_converter.py
@@ -33,6 +33,10 @@ def uses_beta_renderer(print_format) -> bool:
 		return False
 	if print_format.get("custom_format") or print_format.get("raw_printing"):
 		return False
+	# Print Designer formats carry their own format_data schema and renderer;
+	# also covers rows whose beta flag was flipped wrongly on insert
+	if print_format.get("print_designer"):
+		return False
 	if print_format.get("print_format_builder_beta"):
 		# a standard format with no layout is a file-based Jinja format whose
 		# flag was set wrongly on insert — the beta renderer has nothing to draw

--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -76,9 +76,14 @@ class PrintFormat(Document):
 		if self.print_format_for == "Report":
 			self.custom_format = 1
 
-		# standard formats render from their app's .html template or a classic layout,
-		# neither of which the beta renderer can read
-		if self.is_new() and not self.custom_format and self.standard != "Yes":
+		# standard formats render from their app's .html template and Print Designer
+		# formats from their own renderer — the beta renderer can read neither
+		if (
+			self.is_new()
+			and not self.custom_format
+			and self.standard != "Yes"
+			and not self.get("print_designer")
+		):
 			self.print_format_builder_beta = 1
 
 		if self.print_format_builder_beta and not self.custom_format:

--- a/frappe/printing/doctype/print_format/test_print_format.py
+++ b/frappe/printing/doctype/print_format/test_print_format.py
@@ -397,6 +397,25 @@ class TestClassicConverter(IntegrationTestCase):
 		doc.format_data = '{"sections": []}'
 		self.assertTrue(uses_beta_renderer(doc))
 
+	def test_print_designer_format_stays_off_the_beta_renderer(self):
+		from frappe.printing.doctype.print_format.classic_converter import uses_beta_renderer
+
+		doc = frappe.new_doc("Print Format")
+		doc.name = "_Test Print Designer Format"
+		doc.doc_type = "User"
+		doc.module = "Core"
+		doc.custom_format = 0
+		doc.print_designer = 1
+		doc.format_data = '{"header": [], "body": []}'
+		doc.before_save()
+
+		self.assertEqual(doc.print_format_builder_beta, 0)
+		self.assertFalse(uses_beta_renderer(doc))
+
+		# rows already flipped on insert must not reach the beta renderer either
+		doc.print_format_builder_beta = 1
+		self.assertFalse(uses_beta_renderer(doc))
+
 	def test_convert_print_format_document(self):
 		from frappe.printing.doctype.print_format.classic_converter import convert_print_format
 


### PR DESCRIPTION
- `before_save` no longer flips `print_format_builder_beta` on Print Designer formats
- `uses_beta_renderer` returns false for `print_designer` formats regardless of the flag, so rows already flipped render through their own pipeline again — no data repair needed

Why: `print_designer` is a field the Print Designer app adds, so core's auto-enable on insert didn't know to skip it. A newly created PD format got the beta flag, `uses_beta_renderer` then routed it to the beta generator, which can't read PD's `format_data` schema — the preview showed only the letterhead. Existing PD formats were never touched by the classic migration (their `format_data` isn't a classic list), so only formats created after the auto-enable landed are affected.

no-docs
