### PR TITLE
fix(ui): migrate grid buttons to Espresso

### DIFF
--- a/frappe/automation/doctype/assignment_rule/assignment_rule.js
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.js
@@ -37,7 +37,7 @@ frappe.ui.form.on("Assignment Rule", {
 
 		let set_days = (e) => {
 			frm.clear_table("assignment_days");
-			const label = $(e.currentTarget).text();
+			const label = $(e.currentTarget).text().trim();
 			get_days(label).forEach((day) => frm.add_child("assignment_days", { day: day }));
 			frm.refresh_field("assignment_days");
 		};

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -113,39 +113,57 @@ export default class Grid {
 				<div class="small form-clickable-section grid-footer">
 					<div class="flex justify-between">
 						<div class="grid-buttons">
-							<button type="button" class="btn btn-xs btn-danger grid-remove-rows hidden"
-								data-action="delete_rows">
-								${__("Delete")}
-							</button>
-							<button type="button" class="btn btn-xs btn-secondary grid-edit-rows hidden"
-								data-action="bulk_edit_rows">
-								${__("Edit")}
-							</button>
-							<button type="button" class="btn btn-xs btn-danger grid-remove-all-rows hidden"
-							data-action="delete_all_rows">
-							${__("Delete all")}
-							</button>
-							<button type="button" class="btn btn-xs btn-secondary grid-duplicate-rows hidden"
-								data-action="duplicate_rows">
-								${__("Duplicate rows")}
-							</button>
+							${frappe.ui.button.html({
+								label: __("Delete"),
+								size: "sm",
+								theme: "red",
+								css_class: "grid-remove-rows hidden",
+								attrs: { "data-action": "delete_rows" },
+							})}
+							${frappe.ui.button.html({
+								label: __("Edit"),
+								size: "sm",
+								css_class: "grid-edit-rows hidden",
+								attrs: { "data-action": "bulk_edit_rows" },
+							})}
+							${frappe.ui.button.html({
+								label: __("Delete all"),
+								size: "sm",
+								theme: "red",
+								css_class: "grid-remove-all-rows hidden",
+								attrs: { "data-action": "delete_all_rows" },
+							})}
+							${frappe.ui.button.html({
+								label: __("Duplicate rows"),
+								size: "sm",
+								css_class: "grid-duplicate-rows hidden",
+								attrs: { "data-action": "duplicate_rows" },
+							})}
 							<!-- hack to allow firefox include this in tabs -->
-							<button type="button" class="btn btn-xs btn-secondary grid-add-row">
-								${__("Add row")}
-							</button>
-							<button type="button" class="grid-add-multiple-rows btn btn-xs btn-secondary hidden">
-								${__("Add multiple")}</a>
-							</button>
+							${frappe.ui.button.html({
+								label: __("Add row"),
+								size: "sm",
+								css_class: "grid-add-row",
+							})}
+							${frappe.ui.button.html({
+								label: __("Add multiple"),
+								size: "sm",
+								css_class: "grid-add-multiple-rows hidden",
+							})}
 						</div>
 						<div class="grid-pagination">
 						</div>
 						<div class="grid-bulk-actions text-right">
-							<button type="button" class="grid-download btn btn-xs btn-secondary hidden">
-								${__("Download")}
-							</button>
-							<button type="button" class="grid-upload btn btn-xs btn-secondary hidden">
-								${__("Upload")}
-							</button>
+							${frappe.ui.button.html({
+								label: __("Download"),
+								size: "sm",
+								css_class: "grid-download hidden",
+							})}
+							${frappe.ui.button.html({
+								label: __("Upload"),
+								size: "sm",
+								css_class: "grid-upload hidden",
+							})}
 						</div>
 					</div>
 				</div>
@@ -287,13 +305,22 @@ export default class Grid {
 
 			// update "Delete" and "Duplicate" button labels
 			if (num_selected_rows == 1) {
-				this.remove_rows_button.text(__("Delete row"));
-				this.edit_rows_button.text(__("Edit row"));
-				this.duplicate_rows_button.text(__("Duplicate row"));
+				this.set_button_label(this.remove_rows_button, __("Delete row"));
+				this.set_button_label(this.edit_rows_button, __("Edit row"));
+				this.set_button_label(this.duplicate_rows_button, __("Duplicate row"));
 			} else {
-				this.remove_rows_button.text(__("Delete {0} rows", [num_selected_rows]));
-				this.edit_rows_button.text(__("Edit {0} rows", [num_selected_rows]));
-				this.duplicate_rows_button.text(__("Duplicate {0} rows", [num_selected_rows]));
+				this.set_button_label(
+					this.remove_rows_button,
+					__("Delete {0} rows", [num_selected_rows])
+				);
+				this.set_button_label(
+					this.edit_rows_button,
+					__("Edit {0} rows", [num_selected_rows])
+				);
+				this.set_button_label(
+					this.duplicate_rows_button,
+					__("Duplicate {0} rows", [num_selected_rows])
+				);
 			}
 
 			this.refresh_remove_rows_button();
@@ -421,8 +448,17 @@ export default class Grid {
 		this.remove_all_rows_button.toggleClass("hidden", !show_delete_all_btn);
 
 		if (show_delete_all_btn) {
-			this.remove_all_rows_button.text(__("Delete all {0} rows", [this.data.length]));
+			this.set_button_label(
+				this.remove_all_rows_button,
+				__("Delete all {0} rows", [this.data.length])
+			);
 		}
+	}
+
+	set_button_label($btn, label) {
+		// es buttons keep their label in a span; .text() on the button itself
+		// would wipe the spinner and loading-label structure
+		$btn.find(".es-button__label").text(label);
 	}
 
 	refresh_edit_rows_button() {
@@ -1718,8 +1754,8 @@ export default class Grid {
 		const $wrapper = position === "top" ? this.grid_custom_buttons : this.grid_buttons;
 		let $btn = this.custom_buttons[label];
 		if (!$btn) {
-			$btn = $(`<button type="button" class="btn btn-secondary btn-xs btn-custom">`)
-				.html(__(label))
+			$btn = frappe.ui
+				.button({ label: __(label), size: "sm", css_class: "btn-custom" })
 				.prependTo($wrapper)
 				.on("click", click);
 			this.custom_buttons[label] = $btn;

--- a/frappe/public/js/frappe/form/grid_pagination.js
+++ b/frappe/public/js/frappe/form/grid_pagination.js
@@ -119,15 +119,29 @@ export default class GridPagination {
 				<span class="total-page-number page-number"> ${__(this.total_pages)} </span>
 			</div>`;
 
-		return $(`<button class="btn btn-secondary btn-xs first-page"">
-				<span>${__("First")}</span>
-			</button>
-			<button class="btn btn-secondary btn-xs prev-page">${frappe.utils.icon("chevron-left")}</button>
+		return $(`${frappe.ui.button.html({
+			label: __("First"),
+			size: "sm",
+			css_class: "first-page",
+		})}
+			${frappe.ui.button.html({
+				icon: "chevron-left",
+				title: __("Previous page"),
+				size: "sm",
+				css_class: "prev-page",
+			})}
 			${page_text_html}
-			<button class="btn btn-secondary btn-xs next-page">${frappe.utils.icon("chevron-right")}</button>
-			<button class="btn btn-secondary btn-xs last-page">
-				<span>${__("Last")}</span>
-			</button>`);
+			${frappe.ui.button.html({
+				icon: "chevron-right",
+				title: __("Next page"),
+				size: "sm",
+				css_class: "next-page",
+			})}
+			${frappe.ui.button.html({
+				label: __("Last"),
+				size: "sm",
+				css_class: "last-page",
+			})}`);
 	}
 
 	render_next_page() {

--- a/frappe/public/js/frappe/form/grid_row_form.js
+++ b/frappe/public/js/frappe/form/grid_row_form.js
@@ -46,20 +46,33 @@ export default class GridRowForm {
 					<span class="panel-title">
 						${__("Editing Row")} #<span class="grid-form-row-index"></span></span>
 					<span class="row-actions">
-						<button class="btn btn-secondary btn-sm pull-right grid-collapse-row">
-							${frappe.utils.icon("chevron-down")}
-						</button>
-						<button class="btn btn-secondary btn-sm pull-right grid-move-row hidden-xs">
-							${__("Move")}</button>
-						<button class="btn btn-secondary btn-sm pull-right grid-duplicate-row hidden-xs">
-							${frappe.utils.icon("copy")}
-							${__("Duplicate")}
-						</button>
-						<button class="btn btn-secondary btn-sm pull-right grid-insert-row hidden-xs">
-							${__("Insert Above")}</button>
-						<button class="btn btn-secondary btn-sm pull-right grid-insert-row-below hidden-xs">
-							${__("Insert Below")}</button>
-						<button class="btn btn-danger btn-sm pull-right grid-delete-row">${__("Delete")}</button>
+						${frappe.ui.button.html({
+							icon: "chevron-down",
+							title: __("Collapse"),
+							css_class: "pull-right grid-collapse-row",
+						})}
+						${frappe.ui.button.html({
+							label: __("Move"),
+							css_class: "pull-right grid-move-row hidden-xs",
+						})}
+						${frappe.ui.button.html({
+							icon: "copy",
+							label: __("Duplicate"),
+							css_class: "pull-right grid-duplicate-row hidden-xs",
+						})}
+						${frappe.ui.button.html({
+							label: __("Insert Above"),
+							css_class: "pull-right grid-insert-row hidden-xs",
+						})}
+						${frappe.ui.button.html({
+							label: __("Insert Below"),
+							css_class: "pull-right grid-insert-row-below hidden-xs",
+						})}
+						${frappe.ui.button.html({
+							label: __("Delete"),
+							theme: "red",
+							css_class: "pull-right grid-delete-row",
+						})}
 					</span>
 				</div>
 			</div>
@@ -72,9 +85,10 @@ export default class GridRowForm {
 						<kbd>${__("Ctrl + Up")}</kbd> . <kbd>${__("Ctrl + Down")}</kbd> . <kbd>${__("ESC")}</kbd>
 					</div>
 					<span class="row-actions">
-						<button class="btn btn-secondary btn-sm pull-right grid-append-row">
-							${__("Insert Below")}
-						</button>
+						${frappe.ui.button.html({
+							label: __("Insert Below"),
+							css_class: "pull-right grid-append-row",
+						})}
 					</span>
 				</div>
 			</div>`;

--- a/frappe/public/js/frappe/ui/components/button.js
+++ b/frappe/public/js/frappe/ui/components/button.js
@@ -80,9 +80,9 @@ function button_html(opts = {}) {
 
 	const classes = escape(["es-button", opts.css_class].filter(Boolean).join(" "));
 
-	return `<button class="${classes}" ${attrs.join(" ")}>
-		${content_html(opts)}
-	</button>`;
+	// no whitespace around the content: legacy callers read labels back with
+	// $(btn).text(), which includes every text node inside the button
+	return `<button class="${classes}" ${attrs.join(" ")}>${content_html(opts)}</button>`;
 }
 
 // The button's children: spinner + loading label + icons + label. Shared by

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -588,12 +588,6 @@
 		}
 	}
 
-	.grid-delete-row {
-		.icon use {
-			stroke: var(--fg-color);
-		}
-	}
-
 	.grid-append-row {
 		margin-top: calc(-1 * var(--margin-xs));
 	}
@@ -727,10 +721,6 @@
 	padding: 0;
 }
 
-.grid-footer {
-	margin-top: var(--margin-sm);
-}
-
 .grid-footer,
 .grid-custom-buttons {
 	padding: var(--padding-sm) 0px;
@@ -742,7 +732,8 @@
 		margin-bottom: -3px;
 	}
 
-	.btn:not(:last-child) {
+	.btn:not(:last-child),
+	.es-button:not(:last-child) {
 		margin-right: 4px;
 	}
 }
@@ -750,6 +741,7 @@
 .grid-pagination {
 	padding: 0;
 	display: flex;
+	align-items: center;
 
 	.last-page {
 		margin-left: 5px;
@@ -773,13 +765,6 @@
 	}
 }
 
-.prev-page,
-.next-page {
-	.icon {
-		width: 10px;
-	}
-}
-
 .prev-page {
 	margin-left: var(--margin-xs);
 	text-decoration: none;
@@ -797,11 +782,6 @@
 
 .grid-footer-toolbar {
 	padding: var(--padding-md) var(--padding-sm) var(--padding-xs) var(--padding-sm);
-
-	// border-top: 1px solid var(--border-color);
-	span {
-		margin-right: var(--margin-xs);
-	}
 
 	button {
 		margin-left: var(--margin-xs);


### PR DESCRIPTION
Beautiful Espresso buttons

<img width="1164" height="209" alt="image" src="https://github.com/user-attachments/assets/a6b2f202-5c93-44fe-9a1b-67629066c855" />


`no-docs`