### PR TITLE
fix(ui): keep form menu when sidebar is disabled

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -336,9 +336,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 		this.page.clear_icons();
 		this.page.clear_menu();
 
-		if (frappe.boot.desk_settings.form_sidebar) {
-			this.make_menu_items();
-		}
+		this.make_menu_items();
 
 		if (frappe.boot.desk_settings.form_navigation_buttons) {
 			this.make_navigation();
@@ -488,7 +486,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 	}
 
 	add_open_sidebar() {
-		if (this.page.hide_sidebar) {
+		if (this.page.hide_sidebar || !frappe.boot.desk_settings.form_sidebar) {
 			return;
 		}
 		this.page.add_menu_item(


### PR DESCRIPTION
## Summary

Disabling **Sidebar** in **User > Settings > Form Settings** also removed the entire form menu, including Print, Email, Duplicate, Rename, Delete, Show Links, and the toolbar print icon. On `develop` the ⋯ menu disappeared entirely; on `v15` it opened empty, leaving printing accessible only via `Ctrl+P`.

`make_menu_items()` was incorrectly gated on `desk_settings.form_sidebar`. That made sense when the setting was role-based, but after moving to User settings, a single checkbox hid the menu. This removes that gate while keeping the sidebar check for `add_open_sidebar()`, since "Toggle Sidebar" depends on `frm.sidebar`.

## Setting unchecked

<img width="875" height="513" alt="Screenshot 2026-07-31 at 6 25 33 PM" src="https://github.com/user-attachments/assets/fbcd1c05-86e3-4882-a480-aad1235e4bec" />


## Develop(Before/After)

<img width="1460" height="866" alt="Screenshot 2026-07-31 at 6 27 19 PM" src="https://github.com/user-attachments/assets/1073e876-2f42-416f-b632-f178eb10646d" />
<img width="1458" height="868" alt="Screenshot 2026-07-31 at 6 26 36 PM" src="https://github.com/user-attachments/assets/2483d73f-e0d6-4e16-b585-2855ae523a59" />

## v15

<img width="1512" height="907" alt="Screenshot 2026-07-31 at 6 28 43 PM" src="https://github.com/user-attachments/assets/aff7fca6-0e9e-46de-b654-93b68ef4d8f4" />

## Note

I am not sure if this behaviour was intentional or missed in develop, but IMO the menu option should be there, otherwise how can user access the doc related settings?