### PR TITLE
fix(desktop): correct icon names for Edit Profile and Frappe Support menu items

### DIFF
--- a/frappe/public/js/desktop_icons.bundle.js
+++ b/frappe/public/js/desktop_icons.bundle.js
@@ -435,7 +435,7 @@ class DesktopPage {
 		let is_dark = document.documentElement.getAttribute("data-theme") === "dark";
 		let menu_items = [
 			{
-				icon: "edit",
+				icon: "pencil",
 				label: "Edit Profile",
 				url: `/desk/user/${frappe.session.user}`,
 			},
@@ -454,7 +454,7 @@ class DesktopPage {
 				},
 			},
 			{
-				icon: "support",
+				icon: "life-buoy",
 				label: "Frappe Support",
 				onClick: function () {
 					window.open("https://support.frappe.io/help", "_blank");


### PR DESCRIPTION
Resolve: #41448

---

**Before Fix**

<img width="228" height="266" alt="image" src="https://github.com/user-attachments/assets/47c9d412-5269-4f9b-9906-7705d8452959" />


**After Fix**

<img width="228" height="266" alt="image" src="https://github.com/user-attachments/assets/5082c33c-0708-45bf-bd89-0b963f036ef4" />

