### PR TITLE
fix(print): render at default font size when a format stores zero

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -271,3 +271,4 @@ frappe.patches.v16_0.clear_if_owner_above_permlevel_zero
 frappe.patches.v16_0.migrate_classic_print_formats
 frappe.patches.v16_0.rename_lucide_workspace_icons
 frappe.patches.v16_0.keep_existing_sites_on_desktop_icons
+frappe.patches.v16_0.repair_converted_print_formats

--- a/frappe/patches/v16_0/repair_converted_print_formats.py
+++ b/frappe/patches/v16_0/repair_converted_print_formats.py
@@ -1,0 +1,64 @@
+import json
+
+import frappe
+from frappe.printing.doctype.print_format.classic_converter import DEFAULT_COLUMN_WIDTH_PCT
+
+
+def execute():
+	"""Repair formats converted by migrate_classic_print_formats before the
+	converter fixes: font_size landed as 0 (invisible render) and the serial
+	column as 5.33% (too narrow). Touches only those two defects so builder
+	edits made since the conversion survive."""
+	names = frappe.get_all(
+		"Print Format",
+		filters={"print_format_builder_beta": 1, "classic_format_data": ("is", "set")},
+		pluck="name",
+	)
+	for name in names:
+		values = {}
+		font_size, format_data = frappe.db.get_value("Print Format", name, ["font_size", "format_data"])
+		if not font_size:
+			values["font_size"] = 14
+		repaired = widen_serial_columns(format_data)
+		if repaired:
+			values["format_data"] = repaired
+		if values:
+			frappe.db.set_value("Print Format", name, values, update_modified=False)
+
+
+def widen_serial_columns(format_data):
+	try:
+		layout = json.loads(format_data)
+	except (TypeError, ValueError):
+		return None
+	if not isinstance(layout, dict):
+		return None
+
+	changed = False
+	zones = [layout.get("header"), layout.get("footer"), *layout.get("sections", [])]
+	for zone in zones:
+		for column in (zone or {}).get("columns", []):
+			for field in column.get("fields", []):
+				if widen_serial_column(field.get("table_columns")):
+					changed = True
+	return json.dumps(layout, indent=1) if changed else None
+
+
+def widen_serial_column(table_columns):
+	if not table_columns:
+		return False
+	sr = table_columns[0]
+	width = sr.get("width")
+	if sr.get("fieldname") != "idx" or not width or width >= DEFAULT_COLUMN_WIDTH_PCT:
+		return False
+
+	# widen Sr to the default and shrink the other columns by the difference,
+	# keeping the total unchanged
+	others = sum(col.get("width") or 0 for col in table_columns[1:])
+	if others:
+		factor = (others - (DEFAULT_COLUMN_WIDTH_PCT - width)) / others
+		for col in table_columns[1:]:
+			if col.get("width"):
+				col["width"] = round(col["width"] * factor, 2)
+	sr["width"] = DEFAULT_COLUMN_WIDTH_PCT
+	return True

--- a/frappe/printing/doctype/print_format/classic_converter.py
+++ b/frappe/printing/doctype/print_format/classic_converter.py
@@ -249,6 +249,8 @@ def convert_print_format(doc):
 	doc.format_data = json.dumps(layout, indent=1)
 	doc.print_format_builder = 0
 	doc.print_format_builder_beta = 1
+	if not doc.font_size:
+		doc.font_size = 14
 	doc.pdf_generator = "chrome"
 	if not doc.page_number or doc.page_number == "Hide":
 		doc.page_number = "Bottom Center"
@@ -392,6 +394,7 @@ def migrate_all_classic_formats():
 						"print_format_builder_beta": 1,
 						"pdf_generator": doc.pdf_generator,
 						"page_number": doc.page_number,
+						"font_size": doc.font_size,
 					},
 					update_modified=False,
 				)

--- a/frappe/printing/doctype/print_format/classic_converter.py
+++ b/frappe/printing/doctype/print_format/classic_converter.py
@@ -160,7 +160,7 @@ def convert_table_columns(df, meta_df, dropped) -> list:
 			"fieldname": "idx",
 			"fieldtype": "Int",
 			"options": None,
-			"width": parse_print_width("40px"),
+			"width": DEFAULT_COLUMN_WIDTH_PCT,
 		}
 	]
 

--- a/frappe/printing/doctype/print_format/test_print_format.py
+++ b/frappe/printing/doctype/print_format/test_print_format.py
@@ -231,7 +231,7 @@ class TestClassicConverter(IntegrationTestCase):
 										"fieldname": "idx",
 										"fieldtype": "Int",
 										"options": None,
-										"width": 5.33,
+										"width": 10,
 									},
 									{
 										"label": "Role",

--- a/frappe/printing/doctype/print_format/test_print_format.py
+++ b/frappe/printing/doctype/print_format/test_print_format.py
@@ -456,6 +456,15 @@ class TestClassicConverter(IntegrationTestCase):
 		self.assertIn('data-fieldname="idx"', html)
 		self.assertIn("print-heading", html)
 
+	def test_zero_font_size_renders_at_default(self):
+		# app-shipped classic fixtures carry no font_size, which lands as 0 — the
+		# stylesheet must not emit font-size: 0px or the whole page is invisible
+		self.make_classic_format()
+		frappe.db.set_value("Print Format", self.FORMAT_NAME, "font_size", 0)
+		html = frappe.get_print("User", "Administrator", print_format=self.FORMAT_NAME)
+		self.assertNotIn("font-size: 0px", html)
+		self.assertIn("font-size: 14px", html)
+
 	def test_migrate_all_classic_formats(self):
 		from frappe.printing.doctype.print_format.classic_converter import migrate_all_classic_formats
 

--- a/frappe/printing/doctype/print_format/test_print_format.py
+++ b/frappe/printing/doctype/print_format/test_print_format.py
@@ -484,6 +484,41 @@ class TestClassicConverter(IntegrationTestCase):
 		self.assertEqual(doc.print_format_builder_beta, 1)
 		self.assertEqual(frappe.parse_json(doc.classic_format_data), self.CLASSIC_FORMAT_DATA)
 
+	def test_repair_converted_print_formats(self):
+		from frappe.patches.v16_0.repair_converted_print_formats import execute
+
+		self.make_classic_format()
+		from frappe.printing.doctype.print_format.classic_converter import migrate_all_classic_formats
+
+		migrate_all_classic_formats()
+
+		# recreate the pre-fix conversion output: zero font size, 5.33% serial column
+		doc = frappe.get_doc("Print Format", self.FORMAT_NAME)
+		layout = frappe.parse_json(doc.format_data)
+		table = layout["sections"][0]["columns"][1]["fields"][1]
+		table["table_columns"][0]["width"] = 5.33
+		table["table_columns"][1]["width"] = 94.67
+		frappe.db.set_value(
+			"Print Format",
+			self.FORMAT_NAME,
+			{"font_size": 0, "format_data": frappe.as_json(layout)},
+		)
+
+		execute()
+
+		doc.reload()
+		self.assertEqual(doc.font_size, 14)
+		columns = frappe.parse_json(doc.format_data)["sections"][0]["columns"][1]["fields"][1][
+			"table_columns"
+		]
+		self.assertEqual(columns[0]["width"], 10)
+		self.assertEqual(columns[1]["width"], 90.0)
+
+		# already-repaired rows are untouched
+		modified = frappe.db.get_value("Print Format", self.FORMAT_NAME, "format_data")
+		execute()
+		self.assertEqual(frappe.db.get_value("Print Format", self.FORMAT_NAME, "format_data"), modified)
+
 	def test_migration_skips_corrupt_format(self):
 		"""A format with unparseable format_data is skipped, not fatal to the run."""
 		from frappe.printing.doctype.print_format.classic_converter import migrate_all_classic_formats

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -194,7 +194,7 @@ let rootStyles = computed(() => {
 let bodyStyles = computed(() => {
 	const { font_size, font } = print_format.value;
 	const styles = {};
-	if (font_size) styles.fontSize = `${parseFloat(font_size)}px`;
+	styles.fontSize = `${parseFloat(font_size) || 14}px`;
 	if (font) styles.fontFamily = `'${font}', sans-serif`;
 	return styles;
 });

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -529,11 +529,14 @@ function remove_column(index) {
 	position: relative;
 }
 
-/* same ring as every other hover/selection state (--pfb-ring), so a hovered
-   column reads the same as a hovered field or section */
-.column.pfb-column-hover {
-	outline: var(--pfb-ring);
-	outline-offset: -2px;
+/* same ring as every other hover/selection state (--pfb-ring); drawn inside the
+   15px bootstrap gutter — the column box bleeds past the section edge */
+.column.pfb-column-hover::after {
+	content: "";
+	position: absolute;
+	inset: 0 15px;
+	border: var(--pfb-ring);
+	pointer-events: none;
 }
 
 .column-divider {

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -21,7 +21,7 @@
 }
 
 html, body {
-	font-size: {{ print_format.font_size }}px;
+	font-size: {{ print_format.font_size or 14 }}px;
 }
 
 body {


### PR DESCRIPTION
- The print stylesheet falls back to 14px when a format's `font_size` is 0, instead of emitting `font-size: 0px` and rendering the whole page invisible
- The classic converter and migration now store the default font size for formats that had none
- The builder's column hover ring draws inside the bootstrap gutter — the column box bleeds 15px past the section edge, so the outline stuck out of the section
- Converted child tables get a 10% serial column instead of 5.33% (the classic 40px mapped too narrow)
- A repair patch fixes already-converted formats in place — only the zero font size and narrow serial columns, so builder edits made since the conversion survive; sites that migrate with the fixed converter get correct output and the patch is a no-op

Why: app-shipped classic fixtures (e.g. hrms Salary Slip Standard) carry no `font_size`, which lands as 0 in the Int field. The stylesheet used the value as-is, so every converted format without a font size rendered a structurally complete page at zero font size — it looked blank in the preview and the PDF. frappe.io has 7 such formats today; the stylesheet fallback fixes them without a data migration.

no-docs
