### PR TITLE
fix(grid): unblock clicks on checklist checkboxes in Text Editor grid fields

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -919,7 +919,12 @@ export default class Grid {
 			handle: ".sortable-handle",
 			draggable: ".grid-row",
 			animation: 100,
-			filter: "li, a",
+			filter: (evt) => {
+				if (evt.target.closest(".ql-editor")) {
+					return false;
+				}
+				return !!evt.target.closest("li, a");
+			},
 			onMove: (event) => {
 				// don't move if editable
 				if (!this.is_editable()) {


### PR DESCRIPTION
Resolve: #28482

---
Sortable's `filter: "li, a"` (used to stop row-drag from starting on dropdown/link elements) was also matching Quill's `<li>` checklist items in Text Editor child table fields. It called `preventDefault()` on left-click only (Sortable ignores right-click), so the checklist checkbox never toggled on left-click but did on right-click. Fixed by skipping the filter for clicks inside `.ql-editor.`

**Before**

https://github.com/user-attachments/assets/8646b4fe-8599-446e-8684-d111568ccb33



**After**

https://github.com/user-attachments/assets/08b12136-9967-4898-9b6b-8a6e9be2be6f

