### PR TITLE
ci: configure vouch

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -18,7 +18,6 @@ Copilot
 dependabot[bot]
 frappe-pr-bot
 gajjug004
-Henil666
 karm1000
 kaulith
 KerollesFathy

--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -5,61 +5,21 @@
 # Only vouched users may open pull requests. Maintainers and users with
 # write access are automatically allowed. Denounced users are blocked.
 #
-# Seeded from authors of PRs merged since 2026-02-01.
-#
 # Syntax:
 #   - One handle per line (without @), sorted alphabetically.
 #   - Optional platform prefix: platform:username (e.g., github:user).
 #   - Denounce with minus prefix: -username or -platform:username.
 #   - Optional details after a space following the handle.
-AarDG10
 Abdeali099
-aerodeval
 Anish59312
-ankush
 barredterra
 Bowrna
 Copilot
-deepeshgarg007
 dependabot[bot]
-diptanilsaha
 frappe-pr-bot
 gajjug004
-GursheenK
 Henil666
-iamejaaz
-iamkhanraheel
-Jatin3128
 karm1000
 kaulith
 KerollesFathy
-khushi8112
-krishna-254
 mergify[bot]
-michellealva
-mihir-kandoi
-nabinhait
-netchampfaris
-nextchamp-saqib
-Nihantra-Patel
-nikkothari22
-nishkagosalia
-prathameshkurunkar7
-ps173
-regdocs
-RitvikSardana
-rohitwaghchaure
-ruchamahabal
-ruthra-kumar
-s-aga-r
-safwansamsudeen
-SandraFrappe
-shariquerik
-Shllokkk
-ShrihariMahabal
-sokumon
-ssiyad
-sumitjain236
-surajshetty3416
-tanmoysrt
-Vibhuti410

--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -1,0 +1,65 @@
+# Vouched contributors for this project.
+#
+# See https://github.com/mitchellh/vouch for details.
+#
+# Only vouched users may open pull requests. Maintainers and users with
+# write access are automatically allowed. Denounced users are blocked.
+#
+# Seeded from authors of PRs merged since 2026-02-01.
+#
+# Syntax:
+#   - One handle per line (without @), sorted alphabetically.
+#   - Optional platform prefix: platform:username (e.g., github:user).
+#   - Denounce with minus prefix: -username or -platform:username.
+#   - Optional details after a space following the handle.
+AarDG10
+Abdeali099
+aerodeval
+Anish59312
+ankush
+barredterra
+Bowrna
+Copilot
+deepeshgarg007
+dependabot[bot]
+diptanilsaha
+frappe-pr-bot
+gajjug004
+GursheenK
+Henil666
+iamejaaz
+iamkhanraheel
+Jatin3128
+karm1000
+kaulith
+KerollesFathy
+khushi8112
+krishna-254
+mergify[bot]
+michellealva
+mihir-kandoi
+nabinhait
+netchampfaris
+nextchamp-saqib
+Nihantra-Patel
+nikkothari22
+nishkagosalia
+prathameshkurunkar7
+ps173
+regdocs
+RitvikSardana
+rohitwaghchaure
+ruchamahabal
+ruthra-kumar
+s-aga-r
+safwansamsudeen
+SandraFrappe
+shariquerik
+Shllokkk
+ShrihariMahabal
+sokumon
+ssiyad
+sumitjain236
+surajshetty3416
+tanmoysrt
+Vibhuti410

--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -1,0 +1,27 @@
+name: Check PR
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/recheck'))
+    steps:
+      - uses: mitchellh/vouch/action/check-pr@v1
+        with:
+          pr-number: ${{ github.event.pull_request.number || github.event.issue.number }}
+          auto-close: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -19,7 +19,7 @@ jobs:
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '/recheck'))
     steps:
-      - uses: mitchellh/vouch/action/check-pr@v1
+      - uses: mitchellh/vouch/action/check-pr@d66fa29a64600490892131ad87597c30c91fcac4 # v1.5.0
         with:
           pr-number: ${{ github.event.pull_request.number || github.event.issue.number }}
           auto-close: true


### PR DESCRIPTION
See https://github.com/mitchellh/vouch for details.

Only vouched users may open pull requests. Maintainers and users with write access are automatically allowed. Denounced users are blocked.

Seeded from authors of PRs merged in the past 6 months.