### PR TITLE
fix(quill): text editor options not visible on hover or when option is selected

### DIFF
--- a/frappe/public/scss/common/quill.scss
+++ b/frappe/public/scss/common/quill.scss
@@ -54,7 +54,9 @@
 .ql-snow .ql-toolbar .ql-picker-item:hover,
 .ql-snow.ql-toolbar .ql-picker-item.ql-selected,
 .ql-snow .ql-toolbar .ql-picker-item.ql-selected {
-	color: var(--invert-neutral);
+	color: var(--text-color);
+	background-color: var(--control-bg);
+	border-radius: var(--radius-sm);
 }
 
 .ql-snow.ql-toolbar button:hover .ql-fill,
@@ -85,7 +87,7 @@
 .ql-snow .ql-toolbar .ql-picker-item:hover .ql-stroke.ql-fill,
 .ql-snow.ql-toolbar .ql-picker-item.ql-selected .ql-stroke.ql-fill,
 .ql-snow .ql-toolbar .ql-picker-item.ql-selected .ql-stroke.ql-fill {
-	fill: var(--invert-neutral);
+	fill: var(--text-color);
 }
 
 .ql-snow.ql-toolbar button:hover .ql-stroke,
@@ -116,7 +118,7 @@
 .ql-snow .ql-toolbar .ql-picker-item:hover .ql-stroke-miter,
 .ql-snow.ql-toolbar .ql-picker-item.ql-selected .ql-stroke-miter,
 .ql-snow .ql-toolbar .ql-picker-item.ql-selected .ql-stroke-miter {
-	stroke: var(--invert-neutral);
+	stroke: var(--text-color);
 }
 
 .ql-toolbar.ql-snow {


### PR DESCRIPTION
Resolve: #41460 

---
### Problem
Quill toolbar buttons used `var(--invert-neutral)`, which doesn't exist
(removed in the Espresso theme migration). Hover/active state was broken
and the browser console logged it as undefined.

### Fix
Swapped it for `var(--text-color)` and added a background tint so hover
is actually visible in both light and dark theme.

https://github.com/user-attachments/assets/2adcd9be-b31e-4b22-a953-a78743a7fcf0

