### PR TITLE
fix(print): harden the print format renderer against malformed layouts

### DIFF
--- a/frappe/printing/doctype/print_format/classic_converter.py
+++ b/frappe/printing/doctype/print_format/classic_converter.py
@@ -60,7 +60,7 @@ def convert_classic_to_beta(format_data, meta, print_format=None) -> tuple[dict,
 		"footer": {"columns": [{"label": "", "fields": []}]},
 	}
 
-	data = [frappe._dict(df) for df in (format_data or [])]
+	data = [frappe._dict(df) for df in (format_data or []) if isinstance(df, dict)]
 
 	if data and data[0].fieldname == "print_heading_template":
 		head = data.pop(0)
@@ -214,6 +214,9 @@ def parse_print_width(print_width) -> float | None:
 
 
 def distribute_widths(columns) -> list:
+	for col in columns:
+		if (col.get("width") or 0) < 0:
+			col["width"] = None
 	unsized = [col for col in columns if not col["width"]]
 	assigned = sum(col["width"] for col in columns if col["width"])
 	if unsized:

--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -126,6 +126,28 @@ class PrintFormat(Document):
 			frappe.throw(_("{0} is required").format(frappe.bold(_("Report"))), frappe.MandatoryError)
 
 		self.validate_colors()
+		self.validate_conditions()
+
+	def validate_conditions(self):
+		"""Reject a layout whose visibility conditions cannot compile.
+
+		A condition that fails at render time is treated as "show", so a typo is
+		invisible unless it is caught here."""
+		try:
+			layout = frappe.parse_json(self.format_data) if self.format_data else None
+		except Exception:
+			return
+		if not isinstance(layout, dict):
+			return
+
+		for where, condition in _iter_conditions(layout):
+			try:
+				compile(condition, "<condition>", "eval")
+			except SyntaxError as e:
+				frappe.throw(
+					_("{0} is not a valid condition: {1}").format(frappe.bold(where), e.msg),
+					title=_("Invalid Condition"),
+				)
 
 	def validate_colors(self):
 		for fieldname in ("label_color", "value_color"):
@@ -222,6 +244,35 @@ class PrintFormat(Document):
 	def on_trash(self):
 		if self.doc_type:
 			frappe.clear_cache(doctype=self.doc_type)
+
+
+def _iter_conditions(layout):
+	"""Yield (label, expression) for every condition in a beta layout."""
+	zones = [layout.get("header"), layout.get("footer"), *(layout.get("sections") or [])]
+	for zone in zones:
+		if not isinstance(zone, dict):
+			continue
+		yield from _condition(zone, zone.get("label") or _("Section"), "visible_if")
+		columns = zone.get("columns")
+		for column in columns if isinstance(columns, list) else []:
+			fields = (column or {}).get("fields") if isinstance(column, dict) else None
+			for df in fields if isinstance(fields, list) else []:
+				if not isinstance(df, dict):
+					continue
+				label = df.get("label") or df.get("fieldname") or _("Field")
+				yield from _condition(df, label, "visible_if")
+				yield from _condition(df, label, "row_condition")
+				table_columns = df.get("table_columns")
+				for col in table_columns if isinstance(table_columns, list) else []:
+					if isinstance(col, dict):
+						yield from _condition(col, col.get("label") or label, "column_condition")
+
+
+def _condition(holder, label, key):
+	"""Yield (label, expression) only when the value is actually an expression."""
+	condition = holder.get(key)
+	if isinstance(condition, str) and condition.strip():
+		yield label, condition
 
 
 @frappe.whitelist()

--- a/frappe/printing/doctype/print_format/test_print_format.py
+++ b/frappe/printing/doctype/print_format/test_print_format.py
@@ -155,6 +155,129 @@ class TestPrintFormatBuilderElements(IntegrationTestCase):
 		self.assertIn(b"<svg", base64.b64decode(data_uri[len(prefix) :]))
 
 
+class TestPrintFormatHardening(IntegrationTestCase):
+	"""Malformed layouts and conditions must not take the print down."""
+
+	NAME = "_Test Hardening"
+
+	def make(self, layout, **kwargs):
+		frappe.delete_doc("Print Format", self.NAME, force=True, ignore_missing=True)
+		doc = frappe.get_doc(
+			{
+				"doctype": "Print Format",
+				"name": self.NAME,
+				"doc_type": "User",
+				"standard": "No",
+				"print_format_builder_beta": 1,
+				"format_data": layout if isinstance(layout, str) else frappe.as_json(layout),
+				**kwargs,
+			}
+		)
+		doc.insert()
+		self.addCleanup(frappe.delete_doc, "Print Format", self.NAME, force=True, ignore_missing=True)
+		return doc
+
+	def render(self, layout, **kwargs):
+		from frappe.utils.print_format_generator import get_html
+
+		self.make(layout, **kwargs)
+		return get_html("User", "Administrator", self.NAME)
+
+	@staticmethod
+	def layout(*fields, **section):
+		sec = {"label": "", "columns": [{"label": "", "fields": list(fields)}]}
+		sec.update(section)
+		return {"sections": [sec], "header": {"columns": []}, "footer": {"columns": []}}
+
+	DATA: ClassVar[dict] = {"label": "First Name", "fieldname": "first_name", "fieldtype": "Data"}
+
+	def test_malformed_layout_renders_empty_instead_of_erroring(self):
+		for label, format_data in {
+			"corrupt json": '{"sections": [BROKEN',
+			"sections is a string": '{"sections": "nope"}',
+			"sections is null": '{"sections": null}',
+			"section without columns": '{"sections": [{"label": "x"}]}',
+			"column without fields": '{"sections": [{"columns": [{"label": ""}]}]}',
+			"non-dict field": '{"sections": [{"columns": [{"fields": ["nope"]}]}]}',
+		}.items():
+			with self.subTest(layout=label):
+				self.assertIn("print-format-doc", self.render(format_data))
+
+	def test_broken_condition_is_rejected_on_save(self):
+		with self.assertRaises(frappe.ValidationError):
+			self.make(self.layout({**self.DATA, "visible_if": "doc.first_name ==== 'x'"}))
+
+		self.make(self.layout({**self.DATA, "visible_if": "   "}))
+
+	def test_runtime_condition_failure_shows_field_and_logs(self):
+		before = frappe.db.count("Error Log")
+		html = self.render(self.layout({**self.DATA, "label": "PROBE", "visible_if": "doc.nope.nope"}))
+		self.assertIn("PROBE", html)
+		self.assertGreater(frappe.db.count("Error Log"), before)
+
+	def test_malformed_table_columns_do_not_crash(self):
+		table = {"label": "T", "fieldname": "roles", "fieldtype": "Table", "options": "Has Role"}
+		for table_columns in (["nope", 3], "nope", {"a": 1}, 7, ""):
+			with self.subTest(table_columns=table_columns):
+				html = self.render(self.layout({**table, "table_columns": table_columns}))
+				self.assertIn("print-format-doc", html)
+
+	def test_non_string_condition_does_not_crash(self):
+		for condition in (5, ["a"], {"a": 1}):
+			with self.subTest(condition=condition):
+				html = self.render(self.layout({**self.DATA, "label": "PROBE", "visible_if": condition}))
+				self.assertIn("PROBE", html)
+
+	def test_failing_row_condition_logs_once_not_once_per_row(self):
+		frappe.db.delete("Error Log")
+		self.render(
+			self.layout(
+				{
+					"label": "T",
+					"fieldname": "roles",
+					"fieldtype": "Table",
+					"options": "Has Role",
+					"row_condition": "row.nope.nope",
+					"table_columns": [
+						{"label": "Role", "fieldname": "role", "fieldtype": "Link", "width": 100}
+					],
+				}
+			)
+		)
+		self.assertGreater(frappe.db.count("Has Role", {"parent": "Administrator"}), 1)
+		self.assertEqual(frappe.db.count("Error Log"), 1)
+
+	def test_labels_are_escaped(self):
+		payload = "<script>alert(1)</script>"
+		self.assertNotIn(payload, self.render(self.layout({**self.DATA, "label": payload})))
+		self.assertNotIn(
+			payload,
+			self.render(
+				{
+					"sections": [{"label": payload, "columns": [{"label": "", "fields": [self.DATA]}]}],
+					"header": {"columns": []},
+					"footer": {"columns": []},
+				}
+			),
+		)
+		self.assertNotIn(
+			payload,
+			self.render(
+				self.layout(
+					{
+						"label": "T",
+						"fieldname": "roles",
+						"fieldtype": "Table",
+						"options": "Has Role",
+						"table_columns": [
+							{"label": payload, "fieldname": "role", "fieldtype": "Link", "width": 100}
+						],
+					}
+				)
+			),
+		)
+
+
 class TestClassicConverter(IntegrationTestCase):
 	"""Conversion of classic print-format-builder layouts to the beta builder."""
 
@@ -663,7 +786,7 @@ class TestPrintFormatChildTableVisibility(IntegrationTestCase):
 		).insert(ignore_permissions=True)
 		self.addCleanup(frappe.delete_doc, "Contact", self.contact.name, force=True)
 
-	def render(self, df):
+	def render(self, df, skip_validation=False):
 		from frappe.utils.print_format_generator import get_html
 
 		frappe.delete_doc("Print Format", self.FORMAT_NAME, force=True, ignore_missing=True)
@@ -672,7 +795,7 @@ class TestPrintFormatChildTableVisibility(IntegrationTestCase):
 			"header": {"columns": []},
 			"footer": {"columns": []},
 		}
-		frappe.get_doc(
+		doc = frappe.get_doc(
 			{
 				"doctype": "Print Format",
 				"name": self.FORMAT_NAME,
@@ -681,7 +804,10 @@ class TestPrintFormatChildTableVisibility(IntegrationTestCase):
 				"print_format_builder_beta": 1,
 				"format_data": frappe.as_json(format_data),
 			}
-		).insert()
+		)
+		if skip_validation:
+			doc.flags.ignore_validate = True
+		doc.insert()
 		self.addCleanup(frappe.delete_doc, "Print Format", self.FORMAT_NAME, force=True)
 		return get_html("Contact", self.contact.name, self.FORMAT_NAME)
 
@@ -705,7 +831,7 @@ class TestPrintFormatChildTableVisibility(IntegrationTestCase):
 		self.assertNotIn("secondary@example.com", html)
 
 	def test_bad_row_condition_keeps_all_rows(self):
-		html = self.render(self.table_field(row_condition="row.does_not_exist >"))
+		html = self.render(self.table_field(row_condition="row.does_not_exist >"), skip_validation=True)
 		self.assertIn("primary@example.com", html)
 		self.assertIn("secondary@example.com", html)
 
@@ -745,7 +871,7 @@ class TestPrintFormatChildTableVisibility(IntegrationTestCase):
 	def test_bad_column_condition_keeps_column(self):
 		df = self.table_field()
 		df["table_columns"][1]["column_condition"] = "doc.does_not_exist >"
-		html = self.render(df)
+		html = self.render(df, skip_validation=True)
 		self.assertIn('data-fieldname="is_primary"', html)
 		self.assertIn('data-fieldname="email_id"', html)
 

--- a/frappe/templates/print_format/macros/AttachImage.html
+++ b/frappe/templates/print_format/macros/AttachImage.html
@@ -2,6 +2,6 @@
 
 {%- block value -%}
 <div class="value">
-    <img class="w-100" src="{{ value }}" alt="{{ _(df.label) }}">
+    <img class="w-100" src="{{ value }}" alt="{{ _(df.label)|e }}">
 </div>
 {%- endblock -%}

--- a/frappe/templates/print_format/macros/Data.html
+++ b/frappe/templates/print_format/macros/Data.html
@@ -10,7 +10,7 @@
 <div class="field {{ _orientation }}{% if _inline and _orientation != 'left-right' %} field-inline{% endif %}{% if _align %} field-align-{{ _align }}{% endif %}{% if _justify and _orientation == 'left-right' and _align not in ('center', 'right') %} field-justify-{{ _justify }}{% endif %}" {% if _fstyle %}style="{{ _fstyle|e }}"{% endif %} {{ field_attributes(df) }}>
 	{%- block label -%}
 	{%- if _show_label != 'hide' -%}
-	<div class="label"{% if _lbl_style %} style="{{ _lbl_style|e }}"{% endif %}>{{ _(df.label) }}</div>
+	<div class="label"{% if _lbl_style %} style="{{ _lbl_style|e }}"{% endif %}>{{ _(df.label)|e }}</div>
 	{%- endif -%}
 	{%- endblock -%}
 	{%- block value -%}

--- a/frappe/templates/print_format/macros/Image.html
+++ b/frappe/templates/print_format/macros/Image.html
@@ -1,6 +1,6 @@
 {%- set src = df.image_url or value -%}
 {%- if src -%}
 <div class="field print-image{% if df.align %} field-align-{{ df.align }}{% endif %}"{% if df.custom_style %} style="{{ df.custom_style|e }}"{% endif %} {{ field_attributes(df) }}>
-	<img src="{{ src }}" alt="{{ _(df.label) if df.label else '' }}" style="max-width: 100%;{% if df.width %} width: {{ df.width|e }};{% endif %}">
+	<img src="{{ src }}" alt="{{ (_(df.label) if df.label else '')|e }}" style="max-width: 100%;{% if df.width %} width: {{ df.width|e }};{% endif %}">
 </div>
 {%- endif -%}

--- a/frappe/templates/print_format/macros/Repeater.html
+++ b/frappe/templates/print_format/macros/Repeater.html
@@ -1,7 +1,7 @@
 {%- set _show_label = df.show_label if df.show_label else 'show' -%}
 {% if df.source and doc.get(df.source) %}
 <div class="pfb-repeater"{% if df.custom_style %} style="{{ df.custom_style|e }}"{% endif %} {{ field_attributes(df) }}>
-	{% if df.label and _show_label != 'hide' %}<div class="label">{{ _(df.label) }}</div>{% endif %}
+	{% if df.label and _show_label != 'hide' %}<div class="label">{{ _(df.label)|e }}</div>{% endif %}
 	<table class="pfb-repeater-table">
 		<colgroup>
 			{% for col in (df.repeater_columns or []) %}

--- a/frappe/templates/print_format/macros/Signature.html
+++ b/frappe/templates/print_format/macros/Signature.html
@@ -2,6 +2,6 @@
 
 {%- block value -%}
 <div class="value">
-    <img src="{{ value }}" alt="{{ _(df.label) }}">
+    <img src="{{ value }}" alt="{{ _(df.label)|e }}">
 </div>
 {%- endblock -%}

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -14,7 +14,7 @@
 	{%- set _show_label = df.show_label if df.show_label else 'show' -%}
 	{% if df.label and _show_label != 'hide' %}
 	<div class="label">
-		{{ _(df.label) }}
+		{{ _(df.label)|e }}
 	</div>
 	{% endif %}
 	<table class="table"{% if _frame_style %} style="{{ _frame_style|e }}"{% endif %}>
@@ -25,7 +25,7 @@
 				{% for column in columns %}
 				{%- set _merged_col = column.merged_fields and column.merged_fields|length > 0 -%}
 				<th class="column-header{% if _merged_col %} column-value--merged{% endif %}" width="{{ column.width }}%"{% if _cell_style %} style="{{ _cell_style|e }}"{% endif %} {{ field_attributes(column) }}>
-					{{ _(column.label or column.fieldname) }}
+					{{ _(column.label or column.fieldname)|e }}
 				</th>
 				{% endfor %}
 			</tr>

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -109,7 +109,7 @@
 	{%- endif -%}
 	<div class="section {{ resolve_class({'page-break': section.page_break, 'keep-together': section.keep_together}) }}{{ ' section--grid' if section.field_borders else '' }}{{ ' section--grid-' + section.grid_borders if section.field_borders and section.grid_borders else '' }}"{% if ns3.section_style %} style="{{ ns3.section_style|e }}"{% endif %}>
 		{% if section.label and section.show_label != 'hide' %}
-		<div class="section-label">{{ _(section.label) }}</div>
+		<div class="section-label">{{ _(section.label)|e }}</div>
 		{% endif %}
 
 		{#- Detect right-aligned columns to pick the right row layout class -#}

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See LICENSE
 
+import copy
 from typing import ClassVar
 
 import frappe
@@ -251,6 +252,7 @@ class PrintFormatGenerator:
 		self.style = style
 		self.settings_override = settings or {}
 		self._header_absorbs_top_margin = False
+		self._logged_conditions = set()
 
 		if letterhead == _("No Letterhead"):
 			letterhead = None
@@ -535,13 +537,19 @@ class PrintFormatGenerator:
 			"</div>"
 		)
 
+	EMPTY_LAYOUT: ClassVar[dict] = {
+		"sections": [],
+		"header": {"columns": []},
+		"footer": {"columns": []},
+	}
+
 	def get_layout(self, print_format):
-		layout = frappe.parse_json(print_format.format_data) or {
-			"sections": [],
-			"header": {"columns": []},
-			"footer": {"columns": []},
-		}
-		if isinstance(layout, list):
+		try:
+			layout = frappe.parse_json(print_format.format_data) or copy.deepcopy(self.EMPTY_LAYOUT)
+		except Exception:
+			frappe.log_error(title=f"Unreadable print format layout: {print_format.name}")
+			layout = copy.deepcopy(self.EMPTY_LAYOUT)
+		if isinstance(layout, list) and layout:
 			from frappe.printing.doctype.print_format.classic_converter import convert_classic_to_beta
 
 			layout, _dropped = convert_classic_to_beta(
@@ -549,10 +557,42 @@ class PrintFormatGenerator:
 			)
 			if not print_format.page_number or print_format.page_number == "Hide":
 				print_format.page_number = "Bottom Center"
+		layout = self.normalise_layout(layout)
 		layout = self.apply_permlevel_access(layout)
 		layout = self.set_field_renderers(layout)
 		layout = self.prune_table_columns(layout)
 		layout = self.process_margin_texts(layout)
+		return layout
+
+	def normalise_layout(self, layout):
+		"""Drop anything the builder could not have produced, rather than crashing."""
+		if not isinstance(layout, dict):
+			return copy.deepcopy(self.EMPTY_LAYOUT)
+
+		def clean_zone(zone):
+			if not isinstance(zone, dict):
+				return {"columns": []}
+			columns = [
+				{**col, "fields": [clean_field(f) for f in col.get("fields") or [] if isinstance(f, dict)]}
+				for col in zone.get("columns") or []
+				if isinstance(col, dict)
+			]
+			return {**zone, "columns": columns}
+
+		def clean_field(df):
+			if "table_columns" not in df:
+				return df
+			table_columns = df["table_columns"]
+			if not isinstance(table_columns, list):
+				table_columns = []
+			return {**df, "table_columns": [c for c in table_columns if isinstance(c, dict)]}
+
+		sections = layout.get("sections")
+		layout["sections"] = (
+			[clean_zone(s) for s in sections if isinstance(s, dict)] if isinstance(sections, list) else []
+		)
+		for zone in ("header", "footer"):
+			layout[zone] = clean_zone(layout.get(zone))
 		return layout
 
 	def layout_columns(self, layout):
@@ -630,21 +670,36 @@ class PrintFormatGenerator:
 				df["table_columns"] = kept
 		return layout
 
-	def column_condition_met(self, col, eval_locals):
-		condition = col.get("column_condition")
-		if not condition:
+	def eval_condition(self, condition, eval_locals, where):
+		"""Evaluate a visibility condition. A broken expression keeps the thing
+		visible, logged once per expression so a row condition cannot write one log
+		row per child row."""
+		if not isinstance(condition, str):
 			return True
 		try:
 			return bool(frappe.safe_eval(condition, None, eval_locals))
 		except Exception:
+			if condition not in self._logged_conditions:
+				self._logged_conditions.add(condition)
+				frappe.log_error(
+					title=f"Print format condition failed: {self.print_format.name}",
+					message=f"{where}: {condition}",
+				)
 			return True
+
+	def column_condition_met(self, col, eval_locals):
+		condition = col.get("column_condition")
+		if not condition:
+			return True
+		return self.eval_condition(
+			condition, eval_locals, f"column {col.get('label') or col.get('fieldname')}"
+		)
 
 	def _prepare_field(self, df, section, eval_locals):
 		if df.get("visible_if"):
-			try:
-				df["_hidden"] = not frappe.safe_eval(df["visible_if"], eval_locals)
-			except Exception:
-				df["_hidden"] = False
+			df["_hidden"] = not self.eval_condition(
+				df["visible_if"], eval_locals, f"field {df.get('label') or df.get('fieldname')}"
+			)
 		fieldtype = df.get("fieldtype", "Data")
 		df["renderer"] = self._FIELD_RENDERERS.get(fieldtype) or fieldtype.replace(" ", "")
 		df["section"] = section
@@ -655,10 +710,9 @@ class PrintFormatGenerator:
 		eval_locals = {"doc": self.doc, "print_settings": self.print_settings}
 		for section in layout["sections"]:
 			if section.get("visible_if"):
-				try:
-					section["_hidden"] = not frappe.safe_eval(section["visible_if"], eval_locals)
-				except Exception:
-					section["_hidden"] = False
+				section["_hidden"] = not self.eval_condition(
+					section["visible_if"], eval_locals, f"section {section.get('label') or ''}"
+				)
 			for column in section["columns"]:
 				for df in column["fields"]:
 					self._prepare_field(df, section, eval_locals)
@@ -689,11 +743,7 @@ class PrintFormatGenerator:
 		eval_locals = {"doc": self.doc, "print_settings": self.print_settings}
 		kept = []
 		for row in self.doc.get(source) or []:
-			try:
-				keep = frappe.safe_eval(condition, None, {**eval_locals, "row": row})
-			except Exception:
-				keep = True
-			if keep:
+			if self.eval_condition(condition, {**eval_locals, "row": row}, f"rows of {source}"):
 				kept.append(row)
 		df["_rows"] = kept
 

--- a/frappe/utils/test_print_format_generator.py
+++ b/frappe/utils/test_print_format_generator.py
@@ -1401,7 +1401,7 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 		self.assertNotIn("print-repeating-frame", html)
 		self.assertIn("LETTERHEAD_TOP", html)
 
-	def _user_beta_format(self, layout):
+	def _user_beta_format(self, layout, skip_validation=False):
 		import json
 
 		pf = frappe.get_doc(
@@ -1414,7 +1414,10 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 				"standard": "No",
 				"format_data": json.dumps(layout),
 			}
-		).insert(ignore_permissions=True)
+		)
+		if skip_validation:
+			pf.flags.ignore_validate = True
+		pf.insert(ignore_permissions=True)
 		self.addCleanup(pf.delete, ignore_permissions=True)
 		return pf
 
@@ -1429,7 +1432,7 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 		n = len(user.roles)
 		self.assertGreaterEqual(n, 2)
 
-		def rows_for(condition):
+		def rows_for(condition, skip_validation=False):
 			df = {
 				"fieldtype": "Repeater",
 				"fieldname": "_rep",
@@ -1445,14 +1448,15 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 				"header": {"columns": [{"label": "", "fields": []}]},
 				"footer": {"columns": [{"label": "", "fields": []}]},
 			}
-			html = PrintFormatGenerator(self._user_beta_format(layout), user).get_html_preview()
+			pf = self._user_beta_format(layout, skip_validation=skip_validation)
+			html = PrintFormatGenerator(pf, user).get_html_preview()
 			block = re.search(r"pfb-repeater-table.*?</table>", html, re.S)
 			return len(re.findall(r"<tr>", block.group(0))) if block else 0
 
 		self.assertEqual(rows_for(None), n)
 		self.assertEqual(rows_for("row.idx == 1"), 1)
 		self.assertEqual(rows_for("False"), 0)
-		self.assertEqual(rows_for("this is (( invalid"), n)
+		self.assertEqual(rows_for("this is (( invalid", skip_validation=True), n)
 		# print_settings is in scope alongside doc/row
 		with self.change_settings("Print Settings", pdf_page_size="A4"):
 			self.assertEqual(rows_for("print_settings.pdf_page_size == 'A4'"), n)


### PR DESCRIPTION
- Malformed layouts (truncated JSON, wrong types, non-dict fields or table columns) print empty instead of raising a 500
- Visibility conditions are checked when the format is saved; a condition that fails at render time still shows the field but is logged once
- Field, section and table column labels are escaped

Why: a typo in a condition used to silently resolve to "show", and no format on frappe.io relies on HTML in a label.

no-docs
