### PR TITLE
fix: support job ID and job name filters in RQ Job list- #41471

### DIFF
--- a/frappe/core/doctype/rq_job/rq_job.py
+++ b/frappe/core/doctype/rq_job/rq_job.py
@@ -12,6 +12,7 @@ from rq.queue import Queue
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.types import Filters
 from frappe.utils import (
 	cint,
 	compare,
@@ -88,7 +89,7 @@ class RQJob(Document):
 
 	@staticmethod
 	def get_matching_job_ids(filters) -> list[str]:
-		filters = filters or []
+		filters = Filters(filters or [], doctype="RQ Job")
 		filter_dict = make_filter_dict(filters)
 
 		queues = _eval_filters(filter_dict.get("queue"), QUEUES + get_custom_queues())
@@ -102,7 +103,7 @@ class RQJob(Document):
 				matched_job_ids.extend(fetch_job_ids(queue, status))
 
 		matched_job_ids = filter_current_site_jobs(matched_job_ids)
-		filters = [filter for filter in filters if filter[1] not in {"queue", "status"}]
+		filters = [filter for filter in filters if filter.fieldname not in {"queue", "status"}]
 		return filter_job_ids(matched_job_ids, filters)
 
 	@check_permissions
@@ -197,14 +198,14 @@ def filter_job_ids(job_ids: list[str], filters) -> list[str]:
 	if not filters:
 		return job_ids
 
-	identifier_filters = [filter for filter in filters if filter[1] in {"name", "job_id"}]
+	identifier_filters = [filter for filter in filters if filter.fieldname in {"name", "job_id"}]
 	if identifier_filters:
 		job_ids = [
 			job_id
 			for job_id in job_ids
-			if all(compare(job_id, filter[2], filter[3]) for filter in identifier_filters)
+			if all(compare(job_id, filter.operator, filter.value) for filter in identifier_filters)
 		]
-		filters = [filter for filter in filters if filter[1] not in {"name", "job_id"}]
+		filters = [filter for filter in filters if filter.fieldname not in {"name", "job_id"}]
 
 	if not filters:
 		return job_ids

--- a/frappe/core/doctype/rq_job/rq_job.py
+++ b/frappe/core/doctype/rq_job/rq_job.py
@@ -17,6 +17,7 @@ from frappe.utils import (
 	compare,
 	convert_utc_to_system_timezone,
 	create_batch,
+	evaluate_filters,
 	make_filter_dict,
 )
 from frappe.utils.background_jobs import get_queues, get_redis_conn
@@ -87,10 +88,11 @@ class RQJob(Document):
 
 	@staticmethod
 	def get_matching_job_ids(filters) -> list[str]:
-		filters = make_filter_dict(filters or [])
+		filters = filters or []
+		filter_dict = make_filter_dict(filters)
 
-		queues = _eval_filters(filters.get("queue"), QUEUES + get_custom_queues())
-		statuses = _eval_filters(filters.get("status"), JOB_STATUSES)
+		queues = _eval_filters(filter_dict.get("queue"), QUEUES + get_custom_queues())
+		statuses = _eval_filters(filter_dict.get("status"), JOB_STATUSES)
 
 		matched_job_ids = []
 		for queue in get_queues():
@@ -99,7 +101,9 @@ class RQJob(Document):
 			for status in statuses:
 				matched_job_ids.extend(fetch_job_ids(queue, status))
 
-		return filter_current_site_jobs(matched_job_ids)
+		matched_job_ids = filter_current_site_jobs(matched_job_ids)
+		filters = [filter for filter in filters if filter[1] not in {"queue", "status"}]
+		return filter_job_ids(matched_job_ids, filters)
 
 	@check_permissions
 	def delete(self):
@@ -187,6 +191,15 @@ def filter_current_site_jobs(job_ids: list[str]) -> list[str]:
 	site = frappe.local.site
 
 	return [j for j in job_ids if j.startswith(site)]
+
+
+def filter_job_ids(job_ids: list[str], filters) -> list[str]:
+	if not filters:
+		return job_ids
+
+	conn = get_redis_conn()
+	jobs = Job.fetch_many(job_ids=job_ids, connection=conn)
+	return [job.id for job in jobs if job and evaluate_filters(serialize_job(job), filters)]
 
 
 def _eval_filters(filter, values: list[str]) -> list[str]:

--- a/frappe/core/doctype/rq_job/rq_job.py
+++ b/frappe/core/doctype/rq_job/rq_job.py
@@ -197,6 +197,18 @@ def filter_job_ids(job_ids: list[str], filters) -> list[str]:
 	if not filters:
 		return job_ids
 
+	identifier_filters = [filter for filter in filters if filter[1] in {"name", "job_id"}]
+	if identifier_filters:
+		job_ids = [
+			job_id
+			for job_id in job_ids
+			if all(compare(job_id, filter[2], filter[3]) for filter in identifier_filters)
+		]
+		filters = [filter for filter in filters if filter[1] not in {"name", "job_id"}]
+
+	if not filters:
+		return job_ids
+
 	conn = get_redis_conn()
 	jobs = Job.fetch_many(job_ids=job_ids, connection=conn)
 	return [job.id for job in jobs if job and evaluate_filters(serialize_job(job), filters)]

--- a/frappe/core/doctype/rq_job/test_rq_job.py
+++ b/frappe/core/doctype/rq_job/test_rq_job.py
@@ -77,8 +77,19 @@ class TestRQJob(IntegrationTestCase):
 			frappe.get_all("RQ Job", filters={"job_name": "__missing_job_name__"}),
 			[],
 		)
+
+		for filters in ({"job_id": job.id}, [["job_id", "=", job.id]]):
+			jobs = RQJob.get_list(filters=filters, page_length=1)
+			self.assertEqual([result.name for result in jobs], [job.id])
+
 		with patch.object(Job, "fetch_many", side_effect=AssertionError("exact ID filter fetched jobs")):
-			self.assertEqual(RQJob.get_count(filters=[["RQ Job", "job_id", "=", job.id]]), 1)
+			for filters in (
+				{"job_id": job.id},
+				[["job_id", job.id]],
+				[["job_id", "=", job.id]],
+				[["RQ Job", "job_id", "=", job.id]],
+			):
+				self.assertEqual(RQJob.get_count(filters=filters), 1)
 
 	def test_configurable_ttl(self):
 		frappe.conf.rq_job_failure_ttl = 600

--- a/frappe/core/doctype/rq_job/test_rq_job.py
+++ b/frappe/core/doctype/rq_job/test_rq_job.py
@@ -53,6 +53,31 @@ class TestRQJob(IntegrationTestCase):
 		)
 		self.check_status(job, "finished")
 
+	def test_get_list_filtering_by_job_fields(self):
+		job = frappe.enqueue(method=self.BG_JOB, queue="short")
+		self.check_status(job, "finished")
+
+		for fieldname in ("name", "job_id"):
+			jobs = frappe.get_all(
+				"RQ Job",
+				filters={fieldname: job.id},
+				page_length=1,
+			)
+			self.assertEqual([result.name for result in jobs], [job.id])
+
+		jobs = frappe.get_all(
+			"RQ Job",
+			filters={"job_name": ("like", "%test_rq_job.test_func")},
+		)
+		self.assertTrue(jobs)
+		self.assertTrue(all(result.job_name == self.BG_JOB for result in jobs))
+
+		self.assertEqual(
+			frappe.get_all("RQ Job", filters={"job_name": "__missing_job_name__"}),
+			[],
+		)
+		self.assertEqual(RQJob.get_count(filters=[["RQ Job", "job_id", "=", job.id]]), 1)
+
 	def test_configurable_ttl(self):
 		frappe.conf.rq_job_failure_ttl = 600
 		job = frappe.enqueue(method=self.BG_JOB, queue="short")

--- a/frappe/core/doctype/rq_job/test_rq_job.py
+++ b/frappe/core/doctype/rq_job/test_rq_job.py
@@ -3,6 +3,7 @@
 # See license.txt
 
 import time
+from unittest.mock import patch
 
 from rq import exceptions as rq_exc
 from rq.job import Job
@@ -76,7 +77,8 @@ class TestRQJob(IntegrationTestCase):
 			frappe.get_all("RQ Job", filters={"job_name": "__missing_job_name__"}),
 			[],
 		)
-		self.assertEqual(RQJob.get_count(filters=[["RQ Job", "job_id", "=", job.id]]), 1)
+		with patch.object(Job, "fetch_many", side_effect=AssertionError("exact ID filter fetched jobs")):
+			self.assertEqual(RQJob.get_count(filters=[["RQ Job", "job_id", "=", job.id]]), 1)
 
 	def test_configurable_ttl(self):
 		frappe.conf.rq_job_failure_ttl = 600


### PR DESCRIPTION

  PR description:

  ## Problem

  The RQ Job virtual DocType only applied filters for `queue` and `status`. Other list-view filters, including Job ID
  (`name`/`job_id`) and Job Name (`job_name`), were silently ignored.

  ## Solution

  This change preserves the existing queue and status pre-filtering, then applies the remaining standard Frappe filters
  to serialized RQ Job data before pagination.

  It adds support for filtering by:

  - ID (`name`)
  - Job ID (`job_id`)
  - Job Name (`job_name`)
  - Standard filter operators such as `like`

  ## Tests

  Added regression tests covering:

  - Filtering by `name`
  - Filtering by `job_id`
  - Filtering `job_name` with `like`
  - No results for a missing job name