### PR TITLE
fix: use typed fallback literals for 'is set' filters on postgres temporal fields

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -1114,14 +1114,33 @@ from {tables}
 				fallback = f"'{FallBackDateTimeStr}'"
 
 			elif f.operator.lower() == "is":
-				fallback = "''"
-				if f.value == "set":
-					f.operator = "!="
-					can_be_null = False
-				elif f.value == "not set":
-					f.operator = "="
-					can_be_null = not getattr(df, "not_nullable", False)
-				f.value = value = ""
+				if frappe.conf.db_type == "postgres" and df and df.fieldtype in ("Date", "Datetime", "Time"):
+					if df.fieldtype == "Date":
+						fallback = "'0001-01-01'"
+					elif df.fieldtype == "Time":
+						fallback = "'00:00:00'"
+					else:
+						fallback = f"'{FallBackDateTimeStr}'"
+
+					if f.value == "set":
+						f.operator = "!="
+						can_be_null = False
+					elif f.value == "not set":
+						f.operator = "="
+						can_be_null = not getattr(df, "not_nullable", False)
+
+					f.value = ""
+					value = fallback
+					escape = False
+				else:
+					fallback = "''"
+					if f.value == "set":
+						f.operator = "!="
+						can_be_null = False
+					elif f.value == "not set":
+						f.operator = "="
+						can_be_null = not getattr(df, "not_nullable", False)
+					f.value = value = ""
 
 			elif df and df.fieldtype == "Date":
 				value = frappe.db.format_date(f.value)

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -1111,6 +1111,40 @@ class TestDBQuery(IntegrationTestCase):
 		res = DatabaseQuery("DocType").execute(filters={"autoname": ["is", "set"]})
 		self.assertFalse({"name": "Property Setter"} in res)
 
+	def test_is_set_filter_for_datetime_field(self):
+		"""`is set`/`is not set` filters must work for temporal fields on PostgreSQL too."""
+		from frappe.utils import add_to_date, now_datetime
+
+		frappe.db.delete("Event", {"subject": ("like", "Is Set Filter Test%")})
+
+		starts_on = now_datetime()
+		with_ends_on = frappe.get_doc(
+			{
+				"doctype": "Event",
+				"subject": "Is Set Filter Test - with ends_on",
+				"event_type": "Public",
+				"starts_on": starts_on,
+				"ends_on": add_to_date(starts_on, hours=1),
+			}
+		).insert(ignore_permissions=True)
+
+		without_ends_on = frappe.get_doc(
+			{
+				"doctype": "Event",
+				"subject": "Is Set Filter Test - without ends_on",
+				"event_type": "Public",
+				"starts_on": starts_on,
+			}
+		).insert(ignore_permissions=True)
+
+		def event_names(filters):
+			return {d["name"] for d in DatabaseQuery("Event").execute(filters=filters, fields=["name"])}
+
+		self.assertIn(with_ends_on.name, event_names({"ends_on": ["is", "set"]}))
+		self.assertNotIn(without_ends_on.name, event_names({"ends_on": ["is", "set"]}))
+		self.assertIn(without_ends_on.name, event_names({"ends_on": ["is", "not set"]}))
+		self.assertNotIn(with_ends_on.name, event_names({"ends_on": ["is", "not set"]}))
+
 	def test_set_field_tables(self):
 		# Tests _in_standard_sql_methods method in test_set_field_tables
 		# The following query will break if the above method is broken


### PR DESCRIPTION
Closes #41074

### Problem
`is set` / `is not set` filters are built in `frappe/model/db_query.py` as `!= ''` / `= ''`. On PostgreSQL an empty string is an invalid literal for `Date`, `Datetime` and `Time` columns, so any filtered query fails with:

```
psycopg2.errors.InvalidDatetimeFormat: invalid input syntax for type timestamp: ""
LINE 3: where "tabEvent"."ends_on" != '' and ...
```

### Fix
For those three field types on PostgreSQL, the condition now uses the same typed fallback literals already used by the `between` operator (`'0001-01-01'`, `'00:00:00'`, `FallBackDateTimeStr`) with `escape = False`. MariaDB output is unchanged.

### Test
Added `test_is_set_filter_for_datetime_field` in `frappe/tests/test_db_query.py`. Verified locally against real MariaDB and PostgreSQL 18: passes with the fix, and reproduces the `InvalidDatetimeFormat` error when the fix is reverted.