### PR TITLE
fix(print): restore page margins on converted formats

### DIFF
--- a/frappe/patches/v16_0/repair_converted_print_formats.py
+++ b/frappe/patches/v16_0/repair_converted_print_formats.py
@@ -4,28 +4,24 @@ import frappe
 from frappe.printing.doctype.print_format.classic_converter import (
 	CONVERTED_SECTION_GAP_PX,
 	DEFAULT_COLUMN_WIDTH_PCT,
+	NUMERIC_DEFAULT_FIELDS,
+	missing_numeric_defaults,
 )
 
 
 def execute():
-	"""Repair formats converted by migrate_classic_print_formats before the
-	converter fixes: font_size landed as 0 (invisible render), the serial column as
-	5.33% (too narrow) and sections with no spacing between them. Touches only those
-	defects so builder edits made since the conversion survive.
-
-	Re-runnable: patches.txt carries a dated entry so sites that already ran an
-	earlier version of this patch pick up the later fixes."""
+	"""Repair formats converted before the converter fixes: numeric fields left at 0,
+	narrow serial columns, sections with no spacing. Nothing else is touched."""
 	names = frappe.get_all(
 		"Print Format",
 		filters={"print_format_builder_beta": 1, "classic_format_data": ("is", "set")},
 		pluck="name",
 	)
+	fields = ["format_data", *NUMERIC_DEFAULT_FIELDS]
 	for name in names:
-		values = {}
-		font_size, format_data = frappe.db.get_value("Print Format", name, ["font_size", "format_data"])
-		if not font_size:
-			values["font_size"] = 14
-		repaired = repair_layout(format_data)
+		row = frappe.db.get_value("Print Format", name, fields, as_dict=True)
+		values = missing_numeric_defaults(row)
+		repaired = repair_layout(row.format_data)
 		if repaired:
 			values["format_data"] = repaired
 		if values:

--- a/frappe/printing/doctype/print_format/classic_converter.py
+++ b/frappe/printing/doctype/print_format/classic_converter.py
@@ -4,13 +4,15 @@
 import json
 
 import frappe
-from frappe.utils import cint
+from frappe.utils import cint, flt
 
 ASSUMED_BODY_WIDTH_PX = 750
 DEFAULT_COLUMN_WIDTH_PCT = 10
 # classic wrapped text and table blocks in `padding: 10px 0px`; the beta renderer
 # has no such default, so converted sections carry the gap explicitly
 CONVERTED_SECTION_GAP_PX = 10
+MARGIN_FIELDS = ("margin_top", "margin_bottom", "margin_left", "margin_right")
+NUMERIC_DEFAULT_FIELDS = ("font_size", *MARGIN_FIELDS)
 
 DEFAULT_PRINT_HEADING = (
 	'{%- set heading = doc.get("select_print_heading") or doc.get("print_heading") or doc.doctype -%}'
@@ -233,6 +235,15 @@ def distribute_widths(columns) -> list:
 	return columns
 
 
+def missing_numeric_defaults(values) -> dict:
+	"""DocType defaults for numeric fields left unset. Margins only when all four are."""
+	meta = frappe.get_meta("Print Format")
+	fields = list(NUMERIC_DEFAULT_FIELDS)
+	if any(values.get(f) for f in MARGIN_FIELDS):
+		fields = [f for f in fields if f not in MARGIN_FIELDS]
+	return {f: flt(meta.get_field(f).default) for f in fields if not values.get(f)}
+
+
 def convert_print_format(doc):
 	"""Convert a classic Print Format document to beta in place (does not save).
 
@@ -255,8 +266,8 @@ def convert_print_format(doc):
 	doc.format_data = json.dumps(layout, indent=1)
 	doc.print_format_builder = 0
 	doc.print_format_builder_beta = 1
-	if not doc.font_size:
-		doc.font_size = 14
+	for fieldname, value in missing_numeric_defaults(doc).items():
+		doc.set(fieldname, value)
 	doc.pdf_generator = "chrome"
 	if not doc.page_number or doc.page_number == "Hide":
 		doc.page_number = "Bottom Center"
@@ -400,7 +411,7 @@ def migrate_all_classic_formats():
 						"print_format_builder_beta": 1,
 						"pdf_generator": doc.pdf_generator,
 						"page_number": doc.page_number,
-						"font_size": doc.font_size,
+						**{f: doc.get(f) for f in NUMERIC_DEFAULT_FIELDS},
 					},
 					update_modified=False,
 				)

--- a/frappe/printing/doctype/print_format/test_print_format.py
+++ b/frappe/printing/doctype/print_format/test_print_format.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 import frappe
 from frappe.tests import IntegrationTestCase
+from frappe.utils import flt
 
 if TYPE_CHECKING:
 	from frappe.printing.doctype.print_format.print_format import PrintFormat
@@ -534,6 +535,29 @@ class TestClassicConverter(IntegrationTestCase):
 
 		# re-running changes nothing
 		self.assertFalse(add_section_spacing(untouched))
+
+	def test_conversion_fills_numeric_fields_left_empty(self):
+		from frappe.printing.doctype.print_format.classic_converter import (
+			NUMERIC_DEFAULT_FIELDS,
+			convert_print_format,
+		)
+
+		doc = self.make_classic_format()
+		for fieldname in NUMERIC_DEFAULT_FIELDS:
+			doc.set(fieldname, 0)
+		convert_print_format(doc)
+
+		meta = frappe.get_meta("Print Format")
+		for fieldname in NUMERIC_DEFAULT_FIELDS:
+			with self.subTest(fieldname=fieldname):
+				self.assertEqual(doc.get(fieldname), flt(meta.get_field(fieldname).default))
+
+		doc.margin_left = 3
+		for fieldname in ("margin_top", "margin_bottom", "margin_right"):
+			doc.set(fieldname, 0)
+		convert_print_format(doc)
+		self.assertEqual(doc.margin_left, 3)
+		self.assertEqual(doc.margin_right, 0)
 
 	def test_repair_converted_print_formats(self):
 		from frappe.patches.v16_0.repair_converted_print_formats import execute


### PR DESCRIPTION
- Fill `font_size` and the four `margin_*` fields from the DocType defaults when a converted format left them empty
- Repair patch does the same for formats converted earlier

Why: fixtures ship these empty, a Float stores that as 0, and the beta stylesheet writes it straight into `@page` — 0mm margins run the content into the paper edge. 7 formats on frappe.io.

no-docs
