### PR TITLE
fix: show user permission denial reason instead of generic message

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -673,14 +673,18 @@ class Document(BaseDocument):
 		self.raise_no_permission_to(perm_type)
 
 	def raise_no_permission_to(self, perm_type):
-		"""Raise `frappe.PermissionError`."""
-		frappe.flags.error_message = _(
-			"You need the '{0}' permission on {1} {2} to perform this action."
-		).format(
-			_(perm_type),
-			frappe.bold(_(self.doctype)),
-			self.name or "",
-		)
+		"""Raise `frappe.PermissionError` with the specific denial reason when known."""
+		reasons = frappe.flags.pop("permission_denial_reasons", None)
+		if reasons:
+			frappe.flags.error_message = ("<br>").join(reasons)
+		else:
+			frappe.flags.error_message = _(
+				"You need the '{0}' permission on {1} {2} to perform this action."
+			).format(
+				_(perm_type),
+				frappe.bold(_(self.doctype)),
+				self.name or "",
+			)
 		raise frappe.PermissionError
 
 	def insert(

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -677,6 +677,11 @@ class Document(BaseDocument):
 		reasons = frappe.flags.pop("permission_denial_reasons", None)
 		if reasons:
 			frappe.flags.error_message = ("<br>").join(reasons)
+			# has_permission already pushed the same reasons via msgprint;
+			# drop that copy so the client shows the message only once
+			frappe.local.message_log = [
+				m for m in frappe.local.message_log if m.get("message") != frappe.flags.error_message
+			]
 		else:
 			frappe.flags.error_message = _(
 				"You need the '{0}' permission on {1} {2} to perform this action."

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -649,14 +649,15 @@ class Document(BaseDocument):
 
 	def check_permission(self, permtype="read", permlevel=None):
 		"""Raise `frappe.PermissionError` if not permitted"""
-		if not self.has_permission(permtype):
+		if not self.has_permission(permtype, throw=True):
 			self._handle_permission_failure(permtype)
 
-	def has_permission(self, permtype="read", *, debug=False, user=None) -> bool:
+	def has_permission(self, permtype="read", *, debug=False, user=None, throw=False) -> bool:
 		"""
 		Call `frappe.permissions.has_permission` if `ignore_permissions` flag isn't truthy
 
 		:param permtype: `read`, `write`, `submit`, `cancel`, `delete`, etc.
+		:param throw: Raise `frappe.PermissionError` with the denial reason instead of returning False.
 		"""
 
 		if self.flags.ignore_permissions:
@@ -664,7 +665,9 @@ class Document(BaseDocument):
 
 		import frappe.permissions
 
-		return frappe.permissions.has_permission(self.doctype, permtype, self, debug=debug, user=user)
+		return frappe.permissions.has_permission(
+			self.doctype, permtype, self, debug=debug, user=user, throw=throw
+		)
 
 	def _handle_permission_failure(self, perm_type):
 		from frappe.permissions import check_doctype_permission
@@ -673,23 +676,14 @@ class Document(BaseDocument):
 		self.raise_no_permission_to(perm_type)
 
 	def raise_no_permission_to(self, perm_type):
-		"""Raise `frappe.PermissionError` with the specific denial reason when known."""
-		reasons = frappe.flags.pop("permission_denial_reasons", None)
-		if reasons:
-			frappe.flags.error_message = ("<br>").join(reasons)
-			# has_permission already pushed the same reasons via msgprint;
-			# drop that copy so the client shows the message only once
-			frappe.local.message_log = [
-				m for m in frappe.local.message_log if m.get("message") != frappe.flags.error_message
-			]
-		else:
-			frappe.flags.error_message = _(
-				"You need the '{0}' permission on {1} {2} to perform this action."
-			).format(
-				_(perm_type),
-				frappe.bold(_(self.doctype)),
-				self.name or "",
-			)
+		"""Raise `frappe.PermissionError`."""
+		frappe.flags.error_message = _(
+			"You need the '{0}' permission on {1} {2} to perform this action."
+		).format(
+			_(perm_type),
+			frappe.bold(_(self.doctype)),
+			self.name or "",
+		)
 		raise frappe.PermissionError
 
 	def insert(

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -46,17 +46,24 @@ def print_has_permission_check_logs(func):
 		print_logs = kwargs.get("print_logs", True)
 		self_perm_check = True if not kwargs.get("user") else kwargs.get("user") == frappe.session.user
 
-		if print_logs:
+		# nested has_permission calls must not reset or pop the outermost call's logs
+		owns_log_collection = print_logs and frappe.flags.get("has_permission_check_logs") is None
+		if owns_log_collection:
 			frappe.flags["has_permission_check_logs"] = []
 
 		result = func(*args, **kwargs)
 
 		# print only if access denied
 		# and if user is checking their own permission
-		if not result and self_perm_check and print_logs:
-			msgprint(("<br>").join(frappe.flags.get("has_permission_check_logs", [])))
+		if not result and self_perm_check and owns_log_collection:
+			logs = frappe.flags.get("has_permission_check_logs", [])
+			if logs:
+				# keep the specific denial reasons so callers raising
+				# PermissionError can show them instead of a generic message
+				frappe.flags.permission_denial_reasons = list(logs)
+			msgprint(("<br>").join(logs))
 
-		if print_logs:
+		if owns_log_collection:
 			frappe.flags.pop("has_permission_check_logs", None)
 		return result
 

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -56,12 +56,11 @@ def print_has_permission_check_logs(func):
 		# print only if access denied
 		# and if user is checking their own permission
 		if not result and self_perm_check and owns_log_collection:
-			logs = frappe.flags.get("has_permission_check_logs", [])
-			if logs:
-				# keep the specific denial reasons so callers raising
-				# PermissionError can show them instead of a generic message
-				frappe.flags.permission_denial_reasons = list(logs)
-			msgprint(("<br>").join(logs))
+			message = ("<br>").join(frappe.flags.get("has_permission_check_logs", []))
+			if kwargs.get("throw") and message:
+				frappe.flags.pop("has_permission_check_logs", None)
+				frappe.throw(message, frappe.PermissionError, title=_("Not permitted"))
+			msgprint(message)
 
 		if owns_log_collection:
 			frappe.flags.pop("has_permission_check_logs", None)
@@ -94,6 +93,7 @@ def has_permission(
 	print_logs=True,
 	debug=False,
 	ignore_share_permissions=False,
+	throw=False,
 ) -> bool:
 	"""Return True if user has permission `ptype` for given `doctype`.
 	If `doc` is passed, also check user, share and owner permissions.
@@ -106,6 +106,8 @@ def has_permission(
 	                which explains why the permission check failed.
 	:param parent_doctype:
 	        Required when checking permission for a child DocType (unless doc is specified)
+	:param throw: If True, raise `frappe.PermissionError` on denial with the
+	        specific denial reason instead of returning False.
 	"""
 
 	if not user:
@@ -452,7 +454,7 @@ def has_user_permission(doc, user=None, debug=False, *, ptype=None, strict=True)
 					msg = _(
 						"You are not allowed to access this {0} record because it is linked to {1} '{2}' in row {3}, field {4}"
 					).format(
-						_(meta.name),
+						_(doctype),
 						_(field.options),
 						d.get(field.fieldname) or _("empty"),
 						d.idx,

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -116,6 +116,17 @@ class TestPermissions(IntegrationTestCase):
 		self.assertTrue(post1.has_permission("read"))
 		self.assertTrue(get_doc_permissions(post1).get("read"))
 
+	def test_permission_error_shows_user_permission_reason(self):
+		"""check_permission must surface the link-field denial reason, not the generic message."""
+		add_user_permission("Test Blog Category", "_Test Blog Category 1", "test2@example.com")
+
+		frappe.set_user("test2@example.com")
+
+		post = frappe.get_doc("Test Blog Post", "_Test Blog Post")
+		self.assertRaises(frappe.PermissionError, post.check_permission, "read")
+		self.assertIn("because it is linked to", frappe.flags.error_message)
+		self.assertNotIn("You need the", frappe.flags.error_message)
+
 	def test_user_permissions_in_report(self):
 		add_user_permission("Test Blog Category", "_Test Blog Category 1", "test2@example.com")
 

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -127,6 +127,11 @@ class TestPermissions(IntegrationTestCase):
 		self.assertIn("because it is linked to", frappe.flags.error_message)
 		self.assertNotIn("You need the", frappe.flags.error_message)
 
+		# reason must not additionally appear as a server message (double dialog)
+		self.assertNotIn(
+			frappe.flags.error_message, [m.get("message") for m in frappe.local.message_log]
+		)
+
 	def test_user_permissions_in_report(self):
 		add_user_permission("Test Blog Category", "_Test Blog Category 1", "test2@example.com")
 

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -123,14 +123,21 @@ class TestPermissions(IntegrationTestCase):
 		frappe.set_user("test2@example.com")
 
 		post = frappe.get_doc("Test Blog Post", "_Test Blog Post")
-		self.assertRaises(frappe.PermissionError, post.check_permission, "read")
-		self.assertIn("because it is linked to", frappe.flags.error_message)
-		self.assertNotIn("You need the", frappe.flags.error_message)
-
-		# reason must not additionally appear as a server message (double dialog)
-		self.assertNotIn(
-			frappe.flags.error_message, [m.get("message") for m in frappe.local.message_log]
+		messages_before = len(frappe.local.message_log)
+		self.assertRaisesRegex(
+			frappe.PermissionError,
+			"Test Blog Post record because it is linked to",
+			post.check_permission,
+			"read",
 		)
+
+		# reason must reach the client exactly once
+		reasons = [
+			m.get("message")
+			for m in frappe.local.message_log[messages_before:]
+			if "because it is linked to" in m.get("message", "")
+		]
+		self.assertEqual(len(reasons), 1)
 
 	def test_user_permissions_in_report(self):
 		add_user_permission("Test Blog Category", "_Test Blog Category 1", "test2@example.com")


### PR DESCRIPTION
### Before

https://github.com/user-attachments/assets/de93960e-ddb5-480f-9cda-f66816b0356e

### After

https://github.com/user-attachments/assets/fd0769bb-2260-4925-831e-2ea967c7d04c



- make `print_has_permission_check_logs` reentrancy-safe: nested `has_permission` calls no longer reset/pop the outer call's collected logs, which silently discarded the specific denial reason
- `raise_no_permission_to` now shows the collected reason (e.g. "linked to Company 'X' in row 2, field Company") instead of the generic "You need the 'read' permission on ...", falling back to the generic message when no reason was collected
- add test asserting the denial reason surfaces through `check_permission`

Why: user-permission failures on link fields (including child table rows) showed a misleading message claiming the user lacks doctype-level read permission.