### PR TITLE
fix: more fixes in duckdb sync

### DIFF
--- a/frappe/core/doctype/duckdb_sync/duckdb_sync.py
+++ b/frappe/core/doctype/duckdb_sync/duckdb_sync.py
@@ -72,6 +72,21 @@ class DuckDBSync(Document):
 
 			delete_duckdb_file(self.filename)
 
+	@staticmethod
+	def clear_old_logs(days=45):
+		from frappe.query_builder import Interval
+		from frappe.query_builder.functions import Now
+
+		duckdb_sync = frappe.qb.DocType("DuckDB Sync")
+		to_delete = (
+			frappe.qb.from_(duckdb_sync)
+			.select(duckdb_sync.name)
+			.where(duckdb_sync.modified < (Now() - Interval(days=days)))
+		).run(as_dict=True, pluck="name")
+		for x in to_delete:
+			frappe.get_doc("DuckDB Sync", x).cancel()
+			frappe.delete_doc("DuckDB Sync", x)
+
 
 @frappe.whitelist()
 def is_data_sync_pending(docname: str):
@@ -92,21 +107,88 @@ def start_data_sync(docname: str):
 	)
 
 
-def cleanup_old_syncs():
-	cutoff = frappe.utils.add_days(frappe.utils.now_datetime(), -7)
-	old_syncs = frappe.get_all(
-		"DuckDB Sync",
-		filters={"creation": ["<", cutoff], "docstatus": 1},
-	)
-	for sync in old_syncs:
-		try:
-			doc = frappe.get_doc("DuckDB Sync", sync.name)
-			doc.cancel()
-			doc.delete()
-			frappe.db.commit()
-		except Exception:
-			frappe.log_error("DuckDB cleanup failed", frappe.get_traceback())
-			frappe.db.rollback()
+def sync_using_pyarrow(conn, dt, duck_tb):
+	conn.execute(f'delete from "{duck_tb.table_name}";').fetchall()
+
+	_dt = qb.DocType(dt)
+	columns = frappe.get_meta(dt).get_valid_columns()
+	query = qb.from_(_dt)
+	for col in columns:
+		query = query.select(_dt[col])
+	schema = duck_tb.get_arrow_schema()
+
+	with frappe.db.unbuffered_cursor():
+		iter = query.run(as_dict=True, as_iterator=True)
+		field_list = ", ".join(f'"{c}"' for c in schema.names)
+		time_columns = [
+			name for name, dtype in zip(schema.names, schema.types, strict=False) if pa.types.is_time(dtype)
+		]
+
+		def timedelta_to_time(td):
+			total_seconds = int(td.total_seconds()) % 86400
+			hours, remainder = divmod(total_seconds, 3600)
+			minutes, seconds = divmod(remainder, 60)
+			return time(hours, minutes, seconds, td.microseconds)
+
+		# an iterator to create RecordBatch from list
+		def recordbatch_from_list(iter, schema):
+			batch_size = 204800
+			rows = []
+			for row in iter:
+				for col in time_columns:
+					if isinstance(row.get(col), timedelta):
+						row[col] = timedelta_to_time(row[col])
+				rows.append(row)
+				if len(rows) >= batch_size:
+					batch = pa.RecordBatch.from_pylist(rows, schema=schema)
+					yield batch
+					rows = []
+					del batch
+
+			if rows:
+				batch = pa.RecordBatch.from_pylist(rows, schema=schema)
+				yield batch
+				rows = []
+				del batch
+
+		# streaming RecordBatch on demand
+		# sets backpressure on sql cursor through 'recordbatch_from_list' iterator
+		reader = pa.RecordBatchReader.from_batches(schema, recordbatch_from_list(iter, schema))
+
+		for batch in reader:
+			# zero-copy streaming: duckdb understands arrow table's memory layout
+			arrow_table = pa.Table.from_batches([batch])
+			conn.register("arrow_table", arrow_table)
+			conn.execute(
+				f'insert into "{duck_tb.table_name}" ({field_list}) select {field_list} from arrow_table;'
+			).fetchall()
+			conn.unregister("arrow_table")
+			del arrow_table
+
+
+def sync_using_extension(conn, dt, duck_tb):
+	try:
+		conn.execute(f'delete from "{duck_tb.table_name}";').fetchall()
+		conn.sql(
+			f"attach 'user={frappe.conf.db_name} password={frappe.conf.db_password} host={frappe.conf.db_host} database={frappe.conf.db_name} port={frappe.conf.db_port}' as mariadb_db (TYPE mysql);"
+		)
+		columns = frappe.get_meta(dt).get_valid_columns()
+		# quotted fields
+		columns_sql = ", ".join([f'"{x}"' for x in columns])
+		query = f'insert into "{duck_tb.table_name}" ({columns_sql}) select {columns_sql} from mariadb_db."{duck_tb.table_name}";'
+		conn.sql(query)
+	except Exception as e:
+		import re
+
+		sanitized = re.sub(
+			r"(user|password)=\S+",
+			lambda m: f"{m.group(1)}=***",
+			str(e),
+		)
+
+		raise Exception(sanitized) from None
+	finally:
+		conn.close()
 
 
 def sync_data_to_duckdb(docname: str):
@@ -125,68 +207,14 @@ def sync_data_to_duckdb(docname: str):
 		duck_tb = DuckDBTable(dt)
 
 		timeout = frappe.db.get_single_value("System Settings", "sync_timeout") or 25 * 60
+		sync_in_batch = frappe.db.get_single_value("System Settings", "sync_in_batch")
 		conn = frappe.get_doc("DuckDB Sync", docname).get_duckdb_conn()
+		if sync_in_batch:
+			sync_using_pyarrow(conn, dt, duck_tb)
+			conn.close()
+		else:
+			sync_using_extension(conn, dt, duck_tb)
 
-		conn.execute(f'delete from "{duck_tb.table_name}";').fetchall()
-
-		_dt = qb.DocType(dt)
-		columns = frappe.get_meta(dt).get_valid_columns()
-		query = qb.from_(_dt)
-		for col in columns:
-			query = query.select(_dt[col])
-		schema = duck_tb.get_arrow_schema()
-
-		with frappe.db.unbuffered_cursor():
-			iter = query.run(as_dict=True, as_iterator=True)
-			field_list = ", ".join(f'"{c}"' for c in schema.names)
-			time_columns = [
-				name
-				for name, dtype in zip(schema.names, schema.types, strict=False)
-				if pa.types.is_time(dtype)
-			]
-
-			def timedelta_to_time(td):
-				total_seconds = int(td.total_seconds()) % 86400
-				hours, remainder = divmod(total_seconds, 3600)
-				minutes, seconds = divmod(remainder, 60)
-				return time(hours, minutes, seconds, td.microseconds)
-
-			# an iterator to create RecordBatch from list
-			def recordbatch_from_list(iter, schema):
-				batch_size = 204800
-				rows = []
-				for row in iter:
-					for col in time_columns:
-						if isinstance(row.get(col), timedelta):
-							row[col] = timedelta_to_time(row[col])
-					rows.append(row)
-					if len(rows) >= batch_size:
-						batch = pa.RecordBatch.from_pylist(rows, schema=schema)
-						yield batch
-						rows = []
-						del batch
-
-				if rows:
-					batch = pa.RecordBatch.from_pylist(rows, schema=schema)
-					yield batch
-					rows = []
-					del batch
-
-			# streaming RecordBatch on demand
-			# sets backpressure on sql cursor through 'recordbatch_from_list' iterator
-			reader = pa.RecordBatchReader.from_batches(schema, recordbatch_from_list(iter, schema))
-
-			for batch in reader:
-				# zero-copy streaming: duckdb understands arrow table's memory layout
-				arrow_table = pa.Table.from_batches([batch])
-				conn.register("arrow_table", arrow_table)
-				conn.execute(
-					f'insert into "{duck_tb.table_name}" ({field_list}) select {field_list} from arrow_table;'
-				).fetchall()
-				conn.unregister("arrow_table")
-				del arrow_table
-
-		conn.close()
 		# update flag
 		frappe.db.set_value("DuckDB Sync Item", name, "synced", True)
 

--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -102,6 +102,7 @@
   "max_report_rows",
   "snapshot_reports_section",
   "enable_snapshot_reports",
+  "sync_in_batch",
   "frequency",
   "sync_timeout",
   "background_workers",
@@ -775,8 +776,7 @@
   {
    "fieldname": "snapshot_reports_section",
    "fieldtype": "Section Break",
-   "label": "Snapshot Reports",
-   "show_description_on_click": 1
+   "label": "Snapshot Reports"
   },
   {
    "default": "0",
@@ -784,12 +784,19 @@
    "fieldname": "enable_snapshot_reports",
    "fieldtype": "Check",
    "label": "Enable Snapshot Reports"
+  },
+  {
+   "default": "1",
+   "depends_on": "eval: doc.enable_snapshot_reports",
+   "fieldname": "sync_in_batch",
+   "fieldtype": "Check",
+   "label": "Sync In Batches"
   }
  ],
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2026-07-01 16:09:59.407976",
+ "modified": "2026-08-03 11:12:47.811078",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -102,6 +102,7 @@ class SystemSettings(Document):
 		show_absolute_datetime_in_timeline: DF.Check
 		store_attached_pdf_document: DF.Check
 		strip_exif_metadata_from_uploaded_images: DF.Check
+		sync_in_batch: DF.Check
 		sync_timeout: DF.Int
 		time_format: DF.Literal["HH:mm:ss", "HH:mm"]
 		time_zone: DF.Literal[None]

--- a/frappe/database/duckdb/schema.py
+++ b/frappe/database/duckdb/schema.py
@@ -188,7 +188,6 @@ class DuckDBTable(DBTable):
 				options=field.get("options"),
 				unique=field.get("unique"),
 				precision=field.get("precision"),
-				not_nullable=field.get("not_nullable"),
 			)
 		return columns
 

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -267,7 +267,6 @@ scheduler_events = {
 		"frappe.core.doctype.log_settings.log_settings.run_log_clean_up",
 		"frappe.social.doctype.energy_point_settings.energy_point_settings.allocate_review_points",
 		"frappe.core.doctype.user_invitation.user_invitation.mark_expired_invitations",
-		"frappe.core.doctype.duckdb_sync.duckdb_sync.cleanup_old_syncs",
 	],
 	"weekly_long": [
 		"frappe.integrations.doctype.dropbox_settings.dropbox_settings.take_backups_weekly",
@@ -576,6 +575,7 @@ default_log_clearing_doctypes = {
 	"Integration Request": 90,
 	"Activity Log": 90,
 	"Route History": 90,
+	"DuckDB Sync": 45,
 }
 
 # These keys will not be erased when doing frappe.clear_cache()


### PR DESCRIPTION
1. Fixed non-existent keyword based parameter error
2. Configurable sync type - single bulk sync using extensions or batched
3. Configurable cleanup