### PR TITLE
fix: restore notification indicator and unread count in v16

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -81,6 +81,9 @@ def get_bootinfo():
 	bootinfo.home_folder = frappe.db.get_value("File", {"is_home_folder": 1})
 	bootinfo.navbar_settings = get_navbar_settings()
 	bootinfo.notification_settings = get_notification_settings()
+	bootinfo.notification_unread_count = frappe.db.count(
+		"Notification Log", {"read": 0, "for_user": frappe.session.user}
+	)
 	bootinfo.onboarding_tours = get_onboarding_ui_tours()
 	set_time_zone(bootinfo)
 

--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -192,28 +192,27 @@ def get_notification_logs(limit: int = 20):
 
 @frappe.whitelist()
 def mark_all_as_read():
-	unread_docs_list = frappe.get_all(
-		"Notification Log", filters={"read": 0, "for_user": frappe.session.user}
+	frappe.db.set_value(
+		"Notification Log",
+		{"read": 0, "for_user": frappe.session.user},
+		"read",
+		1,
+		update_modified=False,
 	)
-	unread_docnames = [doc.name for doc in unread_docs_list]
-	if unread_docnames:
-		filters = {"name": ["in", unread_docnames]}
-		frappe.db.set_value("Notification Log", filters, "read", 1, update_modified=False)
 
 
 @frappe.whitelist()
 def mark_as_read(docname: str):
-	if frappe.flags.read_only:
+	if frappe.flags.read_only or not docname:
 		return
 
-	if docname:
-		frappe.db.set_value(
-			"Notification Log",
-			{"name": str(docname), "for_user": frappe.session.user},
-			"read",
-			1,
-			update_modified=False,
-		)
+	frappe.db.set_value(
+		"Notification Log",
+		{"name": str(docname), "for_user": frappe.session.user, "read": 0},
+		"read",
+		1,
+		update_modified=False,
+	)
 
 
 @frappe.whitelist()

--- a/frappe/desk/page/desktop/desktop.html
+++ b/frappe/desk/page/desktop/desktop.html
@@ -35,7 +35,7 @@
             </button>
             <div class="desktop-notifications">
                 <div class="dropdown dropdown-notifications">
-                    <button class="btn-reset nav-link text-muted" data-toggle="dropdown" >
+                    <button class="btn-reset nav-link text-muted desktop-notification-icon" data-toggle="dropdown" aria-label="{{ _("Notifications") }}" aria-haspopup="true">
                         <svg
                             class="icon icon-md"
                         >

--- a/frappe/public/js/frappe/ui/notifications/notifications.js
+++ b/frappe/public/js/frappe/ui/notifications/notifications.js
@@ -131,6 +131,7 @@ frappe.ui.Notifications = class Notifications {
 		e.stopImmediatePropagation();
 		this.dropdown_list.find(".unread").removeClass("unread");
 		frappe.call("frappe.desk.doctype.notification_log.notification_log.mark_all_as_read");
+		this.tabs.notifications?.update_count_badge(0);
 	}
 
 	setup_dropdown_events() {
@@ -225,7 +226,18 @@ class NotificationsView extends BaseNotificationsView {
 			.attr("title", __("Notifications"))
 			.tooltip({ delay: { show: 600, hide: 100 }, trigger: "hover" });
 
+		this.bell_indicator = this.parent.find(".desktop-notification-icon");
+		if (!this.bell_indicator.length) {
+			this.bell_indicator = this.parent
+				.closest(".body-sidebar")
+				?.find(".sidebar-notification .sidebar-item-icon");
+		}
+
 		this.setup_notification_listeners();
+
+		this.unread_count = frappe.boot.notification_unread_count || 0;
+		this.update_count_badge(this.unread_count);
+
 		this.get_notifications_list(this.max_length).then((r) => {
 			if (!r.message) return;
 			this.dropdown_items = r.message.notification_logs;
@@ -270,6 +282,7 @@ class NotificationsView extends BaseNotificationsView {
 			})
 			.then(() => {
 				$el.removeClass("unread");
+				this.update_count_badge(Math.max(this.unread_count - 1, 0));
 			});
 	}
 
@@ -385,8 +398,24 @@ class NotificationsView extends BaseNotificationsView {
 	}
 
 	toggle_notification_icon(seen) {
-		this.notifications_icon.find(".notifications-seen").toggle(seen);
-		this.notifications_icon.find(".notifications-unseen").toggle(!seen);
+		this.bell_indicator?.toggleClass("indicator blue", !seen);
+	}
+
+	update_count_badge(count) {
+		this.unread_count = count;
+		const $suffix = this.parent
+			.closest(".body-sidebar")
+			?.find(".sidebar-notification .sidebar-notification-count");
+		if (!$suffix?.length) return;
+
+		if (count > 0) {
+			$suffix
+				.text(count > 99 ? "99+" : count)
+				.attr("aria-label", __("{0} unread notifications", [count]))
+				.removeClass("hidden");
+		} else {
+			$suffix.removeAttr("aria-label").addClass("hidden");
+		}
 	}
 
 	toggle_seen(flag) {
@@ -401,17 +430,20 @@ class NotificationsView extends BaseNotificationsView {
 
 	setup_notification_listeners() {
 		frappe.realtime.on("notification", () => {
+			this.settings.seen = 0;
 			this.toggle_notification_icon(false);
+			this.update_count_badge(this.unread_count + 1);
 			this.update_dropdown();
 		});
 
 		frappe.realtime.on("indicator_hide", () => {
+			this.settings.seen = 1;
 			this.toggle_notification_icon(true);
 		});
 
 		this.parent.on("show.bs.dropdown", () => {
 			this.toggle_seen(true);
-			if (this.notifications_icon.find(".notifications-unseen").is(":visible")) {
+			if (this.bell_indicator?.hasClass("indicator")) {
 				this.toggle_notification_icon(true);
 				frappe.call(
 					"frappe.desk.doctype.notification_log.notification_log.trigger_indicator_hide"

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -522,8 +522,13 @@ frappe.ui.Sidebar = class Sidebar {
 			standard: true,
 			type: "Button",
 			class: "sidebar-notification hidden",
+			suffix: "<span class='sidebar-notification-count hidden' aria-live='polite'></span>",
 			onClick: () => {
-				this.wrapper.find(".dropdown-notifications").toggleClass("hidden");
+				const $dropdown = this.wrapper.find(".dropdown-notifications");
+				$dropdown.toggleClass("hidden");
+				if (!$dropdown.hasClass("hidden")) {
+					$dropdown.trigger("show.bs.dropdown");
+				}
 				if (frappe.is_mobile()) {
 					this.wrapper.removeClass("expanded");
 				}

--- a/frappe/public/scss/desk/notification.scss
+++ b/frappe/public/scss/desk/notification.scss
@@ -75,6 +75,17 @@
 	opacity: 0;
 }
 
+.sidebar-notification-count {
+	min-width: 20px;
+	padding: 1px 7px;
+	background-color: var(--bg-gray-100);
+	color: var(--text-muted);
+	font-size: var(--text-sm);
+	line-height: 1.2;
+	text-align: center;
+	border-radius: 10px;
+}
+
 .sidebar-notification .standard-sidebar-item .item-anchor {
 	overflow: visible;
 }


### PR DESCRIPTION
Backport of #38498, #38658, #38915 and #41156 to `version-16-hotfix`.

v16 replaced the navbar with the new sidebar and desktop page but never carried over the bell markup, so `notifications.js` resolves `.notifications-icon` to nothing and every `toggle_notification_icon()` call is a silent no-op on both bell surfaces. The indicator that worked in v15 has been dead since the Espresso migration.

This restores the indicator and adds the unread count, seeded from `frappe.boot.notification_unread_count` and kept live over realtime. One line is not from any of the backported PRs: v16's sidebar toggles the dropdown by hand and never fires `show.bs.dropdown`, so the indicator would light up and never clear; develop already triggers it explicitly and this matches that.

The perf commit replaces the select-then-update in `mark_all_as_read` with a single UPDATE; the old path builds an IN list of every unread row.

Tested on v16: badge renders from boot on first paint, increments over realtime, holds when the dropdown opens, decrements on reading one, clears on mark-all-read, with the DB unread count matching at every step.

Closes #41459
