### PR TITLE
fix(postgres): give partial and covering indexes their own default name

### DIFF
--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -547,7 +547,9 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 		"""Creates an index with given fields if not already created.
 
 		Default index name is `<table>_<field1>_<field2>_index` (table-qualified so it is unique
-		per *schema*, as postgres requires).
+		per *schema*, as postgres requires). A non-default `using`, `where` or `include` adds a
+		digest of that definition to the name, so a partial or covering index never shares a name
+		with the plain index over the same key columns.
 
 		using: index kind beyond the default btree --
 			"gin_trgm"     GIN + gin_trgm_ops for fast LIKE/ILIKE substring search (needs pg_trgm)
@@ -573,9 +575,12 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 				frappe.throw(f"Invalid index column: {column}")
 		# postgres index names are per-schema, not per-table: an unqualified default name collides
 		# across tables sharing these fields and `CREATE INDEX IF NOT EXISTS` then silently skips
-		# all but the first, leaving the index missing. Qualify with the table (and `using`, so a
-		# trigram index never clashes with the plain one on the same column).
-		index_name = index_name or get_qualified_index_name(table_name, clean_fields, using)
+		# all but the first, leaving the index missing. Qualify with the table and everything else
+		# that makes this index a distinct object -- `using`, the partial predicate and the
+		# INCLUDE list -- so no two differing definitions ever share a name.
+		index_name = index_name or get_qualified_index_name(
+			table_name, clean_fields, using, where=where, include=include
+		)
 
 		if using == "gin_trgm":
 			self.sql_ddl("CREATE EXTENSION IF NOT EXISTS pg_trgm")

--- a/frappe/database/postgres/schema.py
+++ b/frappe/database/postgres/schema.py
@@ -1,4 +1,5 @@
 import hashlib
+import re
 
 import frappe
 from frappe import _
@@ -6,16 +7,50 @@ from frappe.database.schema import DbColumn, DBTable, get_definition
 from frappe.utils import cint, cstr, flt
 from frappe.utils.defaults import get_not_null_defaults
 
+# Separators *outside* quoted tokens, so `id  >  0` and `id > 0` hash alike while `x = 'a  b'`
+# and `x = 'a b'` stay distinct -- collapsing inside a quoted token would give two different
+# predicates one name, and the second index would then be silently skipped. A comment is
+# whitespace to SQL, so a whole run of the two collapses to one space: that keeps the newline
+# ending a line comment significant, since it decides whether what follows is code or comment.
+PREDICATE_SEPARATOR_PATTERN = re.compile(
+	r"""
+	  (?P<quoted>
+	      (?<!\w)[eE]'(?:[^'\\]|''|\\.)*'    # escape string: a \' does not end it
+	    | '(?:[^']|'')*'                     # string literal (only '' escapes a quote)
+	    | "(?:[^"]|"")*"                     # quoted identifier
+	    | \$(?P<tag>\w*)\$.*?\$(?P=tag)\$    # dollar-quoted string
+	  )
+	| (?: \s | --[^\n]* | /\*.*?\*/ )+       # whitespace and comments, in any mix
+	""",
+	re.DOTALL | re.VERBOSE,
+)
+
+
+def _normalise_predicate(where: str | None) -> str:
+	if not where:
+		return ""
+	return PREDICATE_SEPARATOR_PATTERN.sub(lambda match: match.group("quoted") or " ", where).strip()
+
 
 # PostgreSQL index names are unique per *schema*, not per table like MariaDB. Naming an index
 # after just its field(s) therefore collides across tables that share a field (item_code,
 # company, posting_date, lft/rgt, ...) and `CREATE INDEX IF NOT EXISTS` silently skips all but
 # the first -- so most tables never get that index. Qualify the name with the table so it is
 # schema-unique, hashing if it would exceed postgres's 63-byte identifier cap.
-def get_qualified_index_name(table_name: str, fields: list[str], suffix: str | None = None) -> str:
+def get_qualified_index_name(
+	table_name: str,
+	fields: list[str],
+	suffix: str | None = None,
+	*,
+	where: str | None = None,
+	include: list[str] | None = None,
+) -> str:
 	base = f"{table_name}_" + "_".join(fields)
 	if suffix:
 		base += f"_{suffix}"
+	if where or include:
+		variant = f"{_normalise_predicate(where)}|{','.join(include or ())}"
+		base += "_" + hashlib.md5(variant.encode()).hexdigest()[:10]
 	name = f"{base}_index"
 	if len(name.encode()) > 63:
 		digest = hashlib.md5(base.encode()).hexdigest()[:10]

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -1214,6 +1214,66 @@ class TestDDLCommandsPost(IntegrationTestCase):
 			rows = dict(frappe.db.sql(f'SELECT name, shift FROM "{table}"'))
 			self.assertEqual(rows["copied"], rows["inserted"], msg=f"COPY differs from INSERT for {value}")
 
+	def test_default_index_names_separate_plain_partial_and_covering(self) -> None:
+		frappe.db.add_index(self.test_table_name, ["id"])
+		frappe.db.add_index(self.test_table_name, ["id"], where="id > 0")
+		frappe.db.add_index(self.test_table_name, ["id"], where="id > 100")
+		frappe.db.add_index(self.test_table_name, ["id"], include=["content"])
+
+		defs = frappe.db.sql(
+			"""SELECT indexdef FROM pg_indexes
+			WHERE tablename = %s AND indexname LIKE %s""",
+			(f"tab{self.test_table_name}", f"tab{self.test_table_name}_id%_index"),
+			pluck=True,
+		)
+		self.assertEqual(len(defs), 4, msg=f"each definition needs its own index, got {defs}")
+		self.assertEqual(len([d for d in defs if "WHERE (id > 0)" in d]), 1)
+		self.assertEqual(len([d for d in defs if "WHERE (id > 100)" in d]), 1)
+		self.assertEqual(len([d for d in defs if "INCLUDE (content)" in d]), 1)
+
+	def test_default_index_name_is_stable_for_one_definition(self) -> None:
+		from frappe.database.postgres.schema import get_qualified_index_name
+
+		table = f"tab{self.test_table_name}"
+		# a comment is whitespace to SQL, so it does not change which index a predicate names
+		for formatted, plain in (
+			("id  >   0", "id > 0"),
+			("id > 0 /* why */ AND id < 9", "id > 0 AND id < 9"),
+			("id > 0 -- why\nAND id < 9", "id > 0 AND id < 9"),
+		):
+			self.assertEqual(
+				get_qualified_index_name(table, ["id"], where=formatted),
+				get_qualified_index_name(table, ["id"], where=plain),
+				msg=f"{formatted!r} and {plain!r} are the same predicate",
+			)
+
+		# ... but the newline ending a line comment decides what is code, so it stays significant
+		self.assertNotEqual(
+			get_qualified_index_name(table, ["id"], where="id > 0 -- why\nAND id < 9"),
+			get_qualified_index_name(table, ["id"], where="id > 0 -- why AND id < 9"),
+		)
+		# but whitespace inside a quoted token is part of the predicate, not formatting
+		for two_spaces, one_space in (
+			("content = 'a  b'", "content = 'a b'"),
+			('"a  b" > 0', '"a b" > 0'),
+			("content = $$a  b$$", "content = $$a b$$"),
+			("content = $t$a  b$t$", "content = $t$a b$t$"),
+			(r"content = E'a\'  b'", r"content = E'a\' b'"),
+		):
+			self.assertNotEqual(
+				get_qualified_index_name(table, ["id"], where=two_spaces),
+				get_qualified_index_name(table, ["id"], where=one_space),
+				msg=f"{two_spaces!r} and {one_space!r} must not share a name",
+			)
+		self.assertNotEqual(
+			get_qualified_index_name(table, ["id"]),
+			get_qualified_index_name(table, ["id"], where="id > 0"),
+		)
+		self.assertNotEqual(
+			get_qualified_index_name(table, ["id"], include=["content"]),
+			get_qualified_index_name(table, ["id"]),
+		)
+
 	def test_add_index_rejects_unknown_method(self) -> None:
 		# `using` reaches the DDL string verbatim, so an unknown method must be refused, not run.
 		with self.assertRaises(frappe.ValidationError):


### PR DESCRIPTION
`get_qualified_index_name` derived the default name from the table, key fields and `using`, but not from `where` or `include`. A plain, a partial and a covering index over the same column all resolved to one name, and since the DDL is `CREATE INDEX IF NOT EXISTS`, every request after the first was silently skipped — no index, no error.

Repro on postgres 18: `add_index(dt, ["status"])`, then the same call with `where=...`, then with `include=...` leaves exactly one index — whichever ran first.

Mixes a digest of the normalised predicate and INCLUDE list into the name. Whitespace in the predicate is collapsed first so repeat calls stay idempotent. Names without `where`/`include` are unchanged, so framework search indexes keep their current names.

Related to #41486, which stops `updatedb()` mistaking such an index for a framework-managed one. The two are independent; both halves are needed.