### PR TITLE
fix(ui): update badge and buttons in sidebar

### DIFF
--- a/frappe/public/css/espresso/components/badge.css
+++ b/frappe/public/css/espresso/components/badge.css
@@ -132,6 +132,12 @@
   justify-content: center;
 }
 
+/* slot icons size to the affix, whatever size class they carry themselves */
+.es-badge__affix>svg {
+  width: 100%;
+  height: 100%;
+}
+
 .es-badge[data-size="lg"]>svg,
 .es-badge[data-size="lg"] .es-badge__affix {
   width: calc(var(--spacing) * 3);

--- a/frappe/public/css/espresso/components/button.css
+++ b/frappe/public/css/espresso/components/button.css
@@ -74,6 +74,14 @@
     color: var(--bt-fg);
 }
 
+/* the class is element-neutral: links dressed as buttons (empty-state links,
+   attachment preview actions) must not pick up anchor underlines */
+a.es-button,
+a.es-button:hover,
+a.es-button:focus {
+    text-decoration: none;
+}
+
 /* subtle is the default; scope hover/active to default-or-explicit subtle so
        they don't leak onto the other variants. */
 .es-button:not([data-variant]):hover,

--- a/frappe/public/js/frappe/form/sidebar/assign_to.js
+++ b/frappe/public/js/frappe/form/sidebar/assign_to.js
@@ -291,11 +291,15 @@ frappe.ui.form.AssignmentClass = class AssignmentClass {
 		const btn_group = row.find(".btn-group");
 
 		if (assignment === frappe.session.user) {
-			btn_group.append(`
-				<button type="button" class="btn btn-xs complete-btn" title="${__("Done")}">
-					${frappe.utils.icon("check")}
-				</button>
-			`);
+			btn_group.append(
+				frappe.ui.button.html({
+					icon: "check",
+					variant: "ghost",
+					size: "xs",
+					title: __("Done"),
+					css_class: "complete-btn",
+				})
+			);
 			btn_group.find(".complete-btn").click(() => {
 				this.close_assignment(assignment).then((assignments) => {
 					row.remove();
@@ -318,11 +322,15 @@ frappe.ui.form.AssignmentClass = class AssignmentClass {
 		}
 
 		if (assignment === frappe.session.user || this.frm.perm[0].write) {
-			btn_group.append(`
-				<button type="button" class="btn btn-xs remove-btn" title="${__("Cancel")}">
-				${frappe.utils.icon("x")}
-				</button>
-			`);
+			btn_group.append(
+				frappe.ui.button.html({
+					icon: "x",
+					variant: "ghost",
+					size: "xs",
+					title: __("Cancel"),
+					css_class: "remove-btn",
+				})
+			);
 			btn_group.find(".remove-btn").click(() => {
 				this.remove_assignment(assignment).then((assignments) => {
 					row.remove();

--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -190,9 +190,6 @@ frappe.ui.form.Attachments = class Attachments {
 		let preview_type = this.get_preview_type(attachment, file_url);
 		let escaped_file_name = frappe.utils.escape_html(file_name);
 		let escaped_file_url = frappe.utils.escape_html(file_url);
-		let escaped_absolute_file_url = frappe.utils.escape_html(
-			this.get_absolute_file_url(file_url)
-		);
 		let preview_html = "";
 
 		if (preview_type === "pdf") {
@@ -220,25 +217,28 @@ frappe.ui.form.Attachments = class Attachments {
 						<div class="ellipsis" title="${escaped_file_name}">${escaped_file_name}</div>
 					</div>
 					<div class="attachment-preview-actions">
-						<a class="btn btn-link icon-btn attachment-preview-open-link"
+						<a class="es-button attachment-preview-open-link"
+							data-variant="ghost" data-icon-button="true"
 							href="${escaped_file_url}" target="_blank" rel="noopener noreferrer"
 							title="${__("Open file in new tab")}"
+							aria-label="${__("Open file in new tab")}"
 						>
-							${frappe.utils.icon("arrow-up-right", "sm")}
+							${frappe.utils.icon("arrow-up-right", "sm", "", "", "", true)}
 						</a>
-						<button class="btn btn-link icon-btn attachment-preview-copy-link"
-							type="button"
-							data-file-url="${escaped_absolute_file_url}"
-							title="${__("Copy file URL to clipboard")}"
-							aria-label="${__("Copy file URL to clipboard")}"
-						>
-							${frappe.utils.icon("copy", "sm")}
-						</button>
-						<button class="btn btn-link icon-btn attachment-preview-close" type="button" title="${__(
-							"Close"
-						)}">
-							${frappe.utils.icon("x", "sm")}
-						</button>
+						${frappe.ui.button.html({
+							icon: "copy",
+							variant: "ghost",
+							title: __("Copy file URL to clipboard"),
+							css_class: "attachment-preview-copy-link",
+							// raw url: button.html escapes attr values itself
+							attrs: { "data-file-url": this.get_absolute_file_url(file_url) },
+						})}
+						${frappe.ui.button.html({
+							icon: "x",
+							variant: "ghost",
+							title: __("Close"),
+							css_class: "attachment-preview-close",
+						})}
 					</div>
 				</div>
 				<div class="attachment-preview-body">
@@ -311,9 +311,9 @@ frappe.ui.form.Attachments = class Attachments {
 	) {
 		return `<div class="attachment-preview-unavailable">
 			<div class="text-muted">${frappe.utils.escape_html(message)}</div>
-			<a class="btn btn-default btn-sm" href="${file_url}" target="_blank" rel="noopener noreferrer">
-				<span>${__("Open file")}</span>
-				${frappe.utils.icon("arrow-up-right", "xs", "", "", "ml-1")}
+			<a class="es-button" href="${file_url}" target="_blank" rel="noopener noreferrer">
+				<span class="es-button__label">${__("Open file")}</span>
+				${frappe.utils.icon("arrow-up-right", "sm", "", "", "", true)}
 			</a>
 		</div>`;
 	}

--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -94,9 +94,12 @@
 				{%= frappe.utils.icon("users") %}
 				<span class="ellipsis">{%= __("Assign") %}</span>
 			</span>
-			<button class="add-assignment-btn btn btn-link icon-btn">
-				<svg class="icon icon-sm"><use href="#icon-plus"></use></svg>
-			</button>
+			{%= frappe.ui.button.html({
+				icon: "plus",
+				variant: "ghost",
+				title: __("Assign"),
+				css_class: "add-assignment-btn",
+			}) %}
 		</span>
 		<div class="assignments"></div>
 	</div>
@@ -110,9 +113,12 @@
 					{%= __("Attachments") %}
 				</a>
 			</span>
-			<button class="add-attachment-btn btn btn-link icon-btn">
-				<svg class="icon icon-sm"><use href="#icon-plus"></use></svg>
-			</button>
+			{%= frappe.ui.button.html({
+				icon: "plus",
+				variant: "ghost",
+				title: __("Add attachment"),
+				css_class: "add-attachment-btn",
+			}) %}
 		</span>
 	</div>
 	<a class="show-all-btn hidden" href="">
@@ -138,9 +144,12 @@
 				{%= frappe.utils.icon("share-2") %}
 				<span class="ellipsis">{%= __("Share") %}</span>
 			</span>
-			<button class="share-doc-btn btn btn-link icon-btn">
-				<svg class="icon icon-sm"><use href="#icon-plus"></use></svg>
-			</button>
+			{%= frappe.ui.button.html({
+				icon: "plus",
+				variant: "ghost",
+				title: __("Share"),
+				css_class: "share-doc-btn",
+			}) %}
 		</span>
 		<div class="shares"></div>
 	</div>

--- a/frappe/public/js/frappe/form/templates/set_sharing.html
+++ b/frappe/public/js/frappe/form/templates/set_sharing.html
@@ -79,7 +79,12 @@ var all_perms = standard_perms.concat(custom_perms);
 		{% } %}
 	</div>
 	<div>
-		<button class="btn btn-primary btn-sm btn-add-share" style="margin-top: 12px;">{{ __("Add") }}</button>
+		{%= frappe.ui.button.html({
+		label: __("Add"),
+		variant: "solid",
+		css_class: "btn-add-share",
+		attrs: { style: "margin-top: 12px;" },
+	}) %}
 	</div>
 	{% endif %}
 </div>

--- a/frappe/public/js/frappe/ui/components/badge.js
+++ b/frappe/public/js/frappe/ui/components/badge.js
@@ -8,6 +8,7 @@ frappe.provide("frappe.ui");
  * @property {"gray"|"blue"|"green"|"amber"|"red"|"violet"|"orange"} [theme="gray"] "orange" means amber (same as frappe-ui). Old indicator colors (yellow, cyan, purple, pink, grey, darkgrey, light-blue) still work through badge-legacy-colors.css.
  * @property {string} [icon] Lucide icon name, shown before the label.
  * @property {string} [icon_left] Same as `icon`.
+ * @property {string} [icon_right] Lucide icon name, shown after the label inside an `.es-badge__affix` wrapper (the frappe-ui suffix-slot markup). Unlike direct icons, the affix accepts pointer events — bind to `.es-badge__affix` for a clickable suffix (dismissible tags).
  * @property {string} [title] Tooltip; doubles as aria-label when the badge has no visible label.
  * @property {"sm"|"md"|"lg"} [size="md"]
  * @property {"solid"|"subtle"|"outline"|"ghost"} [variant="subtle"]
@@ -40,6 +41,7 @@ function badge_html(opts = {}) {
 	const variant = validated(opts.variant, VARIANTS, "variant", "badge");
 
 	const icon_name = opts.icon_left || opts.icon;
+	const icon_right_name = opts.icon_right;
 
 	const attrs = [];
 	// leave out attributes that match the CSS defaults (gray / md / subtle)
@@ -49,14 +51,30 @@ function badge_html(opts = {}) {
 	if (opts.title) {
 		attrs.push(`title="${escape(opts.title)}"`);
 		// an icon-only badge has no text for screen readers — reuse the title
-		if (icon_name && !opts.label) attrs.push(`aria-label="${escape(opts.title)}"`);
+		if ((icon_name || icon_right_name) && !opts.label) {
+			attrs.push(`aria-label="${escape(opts.title)}"`);
+		}
 	}
 	attrs.push(...safe_attrs(opts.attrs, "badge"));
 
 	const classes = escape(["es-badge", opts.css_class].filter(Boolean).join(" "));
 	const attr_str = attrs.length ? " " + attrs.join(" ") : "";
 	const icon = icon_name ? frappe.utils.icon(icon_name, "sm", "", "", "", true) : "";
-	return `<span class="${classes}"${attr_str}>${icon}${escape(opts.label || "")}</span>`;
+	// suffix rides in the affix wrapper: direct svg children are
+	// pointer-events:none, the affix is the interactive-suffix channel
+	const icon_right = icon_right_name
+		? `<span class="es-badge__affix">${frappe.utils.icon(
+				icon_right_name,
+				"sm",
+				"",
+				"",
+				"",
+				true
+		  )}</span>`
+		: "";
+	return `<span class="${classes}"${attr_str}>${icon}${escape(
+		opts.label || ""
+	)}${icon_right}</span>`;
 }
 
 /**

--- a/frappe/public/js/frappe/ui/tags.js
+++ b/frappe/public/js/frappe/ui/tags.js
@@ -18,7 +18,9 @@ frappe.ui.Tags = class {
 
 		this.$inputWrapper = this.get_list_element(this.$input);
 		this.$placeholder =
-			$(`<button class="add-tags-btn text-muted btn btn-link icon-btn" id="add_tags">
+			$(`<button type="button" class="es-button add-tags-btn" data-variant="ghost" data-icon-button="true" title="${__(
+				"Add Tags"
+			)}" aria-label="${__("Add Tags")}">
 				${__(placeholder)}
 			</button>`);
 		this.$placeholder.appendTo(this.$ul.find(".form-sidebar-items"));
@@ -112,22 +114,51 @@ frappe.ui.Tags = class {
 	}
 
 	get_tag(label) {
-		let colored = true;
-		let $tag = frappe.get_data_pill(
-			label,
-			label,
-			(target, pill_wrapper) => {
-				this.removeTag(target);
-				pill_wrapper.closest(".form-tag-row").remove();
-			},
-			null,
-			colored
-		);
+		let $tag = frappe.ui.badge({
+			label: label,
+			theme: this.get_tag_theme(label),
+			size: "lg",
+			icon_right: "x",
+			css_class: "form-tag",
+			title: label,
+		});
+
+		// wrap the label text so truncation can engage (a bare text node in a
+		// flex container can't ellipsize); also the onTagClick target
+		$tag.contents()
+			.filter((_, node) => node.nodeType === Node.TEXT_NODE && node.textContent.trim())
+			.wrap('<span class="pill-label ellipsis"></span>');
+
+		// the ✕ is the only click target — the badge itself stays inert
+		const $remove = $tag.find(".es-badge__affix");
+		$remove
+			.attr({ role: "button", tabindex: 0, "aria-label": __("Remove") })
+			.on("click", () => {
+				this.removeTag(label);
+				$tag.closest(".form-tag-row").remove();
+			})
+			.on("keydown", (e) => {
+				if (e.key === "Enter" || e.key === " ") {
+					e.preventDefault();
+					$remove.trigger("click");
+				}
+			});
+
 		if (this.onTagClick) {
 			$tag.on("click", ".pill-label", () => {
 				this.onTagClick(label);
 			});
 		}
 		return $tag;
+	}
+
+	get_tag_theme(label) {
+		// same tag → same color, spread over the badge's curated themes
+		const themes = ["blue", "green", "amber", "red", "violet"];
+		let hash = 0;
+		for (let i = 0; i < label.length; i++) {
+			hash = (hash * 31 + label.charCodeAt(i)) % 997;
+		}
+		return themes[hash % themes.length];
 	}
 };

--- a/frappe/public/scss/desk/form_sidebar.scss
+++ b/frappe/public/scss/desk/form_sidebar.scss
@@ -475,7 +475,9 @@ body[data-route^="Form"] {
 .attachment-row,
 .form-tag-row {
 	margin: 4px 0;
+}
 
+.attachment-row {
 	.data-pill {
 		@include get_textstyle("sm", "regular");
 		justify-content: space-between;
@@ -536,13 +538,26 @@ body[data-route^="Form"] {
 
 .form-tag-row {
 	margin-right: var(--margin-xs);
-
-	.data-pill {
-		background-color: var(--subtle-fg);
-		max-width: 150px;
-	}
-
 	display: inline-flex;
+
+	.form-tag {
+		max-width: 150px;
+
+		.pill-label {
+			min-width: 0;
+		}
+
+		// the remove ✕ — the only click target on the tag
+		.es-badge__affix {
+			cursor: pointer;
+			opacity: 0.7;
+
+			&:hover,
+			&:focus-visible {
+				opacity: 1;
+			}
+		}
+	}
 }
 
 .attachments-actions {
@@ -608,17 +623,6 @@ body[data-route^="Form"] .attachment-preview {
 		align-items: center;
 		gap: 2px;
 		flex-shrink: 0;
-
-		.btn-link {
-			text-decoration: none;
-
-			&:hover,
-			&:focus {
-				text-decoration: none;
-				outline: none;
-				box-shadow: none;
-			}
-		}
 	}
 
 	.attachment-preview-body {
@@ -769,11 +773,6 @@ body[data-route^="Form"] .attachment-preview {
 	}
 }
 
-.add-assignment-btn,
-.add-attachment-btn,
-.add-review-btn,
-.add-tags-btn,
-.share-doc-btn,
 .followed-by {
 	max-width: 100%;
 	display: block;


### PR DESCRIPTION
Buttons were rounded, badges were hideous. One by one, Framework is getting prettier.

Before:
<img width="280" height="738" alt="image" src="https://github.com/user-attachments/assets/12cf5d4e-5680-4d34-a878-4e57169a2ab0" />

After:
<img width="280" height="738" alt="image" src="https://github.com/user-attachments/assets/2fce12b0-9d85-4cea-800c-a843b93984e7" />


`no-docs`