### PR TITLE
fix(postgres): scope unique index names to their table

### DIFF
--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -605,10 +605,17 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 		return '"' + '", "'.join(fields) + '"'
 
 	def add_unique(self, doctype, fields, constraint_name=None):
+		from frappe.database.postgres.schema import get_qualified_index_name
+
 		if isinstance(fields, str):
 			fields = [fields]
-		if not constraint_name:
-			constraint_name = "unique_" + "_".join(fields)
+		if constraint_name:
+			legacy_name = constraint_name
+		else:
+			constraint_name = get_qualified_index_name(get_table_name(doctype), fields, "unique")
+			# a table constrained before names were table-qualified still carries the legacy one;
+			# recognise it so we don't add a second constraint enforcing the same uniqueness
+			legacy_name = "unique_" + "_".join(fields)
 
 		if not self.sql(
 			"""
@@ -617,8 +624,8 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 			WHERE table_name=%s
 			AND constraint_type='UNIQUE'
 			AND constraint_schema=%s
-			AND CONSTRAINT_NAME=%s""",
-			("tab" + doctype, self.db_schema, constraint_name),
+			AND CONSTRAINT_NAME IN (%s, %s)""",
+			("tab" + doctype, self.db_schema, constraint_name, legacy_name),
 		):
 			self.commit()
 

--- a/frappe/database/postgres/schema.py
+++ b/frappe/database/postgres/schema.py
@@ -27,6 +27,10 @@ def get_single_column_index_name(table_name: str, fieldname: str) -> str:
 	return get_qualified_index_name(table_name, [fieldname])
 
 
+def get_unique_index_name(table_name: str, fieldname: str) -> str:
+	return get_qualified_index_name(table_name, [fieldname], "unique")
+
+
 class PostgresTable(DBTable):
 	def create(self):
 		varchar_len = frappe.db.VARCHAR_LEN
@@ -183,9 +187,8 @@ class PostgresTable(DBTable):
 		for col in self.add_unique:
 			# if index key not exists
 			if col.fieldname not in new_column_names:
-				create_contraint_query += 'CREATE UNIQUE INDEX IF NOT EXISTS "unique_{index_name}" ON `{table_name}`(`{field}`);'.format(
-					index_name=col.fieldname, table_name=self.table_name, field=col.fieldname
-				)
+				index_name = get_unique_index_name(self.table_name, col.fieldname)
+				create_contraint_query += f'CREATE UNIQUE INDEX IF NOT EXISTS "{index_name}" ON `{self.table_name}`(`{col.fieldname}`);'
 
 		# logic to drop unique constraint for fields deleted from a doctype
 		meta_columns = set(self.columns.keys())
@@ -202,13 +205,14 @@ class PostgresTable(DBTable):
 					SELECT 1
 					FROM pg_indexes
 					WHERE tablename = %s
-					AND indexname IN (%s, %s)
+					AND indexname IN (%s, %s, %s)
 					LIMIT 1
 					""",
 					(
 						self.table_name,
 						f"{self.table_name}_{col}_key",
 						f"unique_{col}",
+						get_unique_index_name(self.table_name, col),
 					),
 				)
 
@@ -257,21 +261,22 @@ class PostgresTable(DBTable):
 					drop_contraint_query += f'ALTER TABLE "{self.table_name}" DROP CONSTRAINT IF EXISTS "{self.table_name}_{col.fieldname}_key" ;'
 
 				# drop the unique index backed by no constraint directly
-				unique_index_exists = frappe.db.sql(
-					"""
-					SELECT 1
-					FROM pg_indexes
-					WHERE tablename = %s
-					AND indexname = %s
-					""",
-					(
-						self.table_name,
-						f"unique_{col.fieldname}",
-					),
-				)
+				for unique_index in (
+					get_unique_index_name(self.table_name, col.fieldname),
+					f"unique_{col.fieldname}",
+				):
+					unique_index_exists = frappe.db.sql(
+						"""
+						SELECT 1
+						FROM pg_indexes
+						WHERE tablename = %s
+						AND indexname = %s
+						""",
+						(self.table_name, unique_index),
+					)
 
-				if unique_index_exists:
-					drop_contraint_query += f'DROP INDEX IF EXISTS "unique_{col.fieldname}" ;'
+					if unique_index_exists:
+						drop_contraint_query += f'DROP INDEX IF EXISTS "{unique_index}" ;'
 
 		change_nullability = []
 		for col in self.change_nullability:

--- a/frappe/tests/test_db_update.py
+++ b/frappe/tests/test_db_update.py
@@ -271,6 +271,26 @@ class TestDBUpdate(IntegrationTestCase):
 		frappe.db.add_index(doctype.name, ["status"])
 		self.assertTrue(get_table_column(doctype.name, "status").index)
 
+	def test_unique_index_name_is_scoped_to_its_table(self):
+		"""Two doctypes sharing a unique fieldname must each get their own enforced index"""
+
+		first = new_doctype(unique=1).insert()
+		second = new_doctype(unique=1).insert()
+		try:
+			# the alter path (as opposed to table creation) is what names the index itself
+			for doctype in (first, second):
+				doctype.fields[0].unique = 0
+				doctype.save()
+				doctype.fields[0].unique = 1
+				doctype.save()
+
+			for doctype in (first, second):
+				self.check_unique_indexes(doctype.name, "some_fieldname")
+		finally:
+			first.delete()
+			second.delete()
+			frappe.db.commit()
+
 	def test_unique_index_on_field_with_search_index(self):
 		"""Unique index must be created even when the field already has a search index"""
 

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -2791,6 +2791,10 @@ class TestQuery(IntegrationTestCase):
 		self.assertFalse(index_exists)
 
 		# test for unique index backed by no constraint created at field alteration post creation
+		from frappe.database.postgres.schema import get_unique_index_name
+
+		unique_index_name = get_unique_index_name(f"tab{trial_dt.name}", "field_one")
+
 		for field in trial_dt.fields:
 			if field.fieldname == "field_one":
 				field.unique = 1
@@ -2806,7 +2810,7 @@ class TestQuery(IntegrationTestCase):
 			""",
 			(
 				f"tab{trial_dt.name}",
-				"unique_field_one",
+				unique_index_name,
 			),
 		)
 		self.assertTrue(index_exists)
@@ -2830,7 +2834,7 @@ class TestQuery(IntegrationTestCase):
 			""",
 			(
 				f"tab{trial_dt.name}",
-				"unique_field_one",
+				unique_index_name,
 			),
 		)
 		self.assertFalse(index_exists)


### PR DESCRIPTION
The alter path named a single-column unique index `unique_<fieldname>`, and `add_unique()` named its constraint `unique_<field1>_<field2>`. Postgres index names are unique per **schema**, not per table, so the first doctype to claim a fieldname took the name globally. Every later doctype with the same unique fieldname matched under `CREATE UNIQUE INDEX IF NOT EXISTS` and was silently skipped — leaving `unique = 1` in the meta and **no constraint in the database**.

Repro on postgres 18: two doctypes each with a unique `some_fieldname`, both toggled through the alter path. The second gets no unique index and accepts duplicate rows without error. Any fieldname more than one doctype marks unique hits this (email, code, serial_no, …). The multi-column `add_unique()` API fails louder but is the same bug — `ADD CONSTRAINT` has no `IF NOT EXISTS`, so the second table errors outright.

Names both through `get_qualified_index_name`. Detection and drop sites still accept the legacy `unique_<fieldname>` spelling so an existing column stays recognised and droppable.