### PR TITLE
fix(postgres): don't treat hand-made indexes as framework search indexes

### DIFF
--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -621,6 +621,9 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 		# A substring match on indexdef would false-positive any column whose name appears
 		# anywhere in a composite index's definition (e.g. `company` matching
 		# `posting_date_company_index`), which then wrongly suppresses creating its own index.
+		# Only plain btree indexes count: a partial, covering or non-btree index cannot be the
+		# framework-managed search index, so reporting it here would both suppress creating the
+		# real one and mark a hand-made index as framework-owned and droppable.
 		# pylint: disable=W1401
 		return self.sql(
 			f"""
@@ -644,9 +647,14 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 					i.indisprimary AS is_primary
 				FROM pg_index i
 				JOIN pg_class tc ON tc.oid = i.indrelid
+				JOIN pg_class ic ON ic.oid = i.indexrelid
+				JOIN pg_am am ON am.oid = ic.relam
 				JOIN pg_namespace n ON n.oid = tc.relnamespace
 				JOIN pg_attribute att ON att.attrelid = tc.oid AND att.attnum = i.indkey[0]
 				WHERE tc.relname = '{table_name}' AND n.nspname = '{self.db_schema}'
+					AND am.amname = 'btree'
+					AND i.indpred IS NULL
+					AND i.indnatts = i.indnkeyatts
 			) b ON b.column_name = a.column_name
 			WHERE a.table_name = '{table_name}'
 				AND a.table_schema = '{self.db_schema}'

--- a/frappe/tests/test_db_update.py
+++ b/frappe/tests/test_db_update.py
@@ -207,6 +207,37 @@ class TestDBUpdate(IntegrationTestCase):
 			doctype.delete()
 			frappe.db.commit()
 
+	@run_only_if(db_type_is.POSTGRES)
+	def test_manual_indexes_are_not_reported_as_search_indexes(self):
+		"""A partial, covering or non-btree index is never the framework's search index"""
+
+		doctype = new_doctype(
+			fields=[
+				{"fieldname": "status", "fieldtype": "Data"},
+				{"fieldname": "payload", "fieldtype": "Data"},
+			]
+		).insert()
+		table = f"tab{doctype.name}"
+		# add_index is DDL and commits itself, so the table outlives this test's rollback and has
+		# to be dropped (and that drop committed) whatever the assertions do
+		self.addCleanup(frappe.db.commit)
+		self.addCleanup(frappe.db.sql_ddl, f'DROP TABLE IF EXISTS "{table}" CASCADE')
+		self.addCleanup(doctype.delete)
+
+		for index_name, kwargs in (
+			("zz_partial_idx", {"where": "status <> 'done'"}),
+			("zz_covering_idx", {"include": ["payload"]}),
+			("zz_trigram_idx", {"using": "gin_trgm"}),
+		):
+			frappe.db.add_index(doctype.name, ["status"], index_name=index_name, **kwargs)
+			column = get_table_column(doctype.name, "status")
+			frappe.db.sql_ddl(f'DROP INDEX IF EXISTS "{index_name}"')
+			self.assertFalse(column.index, msg=f"{index_name} was taken for the search index")
+
+		# but a plain btree index on the column is exactly that
+		frappe.db.add_index(doctype.name, ["status"])
+		self.assertTrue(get_table_column(doctype.name, "status").index)
+
 	def test_unique_index_on_field_with_search_index(self):
 		"""Unique index must be created even when the field already has a search index"""
 


### PR DESCRIPTION
`get_table_columns_description` reported a column as indexed whenever it led any non-unique index. `updatedb()` reads that flag: a column indexed in the database but without `search_index` on its DocField is scheduled for a drop. So a partial or covering index created through `frappe.db.add_index()` both suppressed the real search index and was itself deleted on the next schema sync — silently, since dropping an index is not an error.

Only plain btree indexes are framework-managed. A partial index (`indpred`), a covering one (`indnatts > indnkeyatts`) or a non-btree method (trigram, full-text, brin) can never be the index frappe would have created, so reporting them conflates a hand-made index with a framework-owned one.

A plain default-named index on a field without `search_index` is still dropped — that name belongs to the framework on every backend, and MariaDB drops whatever index leads with the column too. Callers wanting a manual plain index should pass `index_name`.

Related to #41483, which stops partial/covering indexes sharing the plain index's default name in the first place. Independent of it; both halves are needed.