### PR TITLE
fix(postgres): keep Today/Now defaults dynamic across a field type change

### DIFF
--- a/frappe/database/postgres/schema.py
+++ b/frappe/database/postgres/schema.py
@@ -3,7 +3,7 @@ import hashlib
 import frappe
 from frappe import _
 from frappe.database.schema import DbColumn, DBTable, get_definition
-from frappe.utils import cint, flt
+from frappe.utils import cint, cstr, flt
 from frappe.utils.defaults import get_not_null_defaults
 
 
@@ -160,6 +160,11 @@ class PostgresTable(DBTable):
 
 			elif not col.default:
 				# nullable types (e.g. Duration, Rating) keep their NULL default
+				col_default = "NULL"
+
+			elif col.default in frappe.db.DEFAULT_SHORTCUTS or cstr(col.default).startswith(":"):
+				# frappe resolves these per document (Today, Now, __user, :fieldname, ...). Emitting
+				# them as literals would make postgres freeze one value at migration time.
 				col_default = "NULL"
 
 			else:

--- a/frappe/tests/test_db_update.py
+++ b/frappe/tests/test_db_update.py
@@ -134,6 +134,39 @@ class TestDBUpdate(IntegrationTestCase):
 			len(indexes), 1, msg=f"There should be 1 index on {doctype}.{field}, found {indexes}"
 		)
 
+	@run_only_if(db_type_is.POSTGRES)
+	def test_type_change_keeps_dynamic_defaults_dynamic(self):
+		"""A Today/Now default must not be frozen into the column when the type changes"""
+
+		doctype = new_doctype(
+			fields=[
+				{"fieldname": "starts_on", "fieldtype": "Data", "default": "Now"},
+				{"fieldname": "starts_day", "fieldtype": "Data", "default": "Today"},
+			]
+		).insert()
+		table = f"tab{doctype.name}"
+		# the type change below is DDL and commits itself, so the table outlives this test's
+		# rollback and has to be dropped (and that drop committed) whatever the assertions do
+		self.addCleanup(frappe.db.commit)
+		self.addCleanup(frappe.db.sql_ddl, f'DROP TABLE IF EXISTS "{table}" CASCADE')
+		self.addCleanup(doctype.delete)
+
+		for field in doctype.fields:
+			field.fieldtype = "Datetime" if field.fieldname == "starts_on" else "Date"
+		doctype.save()
+
+		for column in ("starts_on", "starts_day"):
+			expression = frappe.db.sql(
+				"""SELECT pg_get_expr(d.adbin, d.adrelid)
+				FROM pg_attrdef d
+				JOIN pg_class c ON c.oid = d.adrelid
+				JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = d.adnum
+				WHERE c.relname = %s AND a.attname = %s""",
+				(table, column),
+				pluck=True,
+			)
+			self.assertFalse(expression, msg=f"{column} kept a frozen literal default: {expression}")
+
 	def test_bigint_conversion(self):
 		doctype = new_doctype(fields=[{"fieldname": "int_field", "fieldtype": "Int"}]).insert()
 


### PR DESCRIPTION
A type change needs a `USING` clause, and the column's existing string `DEFAULT` cannot be cast to the new type, so `alter()` drops it and queues the column for the `set_default` pass. That pass escaped whatever `DocField.default` held — including frappe's dynamic shortcuts. `SET DEFAULT 'Now'` on a timestamp column is resolved by postgres when the DDL is parsed, so the column ends up with one frozen timestamp baked in at migration time.

Repro on postgres 18: a Data field defaulting to `Now`, changed to Datetime, leaves `pg_get_expr` = `'2026-08-03 13:01:21.188559'::timestamp`, and two rows inserted seconds apart both get that identical value. `Today` freezes the migration date the same way.

`build_for_alter_table` already skips `DEFAULT_SHORTCUTS` and `:fieldname` defaults for exactly this reason; the type-change path bypassed it by appending to `set_default` directly. Emit `NULL` for those instead — which is what the column looked like before the type change — and let frappe resolve the value per document.