### PR TITLE
fix(query_builder): correct DateDiff, UnixTimestamp and GroupConcat semantics

### DIFF
--- a/frappe/query_builder/custom.py
+++ b/frappe/query_builder/custom.py
@@ -21,7 +21,7 @@ class GROUP_CONCAT(DistinctOptionFunction):
 		self._separator = separator
 
 	@builder
-	def separator(self, separator: str = ""):
+	def separator(self, separator: str = ","):
 		"""Adds a separator to the GROUP_CONCAT function.
 		Args:
 				separator (str, optional): [separator to be used]. Defaults to ",".
@@ -32,7 +32,9 @@ class GROUP_CONCAT(DistinctOptionFunction):
 		query_alias = self.alias
 		self.alias = None
 		sql = super().get_sql(**kwargs)
-		if self._separator:
+		# an explicit "" is a real request for no delimiter, not "use the default": dropping the
+		# clause would silently fall back to MariaDB's comma while STRING_AGG concatenates bare.
+		if self._separator is not None:
 			assert sql.endswith(")"), "GROUP_CONCAT SQL must end with ')' before injecting SEPARATOR"
 			sql = f"{sql[:-1]} SEPARATOR {frappe.db.escape(self._separator)})"
 

--- a/frappe/query_builder/functions.py
+++ b/frappe/query_builder/functions.py
@@ -143,8 +143,8 @@ class _PostgresUnixTimestamp(Extract):
 		field = self.field if isinstance(self.field, Term) else Term.wrap_constant(self.field)
 		field_sql = field.get_sql(**kwargs)
 		sql = (
-			"CAST(EXTRACT(EPOCH FROM "
-			f"(CAST({field_sql} AS TIMESTAMP) AT TIME ZONE CURRENT_SETTING('TimeZone'))) AS BIGINT)"
+			"CAST(TRUNC(EXTRACT(EPOCH FROM "
+			f"(CAST({field_sql} AS TIMESTAMP) AT TIME ZONE CURRENT_SETTING('TimeZone')))) AS BIGINT)"
 		)
 		if with_alias:
 			return format_alias_sql(sql, self.alias, **kwargs)
@@ -161,15 +161,17 @@ UnixTimestamp = ImportMapper(
 
 class _PostgresDateDiff(ArithmeticExpression):
 	"""Postgres subtracts two dates to get an integer number of days, which matches
-	MariaDB's DATEDIFF(date1, date2). String operands are cast to date so that e.g.
-	DateDiff("2024-01-10", field) renders correctly on both backends."""
+	MariaDB's DATEDIFF(date1, date2). Both operands are cast to date: subtracting
+	timestamps would yield an interval that carries the time of day, so a Datetime
+	field would return a timedelta where MariaDB returns whole days."""
 
 	def __init__(self, date1, date2, alias=None):
-		if isinstance(date1, str):
-			date1 = Cast(date1, "date")
-		if isinstance(date2, str):
-			date2 = Cast(date2, "date")
-		super().__init__(operator=Arithmetic.sub, left=date1, right=date2, alias=alias)
+		super().__init__(
+			operator=Arithmetic.sub,
+			left=Cast(date1, "date"),
+			right=Cast(date2, "date"),
+			alias=alias,
+		)
 
 
 DateDiff = ImportMapper(

--- a/frappe/tests/test_query_builder.py
+++ b/frappe/tests/test_query_builder.py
@@ -2,6 +2,8 @@ import unittest
 from collections.abc import Callable
 from datetime import time
 
+from pypika.functions import Cast
+
 import frappe
 from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.database.operator_map import func_in
@@ -49,6 +51,12 @@ class TestCustomFunctionsMariaDB(IntegrationTestCase):
 		sql = query.get_sql()
 		self.assertIn("SEPARATOR ' | '", sql)
 		self.assertIn("`user_list`", sql)
+
+	def test_concat_with_explicit_empty_separator(self):
+		# "" means "no delimiter", not "use the default" -- dropping the clause would silently
+		# fall back to MariaDB's comma while postgres STRING_AGG concatenates bare.
+		self.assertEqual("GROUP_CONCAT('Notes' SEPARATOR '')", GroupConcat("Notes", "").get_sql())
+		self.assertEqual("GROUP_CONCAT('Notes' SEPARATOR '')", GroupConcat("Notes").separator("").get_sql())
 
 	def test_like_keeps_native_operator(self):
 		# MariaDB LIKE is already case-insensitive; keep the native operator
@@ -271,6 +279,11 @@ class TestCustomFunctionsPostgres(IntegrationTestCase):
 		# .separator() chaining must work on postgres too (STRING_AGG has no native SEPARATOR keyword)
 		self.assertEqual("STRING_AGG('Notes',' | ')", GroupConcat("Notes").separator(" | ").get_sql())
 
+	def test_concat_with_explicit_empty_separator(self):
+		# must mean the same thing as the MariaDB rendering: no delimiter at all
+		self.assertEqual("STRING_AGG('Notes','')", GroupConcat("Notes", "").get_sql())
+		self.assertEqual("STRING_AGG('Notes','')", GroupConcat("Notes").separator("").get_sql())
+
 	def test_like_is_case_insensitive(self):
 		# postgres LIKE is case-sensitive; render ILIKE so search matches MariaDB's case-insensitivity
 		user = frappe.qb.DocType("User")
@@ -364,8 +377,8 @@ class TestCustomFunctionsPostgres(IntegrationTestCase):
 		# Simple Query
 		note = frappe.qb.DocType("Note")
 		self.assertEqual(
-			"cast(extract(epoch from (cast(posting_date as timestamp) "
-			"at time zone current_setting('timezone'))) as bigint)",
+			"cast(trunc(extract(epoch from (cast(posting_date as timestamp) "
+			"at time zone current_setting('timezone')))) as bigint)",
 			UnixTimestamp(note.posting_date).get_sql().lower(),
 		)
 
@@ -378,10 +391,53 @@ class TestCustomFunctionsPostgres(IntegrationTestCase):
 			.select(UnixTimestamp(note.posting_date))
 		)
 		self.assertIn(
-			'cast(extract(epoch from (cast("tabnote"."posting_date" as timestamp) '
-			"at time zone current_setting('timezone'))) as bigint)",
+			'cast(trunc(extract(epoch from (cast("tabnote"."posting_date" as timestamp) '
+			"at time zone current_setting('timezone')))) as bigint)",
 			str(select_query).lower(),
 		)
+
+		# Order by
+		select_query = select_query.orderby(UnixTimestamp(note.posting_date))
+		self.assertIn(
+			'order by cast(trunc(extract(epoch from (cast("tabnote"."posting_date" as timestamp) '
+			"at time zone current_setting('timezone')))) as bigint)",
+			str(select_query).lower(),
+		)
+
+		# Function comparison
+		select_query = select_query.where(
+			UnixTimestamp(note.posting_date) >= UnixTimestamp(Date("2021-01-01"))
+		)
+		self.assertIn(
+			'cast(trunc(extract(epoch from (cast("tabnote"."posting_date" as timestamp) '
+			"at time zone current_setting('timezone')))) as bigint)"
+			">=cast(trunc(extract(epoch from (cast(date('2021-01-01') as timestamp) "
+			"at time zone current_setting('timezone')))) as bigint)",
+			str(select_query).lower(),
+		)
+
+		# aliasing
+		select_query = select_query.select(UnixTimestamp(note.posting_date, alias="unix_ts"))
+		self.assertIn(
+			'cast(trunc(extract(epoch from (cast("tabnote"."posting_date" as timestamp) '
+			"at time zone current_setting('timezone')))) as bigint) \"unix_ts\"",
+			str(select_query).lower(),
+		)
+
+	def test_unix_ts_postgres_truncates_fractional_seconds(self):
+		# MariaDB's UNIX_TIMESTAMP carries the fraction; casting it to an int truncates. A bare
+		# CAST(... AS BIGINT) rounds instead, pushing a .5+ timestamp a second into the future.
+		dt = frappe.qb.DocType("DocType")
+		for fraction, expected in ((".4", 0), (".5", 0), (".6", 0)):
+			stamp = UnixTimestamp(Cast(f"2021-06-01 00:00:00{fraction}", "timestamp"))
+			got = frappe.qb.from_(dt).select(stamp).limit(1).run()[0][0]
+			baseline = (
+				frappe.qb.from_(dt)
+				.select(UnixTimestamp(Cast("2021-06-01 00:00:00", "timestamp")))
+				.limit(1)
+				.run()[0][0]
+			)
+			self.assertEqual(got - baseline, expected, msg=f"fraction {fraction}")
 
 	def test_unix_ts_postgres_uses_session_timezone(self):
 		from datetime import datetime
@@ -402,11 +458,11 @@ class TestCustomFunctionsPostgres(IntegrationTestCase):
 		# Postgres subtracts dates to get an integer day count, matching MariaDB DATEDIFF.
 		note = frappe.qb.DocType("Note")
 		self.assertEqual(
-			"posting_date-creation",
+			"CAST(posting_date AS DATE)-CAST(creation AS DATE)",
 			DateDiff(note.posting_date, note.creation).get_sql(),
 		)
 		self.assertEqual(
-			"CAST('2024-01-10' AS DATE)-creation",
+			"CAST('2024-01-10' AS DATE)-CAST(creation AS DATE)",
 			DateDiff("2024-01-10", note.creation).get_sql(),
 		)
 
@@ -417,35 +473,19 @@ class TestCustomFunctionsPostgres(IntegrationTestCase):
 			.on(todo.refernce_name == note.name)
 			.select(DateDiff(note.posting_date, note.creation))
 		)
-		self.assertIn('select "tabnote"."posting_date"-"tabnote"."creation"', str(select_query).lower())
-
-		# Order by
-		select_query = select_query.orderby(UnixTimestamp(note.posting_date))
 		self.assertIn(
-			'order by cast(extract(epoch from (cast("tabnote"."posting_date" as timestamp) '
-			"at time zone current_setting('timezone'))) as bigint)",
+			'select cast("tabnote"."posting_date" as date)-cast("tabnote"."creation" as date)',
 			str(select_query).lower(),
 		)
 
-		# Function comparison
-		select_query = select_query.where(
-			UnixTimestamp(note.posting_date) >= UnixTimestamp(Date("2021-01-01"))
-		)
-		self.assertIn(
-			'cast(extract(epoch from (cast("tabnote"."posting_date" as timestamp) '
-			"at time zone current_setting('timezone'))) as bigint)"
-			">=cast(extract(epoch from (cast(date('2021-01-01') as timestamp) "
-			"at time zone current_setting('timezone'))) as bigint)",
-			str(select_query).lower(),
-		)
-
-		# aliasing
-		select_query = select_query.select(UnixTimestamp(note.posting_date, alias="unix_ts"))
-		self.assertIn(
-			'cast(extract(epoch from (cast("tabnote"."posting_date" as timestamp) '
-			"at time zone current_setting('timezone'))) as bigint) \"unix_ts\"",
-			str(select_query).lower(),
-		)
+	def test_datediff_postgres_returns_whole_days_for_timestamps(self):
+		# Subtracting two timestamps yields an interval that keeps the time of day, so a Datetime
+		# operand would come back as a timedelta where MariaDB's DATEDIFF returns whole days.
+		dt = frappe.qb.DocType("DocType")
+		diff = DateDiff(Cast("2024-01-10 01:00:00", "timestamp"), Cast("2024-01-01 23:00:00", "timestamp"))
+		got = frappe.qb.from_(dt).select(diff).limit(1).run()[0][0]
+		self.assertEqual(got, 9)
+		self.assertIsInstance(got, int)
 
 	def test_time(self):
 		note = frappe.qb.DocType("Note")


### PR DESCRIPTION
Three cross-backend divergences in the db-aware function mappers.

**DateDiff** cast only string operands to date, so a query-builder Field stayed a timestamp. Postgres subtracts two timestamps into an interval that carries the time of day, so `DateDiff` on a Datetime field returned a `timedelta` where MariaDB's `DATEDIFF` returns whole days: `'2024-01-10 01:00'` minus `'2024-01-01 23:00'` gave `timedelta(days=8, seconds=7200)` instead of `9`. Cast both operands.

**UnixTimestamp** cast `EXTRACT(EPOCH ...)` straight to `BIGINT`, and postgres rounds on that cast: a timestamp ending `.5` or `.6` came back a second in the future. MariaDB's `UNIX_TIMESTAMP` carries the fraction and taking it as an int truncates, so `TRUNC` before the cast — including for pre-1970 values.

**GROUP_CONCAT** tested `if self._separator`, so an explicitly empty separator was indistinguishable from none: MariaDB dropped the clause and fell back to its comma default while postgres `STRING_AGG` received `""` and joined with nothing. Test against `None`, and default the `separator()` builder to `","` so it agrees with its own docstring and with `STRING_AGG.separator()`.