### PR TITLE
fix: emit a real regex operator instead of rewriting finished SQL

### DIFF
--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -75,8 +75,20 @@ LOCATE_SUB_PATTERN = re.compile(r"locate\(([^,]+),([^)]+)(\)?)\)", flags=re.IGNO
 LOCATE_QUERY_PATTERN = re.compile(r"locate\(", flags=re.IGNORECASE)
 PG_TRANSFORM_PATTERN = re.compile(r"([=><]+)\s*([+-]?\d+)(\.0)?(?![a-zA-Z\.\d])")
 FROM_TAB_PATTERN = re.compile(r"from tab([\w-]*)", flags=re.IGNORECASE)
-# MySQL's REGEXP operator -> postgres `~*` (case-insensitive, matching MySQL's default collation)
-REGEXP_PATTERN = re.compile(r"\sREGEXP\s", flags=re.IGNORECASE)
+# MySQL's REGEXP / NOT REGEXP -> postgres `~*` / `!~*` (case-insensitive, matching MySQL's default
+# collation). Group 1 swallows string literals, line comments and block comments so the operator is
+# only rewritten where it is actually an operator -- `SELECT 'a REGEXP b'` must keep its text.
+REGEXP_PATTERN = re.compile(
+	r"('(?:[^']|'')*'|--[^\n]*|/\*.*?\*/)|\s(NOT\s+)?REGEXP\s",
+	flags=re.IGNORECASE | re.DOTALL,
+)
+
+
+def _replace_regexp_operator(match: re.Match) -> str:
+	if match.group(1):
+		return match.group(1)
+	return " !~* " if match.group(2) else " ~* "
+
 
 # Index methods accepted by add_index(using=...): the two custom GIN modes plus postgres'
 # native access methods. Anything else is rejected before it reaches the DDL string.
@@ -824,7 +836,7 @@ def modify_query(query):
 	query = str(query).replace("`", '"')
 	query = replace_locate_with_strpos(query)
 	# MySQL REGEXP operator -> postgres case-insensitive regex match
-	query = REGEXP_PATTERN.sub(" ~* ", query)
+	query = REGEXP_PATTERN.sub(_replace_regexp_operator, query)
 	# select from requires ""
 	query = FROM_TAB_PATTERN.sub(r'from "tab\1"', query)
 

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -76,18 +76,29 @@ LOCATE_QUERY_PATTERN = re.compile(r"locate\(", flags=re.IGNORECASE)
 PG_TRANSFORM_PATTERN = re.compile(r"([=><]+)\s*([+-]?\d+)(\.0)?(?![a-zA-Z\.\d])")
 FROM_TAB_PATTERN = re.compile(r"from tab([\w-]*)", flags=re.IGNORECASE)
 # MySQL's REGEXP / NOT REGEXP -> postgres `~*` / `!~*` (case-insensitive, matching MySQL's default
-# collation). Group 1 swallows string literals, line comments and block comments so the operator is
-# only rewritten where it is actually an operator -- `SELECT 'a REGEXP b'` must keep its text.
+# collation). The `skip` branch swallows every token whose contents are data rather than code, so
+# the operator is only rewritten where it really is an operator: `SELECT 'a REGEXP b'` keeps its
+# text, and a doctype named "My Regexp Rules" keeps its table name (backticks are rewritten to
+# double quotes before this runs, so every frappe identifier arrives quoted).
 REGEXP_PATTERN = re.compile(
-	r"('(?:[^']|'')*'|--[^\n]*|/\*.*?\*/)|\s(NOT\s+)?REGEXP\s",
-	flags=re.IGNORECASE | re.DOTALL,
+	r"""
+	  (?P<skip>
+	      '(?:[^']|'')*'                     # string literal
+	    | "(?:[^"]|"")*"                     # quoted identifier
+	    | \$(?P<tag>\w*)\$.*?\$(?P=tag)\$    # dollar-quoted string
+	    | --[^\n]*                           # line comment
+	    | /\*.*?\*/                          # block comment
+	  )
+	| \s(?P<negated>NOT\s+)?REGEXP\s
+	""",
+	flags=re.IGNORECASE | re.DOTALL | re.VERBOSE,
 )
 
 
 def _replace_regexp_operator(match: re.Match) -> str:
-	if match.group(1):
-		return match.group(1)
-	return " !~* " if match.group(2) else " ~* "
+	if (skipped := match.group("skip")) is not None:
+		return skipped
+	return " !~* " if match.group("negated") else " ~* "
 
 
 # Index methods accepted by add_index(using=...): the two custom GIN modes plus postgres'

--- a/frappe/query_builder/utils.py
+++ b/frappe/query_builder/utils.py
@@ -305,8 +305,34 @@ def patch_like_operators():
 	Term.not_like = not_like  # nosemgrep: frappe-monkey-patching-not-allowed
 
 
+def patch_regex_operator():
+	"""Render the query-builder regex operator in each backend's native spelling.
+
+	pypika's Term.regex emits " REGEX ", which is an operator on neither backend: MySQL spells it
+	REGEXP, postgres uses the case-insensitive match ~*. So `frappe.get_all(filters={"f":
+	["regex", ...]})` produced a syntax error everywhere. Emitting the right operator here also
+	means a generated query no longer depends on the textual REGEXP rewrite in modify_query.
+	"""
+	# pypika has no hook for dialect-specific operator rendering, so patch Term.regex the same way
+	# patch_like_operators above does. The rule anchors on the import, so suppress it there too.
+	from pypika.enums import Comparator, Matching
+	from pypika.terms import BasicCriterion, Term  # nosemgrep: frappe-monkey-patching-not-allowed
+
+	class PostgresMatching(Comparator):
+		regex = " ~* "
+
+	def regex(self, pattern: str):
+		comparator = (
+			PostgresMatching.regex if frappe.db and frappe.db.db_type == "postgres" else Matching.regexp
+		)
+		return BasicCriterion(comparator, self, self.wrap_constant(pattern))
+
+	Term.regex = regex  # nosemgrep: frappe-monkey-patching-not-allowed
+
+
 def patch_all():
 	patch_query_execute()
 	patch_query_aggregation()
 	patch_get_query()
 	patch_like_operators()
+	patch_regex_operator()

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -717,6 +717,28 @@ class TestDB(IntegrationTestCase):
 		)
 
 	@run_only_if(db_type_is.POSTGRES)
+	def test_modify_query_rewrites_regexp_operator_only(self):
+		from frappe.database.postgres.database import modify_query
+
+		self.assertEqual("select 'a' ~* 'b'", modify_query("select 'a' REGEXP 'b'"))
+		self.assertEqual("select 'a' !~* 'b'", modify_query("select 'a' NOT REGEXP 'b'"))
+
+		# the operator only exists outside string literals and comments
+		self.assertEqual("select 'A REGEXP B'", modify_query("select 'A REGEXP B'"))
+		self.assertEqual("select 1 -- a REGEXP here", modify_query("select 1 -- a REGEXP here"))
+		self.assertEqual("select 1 /* a REGEXP here */", modify_query("select 1 /* a REGEXP here */"))
+
+		# and the rewritten operators are valid SQL
+		self.assertEqual(frappe.db.sql("select 'abc' REGEXP 'B'")[0][0], True)
+		self.assertEqual(frappe.db.sql("select 'abc' NOT REGEXP 'z'")[0][0], True)
+		self.assertEqual(frappe.db.sql("select 'A REGEXP B'")[0][0], "A REGEXP B")
+
+	def test_regex_filter_operator(self):
+		# pypika's Term.regex renders " REGEX ", which is not an operator on either backend
+		matched = frappe.get_all("User", filters={"name": ["regex", "^Administrator$"]}, pluck="name")
+		self.assertEqual(matched, ["Administrator"])
+
+	@run_only_if(db_type_is.POSTGRES)
 	def test_modify_values(self):
 		from frappe.database.postgres.database import modify_values
 

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -723,10 +723,18 @@ class TestDB(IntegrationTestCase):
 		self.assertEqual("select 'a' ~* 'b'", modify_query("select 'a' REGEXP 'b'"))
 		self.assertEqual("select 'a' !~* 'b'", modify_query("select 'a' NOT REGEXP 'b'"))
 
-		# the operator only exists outside string literals and comments
+		# the operator only exists outside quoted tokens and comments
 		self.assertEqual("select 'A REGEXP B'", modify_query("select 'A REGEXP B'"))
 		self.assertEqual("select 1 -- a REGEXP here", modify_query("select 1 -- a REGEXP here"))
 		self.assertEqual("select 1 /* a REGEXP here */", modify_query("select 1 /* a REGEXP here */"))
+		self.assertEqual("select $$a REGEXP b$$", modify_query("select $$a REGEXP b$$"))
+		self.assertEqual("select $t$a REGEXP b$t$", modify_query("select $t$a REGEXP b$t$"))
+		# backticks become double quotes before this runs, so a doctype whose name contains the
+		# word must keep its table name intact
+		self.assertEqual(
+			'select 1 from "tabMy Regexp Rules"', modify_query("select 1 from `tabMy Regexp Rules`")
+		)
+		self.assertEqual('select "col REGEXP name"', modify_query('select "col REGEXP name"'))
 
 		# and the rewritten operators are valid SQL
 		self.assertEqual(frappe.db.sql("select 'abc' REGEXP 'B'")[0][0], True)


### PR DESCRIPTION
Two separate problems with the `regex` filter operator.

pypika's `Term.regex` renders `" REGEX "`, which is not an operator on any backend we support: MySQL spells it `REGEXP`, postgres uses `~*`. So `frappe.get_all("User", filters={"name": ["regex", "^adm"]})` raised `syntax error at or near "REGEX"`. Patch `Term.regex` to the native spelling per backend, alongside the existing LIKE → ILIKE patch, so generated queries are correct where they are built rather than depending on a later text rewrite.

`modify_query` then rewrote `REGEXP` across the whole statement with a plain substitution, which cannot tell code from data:

```
SELECT 'A REGEXP B'          ->  SELECT 'A ~* B'         (literal corrupted)
SELECT 1 -- note on REGEXP   ->  SELECT 1 -- note ~*     (comment rewritten)
SELECT 'a' NOT REGEXP 'b'    ->  SELECT 'a' NOT ~* 'b'   (syntax error)
```

Postgres spells negated match `!~*`, not `NOT ~*`. Match string literals, line comments and block comments in the same pass and pass them through untouched, and handle the `NOT` form explicitly. Raw SQL callers keep working; the operator is only rewritten where it is actually an operator.