### PR TITLE
fix(postgres): wrap Time values in COPY like INSERT, and stop leaking test state

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -63,6 +63,7 @@ ALLOWED_TYPES_FOR_VALUES = tuple | list | dict
 
 IFNULL_PATTERN = re.compile(r"ifnull\(", flags=re.IGNORECASE)
 INDEX_PATTERN = re.compile(r"\s*\([^)]+\)\s*")
+DROP_INDEX_PATTERN = re.compile(r"\s*DROP\s+INDEX\s", flags=re.IGNORECASE)
 SINGLE_WORD_PATTERN = re.compile(r'([`"]?)(tab([A-Z]\w+))\1')
 MULTI_WORD_PATTERN = re.compile(r'([`"])(tab([A-Z]\w+)( [A-Z]\w+)+)\1')
 
@@ -1481,6 +1482,12 @@ class Database:
 
 	def log_touched_tables(self, query, query_type):
 		if query_type not in QUERY_TYPES_FOR_LOG_TOUCHED_TABLES:
+			return
+
+		# `DROP INDEX <name>` never names its table, and on postgres the index name is
+		# table-qualified ("tabToDo_reference_type_index"), which the patterns below would read as
+		# a table. Index DDL touches no rows, and CREATE INDEX is already excluded by query_type.
+		if DROP_INDEX_PATTERN.match(query):
 			return
 
 		# single_word_regex is designed to match following patterns

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -801,11 +801,18 @@ def _copy_encode(value):
 	if isinstance(value, datetime.timedelta):
 		# Frappe Time fields are timedelta; str() on a >=1 day delta is "1 day, H:MM:SS", which
 		# postgres cannot parse as time. Emit HH:MM:SS[.ffffff] so the COPY text is always valid.
-		total = int(value.total_seconds())
-		hours, remainder = divmod(total, 3600)
+		# Wrap into a single day the way the INSERT path does: psycopg2 adapts a timedelta to an
+		# interval and postgres reduces it mod 24h on the way into a `time` column, so a 25:03:04
+		# duration stores as 01:03:04 there. A literal "25:03:04" is out of range for `time` and
+		# would make COPY fail where the row-by-row path succeeds.
+		microseconds = (
+			(value.days * 86_400 + value.seconds) * 1_000_000 + value.microseconds
+		) % 86_400_000_000
+		seconds, microseconds = divmod(microseconds, 1_000_000)
+		hours, remainder = divmod(seconds, 3600)
 		minutes, seconds = divmod(remainder, 60)
 		encoded = f"{hours:02d}:{minutes:02d}:{seconds:02d}"
-		return f"{encoded}.{value.microseconds:06d}" if value.microseconds else encoded
+		return f"{encoded}.{microseconds:06d}" if microseconds else encoded
 	return str(value).replace("\\", "\\\\").replace("\t", "\\t").replace("\n", "\\n").replace("\r", "\\r")
 
 

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -260,10 +260,14 @@ class TestDB(IntegrationTestCase):
 
 		frappe.flags.touched_tables = set()
 		cf = create_custom_field("ToDo", {"label": "ToDo Custom Field"})
+		# deleting the Custom Field leaves its column on the table, so without dropping it the next
+		# run adds no column, logs no ALTER TABLE, and never sees tabToDo as touched
+		self.addCleanup(frappe.db.commit)
+		self.addCleanup(frappe.db.sql_ddl, "ALTER TABLE `tabToDo` DROP COLUMN IF EXISTS `todo_custom_field`")
+		if cf:
+			self.addCleanup(cf.delete)
 		self.assertIn("tabToDo", frappe.flags.touched_tables)
 		self.assertIn("tabCustom Field", frappe.flags.touched_tables)
-		if cf:
-			cf.delete()
 		frappe.db.commit()
 		frappe.flags.in_migrate = False
 		frappe.flags.touched_tables.clear()
@@ -1025,6 +1029,10 @@ class TestDDLCommandsPost(IntegrationTestCase):
 	test_table_name = "TestNotes"
 
 	def setUp(self) -> None:
+		# several tests here call APIs that commit (add_index, advisory_lock, ...), so this table
+		# outlives a rollback. Drop first, and unconditionally in tearDown, or one failing test
+		# leaves it behind and every later run dies in setUp with "relation already exists".
+		self._drop_test_tables()
 		frappe.db.sql(
 			f"""
 			CREATE TABLE "tab{self.test_table_name}" ("id" INT NULL, content text, PRIMARY KEY ("id"))
@@ -1032,8 +1040,12 @@ class TestDDLCommandsPost(IntegrationTestCase):
 		)
 
 	def tearDown(self) -> None:
-		frappe.db.sql(f'DROP TABLE "tab{self.test_table_name}"')
 		self.test_table_name = "TestNotes"
+		self._drop_test_tables()
+
+	def _drop_test_tables(self) -> None:
+		for table in ("tabTestNotes", "tabTestNotes_new"):
+			frappe.db.sql_ddl(f'DROP TABLE IF EXISTS "{table}" CASCADE')
 
 	def test_rename(self) -> None:
 		new_table_name = f"{self.test_table_name}_new"
@@ -1148,6 +1160,30 @@ class TestDDLCommandsPost(IntegrationTestCase):
 		self.assertIn("INCLUDE", indexdef)
 		self.assertIn("content", indexdef)
 
+	def test_bulk_insert_matches_insert_for_time_values(self) -> None:
+		import datetime
+
+		from frappe.core.doctype.doctype.test_doctype import new_doctype
+
+		doctype = new_doctype(fields=[{"fieldname": "shift", "fieldtype": "Time"}]).insert()
+		table = f"tab{doctype.name}"
+		self.addCleanup(frappe.db.commit)
+		self.addCleanup(frappe.db.sql_ddl, f'DROP TABLE IF EXISTS "{table}" CASCADE')
+		self.addCleanup(doctype.delete)
+
+		# a Time field is a timedelta and MariaDB's TIME accepts well past 24h, so migrated data
+		# can carry one. COPY must not reject what the row-by-row INSERT path accepts.
+		for value in (
+			datetime.timedelta(hours=13, minutes=3, seconds=4),
+			datetime.timedelta(hours=25, minutes=3, seconds=4),
+			datetime.timedelta(hours=49),
+		):
+			frappe.db.sql(f'DELETE FROM "{table}"')
+			frappe.db.bulk_insert(doctype.name, ["name", "shift"], [["copied", value]])
+			frappe.db.sql(f'INSERT INTO "{table}" (name, shift) VALUES (%s, %s)', ("inserted", value))
+			rows = dict(frappe.db.sql(f'SELECT name, shift FROM "{table}"'))
+			self.assertEqual(rows["copied"], rows["inserted"], msg=f"COPY differs from INSERT for {value}")
+
 	def test_add_index_rejects_unknown_method(self) -> None:
 		# `using` reaches the DDL string verbatim, so an unknown method must be refused, not run.
 		with self.assertRaises(frappe.ValidationError):
@@ -1241,7 +1277,15 @@ class TestDDLCommandsPost(IntegrationTestCase):
 	def test_sequence_table_creation(self):
 		from frappe.core.doctype.doctype.test_doctype import new_doctype
 
+		# fixed name: an earlier failed run would otherwise make every later one fail on insert
+		if frappe.db.exists("DocType", "autoinc_dt_seq_test"):
+			frappe.delete_doc("DocType", "autoinc_dt_seq_test", force=True, ignore_permissions=True)
+
 		dt = new_doctype("autoinc_dt_seq_test", autoname="autoincrement").insert(ignore_permissions=True)
+		self.addCleanup(
+			lambda: frappe.db.exists("DocType", "autoinc_dt_seq_test")
+			and frappe.delete_doc("DocType", "autoinc_dt_seq_test", force=True, ignore_permissions=True)
+		)
 
 		if frappe.db.db_type == "postgres":
 			self.assertTrue(


### PR DESCRIPTION
`bulk_insert` streams through COPY, and `_copy_encode` wrote a `timedelta` as a plain `HH:MM:SS`. Postgres `time` tops out at 24h, so a Time value past a day made COPY fail with `DatetimeFieldOverflow` where the INSERT path it replaced succeeded: psycopg2 adapts a timedelta to an interval, which postgres reduces mod 24h on the way into the column (`25:03:04` stores as `01:03:04`). MariaDB TIME accepts up to 838h, so migrated data can carry such values. Wrap in `_copy_encode` so both paths agree, negative deltas included.

`log_touched_tables` recorded `tabToDo_reference_type_index` as a touched table. `DROP INDEX` never names its table, and postgres index names are table-qualified, so the table-name patterns matched the index. That name reaches `touched_tables.json`, which migrate writes for partial backups. Index DDL touches no rows and `CREATE INDEX` is already excluded by `query_type`, so skip `DROP INDEX` too.

Test isolation, all in the postgres path where DDL commits mid-test and survives the usual rollback:

- `TestDDLCommandsPost` created `tabTestNotes` in setUp without `IF NOT EXISTS` and dropped it in tearDown without `IF EXISTS`. One failing test left the table behind and every later run died in setUp — 17 errors from one root failure. Drop before creating and unconditionally after.
- `test_sequence_table_creation` and `test_log_touched_tables` use fixed names; the first now clears a stale doctype and registers cleanup, the second drops the column that survives its Custom Field deletion. Without that the touched-tables assertion passes once and fails on every later run.

`test_db` now gives identical results on back-to-back runs against the same site.