### PR TITLE
fix: adjust end date for all-day events in calendar (backport #38425)

### DIFF
--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -417,6 +417,10 @@ frappe.views.Calendar = class Calendar {
 				d.end = frappe.datetime.add_days(d.start, 1);
 			}
 
+			if (d.allDay && d.end) {
+				d.end = frappe.datetime.add_days(d.end, 1);
+			}
+
 			me.prepare_colors(d);
 
 			d.title = frappe.utils.html2text(d.title);


### PR DESCRIPTION
Changes:
- Increment end date by 1 day for all-day calendar events to fix multi-day rendering in FullCalendar. 

previous:
<img width="2438" height="2068" alt="image" src="https://github.com/user-attachments/assets/df3b37ac-b7ba-4b5e-8fd8-534d666f71fe" />

after change:
<img width="2438" height="2068" alt="image" src="https://github.com/user-attachments/assets/ddefd82c-832a-4ee4-8c71-ec96caeb1f78" />

**Note:** Backport of pull request https://github.com/frappe/frappe/pull/38425