### PR TITLE
fix(postgres): don't let an escape string desynchronise the REGEXP scan

### DIFF
--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -83,7 +83,8 @@ FROM_TAB_PATTERN = re.compile(r"from tab([\w-]*)", flags=re.IGNORECASE)
 REGEXP_PATTERN = re.compile(
 	r"""
 	  (?P<skip>
-	      '(?:[^']|'')*'                     # string literal
+	      (?<!\w)[eE]'(?:[^'\\]|''|\\.)*'    # escape string: a \' does not end it
+	    | '(?:[^']|'')*'                     # string literal (only '' escapes a quote)
 	    | "(?:[^"]|"")*"                     # quoted identifier
 	    | \$(?P<tag>\w*)\$.*?\$(?P=tag)\$    # dollar-quoted string
 	    | --[^\n]*                           # line comment

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -739,6 +739,14 @@ class TestDB(IntegrationTestCase):
 			'select 1 from "tabMy Regexp Rules"', modify_query("select 1 from `tabMy Regexp Rules`")
 		)
 		self.assertEqual('select "col REGEXP name"', modify_query('select "col REGEXP name"'))
+		self.assertEqual(r"select E'a\' REGEXP b'", modify_query(r"select E'a\' REGEXP b'"))
+		# an escape string must not desynchronise the scan: a real operator after one still converts
+		self.assertEqual(
+			r"select E'x\' REGEXP y' , 'z' ~* 'w'",
+			modify_query(r"select E'x\' REGEXP y' , 'z' REGEXP 'w'"),
+		)
+		# ... while a standard literal ends at its closing quote even with a trailing backslash
+		self.assertEqual(r"select 'a\' as c, 'b' ~* 'c'", modify_query(r"select 'a\' as c, 'b' REGEXP 'c'"))
 
 		# and the rewritten operators are valid SQL
 		self.assertEqual(frappe.db.sql("select 'abc' REGEXP 'B'")[0][0], True)


### PR DESCRIPTION
Follow-up to #41489. That PR's skip branch covers standard literals, quoted identifiers, dollar-quoted strings and comments, but not postgres escape strings. In `E'...'` a backslash escapes the quote, so the standard-literal alternative ends the token early at the `\'` and the scan continues from inside the string:

```
SELECT E'a\' REGEXP b'   ->   SELECT E'a\' ~* b'
```

The corrupted literal is the lesser problem. The scan is also left misaligned for the rest of the statement, so a genuine operator after one of these is never seen:

```
SELECT E'x\' REGEXP y' , 'z' REGEXP 'w'
```

kept its second `REGEXP` verbatim and postgres rejected the whole statement with a syntax error.

Escape strings get their own alternative, ordered ahead of the standard one so `standard_conforming_strings=on` literals keep treating `''` as the only escape and a trailing `'a\'` still closes at its second quote — verified both ways.