### PR TITLE
fix: apply user permissions on child table links in list queries

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -6,7 +6,14 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from pypika.enums import Arithmetic
 from pypika.queries import QueryBuilder, Table
-from pypika.terms import AggregateFunction, ArithmeticExpression, Star, Term, ValueWrapper
+from pypika.terms import (
+	AggregateFunction,
+	ArithmeticExpression,
+	ExistsCriterion,
+	Star,
+	Term,
+	ValueWrapper,
+)
 
 import frappe
 from frappe import _
@@ -1644,6 +1651,51 @@ class Engine:
 						empty_value_condition = functions.IfNull(table[field_name], "") == ""
 						value_condition = table[field_name].isin(docs)
 						conditions.append(empty_value_condition | value_condition)
+
+		conditions.extend(self.get_child_table_user_permission_conditions(doctype, table, user_permissions))
+
+		return conditions
+
+	def get_child_table_user_permission_conditions(
+		self, doctype: str, table: Table, user_permissions: dict
+	) -> list[Criterion]:
+		"""Exclude records whose child rows link to docs restricted by user
+		permissions, mirroring the link field checks in `has_user_permission`."""
+		conditions = []
+		strict_user_permissions = frappe.get_system_settings("apply_strict_user_permissions")
+
+		for child_doctype in sorted({df.options for df in frappe.get_meta(doctype).get_table_fields()}):
+			child_table = frappe.qb.DocType(child_doctype)
+			row_conditions = []
+
+			for df in frappe.get_meta(child_doctype).get_link_fields():
+				if df.get("ignore_user_permissions"):
+					continue
+
+				allowed_docs = frappe.permissions.get_allowed_docs_for_doctype(
+					user_permissions.get(df.get("options"), []), doctype
+				)
+				if not allowed_docs:
+					continue
+
+				empty_value_condition = functions.IfNull(child_table[df.fieldname], "") == ""
+				not_allowed_condition = child_table[df.fieldname].notin(allowed_docs)
+				if strict_user_permissions:
+					row_conditions.append(empty_value_condition | not_allowed_condition)
+				else:
+					row_conditions.append(empty_value_condition.negate() & not_allowed_condition)
+
+			if row_conditions:
+				restricted_rows = (
+					frappe.qb.from_(child_table)
+					.select(child_table.name)
+					.where(
+						(child_table.parenttype == doctype)
+						& (child_table.parent == table.name)
+						& Criterion.any(row_conditions)
+					)
+				)
+				conditions.append(ExistsCriterion(restricted_rows).negate())
 
 		return conditions
 

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -116,6 +116,67 @@ class TestPermissions(IntegrationTestCase):
 		self.assertTrue(post1.has_permission("read"))
 		self.assertTrue(get_doc_permissions(post1).get("read"))
 
+	def test_user_permissions_on_child_table_in_list(self):
+		"""get_list must exclude records whose child rows link to restricted docs."""
+		frappe.set_user("Administrator")
+		child = new_doctype(
+			istable=1,
+			fields=[
+				{
+					"label": "Blog Category",
+					"fieldname": "blog_category",
+					"fieldtype": "Link",
+					"options": "Test Blog Category",
+				}
+			],
+		).insert()
+		parent = new_doctype(
+			fields=[
+				{
+					"label": "Categories",
+					"fieldname": "categories",
+					"fieldtype": "Table",
+					"options": child.name,
+				}
+			],
+		).insert()
+		self.addCleanup(_delete_doctypes, [parent.name, child.name], False)
+		self.addCleanup(self.set_strict_user_permissions, 0)
+		self.addCleanup(frappe.set_user, "Administrator")
+
+		allowed = frappe.get_doc(
+			doctype=parent.name, categories=[{"blog_category": "_Test Blog Category 1"}]
+		).insert()
+		restricted = frappe.get_doc(
+			doctype=parent.name, categories=[{"blog_category": "_Test Blog Category"}]
+		).insert()
+		empty_row = frappe.get_doc(doctype=parent.name, categories=[{}]).insert()
+		no_rows = frappe.get_doc(doctype=parent.name).insert()
+
+		add_user_permission("Test Blog Category", "_Test Blog Category 1", "test1@example.com")
+		frappe.set_user("test1@example.com")
+
+		visible = frappe.get_list(parent.name, pluck="name")
+		self.assertIn(allowed.name, visible)
+		self.assertIn(empty_row.name, visible)
+		self.assertIn(no_rows.name, visible)
+		self.assertNotIn(restricted.name, visible)
+
+		# list visibility must match document access
+		self.assertTrue(frappe.get_doc(parent.name, allowed.name).has_permission("read"))
+		self.assertFalse(frappe.get_doc(parent.name, restricted.name).has_permission("read"))
+
+		# strict mode also excludes empty child link values
+		frappe.set_user("Administrator")
+		self.set_strict_user_permissions(1)
+		frappe.set_user("test1@example.com")
+
+		visible = frappe.get_list(parent.name, pluck="name")
+		self.assertIn(allowed.name, visible)
+		self.assertIn(no_rows.name, visible)
+		self.assertNotIn(empty_row.name, visible)
+		self.assertNotIn(restricted.name, visible)
+
 	def test_user_permissions_in_report(self):
 		add_user_permission("Test Blog Category", "_Test Blog Category 1", "test2@example.com")
 


### PR DESCRIPTION
- link searches and list views showed records the user cannot open when a child table row links to a doc restricted by user permissions (e.g. an Item whose Item Default row references a non-permitted Company)
- `get_user_permission_conditions` now adds one `not exists` subquery per restricted child table, mirroring the link field checks in `has_user_permission` (including `ignore_user_permissions`, `applicable_for` and strict mode semantics)
- add test covering allowed/restricted/empty/no-row cases in both strict and non-strict modes

Why: the list query and the document permission check disagreed, so link fields offered options that failed with "Not permitted" on selection.

## Performance

Benchmarked on MariaDB with 30k Items. Two datasets: **realistic** (20k Item Default rows, ~0.7 per item) and **stress** (1M Item Default rows, 33 per item across 1k companies). "Without restriction" = user with no applicable user permissions; "with restriction" = user limited to one Company via user permission.

### 30k Items / 20k child rows (realistic)

| query | without restriction | with restriction (before) | with restriction (after) |
|---|---|---|---|
| list page (20 rows) | 0.46 ms | 0.98 ms | 8.4 ms |
| full fetch (~20k rows) | 8.8 ms | 12.7 ms | 33 ms |
| link search | 34 ms | 36.6 ms | 47 ms |

### 30k Items / 1M child rows (stress)

| query | without restriction | with restriction (before) | with restriction (after) |
|---|---|---|---|
| list page (20 rows) | 0.20 ms | 1.11 ms | ~400-530 ms |
| full fetch | 8.4 ms | 13.8 ms | ~430 ms |
| link search | 39.8 ms | 40.6 ms | 213 ms |

Users without an applicable user permission are unaffected at every scale — the subquery is not added to their queries at all. For restricted users the optimizer materializes the child-table scan once per query, so overhead is roughly linear in child-table row count (~0.4 ms per 1k rows) and independent of page size. Alternative shapes (`not in`, anti-join, covering index, forced in-to-exists) were benchmarked; none dominates across distributions. Sites where a restricted user must browse doctypes with 100k+ child rows can exempt fields via `ignore_user_permissions`.