### PR TITLE
feat(ui): redesigned text editor field

### DIFF
--- a/frappe/public/css/espresso/components/tooltip.css
+++ b/frappe/public/css/espresso/components/tooltip.css
@@ -47,6 +47,31 @@
     user-select: none;
 }
 
+/* ---- keyboard hint: one <kbd> per key after the label ----
+   Bootstrap and desk/global.scss both style bare kbd (dark chip, padding,
+   box-shadow) and load after this file — the two-class selector
+   out-specifies them, same trick as the menu shortcuts. */
+.es-tooltip .es-tooltip__shortcut {
+    display: inline-flex;
+    align-items: center;
+    gap: 1px;
+    margin-inline-start: calc(var(--spacing) * 1.5);
+    vertical-align: bottom;
+}
+
+.es-tooltip kbd {
+    padding: 0;
+    height: auto;
+    background: transparent;
+    border-radius: 0;
+    font-family: inherit;
+    font-size: var(--text-xs);
+    line-height: calc(var(--spacing) * 4);
+    letter-spacing: normal;
+    color: var(--ink-gray-4);
+    box-shadow: none;
+}
+
 /* ---- arrow: an 8x4 triangle on the edge facing the trigger ----
    Made from borders: a 4px transparent frame where only the side facing
    away from the bubble is filled, which reads as a triangle. --arrow-offset

--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -16,6 +16,55 @@ BreakBlot.tagName = "br";
 
 Quill.register(BreakBlot);
 
+// toolbar icons: swap Quill's stock SVGs for the app's lucide set (the same
+// glyphs frappe-ui's TextEditor uses). Display-only — Quill still binds every
+// handler through the ql-* classes, and app-supplied toolbars get them too.
+const quill_icons = Quill.import("ui/icons");
+const toolbar_icon = (name) => frappe.utils.icon(name, "sm", "", "", "", true);
+Object.assign(quill_icons, {
+	bold: toolbar_icon("bold"),
+	italic: toolbar_icon("italic"),
+	underline: toolbar_icon("underline"),
+	strike: toolbar_icon("strikethrough"),
+	blockquote: toolbar_icon("quote"),
+	"code-block": toolbar_icon("code"),
+	code: toolbar_icon("code"),
+	link: toolbar_icon("link-2"),
+	image: toolbar_icon("image-plus"),
+	video: toolbar_icon("video"),
+	clean: toolbar_icon("eraser"),
+	color: toolbar_icon("paint-bucket"),
+	background: toolbar_icon("highlighter"),
+	formula: toolbar_icon("sigma"),
+	table: toolbar_icon("table-properties"),
+});
+Object.assign(quill_icons.list, {
+	ordered: toolbar_icon("list-ordered"),
+	bullet: toolbar_icon("list"),
+	check: toolbar_icon("list-check"),
+});
+Object.assign(quill_icons.indent, {
+	"+1": toolbar_icon("list-indent-increase"),
+	"-1": toolbar_icon("list-indent-decrease"),
+});
+Object.assign(quill_icons.direction, {
+	"": toolbar_icon("pilcrow-right"),
+	rtl: toolbar_icon("pilcrow-left"),
+});
+Object.assign(quill_icons.align, {
+	"": toolbar_icon("text-align-start"),
+	center: toolbar_icon("text-align-center"),
+	right: toolbar_icon("text-align-end"),
+	justify: toolbar_icon("text-align-justify"),
+});
+Object.assign(quill_icons.script, {
+	sub: toolbar_icon("subscript"),
+	super: toolbar_icon("superscript"),
+});
+for (let level = 1; level <= 6; level++) {
+	quill_icons.header[String(level)] = toolbar_icon(`heading-${level}`);
+}
+
 // font size
 let font_sizes = [
 	false,
@@ -153,6 +202,131 @@ frappe.ui.form.ControlTextEditor = class ControlTextEditor extends frappe.ui.for
 		this.bind_events();
 		const toolbar = this.quill.getModule("toolbar");
 		toolbar.addHandler("table", this.handle_table_actions);
+		this.add_toolbar_tooltips(toolbar);
+		this.dress_toolbar_pickers(toolbar);
+	}
+
+	dress_toolbar_pickers(toolbar) {
+		if (!toolbar?.container) return;
+		// swap quill's stock up/down caret for the app chevron. Text pickers
+		// only: icon and color pickers show the current selection as their
+		// label, so they have no caret. Quill never rewrites these labels
+		// after construction, so the swap sticks. A bare sprite reference,
+		// NOT frappe.utils.icon — the global .icon class carries
+		// margin: 0 auto, which floats the caret to the middle of the
+		// space-between label
+		toolbar.container
+			.querySelectorAll(
+				".ql-picker:not(.ql-icon-picker):not(.ql-color-picker) .ql-picker-label > svg"
+			)
+			.forEach((svg) => {
+				svg.outerHTML = `<svg class="ql-picker-caret" aria-hidden="true" stroke="currentColor" fill="none">
+					<use href="#icon-chevron-down"></use>
+				</svg>`;
+			});
+
+		// header picker → frappe-ui's "Text style" rows: an icon per level and
+		// "Paragraph" instead of "Normal". Labels ride quill's own data-label
+		// channel (its CSS renders attr(data-label) above the hardcoded
+		// 'Heading N' strings, and selectItem copies it to the label on every
+		// selection) — which also makes them translatable, unlike the stock
+		// ::before content
+		const sprite_icon = (name, attrs = "") =>
+			`<svg aria-hidden="true" stroke="currentColor" fill="none" ${attrs}>
+				<use href="#icon-${name}"></use>
+			</svg>`;
+		toolbar.container.querySelectorAll(".ql-picker.ql-header").forEach((picker) => {
+			picker.querySelectorAll(".ql-picker-item").forEach((item) => {
+				const level = item.getAttribute("data-value");
+				const is_heading = /^[1-6]$/.test(level || "");
+				item.setAttribute(
+					"data-label",
+					is_heading ? __("Heading {0}", [level]) : __("Paragraph")
+				);
+				item.insertAdjacentHTML(
+					"afterbegin",
+					sprite_icon(is_heading ? `heading-${level}` : "type")
+				);
+			});
+			// the label shows the selected level's ICON, not text: all seven
+			// ride in the label and CSS reveals the one matching the label's
+			// data-value, which quill keeps in sync on every selection
+			const label = picker.querySelector(".ql-picker-label");
+			if (label) {
+				const level_icons = ["p", "1", "2", "3", "4", "5", "6"]
+					.map((level) =>
+						sprite_icon(
+							level === "p" ? "type" : `heading-${level}`,
+							`class="ql-label-icon" data-level="${level}"`
+						)
+					)
+					.join("");
+				label.insertAdjacentHTML("afterbegin", level_icons);
+			}
+		});
+
+		// font size: a static icon label too — the ql-active chip signals a
+		// non-default size, the dropdown shows the value
+		toolbar.container
+			.querySelectorAll(".ql-picker.ql-size .ql-picker-label")
+			.forEach((label) => {
+				label.insertAdjacentHTML(
+					"afterbegin",
+					sprite_icon("a-large-small", 'class="ql-label-icon"')
+				);
+			});
+	}
+
+	add_toolbar_tooltips(toolbar) {
+		if (!toolbar?.container) return;
+
+		// title-attr fallback path only; the es tooltip renders combos itself
+		const shortcut_hint = (combo) =>
+			frappe.ui.keys?.get_shortcut_label
+				? ` (${frappe.ui.keys.get_shortcut_label(combo)})`
+				: "";
+
+		const tooltips = {
+			"button.ql-bold": { text: __("Bold"), shortcut: "ctrl+b" },
+			"button.ql-italic": { text: __("Italic"), shortcut: "ctrl+i" },
+			"button.ql-underline": { text: __("Underline"), shortcut: "ctrl+u" },
+			"button.ql-strike": __("Strikethrough"),
+			"button.ql-clean": __("Remove formatting"),
+			"button.ql-blockquote": __("Blockquote"),
+			"button.ql-code-block": __("Code block"),
+			"button.ql-link": __("Insert link"),
+			"button.ql-image": __("Insert image"),
+			"button.ql-video": __("Insert video"),
+			'button.ql-list[value="ordered"]': __("Numbered list"),
+			'button.ql-list[value="bullet"]': __("Bullet list"),
+			'button.ql-list[value="check"]': __("Task list"),
+			'button.ql-indent[value="+1"]': __("Increase indent"),
+			'button.ql-indent[value="-1"]': __("Decrease indent"),
+			'button.ql-script[value="sub"]': __("Subscript"),
+			'button.ql-script[value="super"]': __("Superscript"),
+			"button.ql-direction": __("Text direction"),
+			".ql-header .ql-picker-label": __("Text style"),
+			".ql-size .ql-picker-label": __("Font size"),
+			".ql-color .ql-picker-label": __("Text color"),
+			".ql-background .ql-picker-label": __("Background color"),
+			".ql-align .ql-picker-label": __("Alignment"),
+			".ql-table .ql-picker-label": __("Table"),
+		};
+
+		for (const [selector, tip] of Object.entries(tooltips)) {
+			const opts = typeof tip === "string" ? { text: tip } : tip;
+			toolbar.container.querySelectorAll(selector).forEach((el) => {
+				if (frappe.ui.tooltip) {
+					frappe.ui.tooltip(el, opts);
+				} else {
+					el.title = opts.text + (opts.shortcut ? shortcut_hint(opts.shortcut) : "");
+				}
+				// the buttons are icon-only — give them a name too
+				if (!el.getAttribute("aria-label")) {
+					el.setAttribute("aria-label", opts.text);
+				}
+			});
+		}
 	}
 
 	handle_table_actions(value) {
@@ -249,7 +423,7 @@ frappe.ui.form.ControlTextEditor = class ControlTextEditor extends frappe.ui.for
 			theme: this.df.theme || "snow",
 			readOnly: this.disabled || this.df.read_only,
 			bounds: this.quill_container[0],
-			placeholder: __(this.df.placeholder || ""),
+			placeholder: __(this.df.placeholder || "Type something..."),
 		};
 
 		// In a grid row where space is constrained, hide the toolbar.

--- a/frappe/public/js/frappe/ui/components/menu.js
+++ b/frappe/public/js/frappe/ui/components/menu.js
@@ -1,4 +1,4 @@
-import { validated, safe_href } from "./utils.js";
+import { validated, safe_href, shortcut_keys } from "./utils.js";
 import { place } from "./position.js";
 
 /**
@@ -133,25 +133,6 @@ function icon_html(name, svg_class, component) {
 		return "";
 	}
 	return frappe.utils.icon(name, "sm", "", "", svg_class, true);
-}
-
-// same OS mapping as frappe.ui.keys.get_shortcut_label, but per key — that
-// util returns one joined string ("⌘P") and we render one <kbd> per key
-const MAC_KEY_SYMBOLS = { ctrl: "⌘", meta: "⌘", cmd: "⌘", alt: "⌥", shift: "⇧" };
-
-function shortcut_keys(shortcut) {
-	if (Array.isArray(shortcut)) return shortcut.map(String);
-	const mac = frappe.utils.is_mac && frappe.utils.is_mac();
-	return String(shortcut)
-		.split("+")
-		.map((key) => key.trim())
-		.filter(Boolean)
-		.map((key) => {
-			if (mac && MAC_KEY_SYMBOLS[key.toLowerCase()]) {
-				return MAC_KEY_SYMBOLS[key.toLowerCase()];
-			}
-			return frappe.utils.to_title_case(key);
-		});
 }
 
 // Underline the first free a-z letter of the label so Alt+letter can activate

--- a/frappe/public/js/frappe/ui/components/tooltip.js
+++ b/frappe/public/js/frappe/ui/components/tooltip.js
@@ -1,11 +1,12 @@
 import { place, SIDES, ALIGNS } from "./position.js";
-import { validated } from "./utils.js";
+import { validated, shortcut_keys } from "./utils.js";
 
 frappe.provide("frappe.ui");
 
 /**
  * @typedef {Object} TooltipOpts
  * @property {string} text The label. Rendered as text, never HTML.
+ * @property {string|string[]} [shortcut] Keyboard hint after the label, one <kbd> per key — pass the raw combo ("ctrl+b") and each key becomes its OS form (⌘B on Mac), or an array of already-formatted keys. Display only; binding stays the caller's job.
  * @property {"top"|"right"|"bottom"|"left"} [side="top"] Which side of the trigger the bubble prefers.
  * @property {"start"|"center"|"end"} [align="center"] How the bubble lines up along that side.
  * @property {number} [delay=500] Hover delay in ms before showing. Focus always shows immediately.
@@ -53,6 +54,7 @@ frappe.ui.Tooltip = class Tooltip {
 		}
 
 		this.text = opts.text || "";
+		this.shortcut = opts.shortcut || null;
 		this.side = validated(opts.side, SIDES, "side", "Tooltip") || "top";
 		this.align = validated(opts.align, ALIGNS, "align", "Tooltip") || "center";
 		this.delay = opts.delay == null ? 500 : opts.delay;
@@ -105,7 +107,21 @@ frappe.ui.Tooltip = class Tooltip {
 		bubble.className = "es-tooltip";
 		bubble.setAttribute("role", "tooltip");
 		bubble.id = `es-tooltip-${++id_counter}`;
-		bubble.textContent = this.text; // text, never HTML
+		bubble.textContent = this.text; // text, never HTML (set_text edits this node)
+
+		if (this.shortcut) {
+			const hint = document.createElement("span");
+			hint.className = "es-tooltip__shortcut";
+			// symbols like ⌘ read poorly; the label alone stays the
+			// accessible description (same call as the menu shortcuts)
+			hint.setAttribute("aria-hidden", "true");
+			for (const key of shortcut_keys(this.shortcut)) {
+				const kbd = document.createElement("kbd");
+				kbd.textContent = key;
+				hint.appendChild(kbd);
+			}
+			bubble.appendChild(hint);
+		}
 
 		const arrow = document.createElement("span");
 		arrow.className = "es-tooltip__arrow";

--- a/frappe/public/js/frappe/ui/components/utils.js
+++ b/frappe/public/js/frappe/ui/components/utils.js
@@ -49,6 +49,31 @@ export function safe_href(href, component) {
 	return href;
 }
 
+// same OS mapping as frappe.ui.keys.get_shortcut_label, but per key — that
+// util returns one joined string ("⌘P") while the components render one
+// <kbd> per key (menus, tooltips)
+const MAC_KEY_SYMBOLS = { ctrl: "⌘", meta: "⌘", cmd: "⌘", alt: "⌥", shift: "⇧" };
+
+/**
+ * Raw combo ("ctrl+p") → per-key display strings in OS form (["⌘", "P"] on
+ * Mac). Arrays pass through as already-formatted keys. Display only —
+ * binding stays the caller's job.
+ */
+export function shortcut_keys(shortcut) {
+	if (Array.isArray(shortcut)) return shortcut.map(String);
+	const mac = frappe.utils.is_mac && frappe.utils.is_mac();
+	return String(shortcut)
+		.split("+")
+		.map((key) => key.trim())
+		.filter(Boolean)
+		.map((key) => {
+			if (mac && MAC_KEY_SYMBOLS[key.toLowerCase()]) {
+				return MAC_KEY_SYMBOLS[key.toLowerCase()];
+			}
+			return frappe.utils.to_title_case(key);
+		});
+}
+
 /**
  * Turn an attrs object into escaped `key="value"` strings.
  * Attribute names become markup, so only normal-looking names are allowed;

--- a/frappe/public/scss/common/controls.scss
+++ b/frappe/public/scss/common/controls.scss
@@ -165,6 +165,10 @@ select.form-control {
 		background-color: var(--control-bg);
 	}
 
+	.ql-container.ql-snow .ql-editor:not(.read-mode) {
+		background-color: var(--surface-base);
+	}
+
 	.address-box,
 	.contact-box {
 		background-color: var(--control-bg);

--- a/frappe/public/scss/common/quill.scss
+++ b/frappe/public/scss/common/quill.scss
@@ -3,7 +3,7 @@
 
 .ql-toolbar.ql-snow,
 .ql-container.ql-snow {
-	border-color: var(--border-color);
+	border-color: var(--outline-gray-2);
 	font-family: inherit;
 }
 
@@ -39,107 +39,85 @@
 
 /*!rtl:end:ignore:quill*/
 
-// Quill doesn't use variables for :(
-.ql-snow.ql-toolbar button:hover,
-.ql-snow .ql-toolbar button:hover,
-.ql-snow.ql-toolbar button:focus,
-.ql-snow .ql-toolbar button:focus,
-.ql-snow.ql-toolbar button.ql-active,
-.ql-snow .ql-toolbar button.ql-active,
-.ql-snow.ql-toolbar .ql-picker-label:hover,
-.ql-snow .ql-toolbar .ql-picker-label:hover,
-.ql-snow.ql-toolbar .ql-picker-label.ql-active,
-.ql-snow .ql-toolbar .ql-picker-label.ql-active,
-.ql-snow.ql-toolbar .ql-picker-item:hover,
-.ql-snow .ql-toolbar .ql-picker-item:hover,
-.ql-snow.ql-toolbar .ql-picker-item.ql-selected,
-.ql-snow .ql-toolbar .ql-picker-item.ql-selected {
-	color: var(--invert-neutral);
-}
-
-.ql-snow.ql-toolbar button:hover .ql-fill,
-.ql-snow .ql-toolbar button:hover .ql-fill,
-.ql-snow.ql-toolbar button:focus .ql-fill,
-.ql-snow .ql-toolbar button:focus .ql-fill,
-.ql-snow.ql-toolbar button.ql-active .ql-fill,
-.ql-snow .ql-toolbar button.ql-active .ql-fill,
-.ql-snow.ql-toolbar .ql-picker-label:hover .ql-fill,
-.ql-snow .ql-toolbar .ql-picker-label:hover .ql-fill,
-.ql-snow.ql-toolbar .ql-picker-label.ql-active .ql-fill,
-.ql-snow .ql-toolbar .ql-picker-label.ql-active .ql-fill,
-.ql-snow.ql-toolbar .ql-picker-item:hover .ql-fill,
-.ql-snow .ql-toolbar .ql-picker-item:hover .ql-fill,
-.ql-snow.ql-toolbar .ql-picker-item.ql-selected .ql-fill,
-.ql-snow .ql-toolbar .ql-picker-item.ql-selected .ql-fill,
-.ql-snow.ql-toolbar button:hover .ql-stroke.ql-fill,
-.ql-snow .ql-toolbar button:hover .ql-stroke.ql-fill,
-.ql-snow.ql-toolbar button:focus .ql-stroke.ql-fill,
-.ql-snow .ql-toolbar button:focus .ql-stroke.ql-fill,
-.ql-snow.ql-toolbar button.ql-active .ql-stroke.ql-fill,
-.ql-snow .ql-toolbar button.ql-active .ql-stroke.ql-fill,
-.ql-snow.ql-toolbar .ql-picker-label:hover .ql-stroke.ql-fill,
-.ql-snow .ql-toolbar .ql-picker-label:hover .ql-stroke.ql-fill,
-.ql-snow.ql-toolbar .ql-picker-label.ql-active .ql-stroke.ql-fill,
-.ql-snow .ql-toolbar .ql-picker-label.ql-active .ql-stroke.ql-fill,
-.ql-snow.ql-toolbar .ql-picker-item:hover .ql-stroke.ql-fill,
-.ql-snow .ql-toolbar .ql-picker-item:hover .ql-stroke.ql-fill,
-.ql-snow.ql-toolbar .ql-picker-item.ql-selected .ql-stroke.ql-fill,
-.ql-snow .ql-toolbar .ql-picker-item.ql-selected .ql-stroke.ql-fill {
-	fill: var(--invert-neutral);
-}
-
-.ql-snow.ql-toolbar button:hover .ql-stroke,
-.ql-snow .ql-toolbar button:hover .ql-stroke,
-.ql-snow.ql-toolbar button:focus .ql-stroke,
-.ql-snow .ql-toolbar button:focus .ql-stroke,
-.ql-snow.ql-toolbar button.ql-active .ql-stroke,
-.ql-snow .ql-toolbar button.ql-active .ql-stroke,
-.ql-snow.ql-toolbar .ql-picker-label:hover .ql-stroke,
-.ql-snow .ql-toolbar .ql-picker-label:hover .ql-stroke,
-.ql-snow.ql-toolbar .ql-picker-label.ql-active .ql-stroke,
-.ql-snow .ql-toolbar .ql-picker-label.ql-active .ql-stroke,
-.ql-snow.ql-toolbar .ql-picker-item:hover .ql-stroke,
-.ql-snow .ql-toolbar .ql-picker-item:hover .ql-stroke,
-.ql-snow.ql-toolbar .ql-picker-item.ql-selected .ql-stroke,
-.ql-snow .ql-toolbar .ql-picker-item.ql-selected .ql-stroke,
-.ql-snow.ql-toolbar button:hover .ql-stroke-miter,
-.ql-snow .ql-toolbar button:hover .ql-stroke-miter,
-.ql-snow.ql-toolbar button:focus .ql-stroke-miter,
-.ql-snow .ql-toolbar button:focus .ql-stroke-miter,
-.ql-snow.ql-toolbar button.ql-active .ql-stroke-miter,
-.ql-snow .ql-toolbar button.ql-active .ql-stroke-miter,
-.ql-snow.ql-toolbar .ql-picker-label:hover .ql-stroke-miter,
-.ql-snow .ql-toolbar .ql-picker-label:hover .ql-stroke-miter,
-.ql-snow.ql-toolbar .ql-picker-label.ql-active .ql-stroke-miter,
-.ql-snow .ql-toolbar .ql-picker-label.ql-active .ql-stroke-miter,
-.ql-snow.ql-toolbar .ql-picker-item:hover .ql-stroke-miter,
-.ql-snow .ql-toolbar .ql-picker-item:hover .ql-stroke-miter,
-.ql-snow.ql-toolbar .ql-picker-item.ql-selected .ql-stroke-miter,
-.ql-snow .ql-toolbar .ql-picker-item.ql-selected .ql-stroke-miter {
-	stroke: var(--invert-neutral);
-}
-
+// Toolbar — espresso chrome on Quill's stock DOM. The icons are the app's
+// lucide sprite (swapped via the ui/icons registry in text_editor.js) and
+// follow currentColor, so state styling is a plain `color` per state — the
+// old .ql-stroke/.ql-fill override matrices are gone with Quill's own SVGs.
 .ql-toolbar.ql-snow {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	row-gap: 2px;
+	padding: 4px;
+	background-color: var(--surface-gray-1);
 	border-top-left-radius: var(--radius);
 	border-top-right-radius: var(--radius);
-	background-color: var(--gray-50);
-	border-bottom: 1px solid var(--border-color);
-	padding: 0;
-	padding-top: 4px;
+	border-bottom: 1px solid var(--outline-gray-1);
 
-	.ql-picker-label::before {
-		color: var(--text-color);
+	.ql-formats {
+		display: inline-flex;
+		align-items: center;
+		gap: 2px;
+		margin: 0;
+
+		// hairline between groups instead of Quill's margin gaps
+		&:not(:last-child)::after {
+			content: "";
+			width: 1px;
+			height: 16px;
+			background-color: var(--outline-gray-2);
+			margin-inline: 6px;
+		}
 	}
-}
 
-[data-theme="dark"] {
-	.ql-toolbar.ql-snow {
-		background-color: var(--gray-900);
+	button {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 24px;
+		height: 24px;
+		padding: 4px;
+		border-radius: var(--radius);
+		color: var(--ink-gray-8);
+		transition: background-color 120ms ease, color 120ms ease;
+
+		// bare :focus too — snow paints focused buttons #06c, and focus
+		// lingers after a click
+		&:focus {
+			color: var(--ink-gray-8);
+		}
+
+		&:hover,
+		&:focus-visible {
+			background-color: var(--surface-gray-2);
+			color: var(--ink-gray-8);
+		}
+
+		&.ql-active {
+			background-color: var(--surface-gray-3);
+			color: var(--ink-gray-9);
+		}
+	}
+
+	.icon {
+		width: 16px;
+		height: 16px;
+		stroke: currentColor;
+		fill: none;
+	}
+
+	// the caret in picker labels is still Quill's stock svg
+	.ql-stroke {
+		stroke: currentColor;
+	}
+
+	.ql-fill {
+		fill: currentColor;
 	}
 }
 
 .ql-container.ql-snow {
-	background-color: var(--gray-100);
+	background-color: var(--surface-gray-1);
 	border-bottom-left-radius: var(--radius);
 	border-bottom-right-radius: var(--radius);
 }
@@ -152,23 +130,92 @@
 		resize: vertical;
 	}
 
-	.ql-stroke {
-		stroke: var(--icon-stroke);
-		stroke-width: 1.2px;
+	// placeholder: stock is italic near-black
+	.ql-editor.ql-blank::before {
+		color: var(--ink-gray-4);
+		font-style: normal;
 	}
 
-	.ql-picker-options {
-		border-color: var(--border-color) !important;
-		background-color: var(--bg-color);
-		border-radius: var(--radius);
-	}
-
+	// ---- link editor: the es-popover look on quill's stock DOM ----
+	// quill drives BOTH visibility (.ql-hidden) and the preview/edit mode
+	// switch (display on the input, preview and remove links) — so the flex
+	// layout is scoped to :not(.ql-hidden) and no child display is ever set
+	// here (the picker-options lesson)
 	.ql-tooltip {
-		background-color: var(--fg-color);
-		border-radius: var(--radius);
+		background-color: var(--surface-elevation-2);
 		border: none;
-		color: var(--text-color);
-		box-shadow: var(--shadow-base);
+		border-radius: var(--radius-lg);
+		box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.05), var(--elevation-2xl);
+		color: var(--ink-gray-8);
+		padding: 8px;
+		z-index: 1;
+
+		&:not(.ql-hidden) {
+			display: flex;
+			align-items: center;
+			gap: 8px;
+		}
+
+		// "Visit URL:" / "Enter link:" — quill's mode caption
+		&::before {
+			@include get_textstyle("sm", "regular");
+			color: var(--ink-gray-5);
+			line-height: 1;
+			margin-right: 0; // the flex gap spaces it
+		}
+
+		input[type="text"] {
+			// display stays quill's (hidden until .ql-editing)
+			height: 28px;
+			width: 200px;
+			margin: 0;
+			padding: 4px 8px;
+			border: 1px solid var(--outline-gray-2);
+			border-radius: var(--radius);
+			background-color: var(--surface-base);
+			color: var(--ink-gray-8);
+			@include get_textstyle("sm", "regular");
+
+			&:focus {
+				outline: var(--focus-outline-default);
+				outline-offset: 0;
+			}
+		}
+
+		a.ql-preview {
+			@include get_textstyle("sm", "regular");
+			max-width: 240px;
+			line-height: 1;
+			color: var(--ink-blue-7);
+			text-decoration: none;
+
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+
+		// Edit / Save / Remove — quill text buttons; the ::after/::before
+		// margins and the divider come from stock, zeroed for the flex gap
+		a.ql-action,
+		a.ql-remove {
+			@include get_textstyle("sm", "medium");
+			color: var(--ink-gray-7);
+			line-height: 1;
+
+			&:hover {
+				color: var(--ink-gray-9);
+			}
+		}
+
+		a.ql-action::after {
+			border-right: none;
+			margin-left: 0;
+			padding-right: 0;
+		}
+
+		a.ql-remove::before {
+			margin-left: 0;
+		}
 	}
 }
 
@@ -184,34 +231,289 @@
 
 .ql-snow .ql-picker {
 	@include get_textstyle("sm", "regular");
-	color: var(--text-light);
+	height: 24px;
+	color: var(--ink-gray-8);
 }
 
-// font-size dropdown
-.ql-snow .ql-picker.ql-size {
-	width: 58px;
+// COMPOUND .ql-toolbar.ql-snow — snow puts both classes on the same
+// element, so the descendant form (.ql-snow .ql-toolbar) matches nothing.
+// The compound also ties snow's stock #06c hover rules so ours win on
+// source order.
+.ql-toolbar.ql-snow .ql-picker-label {
+	display: inline-flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 4px;
+	width: 100%;
+	border: none;
+	border-radius: var(--radius);
+	padding-inline: 6px 4px;
+	outline: none;
 
+	&::before {
+		line-height: 1;
+		// the pickers have fixed widths so the toolbar doesn't shift when
+		// the selection changes — truncate instead of pushing the caret out
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	&:hover {
+		background-color: var(--surface-gray-2);
+		color: var(--ink-gray-8);
+	}
+
+	// quill marks the label ql-active when a non-default value applies at
+	// the cursor (snow paints it #06c) — same chip as an active button
+	&.ql-active {
+		background-color: var(--surface-gray-3);
+		color: var(--ink-gray-9);
+	}
+}
+
+// the swapped lucide caret (bare sprite svg, no global .icon class) sits in
+// flow at the label's end — the espresso dropdown-trigger chevron. Snow
+// absolutely-positions picker svgs for its own caret; svg.ql-picker-caret
+// ties that rule's specificity so source order undoes it.
+.ql-toolbar.ql-snow .ql-picker-label svg.ql-picker-caret {
+	position: static;
+	margin: 0;
+	top: auto;
+	right: auto;
+	width: 14px;
+	height: 14px;
+	flex-shrink: 0;
+	stroke: currentColor;
+	fill: none;
+}
+
+// uniform menu rows: stock previews each heading at its own size (up to
+// 2em), which fights the row rhythm — the label text already says which
+// level it is
+.ql-toolbar.ql-snow .ql-picker.ql-header .ql-picker-item::before {
+	font-size: var(--text-base);
+}
+
+// header rows carry a level icon; the text is the ::before pseudo (a flex
+// item), so order pulls the icon in front of it. position/top/right undo
+// snow's blanket absolute-positioning of text-picker svgs (its caret rule),
+// which otherwise piles every row icon onto one spot
+.ql-toolbar.ql-snow .ql-picker.ql-header .ql-picker-item {
+	gap: 8px;
+
+	svg {
+		order: -1;
+		position: static;
+		top: auto;
+		right: auto;
+		flex-shrink: 0;
+		width: 16px;
+		height: 16px;
+		margin: 0;
+		stroke: currentColor;
+		fill: none;
+		color: var(--ink-gray-6);
+	}
+}
+
+// hand-injected sprite icons (caret, row icons, label icons) skip the
+// global .icon class (its auto-margin breaks flex layouts) — so supply the
+// stroke geometry that class would have given them; the sprite symbols
+// carry only a viewBox, and the svg default (width 1, butt caps) reads
+// thin next to the real toolbar icons
+.ql-toolbar.ql-snow svg.ql-picker-caret,
+.ql-toolbar.ql-snow .ql-picker.ql-header .ql-picker-item svg,
+.ql-toolbar.ql-snow .ql-picker-label svg.ql-label-icon {
+	stroke-width: 1.5px;
+	stroke-linecap: round;
+	stroke-linejoin: round;
+}
+
+// icon labels (text style, font size): same svg pinning as above — snow's
+// caret rule and the global .icon auto-margin both reach for any svg here.
+// order: -1 puts the icon before the ::before text (the pseudo sorts as
+// the first order-0 flex item)
+.ql-toolbar.ql-snow .ql-picker-label svg.ql-label-icon {
+	order: -1;
+	position: static;
+	top: auto;
+	right: auto;
+	margin: 0;
+	flex-shrink: 0;
+	width: 16px;
+	height: 16px;
+	stroke: currentColor;
+	fill: none;
+}
+
+// the text-style label is icon-only: hide the stock 'Normal'/attr() text
+// (both stock content rules out-specified) and reveal only the icon
+// matching the label's data-value, which quill syncs on every selection
+.ql-toolbar.ql-snow .ql-picker.ql-header .ql-picker-label::before,
+.ql-toolbar.ql-snow
+	.ql-picker.ql-header
+	.ql-picker-label[data-label]:not([data-label=""])::before {
+	content: none;
+}
+
+// the size label shows icon + the current value (the "---" default
+// placeholder stays icon-only; snow's 'Normal' fallback is out-specified)
+.ql-toolbar.ql-snow .ql-picker.ql-size .ql-picker-label::before {
+	content: attr(data-value);
+}
+
+.ql-toolbar.ql-snow .ql-picker.ql-size .ql-picker-label[data-value="---"]::before {
+	content: none;
+}
+
+.ql-toolbar.ql-snow .ql-picker.ql-header .ql-picker-label svg.ql-label-icon {
+	display: none;
+}
+
+.ql-toolbar.ql-snow
+	.ql-picker.ql-header
+	.ql-picker-label:not([data-value])
+	svg.ql-label-icon[data-level="p"] {
+	display: block;
+}
+
+@for $level from 1 through 6 {
+	.ql-toolbar.ql-snow
+		.ql-picker.ql-header
+		.ql-picker-label[data-value="#{$level}"]
+		svg.ql-label-icon[data-level="#{$level}"] {
+		display: block;
+	}
+}
+
+// icon-only labels don't need the text-sized boxes
+.ql-toolbar.ql-snow .ql-picker.ql-header,
+.ql-toolbar.ql-snow .ql-picker.ql-size {
+	width: auto;
+}
+
+.ql-toolbar.ql-snow .ql-picker.ql-expanded .ql-picker-label {
+	background-color: var(--surface-gray-3);
+	color: var(--ink-gray-9);
+	border-color: transparent;
+}
+
+// snow also pokes #06c into svg strokes per state; the picker caret is the
+// only stock svg left — pin it to currentColor everywhere
+.ql-toolbar.ql-snow
+	:is(button, .ql-picker-label, .ql-picker-item):is(:hover, :focus, .ql-active, .ql-selected, .ql-expanded) {
+	.ql-stroke,
+	.ql-stroke-miter {
+		stroke: currentColor;
+	}
+
+	.ql-fill,
+	.ql-stroke.ql-fill {
+		fill: currentColor;
+	}
+}
+
+// dropdown panels, styled like the espresso menus
+.ql-snow .ql-picker-options {
+	padding: 6px;
+	background-color: var(--surface-elevation-2);
+	border: none !important;
+	border-radius: var(--radius-lg);
+	box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.05), var(--elevation-2xl);
+}
+
+// menu-row look for text pickers; color pickers keep their swatch grid and
+// icon pickers get the chip strip below, so both are excluded here
+.ql-snow .ql-picker:not(.ql-color-picker):not(.ql-icon-picker) .ql-picker-item {
+	display: flex;
+	align-items: center;
+	min-height: 28px;
+	padding: 2px 8px;
+	border-radius: var(--radius);
+	color: var(--ink-gray-8);
+
+	&:hover {
+		background-color: var(--surface-alpha-gray-2);
+		color: var(--ink-gray-8);
+	}
+
+	&.ql-selected {
+		color: var(--ink-gray-9);
+	}
+}
+
+.ql-snow .ql-color-picker .ql-picker-item {
+	border-radius: var(--radius-sm);
+
+	&:hover,
+	&.ql-selected {
+		border-color: var(--ink-gray-9);
+	}
+}
+
+// swatch grid panel: same padding rhythm as the row panels
+// (8 swatches × 20px + padding)
+.ql-snow .ql-color-picker .ql-picker-options {
+	padding: 6px;
+	width: 172px;
+}
+
+// icon pickers (align): a horizontal strip of square chips, styled like
+// the toolbar buttons — 4 icons stacked as text rows read wrong.
+// ql-expanded scope is LOAD-BEARING: quill shows/hides the panel via
+// display, so an unconditional display:flex holds it open forever.
+// Padding here too — stock's `.ql-icon-picker .ql-picker-options`
+// (4px 0) out-specifies the generic 6px panel rule.
+.ql-toolbar.ql-snow .ql-icon-picker.ql-expanded .ql-picker-options {
+	display: flex;
+	gap: 2px;
+	padding: 6px;
+}
+
+.ql-toolbar.ql-snow .ql-icon-picker .ql-picker-item {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	padding: 4px;
+	border-radius: var(--radius);
+	color: var(--ink-gray-8);
+
+	svg {
+		// the global .icon class carries margin: 0 auto — pin it
+		margin: 0;
+		width: 16px;
+		height: 16px;
+	}
+
+	&:hover {
+		background-color: var(--surface-gray-2);
+		color: var(--ink-gray-8);
+	}
+
+	&.ql-selected {
+		background-color: var(--surface-gray-3);
+		color: var(--ink-gray-9);
+	}
+}
+
+// font-size dropdown — the label is the a-large-small icon; only the
+// dropdown rows show the px values
+.ql-snow .ql-picker.ql-size {
 	&.ql-expanded {
 		.ql-picker-options {
 			overflow-y: auto;
-			height: 200px;
+			max-height: 240px;
 		}
 	}
 
-	.ql-picker-label,
 	.ql-picker-item {
 		&:before {
 			content: attr(data-value) !important;
 		}
 	}
-}
-
-.ql-snow .ql-picker-label {
-	outline: none;
-}
-
-.ql-formats {
-	margin-bottom: 8px;
 }
 
 .ql-code-block-container {
@@ -230,6 +532,38 @@
 
 	.ql-code-block-container {
 		@extend .ql-code-block-container;
+	}
+}
+
+// bubble toolbar (comment box): the lucide icons follow currentColor, so
+// mirror the theme's stock #ccc → #fff states as plain color
+.ql-bubble .ql-toolbar {
+	button {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		color: #cccccc;
+
+		&:hover,
+		&:focus-visible,
+		&.ql-active {
+			color: #ffffff;
+		}
+	}
+
+	.icon {
+		width: 16px;
+		height: 16px;
+		stroke: currentColor;
+		fill: none;
+	}
+
+	.ql-stroke {
+		stroke: currentColor;
+	}
+
+	.ql-fill {
+		fill: currentColor;
 	}
 }
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/cdb95664-0746-4c5d-a11a-838ee5b29589



`no-docs`