### PR TITLE
refactor(print): open the format builder from Print Format

### DIFF
--- a/cypress/integration/print_format_builder.js
+++ b/cypress/integration/print_format_builder.js
@@ -70,7 +70,7 @@ context("Print Format Builder — create flow", () => {
 		cy.visit("/app/print-format-builder");
 		cy.location("pathname", { timeout: 20000 }).should(
 			"match",
-			/^\/app\/print-format(\/view\/list)?$/
+			/^\/(app|desk)\/print-format(\/view\/list)?$/
 		);
 	});
 
@@ -82,8 +82,8 @@ context("Print Format Builder — create flow", () => {
 		cy.get(".page-actions", { timeout: 20000 }).contains("button", "Edit Format").click();
 
 		cy.location("pathname", { timeout: 20000 }).should(
-			"include",
-			"/app/print-format-builder/"
+			"match",
+			/\/(app|desk)\/print-format-builder\//
 		);
 		cy.get(".print-format-main", { timeout: 20000 }).should("exist");
 	});

--- a/cypress/integration/print_format_builder.js
+++ b/cypress/integration/print_format_builder.js
@@ -65,43 +65,27 @@ context("Print Format Builder — create flow", () => {
 		cy.window().then((win) => cleanup(win, PF_NAME));
 	});
 
-	// 1. Page loads with the Create-or-Edit dialog
-	it("shows the Create or Edit Print Format dialog", () => {
+	// 1. The route no longer creates anything on its own — it sends you to the list
+	it("redirects to the Print Format list when opened without a format", () => {
 		cy.visit("/app/print-format-builder");
-		cy.get_open_dialog().should("contain", "Create or Edit Print Format");
-		cy.get_open_dialog().find(".btn-modal-primary").should("contain", "Create");
+		cy.location("pathname", { timeout: 20000 }).should(
+			"match",
+			/^\/app\/print-format(\/view\/list)?$/
+		);
 	});
 
-	// 2. Filling the dialog and clicking Create inserts a builder format
-	it("creates a new Print Format with print_format_builder_beta=1", () => {
-		cy.intercept("POST", "api/method/frappe.client.insert").as("insert");
+	// 2. The Print Format form is where a format is created, and it opens the builder
+	it("opens the builder from the Print Format form", () => {
+		insert_builder_format(PF_NAME);
 
-		cy.visit("/app/print-format-builder");
-		cy.get_open_dialog().should("be.visible");
+		cy.visit(`/app/print-format/${encodeURIComponent(PF_NAME)}`);
+		cy.get(".page-actions", { timeout: 20000 }).contains("button", "Edit Format").click();
 
-		// The print_format_name field has depends_on: action === 'Create' and
-		// the dialog runs set_value('action', 'Create') *after* show(), so
-		// the depends_on reveal races with the first keystroke and
-		// cy.fill_field drops the leading 'C'. Set the value via .invoke('val')
-		// and trigger input/change so Frappe's Control picks it up without
-		// going through the keyboard simulator at all.
-		cy.fill_field("doctype", "ToDo", "Link");
-		cy.get_open_dialog()
-			.find('[data-fieldname="print_format_name"] input:visible')
-			.should("be.enabled")
-			.invoke("val", PF_NAME)
-			.trigger("input")
-			.trigger("change");
-
-		cy.get_open_dialog().find(".btn-modal-primary").contains("Create").click();
-
-		cy.wait("@insert").then((interception) => {
-			expect(interception.response.statusCode).to.equal(200);
-			const doc = interception.response.body.message;
-			expect(doc.name).to.equal(PF_NAME);
-			expect(doc.doc_type).to.equal("ToDo");
-			expect(Number(doc.print_format_builder_beta)).to.equal(1);
-		});
+		cy.location("pathname", { timeout: 20000 }).should(
+			"include",
+			"/app/print-format-builder/"
+		);
+		cy.get(".print-format-main", { timeout: 20000 }).should("exist");
 	});
 
 	// 3. Loading the builder for an existing format and saving a change

--- a/frappe/printing/page/print_format_builder/print_format_builder.js
+++ b/frappe/printing/page/print_format_builder/print_format_builder.js
@@ -35,100 +35,26 @@ function load_print_format_builder(wrapper) {
 	frappe.print_format_builder?.destroy?.();
 	$parent.empty();
 
-	if (route.length > 1) {
-		// _extra_label is re-appended on every breadcrumbs.update() call so it survives route changes
-		patch_breadcrumbs_once();
-		frappe.breadcrumbs.add({
-			type: "Custom",
-			label: __("Print Format Builder"),
-			route: "/desk/print-format-builder",
-			_extra_label: route[1],
-		});
-		wrapper.page.set_title(route[1]);
-
-		frappe.require("print_format_builder.bundle.js").then(() => {
-			frappe.print_format_builder = new frappe.ui.PrintFormatBuilder({
-				wrapper: $parent,
-				page: wrapper.page,
-				print_format: route[1],
-			});
-		});
-	} else {
-		let d = new frappe.ui.Dialog({
-			title: __("Create or Edit Print Format"),
-			fields: [
-				{
-					label: __("Action"),
-					fieldname: "action",
-					fieldtype: "Select",
-					options: [
-						{ label: __("Create New"), value: "Create" },
-						{ label: __("Edit Existing"), value: "Edit" },
-					],
-					change() {
-						let action = d.get_value("action");
-						d.get_primary_btn().text(action === "Create" ? __("Create") : __("Edit"));
-					},
-				},
-				{
-					label: __("Select Document Type"),
-					fieldname: "doctype",
-					fieldtype: "Link",
-					options: "DocType",
-					filters: {
-						istable: 0,
-					},
-					reqd: 1,
-					default: frappe.route_options ? frappe.route_options.doctype : null,
-				},
-				{
-					label: __("New Print Format Name"),
-					fieldname: "print_format_name",
-					fieldtype: "Data",
-					depends_on: (doc) => doc.action === "Create",
-					mandatory_depends_on: (doc) => doc.action === "Create",
-				},
-				{
-					label: __("Select Print Format"),
-					fieldname: "print_format",
-					fieldtype: "Link",
-					options: "Print Format",
-					only_select: 1,
-					depends_on: (doc) => doc.action === "Edit",
-					get_query() {
-						return {
-							filters: {
-								doc_type: d.get_value("doctype"),
-								print_format_builder_beta: 1,
-							},
-						};
-					},
-					mandatory_depends_on: (doc) => doc.action === "Edit",
-				},
-			],
-			primary_action_label: __("Edit"),
-			primary_action({ action, doctype, print_format, print_format_name }) {
-				if (action === "Edit") {
-					frappe.set_route("print-format-builder", print_format);
-				} else if (action === "Create") {
-					d.get_primary_btn().prop("disabled", true);
-					frappe.db
-						.insert({
-							doctype: "Print Format",
-							name: print_format_name,
-							doc_type: doctype,
-							print_format_builder_beta: 1,
-						})
-						.then((doc) => {
-							frappe.set_route("print-format-builder", doc.name);
-						})
-						.finally(() => {
-							d.get_primary_btn().prop("disabled", false);
-						});
-				}
-			},
-		});
-		d.set_value("action", "Create");
-		d.show();
+	if (route.length < 2) {
+		frappe.set_route("List", "Print Format");
+		return;
 	}
+
+	// _extra_label is re-appended on every breadcrumbs.update() call so it survives route changes
+	patch_breadcrumbs_once();
+	frappe.breadcrumbs.add({
+		type: "Custom",
+		label: __("Print Format"),
+		route: "/desk/print-format",
+		_extra_label: route[1],
+	});
+	wrapper.page.set_title(route[1]);
+
+	frappe.require("print_format_builder.bundle.js").then(() => {
+		frappe.print_format_builder = new frappe.ui.PrintFormatBuilder({
+			wrapper: $parent,
+			page: wrapper.page,
+			print_format: route[1],
+		});
+	});
 }

--- a/frappe/printing/page/print_format_builder/print_format_builder.js
+++ b/frappe/printing/page/print_format_builder/print_format_builder.js
@@ -3,6 +3,7 @@ frappe.pages["print-format-builder"].on_page_load = function (wrapper) {
 		parent: wrapper,
 		title: __("Print Format Builder"),
 		single_column: true,
+		hide_sidebar: true,
 	});
 
 	// hot reload in development

--- a/frappe/printing/workspace/printing/printing.json
+++ b/frappe/printing/workspace/printing/printing.json
@@ -15,7 +15,7 @@
  "label": "Printing",
  "link_type": "DocType",
  "links": [],
- "modified": "2026-07-15 00:51:27.452467",
+ "modified": "2026-08-03 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Printing",
@@ -62,19 +62,6 @@
    "label": "Letter Head",
    "link_to": "Letter Head",
    "link_type": "DocType",
-   "open_in_new_tab": 1,
-   "show_arrow": 0,
-   "type": "Link"
-  },
-  {
-   "child": 0,
-   "collapsible": 1,
-   "icon": "pen-tool",
-   "indent": 0,
-   "keep_closed": 0,
-   "label": "Print Format Builder",
-   "link_to": "print-format-builder",
-   "link_type": "Page",
    "open_in_new_tab": 1,
    "show_arrow": 0,
    "type": "Link"

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -419,7 +419,7 @@ frappe.ui.Sidebar = class Sidebar {
 	// unless the route actually warrants a different sidebar.
 	refresh() {
 		this.apply_page_visibility();
-		if (!this.page_allows_sidebar()) return;
+		if (!this.page_allows_sidebar() && !this.page_allows_dock()) return;
 		// Re-resolve the app context now that the routed doctype's meta is loaded. On a cold/direct
 		// load the router `change` handler ran before the meta was available, so set_current_app()
 		// couldn't derive the app (leaving current_app -- and thus the dock -- unresolved). This
@@ -449,12 +449,13 @@ frappe.ui.Sidebar = class Sidebar {
 		return !!page && !page.hide_sidebar;
 	}
 
-	// The dock is displayed unless the page hides the whole sidebar (`hide_sidebar`, e.g. the
-	// desktop/apps screen) or opts out of just the dock with `hide_workspace_dock` -- both are
-	// standard frappe.ui.Page options, so this is configurable per page.
+	// The dock is displayed unless the page opts out with `hide_workspace_dock` -- both that and
+	// `hide_sidebar` are standard frappe.ui.Page options, and a page picks either shell on its
+	// own: the print format builder keeps the dock while hiding the body sidebar, the
+	// desktop/apps screen sets both.
 	page_allows_dock() {
 		const page = this.current_page();
-		return !!page && !page.hide_sidebar && !page.hide_workspace_dock;
+		return !!page && !page.hide_workspace_dock;
 	}
 
 	// Resolve both shells against the current page's options. This is the one place that turns

--- a/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
@@ -6,17 +6,6 @@
 	>
 		<PrintFormatControls />
 		<div class="canvas-area">
-			<!-- Sidebar-open hint -->
-			<div v-if="sidebar_open && !hint_dismissed" class="pfb-sidebar-hint">
-				<span v-html="frappe.utils.icon('info', 'sm', 'pfb-hint-icon')"></span>
-				<span class="pfb-hint-text">{{
-					__("Tip: Close the left sidebar for more editing space.")
-				}}</span>
-				<button class="pfb-hint-dismiss" @click="dismiss_hint" :aria-label="__('Dismiss')">
-					<span v-html="frappe.utils.icon('x', 'xs')"></span>
-				</button>
-			</div>
-
 			<!-- Canvas toolbar: sample data picker, zoom, preview toggle -->
 			<div class="canvas-toolbar">
 				<div class="canvas-toolbar-left">
@@ -97,7 +86,6 @@ import { computed, ref, onMounted, onUnmounted, provide, nextTick } from "vue";
 
 const props = defineProps(["print_format_name"]);
 
-const HINT_KEY = "pfb_sidebar_hint_dismissed";
 const ZOOM_KEY = "pfb_canvas_zoom";
 const ZOOM_STEP = 10;
 const ZOOM_MIN = 50;
@@ -106,10 +94,7 @@ const ZOOM_MAX = 150;
 let show_preview = ref(false);
 let doc_picker_ref = ref(null);
 let doc_picker_ctrl = ref(null);
-let sidebar_open = ref(false);
-let hint_dismissed = ref(localStorage.getItem(HINT_KEY) === "1");
 let canvas_zoom = ref(parseInt(localStorage.getItem(ZOOM_KEY)) || 100);
-let sidebar_observer_ref = null;
 
 let $store = computed(() => {
 	return getStore(props.print_format_name);
@@ -430,15 +415,6 @@ function reset_zoom() {
 	localStorage.setItem(ZOOM_KEY, 100);
 }
 
-function check_sidebar() {
-	sidebar_open.value = frappe.app?.sidebar?.wrapper?.is(":visible") ?? false;
-}
-
-function dismiss_hint() {
-	hint_dismissed.value = true;
-	localStorage.setItem(HINT_KEY, "1");
-}
-
 function init_doc_picker() {
 	if (!doc_picker_ref.value) return;
 	const meta = $store.value.meta.value;
@@ -499,13 +475,6 @@ function init_doc_picker() {
 onMounted(() => {
 	document.addEventListener("keydown", handle_keydown);
 
-	// Detect desk sidebar open/close via MutationObserver on the wrapper's style attribute
-	check_sidebar();
-	const sidebar_el = frappe.app?.sidebar?.wrapper?.[0];
-	if (sidebar_el) {
-		sidebar_observer_ref = new MutationObserver(check_sidebar);
-		sidebar_observer_ref.observe(sidebar_el, { attributes: true, attributeFilter: ["style"] });
-	}
 	$store.value.fetch().then(() => {
 		if (!$store.value.layout.value) {
 			$store.value.layout.value = $store.value.get_default_layout();
@@ -519,7 +488,6 @@ onUnmounted(() => {
 	document.removeEventListener("keydown", handle_keydown);
 	window.removeEventListener("pointermove", on_canvas_pointermove);
 	window.removeEventListener("pointerup", on_canvas_pointerup);
-	sidebar_observer_ref?.disconnect();
 });
 
 defineExpose({ toggle_preview, open_print_settings, show_preview, $store });
@@ -553,47 +521,6 @@ defineExpose({ toggle_preview, open_print_settings, show_preview, $store });
 	display: flex;
 	flex-direction: column;
 	height: calc(100vh - var(--pfb-chrome-offset));
-}
-
-/* ── Sidebar hint ────────────────────────────────────────── */
-.pfb-sidebar-hint {
-	flex-shrink: 0;
-	display: flex;
-	align-items: center;
-	gap: 6px;
-	padding: 4px 12px;
-	background: var(--gray-50);
-	border-bottom: 1px solid var(--gray-200);
-	font-size: var(--text-xs);
-	color: var(--gray-700);
-}
-
-.pfb-hint-icon {
-	flex-shrink: 0;
-	opacity: 0.7;
-}
-
-.pfb-hint-text {
-	flex: 1;
-}
-
-.pfb-hint-dismiss {
-	flex-shrink: 0;
-	display: flex;
-	align-items: center;
-	padding: 2px;
-	border: none;
-	background: transparent;
-	cursor: pointer;
-	color: var(--gray-500);
-	border-radius: var(--radius);
-	line-height: 1;
-	opacity: 0.7;
-}
-
-.pfb-hint-dismiss:hover {
-	opacity: 1;
-	background: var(--gray-200);
 }
 
 /* ── Canvas toolbar ──────────────────────────────────────── */

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -37,9 +37,9 @@
 			<!-- Header -->
 			<div class="pfb-fields-header">
 				<span class="pfb-fields-header-title">
-					{{ __("DOCUMENT FIELDS") }}
+					{{ __("Document Fields") }}
 					<span class="pfb-fields-header-sep">·</span>
-					{{ (meta.name || "").toUpperCase() }}
+					{{ meta.name }}
 				</span>
 			</div>
 
@@ -915,7 +915,6 @@ function handle_slash_key(e) {
 .pfb-fields-header-title {
 	font-size: var(--text-tiny);
 	font-weight: var(--weight-semibold);
-	letter-spacing: 0.06em;
 	color: var(--text-muted);
 }
 

--- a/frappe/public/js/print_format_builder/components/editor/FieldPreviewRepeater.vue
+++ b/frappe/public/js/print_format_builder/components/editor/FieldPreviewRepeater.vue
@@ -24,22 +24,20 @@
 					{{ repeater_cell(col, i, row) }}
 				</td>
 			</tr>
-			<tr v-if="!(preview_doc[df.source] || []).length">
-				<td class="text-muted pfb-table-note">
-					{{ df.source ? __("No rows") : __("Pick a source table") }}
-				</td>
-			</tr>
-			<tr v-if="(preview_doc[df.source] || []).length > 6">
-				<td :colspan="df.repeater_columns?.length || 1" class="text-muted pfb-table-note">
-					{{
-						__("+ {0} more rows in this document — all print in the real output", [
-							preview_doc[df.source].length - 6,
-						])
-					}}
-				</td>
-			</tr>
 		</tbody>
 	</table>
+	<!-- outside the table: a note row inside tbody would take over `tr:last-child`,
+	     which every last-row border rule is keyed on -->
+	<div v-if="!(preview_doc[df.source] || []).length" class="text-muted pfb-table-note">
+		{{ df.source ? __("No rows") : __("Pick a source table") }}
+	</div>
+	<div v-else-if="preview_doc[df.source].length > 6" class="text-muted pfb-table-note">
+		{{
+			__("+ {0} more rows in this document — all print in the real output", [
+				preview_doc[df.source].length - 6,
+			])
+		}}
+	</div>
 </template>
 
 <script setup>

--- a/frappe/public/js/print_format_builder/components/editor/FieldPreviewTable.vue
+++ b/frappe/public/js/print_format_builder/components/editor/FieldPreviewTable.vue
@@ -95,20 +95,6 @@
 					</template>
 				</td>
 			</tr>
-			<tr v-if="!preview_doc[df.fieldname]?.length">
-				<td :colspan="df.table_columns?.length || 1" class="text-muted pfb-table-note">
-					{{ __("No rows") }}
-				</td>
-			</tr>
-			<tr v-if="(preview_doc[df.fieldname] || []).length > 4">
-				<td :colspan="df.table_columns?.length || 1" class="text-muted pfb-table-note">
-					{{
-						__("+ {0} more rows in this document — all print in the real output", [
-							preview_doc[df.fieldname].length - 4,
-						])
-					}}
-				</td>
-			</tr>
 		</tbody>
 		<!-- after tbody (HTML5 order): user styles that remap tfoot's display can
 		     no longer float the cap up under the header -->
@@ -118,6 +104,18 @@
 			</tr>
 		</tfoot>
 	</table>
+	<!-- outside the table: a note row inside tbody would take over `tr:last-child`,
+	     which every last-row border rule is keyed on -->
+	<div v-if="!preview_doc[df.fieldname]?.length" class="text-muted pfb-table-note">
+		{{ __("No rows") }}
+	</div>
+	<div v-else-if="preview_doc[df.fieldname].length > 4" class="text-muted pfb-table-note">
+		{{
+			__("+ {0} more rows in this document — all print in the real output", [
+				preview_doc[df.fieldname].length - 4,
+			])
+		}}
+	</div>
 </template>
 
 <script setup>

--- a/frappe/utils/test_print_format_parity.py
+++ b/frappe/utils/test_print_format_parity.py
@@ -182,6 +182,28 @@ class TestPrintSurfaceMarkupContract(UnitTestCase):
 			foot = re.search(r"<tfoot>(.*?)</tfoot>", source.read_text(), flags=re.S).group(1)
 			self.assertNotIn("colspan", foot, f"{source.name}: cap must be one cell per column")
 
+	def test_canvas_table_body_holds_only_data_rows(self):
+		"""The shared stylesheet decides where a table's bottom edge lives with
+		`tbody tr:last-child`. The canvas used to append its "No rows" / "+N more
+		rows" note as a <tr> inside <tbody>, so the note became the last row and the
+		real last row kept a border the print surface drops -- a preview-only border
+		break that survived four fixes because every fix was made against the server
+		markup. Notes render after </table>; <tbody> carries data rows only.
+		"""
+		self.assertRegex(SHARED_CSS.read_text(), r"tbody\s+tr:last-child\s+td")
+
+		for source in (
+			BUILDER_DIR / "components" / "editor" / "FieldPreviewTable.vue",
+			BUILDER_DIR / "components" / "editor" / "FieldPreviewRepeater.vue",
+		):
+			text = source.read_text()
+			body = re.search(r"<tbody>(.*?)</tbody>", text, flags=re.S).group(1)
+			rows = re.findall(r"<tr\b[^>]*>", body)
+			self.assertEqual(len(rows), 1, f"{source.name}: <tbody> must hold only the data row")
+			self.assertIn("v-for", rows[0], f"{source.name}: the <tbody> row must be the data row")
+			self.assertNotIn("pfb-table-note", body, f"{source.name}: row notes belong outside the table")
+			self.assertIn("pfb-table-note", text, f"{source.name}: the note itself must survive")
+
 	def test_data_html_field_properties_mirrored_in_canvas(self):
 		"""Every df.* property the regular-field macro reads must be handled by Field.vue."""
 		self._assert_df_props_mirrored(APP_PATH / "templates" / "print_format" / "macros" / "Data.html")


### PR DESCRIPTION
- The builder is reached from Print Format instead of its own workspace link; breadcrumb is now `Print Format / <name>` and the "Create or Edit Print Format" dialog is gone
- Body sidebar is hidden inside the builder (the workspace dock stays), so the "close the sidebar for more space" tip goes with it
- Fields panel header is `Document Fields · Sales Invoice` instead of all-caps
- Child-table borders break in the canvas only: the "+N more rows" note was a `<tr>` in `<tbody>`, so it became `tr:last-child` and the real last row kept a border print drops. Notes now render after `</table>`, with a parity test pinning it

Why: two entry points and a dialog for something the Print Format list already does, plus a tip telling you to undo the layout yourself.

no-docs
