### PR TITLE
fix(list): return undeleted names from bulk delete and trust only that list

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -832,11 +832,13 @@ def delete_items():
 
 	if len(items) > 10:
 		frappe.enqueue("frappe.desk.reportview.delete_bulk", doctype=doctype, items=items)
-	else:
-		delete_bulk(doctype, items)
+		return None
+
+	return delete_bulk(doctype, items)
 
 
 def delete_bulk(doctype, items):
+	"""Delete documents one by one. Returns names that could not be deleted."""
 	undeleted_items = []
 	for i, d in enumerate(items):
 		try:
@@ -861,19 +863,21 @@ def delete_bulk(doctype, items):
 			frappe.db.rollback()
 	if undeleted_items and len(items) != len(undeleted_items):
 		frappe.clear_messages()
-		delete_bulk(doctype, undeleted_items)
+		return delete_bulk(doctype, undeleted_items)
 	elif undeleted_items:
 		frappe.msgprint(
 			_("Failed to delete {0} documents: {1}").format(len(undeleted_items), ", ".join(undeleted_items)),
 			realtime=True,
 			title=_("Bulk Operation Failed"),
 		)
-	else:
-		frappe.msgprint(
-			_(f"Deleted {len(items)} records from {doctype} doctype"),
-			realtime=True,
-			title=_("Bulk Operation Successful"),
-		)
+		return undeleted_items
+
+	frappe.msgprint(
+		_(f"Deleted {len(items)} records from {doctype} doctype"),
+		realtime=True,
+		title=_("Bulk Operation Successful"),
+	)
+	return []
 
 
 @frappe.whitelist()

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -873,7 +873,7 @@ def delete_bulk(doctype, items):
 		return undeleted_items
 
 	frappe.msgprint(
-		_(f"Deleted {len(items)} records from {doctype} doctype"),
+		_("Deleted {0} records from {1} doctype").format(len(items), doctype),
 		realtime=True,
 		title=_("Bulk Operation Successful"),
 	)

--- a/frappe/public/js/frappe/list/bulk_operations.js
+++ b/frappe/public/js/frappe/list/bulk_operations.js
@@ -207,8 +207,14 @@ export default class BulkOperations {
 				},
 			})
 			.then((r) => {
+				// delete_items returns the undeleted names, or null when the job was enqueued.
+				// Only trust an explicit list — otherwise we would clear meta locals for
+				// documents that still exist (failed deletes) or were not deleted yet (async).
 				let failed = r.message;
-				if (!failed) failed = [];
+				if (!Array.isArray(failed)) {
+					if (done) done();
+					return;
+				}
 
 				if (failed.length && !r._server_messages) {
 					frappe.throw(


### PR DESCRIPTION
`delete_bulk` never returned anything, so `failed` was always `[]` and we emitted `delete` for every name (including failed and still-queued async jobs).

**Fix:**
- Server now returns the undeleted names (`[]` on full success, `None` when enqueued)
- Client only fires `delete` when the result is an actual array, and only for names not in that list