### PR TITLE
fix(model): keep boot/meta locals in sync via delete and rename events

### DIFF
--- a/frappe/public/js/frappe/db.js
+++ b/frappe/public/js/frappe/db.js
@@ -100,7 +100,9 @@ frappe.db = {
 	delete_doc: function (doctype, name) {
 		return new Promise((resolve) => {
 			frappe.call("frappe.client.delete", { doctype, name }, (r) => {
-				$(document).trigger("delete", [doctype, name]);
+				if (!r.exc) {
+					$(document).trigger("delete", [doctype, name]);
+				}
 				resolve(r.message);
 			});
 		});

--- a/frappe/public/js/frappe/db.js
+++ b/frappe/public/js/frappe/db.js
@@ -101,7 +101,7 @@ frappe.db = {
 		return new Promise((resolve) => {
 			frappe.call("frappe.client.delete", { doctype, name }, (r) => {
 				if (!r.exc) {
-					$(document).trigger("delete", [doctype, name]);
+					frappe.model.delete_from_locals(doctype, name);
 				}
 				resolve(r.message);
 			});

--- a/frappe/public/js/frappe/db.js
+++ b/frappe/public/js/frappe/db.js
@@ -99,7 +99,10 @@ frappe.db = {
 	},
 	delete_doc: function (doctype, name) {
 		return new Promise((resolve) => {
-			frappe.call("frappe.client.delete", { doctype, name }, (r) => resolve(r.message));
+			frappe.call("frappe.client.delete", { doctype, name }, (r) => {
+				$(document).trigger("delete", [doctype, name]);
+				resolve(r.message);
+			});
 		});
 	},
 	count: function (doctype, args = {}, cache = false) {

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -156,9 +156,8 @@ frappe.ui.form.Toolbar = class Toolbar {
 				)
 				.then((new_docname) => {
 					const reload_form = (input_name) => {
+						frappe.model.rename_doc_in_locals(doctype, docname, input_name, merge);
 						$(document).trigger("rename", [doctype, docname, input_name]);
-						if (locals[doctype] && locals[doctype][docname])
-							delete locals[doctype][docname];
 						this.frm.reload_doc();
 					};
 

--- a/frappe/public/js/frappe/list/bulk_operations.js
+++ b/frappe/public/js/frappe/list/bulk_operations.js
@@ -216,6 +216,12 @@ export default class BulkOperations {
 					return;
 				}
 
+				for (const name of docnames) {
+					if (!failed.includes(name)) {
+						frappe.model.delete_from_locals(this.doctype, name);
+					}
+				}
+
 				if (failed.length && !r._server_messages) {
 					frappe.throw(
 						__("Cannot delete {0}", [failed.map((f) => f.bold()).join(", ")])
@@ -223,11 +229,6 @@ export default class BulkOperations {
 				}
 				if (failed.length < docnames.length) {
 					frappe.utils.play_sound("delete");
-					for (const name of docnames) {
-						if (!failed.includes(name)) {
-							$(document).trigger("delete", [this.doctype, name]);
-						}
-					}
 					if (done) done();
 				}
 			});

--- a/frappe/public/js/frappe/list/bulk_operations.js
+++ b/frappe/public/js/frappe/list/bulk_operations.js
@@ -223,6 +223,11 @@ export default class BulkOperations {
 				}
 				if (failed.length < docnames.length) {
 					frappe.utils.play_sound("delete");
+					for (const name of docnames) {
+						if (!failed.includes(name)) {
+							$(document).trigger("delete", [this.doctype, name]);
+						}
+					}
 					if (done) done();
 				}
 			});

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -758,6 +758,7 @@ $.extend(frappe.model, {
 						if (!r.exc) {
 							frappe.utils.play_sound("delete");
 							frappe.model.clear_doc(doctype, docname);
+							$(document).trigger("delete", [doctype, docname]);
 							if (callback) callback(r, rt);
 						}
 					},

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -757,8 +757,7 @@ $.extend(frappe.model, {
 					callback: function (r, rt) {
 						if (!r.exc) {
 							frappe.utils.play_sound("delete");
-							frappe.model.clear_doc(doctype, docname);
-							$(document).trigger("delete", [doctype, docname]);
+							frappe.model.delete_from_locals(doctype, docname);
 							if (callback) callback(r, rt);
 						}
 					},
@@ -804,13 +803,17 @@ $.extend(frappe.model, {
 				btn: d.get_primary_btn(),
 				callback: function (r, rt) {
 					if (!r.exc) {
+						frappe.model.rename_doc_in_locals(
+							doctype,
+							docname,
+							r.message || args.new_name,
+							args.merge
+						);
 						$(document).trigger("rename", [
 							doctype,
 							docname,
 							r.message || args.new_name,
 						]);
-						if (locals[doctype] && locals[doctype][docname])
-							delete locals[doctype][docname];
 						d.hide();
 						if (callback) callback(r.message);
 					}

--- a/frappe/public/js/frappe/model/sync.js
+++ b/frappe/public/js/frappe/model/sync.js
@@ -223,3 +223,25 @@ Object.assign(frappe.model, {
 		clear_keys(updated_doc, local_parent_doc);
 	},
 });
+
+// Boot/meta copies live under locals[":" + doctype] (see frappe.model.get_list).
+// Keep that namespace aligned when the real document is deleted or renamed —
+// without clear_doc, which only drops the full-document cache before a reload.
+$(document).on("delete", (e, doctype, name) => {
+	if (locals[":" + doctype]) {
+		delete locals[":" + doctype][name];
+	}
+});
+
+$(document).on("rename", (e, doctype, old_name, new_name) => {
+	const meta_doctype = ":" + doctype;
+	if (!locals[meta_doctype]?.[old_name]) {
+		return;
+	}
+	locals[meta_doctype][new_name] = {
+		...locals[meta_doctype][old_name],
+		name: new_name,
+		doctype: meta_doctype,
+	};
+	delete locals[meta_doctype][old_name];
+});

--- a/frappe/public/js/frappe/model/sync.js
+++ b/frappe/public/js/frappe/model/sync.js
@@ -43,14 +43,45 @@ Object.assign(frappe.model, {
 
 	rename_after_save: (d, i) => {
 		frappe.model.new_names[d.localname] = d.name;
+		frappe.model.rename_doc_in_locals(d.doctype, d.localname, d.name);
 		$(document).trigger("rename", [d.doctype, d.localname, d.name]);
-		delete locals[d.doctype][d.localname];
 
 		// update docinfo to new dict keys
 		if (i === 0) {
 			frappe.model.docinfo[d.doctype][d.name] = frappe.model.docinfo[d.doctype][d.localname];
 			frappe.model.docinfo[d.doctype][d.localname] = undefined;
 		}
+	},
+
+	delete_from_locals: (doctype, name) => {
+		frappe.model.clear_doc(doctype, name);
+		if (locals[":" + doctype]) {
+			delete locals[":" + doctype][name];
+		}
+	},
+
+	rename_doc_in_locals: (doctype, old_name, new_name, merge = false) => {
+		if (old_name === new_name) {
+			return;
+		}
+
+		if (locals[doctype]) {
+			delete locals[doctype][old_name];
+		}
+
+		const meta_doctype = ":" + doctype;
+		const doc = locals[meta_doctype]?.[old_name];
+		if (!doc) {
+			return;
+		}
+
+		// The target survives a merge; keep its cached values if present.
+		if (!merge) {
+			doc.name = new_name;
+			doc.doctype = meta_doctype;
+			locals[meta_doctype][new_name] = doc;
+		}
+		delete locals[meta_doctype][old_name];
 	},
 
 	sync_docinfo: (r) => {
@@ -222,26 +253,4 @@ Object.assign(frappe.model, {
 		// clear keys on parent
 		clear_keys(updated_doc, local_parent_doc);
 	},
-});
-
-// Boot/meta copies live under locals[":" + doctype] (see frappe.model.get_list).
-// Keep that namespace aligned when the real document is deleted or renamed —
-// without clear_doc, which only drops the full-document cache before a reload.
-$(document).on("delete", (e, doctype, name) => {
-	if (locals[":" + doctype]) {
-		delete locals[":" + doctype][name];
-	}
-});
-
-$(document).on("rename", (e, doctype, old_name, new_name) => {
-	const meta_doctype = ":" + doctype;
-	if (!locals[meta_doctype]?.[old_name]) {
-		return;
-	}
-	locals[meta_doctype][new_name] = {
-		...locals[meta_doctype][old_name],
-		name: new_name,
-		doctype: meta_doctype,
-	};
-	delete locals[meta_doctype][old_name];
 });


### PR DESCRIPTION
Tested as follows:

1. Build assets and hard-refresh Desk:

```sh
bench build --app frappe
```

Run `bench start` first if needed.

2. Create enabled **Currency** records: "D01", "D02", "B01", "R01", "M01", and "M02". Give "M01" and "M02" different _Symbol_ values.

3. Reload Desk once to populate `locals[":Currency"]`. Do not reload during each test.

4. Delete "D01" from its form. Verify:

```js
console.assert(!locals.Currency?.D01);
console.assert(!locals[":Currency"]?.D01);
```

5. Delete "D02" through the database API:

```js
await frappe.db.delete_doc("Currency", "D02");
console.assert(!locals.Currency?.D02);
console.assert(!locals[":Currency"]?.D02);
```

6. Bulk-delete "B01" together with the site’s default currency. The default currency should fail, while "B01" succeeds. Verify "B01" was removed despite the error:

```js
console.assert(!locals[":Currency"]?.B01);
console.assert(locals[":Currency"]?.[frappe.boot.sysdefaults.currency]);
```

7. Rename "R01" to "R02". Verify:

```js
console.assert(!locals[":Currency"]?.R01);
console.assert(locals[":Currency"]?.R02?.name === "R02");
```

8. Merge "M01" into "M02". Verify "M02" retains its original _Symbol_:

```js
console.assert(!locals[":Currency"]?.M01);
console.assert(locals[":Currency"]?.M02?.symbol === "M02's original symbol");
```