### PR TITLE
fix(oauth2): restrict endpoint HTTP methods

### DIFF
--- a/frappe/integrations/oauth2.py
+++ b/frappe/integrations/oauth2.py
@@ -161,7 +161,7 @@ def authorize(**kwargs):
 			return generate_json_error_response(e)
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(allow_guest=True, methods=["POST"])
 def get_token(*args, **kwargs):
 	try:
 		r = frappe.request
@@ -182,7 +182,7 @@ def get_token(*args, **kwargs):
 		return generate_json_error_response(e)
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(allow_guest=True, methods=["POST"])
 def revoke_token(*args, **kwargs):
 	try:
 		r = frappe.request
@@ -201,7 +201,7 @@ def revoke_token(*args, **kwargs):
 	return
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["GET", "POST"])
 def openid_profile(*args, **kwargs):
 	try:
 		r = frappe.request
@@ -245,7 +245,7 @@ def get_openid_configuration():
 	return response
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(allow_guest=True, methods=["POST"])
 def introspect_token(token: str, token_type_hint: str | None = None):
 	if token_type_hint not in ["access_token", "refresh_token"]:
 		token_type_hint = "access_token"


### PR DESCRIPTION
## Problem
The OAuth endpoints did not declare allowed HTTP methods. Frappe therefore accepted methods outside each endpoint's protocol contract.

## Proof
- [RFC 6749 section 3.2](https://www.rfc-editor.org/rfc/rfc6749.txt) requires POST for token requests.
- [RFC 7009 section 2](https://www.rfc-editor.org/rfc/rfc7009.txt) defines token revocation as a POST request.
- [RFC 7662 section 2.1](https://www.rfc-editor.org/rfc/rfc7662.txt) defines token introspection as a POST request.
- [OpenID Connect Core section 5.3](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo) requires GET and POST support for UserInfo.

Before this change, these whitelisted methods had no method restrictions. Token creation and revocation could therefore enter through unsupported HTTP methods.

## Fix approach
- Restrict token, revocation, and introspection endpoints to POST.
- Allow GET and POST for UserInfo.
- Keep request parsing and endpoint behavior unchanged.

## Compatibility and backport
**Breaking risk: medium.** Standards-compliant clients already use these methods and are unaffected. Existing clients that use GET for token, revocation, or introspection will receive a method rejection.

**Backport: develop only.** This change tightens public endpoint contracts and can break deployed noncompliant clients without a migration path.

## Tests
Tests were not run locally per request. CI will run the suite.