### PR TITLE
fix(recorder): mark Recorder Event as virtual

### DIFF
--- a/frappe/core/doctype/recorder_event/recorder_event.json
+++ b/frappe/core/doctype/recorder_event/recorder_event.json
@@ -88,9 +88,10 @@
    "read_only": 1
   }
  ],
+ "is_virtual": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-07-30 00:00:00.000000",
+ "modified": "2026-08-04 11:18:44.372615",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Recorder Event",


### PR DESCRIPTION
- `Recorder Event` is a child table of `Recorder`, which is `is_virtual: 1`, but was itself missing the flag — so `bench migrate` created a real `tabRecorder Event` table that can never hold a row (timeline data lives in Redis and is built in `Recorder.load_from_db`)
- Both sibling child tables of the same parent (`Recorder Query`, `Recorder Suggested Index`) are already `istable: 1` + `is_virtual: 1`

Why: `validate_fields` in `doctype.py` throws "Child Table {0} for field {1} must be virtual" when a virtual parent has a non-virtual child table, so the shipped JSON did not satisfy a rule the framework enforces. Introduced in #41427.
