### PR TITLE
feat: Ability to disable / enable app

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1456,10 +1456,14 @@ def is_setup_complete():
 	if not frappe.db.table_exists("Installed Application"):
 		return setup_complete
 
+	from frappe.apps import get_disabled_apps
+
+	disabled_apps = get_disabled_apps()
+	wizard_apps = [app for app in ["frappe", "erpnext"] if app not in disabled_apps]
 	if all(
 		frappe.get_all(
 			"Installed Application",
-			{"app_name": ("in", ["frappe", "erpnext"])},
+			{"app_name": ("in", wizard_apps)},
 			pluck="is_setup_complete",
 		)
 	):

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -123,6 +123,8 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
 	# frappe.apps
 	"get_all_apps": ("frappe.apps", "get_all_apps"),
 	"get_installed_apps": ("frappe.apps", "get_installed_apps"),
+	"get_disabled_apps": ("frappe.apps", "get_disabled_apps"),
+	"get_active_apps": ("frappe.apps", "get_active_apps"),
 	# frappe.utils.response
 	"respond_as_web_page": ("frappe.utils.response", "respond_as_web_page"),
 	"redirect_to_message": ("frappe.utils.response", "redirect_to_message"),
@@ -148,7 +150,7 @@ if TYPE_CHECKING:  # pragma: no cover
 	from werkzeug.wrappers import Request
 
 	# Lazy-imported names — resolved at runtime via __getattr__; listed here for editors/type checkers
-	from frappe.apps import get_all_apps, get_installed_apps
+	from frappe.apps import get_active_apps, get_all_apps, get_disabled_apps, get_installed_apps
 	from frappe.cache_manager import clear_cache, reset_metadata_version
 	from frappe.concurrency_limiter import concurrent_limit
 	from frappe.config import get_common_site_config, get_conf, get_site_config

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -631,6 +631,8 @@ def is_whitelisted(method):
 	from frappe.utils import sanitize_html
 
 	app_name = (method.__module__ or "").split(".", 1)[0]
+	from frappe.apps import get_disabled_apps
+
 	if app_name in get_disabled_apps():
 		throw(_("App {0} is not installed").format(app_name), AppNotInstalledError)
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1014,7 +1014,7 @@ def get_doc_hooks():
 def _load_app_hooks(app_name: str | None = None):
 	import types
 
-	from frappe.apps import get_installed_apps
+	from frappe.apps import get_active_apps
 	from frappe.utils import get_module
 
 	hooks = {}

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -630,6 +630,10 @@ def whitelist(allow_guest=False, xss_safe=False, methods=None, force_types=None)
 def is_whitelisted(method):
 	from frappe.utils import sanitize_html
 
+	app_name = (method.__module__ or "").split(".", 1)[0]
+	if app_name in get_disabled_apps():
+		throw(_("App {0} is not installed").format(app_name), AppNotInstalledError)
+
 	is_guest = session["user"] == "Guest"
 	if method not in whitelisted or (is_guest and method not in guest_methods):
 		if method in whitelisted and is_guest and response.get("session_expired"):
@@ -1014,7 +1018,7 @@ def _load_app_hooks(app_name: str | None = None):
 	from frappe.utils import get_module
 
 	hooks = {}
-	apps = [app_name] if app_name else get_installed_apps(_ensure_on_bench=True)
+	apps = [app_name] if app_name else get_active_apps(_ensure_on_bench=True)
 
 	for app in apps:
 		try:

--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -60,6 +60,8 @@ def handle_rpc_call(method: str, doctype: str | None = None):
 
 	try:
 		method = frappe.get_attr(method)
+	except frappe.AppNotInstalledError:
+		raise
 	except Exception as e:
 		frappe.throw(_("Failed to get method {0} with {1}").format(method, str(e)))
 

--- a/frappe/app_state.py
+++ b/frappe/app_state.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 
 import frappe
+from frappe.query_builder.functions import IfNull
 
 
 def is_disabled_app_filtering_active() -> bool:
@@ -83,17 +84,15 @@ def get_module_permission_query_conditions(user, doctype=None):
 	"""Hide records of a disabled app from list views, for any DocType with a `module` field."""
 	disabled_modules = get_disabled_modules()
 	if not disabled_modules:
-		return ""
+		return None
 
-	modules = ", ".join(frappe.db.escape(module) for module in disabled_modules)
-	return f"`tab{doctype}`.`module` not in ({modules})"
+	return IfNull(frappe.qb.DocType(doctype).module, "").notin(list(disabled_modules))
 
 
 def get_app_permission_query_conditions(user, doctype=None):
 	"""Same as above, for DocTypes that name their owner in an `app` field instead."""
 	disabled_apps = frappe.get_disabled_apps()
 	if not disabled_apps:
-		return ""
+		return None
 
-	apps = ", ".join(frappe.db.escape(app) for app in disabled_apps)
-	return f"ifnull(`tab{doctype}`.`app`, '') not in ({apps})"
+	return IfNull(frappe.qb.DocType(doctype).app, "").notin(disabled_apps)

--- a/frappe/app_state.py
+++ b/frappe/app_state.py
@@ -17,6 +17,16 @@ def is_disabled_app_filtering_active() -> bool:
 	)
 
 
+def clear_cache_after_maintenance():
+	"""Drop the caches that a maintenance operation filled.
+
+	While a maintenance flag is set, Frappe caches meta and hooks that still hold the
+	customizations of a disabled app. A site with no disabled app has nothing to drop.
+	"""
+	if frappe.get_disabled_apps():
+		frappe.clear_cache()
+
+
 @frappe.request_cache
 def get_disabled_modules() -> set[str]:
 	"""Return `Module Def` names owned by apps that are disabled on this site.

--- a/frappe/app_state.py
+++ b/frappe/app_state.py
@@ -4,7 +4,7 @@
 import frappe
 
 
-def is_concealment_active() -> bool:
+def is_disabled_app_filtering_active() -> bool:
 	"""Return False during maintenance, so a disabled app is never hidden mid-operation."""
 	return not (
 		frappe.flags.in_install
@@ -13,6 +13,7 @@ def is_concealment_active() -> bool:
 		or frappe.flags.in_import
 		or frappe.flags.in_uninstall
 		or frappe.flags.in_setup_wizard
+		or frappe.flags.in_app_toggle
 	)
 
 
@@ -23,7 +24,7 @@ def get_disabled_modules() -> set[str]:
 	Derived per request rather than cached across them, so it can never contradict the
 	`disabled_apps` global a worker is currently reading.
 	"""
-	if not is_concealment_active():
+	if not is_disabled_app_filtering_active():
 		return set()
 
 	disabled_apps = frappe.get_disabled_apps()

--- a/frappe/app_state.py
+++ b/frappe/app_state.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+
+import frappe
+
+
+def is_concealment_active() -> bool:
+	"""Return False during maintenance, so a disabled app is never hidden mid-operation."""
+	return not (
+		frappe.flags.in_install
+		or frappe.flags.in_migrate
+		or frappe.flags.in_patch
+		or frappe.flags.in_import
+		or frappe.flags.in_uninstall
+		or frappe.flags.in_setup_wizard
+	)
+
+
+@frappe.request_cache
+def get_disabled_modules() -> set[str]:
+	"""Return `Module Def` names owned by apps that are disabled on this site.
+
+	Derived per request rather than cached across them, so it can never contradict the
+	`disabled_apps` global a worker is currently reading.
+	"""
+	if not is_concealment_active():
+		return set()
+
+	disabled_apps = frappe.get_disabled_apps()
+	if not disabled_apps:
+		return set()
+
+	module_def = frappe.qb.DocType("Module Def")
+	return set(
+		frappe.qb.from_(module_def)
+		.select(module_def.name)
+		.where(module_def.app_name.isin(disabled_apps))
+		.run(pluck=True)
+	)
+
+
+@frappe.request_cache
+def get_disabled_doctypes() -> set[str]:
+	"""Return DocTypes owned by apps that are disabled on this site."""
+	disabled_modules = get_disabled_modules()
+	if not disabled_modules:
+		return set()
+
+	doctype = frappe.qb.DocType("DocType")
+	return set(
+		frappe.qb.from_(doctype)
+		.select(doctype.name)
+		.where(doctype.module.isin(list(disabled_modules)))
+		.run(pluck=True)
+	)
+
+
+def is_module_disabled(module: str) -> bool:
+	return bool(module) and module in get_disabled_modules()
+
+
+def filter_out_disabled_doctypes(doctypes: list[str]) -> list[str]:
+	"""Drop DocTypes owned by an app that is disabled on this site."""
+	disabled_doctypes = get_disabled_doctypes()
+	if not disabled_doctypes:
+		return doctypes
+
+	return [doctype for doctype in doctypes if doctype not in disabled_doctypes]
+
+
+def get_module_permission_query_conditions(user, doctype=None):
+	"""Hide records of a disabled app from list views, for any DocType with a `module` field."""
+	disabled_modules = get_disabled_modules()
+	if not disabled_modules:
+		return ""
+
+	modules = ", ".join(frappe.db.escape(module) for module in disabled_modules)
+	return f"`tab{doctype}`.`module` not in ({modules})"
+
+
+def get_app_permission_query_conditions(user, doctype=None):
+	"""Same as above, for DocTypes that name their owner in an `app` field instead."""
+	disabled_apps = frappe.get_disabled_apps()
+	if not disabled_apps:
+		return ""
+
+	apps = ", ".join(frappe.db.escape(app) for app in disabled_apps)
+	return f"ifnull(`tab{doctype}`.`app`, '') not in ({apps})"

--- a/frappe/apps.py
+++ b/frappe/apps.py
@@ -179,3 +179,23 @@ def get_installed_apps(*, _ensure_on_bench: bool = False) -> list[str]:
 		installed = [app for app in installed if app in all_apps]
 
 	return installed
+
+
+def get_disabled_apps() -> list[str]:
+	"""Return apps that are installed on current site but logically disabled."""
+	if getattr(frappe.flags, "in_install_db", True):
+		return []
+
+	if not frappe.db:
+		frappe.connect()
+
+	return orjson.loads(frappe.db.get_global("disabled_apps") or "[]")
+
+
+@request_cache
+def get_active_apps(*, _ensure_on_bench: bool = False) -> list[str]:
+	"""Installed apps excluding those logically disabled on this site."""
+	installed = get_installed_apps(_ensure_on_bench=_ensure_on_bench)
+	disabled = get_disabled_apps()
+
+	return [app for app in installed if app not in disabled]

--- a/frappe/apps.py
+++ b/frappe/apps.py
@@ -35,8 +35,9 @@ def get_docked_apps() -> set[str]:
 @frappe.whitelist()
 @request_cache
 def get_apps():
-	apps = frappe.get_installed_apps()
+	apps = frappe.get_active_apps()
 	docked_apps = get_docked_apps()
+
 	app_list = []
 	for app in apps:
 		if (
@@ -74,7 +75,7 @@ def get_apps():
 
 
 def get_route(app_name):
-	if app_name not in frappe.get_installed_apps():
+	if app_name not in frappe.get_active_apps():
 		return "/apps"  # Invalid defaults
 	apps = frappe.get_hooks("add_to_apps_screen", app_name=app_name)
 	app = next((app for app in apps if app.get("name") == app_name), None)
@@ -112,7 +113,7 @@ def get_default_path():
 
 @frappe.whitelist()
 def set_app_as_default(app_name: str):
-	if app_name not in frappe.get_installed_apps():
+	if app_name not in frappe.get_active_apps():
 		frappe.throw(_("App {} is not installed").format(frappe.bold(app_name)))
 
 	if frappe.db.get_value("User", frappe.session.user, "default_app") == app_name:

--- a/frappe/apps.py
+++ b/frappe/apps.py
@@ -182,9 +182,10 @@ def get_installed_apps(*, _ensure_on_bench: bool = False) -> list[str]:
 	return installed
 
 
+@request_cache
 def get_disabled_apps() -> list[str]:
 	"""Return apps that are installed on current site but logically disabled."""
-	if getattr(frappe.flags, "in_install_db", True):
+	if frappe.flags.in_install_db:
 		return []
 
 	if not frappe.db:

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -9,6 +9,7 @@ import os
 import frappe
 import frappe.defaults
 import frappe.desk.desk_page
+from frappe.app_state import filter_out_disabled_doctypes, get_disabled_modules
 from frappe.core.doctype.installed_applications.installed_applications import (
 	get_setup_wizard_completed_apps,
 )
@@ -69,9 +70,17 @@ def get_bootinfo():
 	bootinfo.all_domains = frappe.get_all("Domain", pluck="name")
 	add_layouts(bootinfo)
 
-	bootinfo.module_app = get_boot_module_app()
-	bootinfo.single_types = frappe.get_all("DocType", {"issingle": 1}, pluck="name")
-	bootinfo.nested_set_doctypes = frappe.get_all("DocField", {"fieldname": "lft"}, pluck="parent")
+	# module_app is keyed by scrubbed module name
+	disabled_modules = {frappe.scrub(module) for module in get_disabled_modules()}
+	bootinfo.module_app = {
+		module: app for module, app in frappe.local.module_app.items() if module not in disabled_modules
+	}
+	bootinfo.single_types = filter_out_disabled_doctypes(
+		frappe.get_all("DocType", {"issingle": 1}, pluck="name")
+	)
+	bootinfo.nested_set_doctypes = filter_out_disabled_doctypes(
+		frappe.get_all("DocField", {"fieldname": "lft"}, pluck="parent")
+	)
 	bootinfo.tree_view_doctypes = get_tree_view_doctypes()
 	add_home_page(bootinfo, doclist)
 	load_translations(bootinfo)
@@ -297,8 +306,7 @@ def get_app_data(allowed_pages: list[str]) -> list[dict]:
 	Workspace = frappe.qb.DocType("Workspace")
 	Module = frappe.qb.DocType("Module Def")
 
-	installed_apps = frappe.get_installed_apps()
-	for app_name in installed_apps:
+	for app_name in frappe.get_active_apps():
 		# get app details from app_info (/apps)
 		apps = frappe.get_hooks("add_to_apps_screen", app_name=app_name)
 		app_info = {}
@@ -500,7 +508,7 @@ def get_link_preview_doctypes():
 		else:
 			link_preview_doctypes.append(custom.doc_type)
 
-	return link_preview_doctypes
+	return filter_out_disabled_doctypes(link_preview_doctypes)
 
 
 def get_additional_filters_from_hooks():
@@ -557,7 +565,7 @@ def get_link_title_doctypes():
 		{"property": "show_title_field_in_link", "value": "1"},
 		["doc_type as name"],
 	)
-	return [d.name for d in dts + custom_dts if d]
+	return filter_out_disabled_doctypes([d.name for d in dts + custom_dts if d])
 
 
 def set_time_zone(bootinfo):
@@ -601,7 +609,7 @@ def load_currency_docs(bootinfo):
 
 @redis_cache
 def get_tree_view_doctypes():
-	return frappe.get_all("DocType", {"default_view": "Tree"}, pluck="name")
+	return filter_out_disabled_doctypes(frappe.get_all("DocType", {"default_view": "Tree"}, pluck="name"))
 
 
 def add_subscription_conf():
@@ -672,6 +680,7 @@ def get_sidebar_items():
 	authored workspace sidebar fall back to one generated on the fly. The legacy
 	`Workspace Sidebar` doctype is no longer read here.
 	"""
+	from frappe.app_state import get_disabled_modules
 	from frappe.desk.doctype.workspace_sidebar.workspace_sidebar import auto_generate_sidebar_from_module
 	from frappe.utils.modules import get_blocked_modules
 
@@ -679,6 +688,7 @@ def get_sidebar_items():
 	# `Workspace` instance as a shared permission context for filtering every item.
 	perm_ctx = frappe.new_doc("Workspace")
 	sidebar_items = {}
+	disabled_modules = get_disabled_modules()
 
 	# Primary source: authored `Workspace.sidebar_items` (the post-merge model). Everything the
 	# boot needs is fetched in batch instead of per workspace doc: `get_workspaces()` already
@@ -688,6 +698,8 @@ def get_sidebar_items():
 	items_by_workspace = get_authored_sidebar_items([w.name for w in workspaces])
 	module_onboarding = get_workspace_module_onboarding([w.name for w in workspaces])
 	for workspace in workspaces:
+		if workspace.module in disabled_modules:
+			continue
 		add_sidebar_entry(
 			sidebar_items,
 			title=workspace.name,
@@ -858,7 +870,7 @@ def add_sidebar_entry(
 def get_desktop_icon_urls():
 	icons_map = {}
 
-	for app in frappe.get_installed_apps():
+	for app in frappe.get_active_apps():
 		app_path = frappe.get_app_path(app)
 		icons_dir = os.path.join(app_path, "public", "icons", "desktop_icons")
 

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -571,7 +571,8 @@ def list_apps(context: CliCtxObj, format):
 		name_len = max(len(app.app_name) for app in apps)
 		ver_len = max(len(app.app_version) for app in apps)
 		template = f"{{0:{name_len}}} {{1:{ver_len}}} {{2}}"
-		return template.format(app.app_name, app.app_version, app.git_branch)
+		row = template.format(app.app_name, app.app_version, app.git_branch)
+		return f"{row} (disabled)" if app.get("disabled") else row
 
 	for site in context.sites:
 		frappe.init(site)
@@ -986,6 +987,43 @@ def remove_from_installed_apps(context: CliCtxObj, app):
 			frappe.init(site)
 			frappe.connect()
 			remove_from_installed_apps(app)
+		finally:
+			frappe.destroy()
+	if not context.sites:
+		raise SiteNotSpecifiedError
+
+
+@click.command("enable-app")
+@click.argument("app")
+@pass_context
+def enable_app(context: CliCtxObj, app):
+	"Enable an app that was disabled on site"
+	from frappe.installer import enable_app as _enable_app
+
+	for site in context.sites:
+		try:
+			frappe.init(site)
+			frappe.connect()
+			_enable_app(app)
+		finally:
+			frappe.destroy()
+	if not context.sites:
+		raise SiteNotSpecifiedError
+
+
+@click.command("disable-app")
+@click.argument("app")
+@pass_context
+def disable_app(context: CliCtxObj, app):
+	"Disable an app on site, keeping its schema and data intact"
+	ensure_app_not_frappe(app)
+	from frappe.installer import disable_app as _disable_app
+
+	for site in context.sites:
+		try:
+			frappe.init(site)
+			frappe.connect()
+			_disable_app(app)
 		finally:
 			frappe.destroy()
 	if not context.sites:
@@ -1696,6 +1734,8 @@ commands = [
 	describe_database_table,
 	backup,
 	drop_site,
+	disable_app,
+	enable_app,
 	install_app,
 	list_apps,
 	migrate,

--- a/frappe/core/doctype/custom_docperm/custom_docperm.json
+++ b/frappe/core/doctype/custom_docperm/custom_docperm.json
@@ -31,7 +31,8 @@
   "column_break_19",
   "share",
   "print",
-  "email"
+  "email",
+  "is_app_disabled"
  ],
  "fields": [
   {
@@ -223,11 +224,19 @@
    "fieldname": "select",
    "fieldtype": "Check",
    "label": "Select"
+  },
+  {
+   "default": "0",
+   "description": "Set while owner app is disabled.",
+   "fieldname": "is_app_disabled",
+   "fieldtype": "Check",
+   "label": "Is App Disabled",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "links": [],
- "modified": "2026-04-09 11:13:35.484376",
+ "modified": "2026-08-05 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Custom DocPerm",

--- a/frappe/core/doctype/custom_docperm/custom_docperm.py
+++ b/frappe/core/doctype/custom_docperm/custom_docperm.py
@@ -24,6 +24,7 @@ class CustomDocPerm(Document):
 		email: DF.Check
 		export: DF.Check
 		if_owner: DF.Check
+		is_app_disabled: DF.Check
 		mask: DF.Check
 		parent: DF.Data | None
 		permlevel: DF.Int

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -9,6 +9,7 @@ from datetime import date, datetime, time
 
 import frappe
 from frappe import _
+from frappe.app_state import clear_cache_after_maintenance
 from frappe.core.doctype.version.version import get_diff
 from frappe.model import no_value_fields
 from frappe.utils import cint, cstr, duration_to_seconds, flt, update_progress_bar
@@ -336,6 +337,7 @@ class Importer:
 	def after_import(self):
 		frappe.flags.in_import = False
 		frappe.flags.mute_emails = False
+		clear_cache_after_maintenance()
 
 	def _publish_skip_progress(self, current_index, total_payload_count):
 		if total_payload_count > 5:

--- a/frappe/core/doctype/installed_application/installed_application.json
+++ b/frappe/core/doctype/installed_application/installed_application.json
@@ -1,15 +1,18 @@
 {
  "actions": [],
- "creation": "2020-05-11 17:44:54.674657",
+ "creation": "2026-08-03 21:14:17.680095",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
   "app_name",
   "app_version",
   "git_branch",
+  "column_break_gfzc",
   "has_setup_wizard",
   "is_setup_complete",
-  "disabled"
+  "disabled",
+  "disable_application",
+  "enable_application"
  ],
  "fields": [
   {
@@ -61,12 +64,28 @@
    "in_list_view": 1,
    "label": "Disabled",
    "read_only": 1
+  },
+  {
+   "fieldname": "column_break_gfzc",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval:!doc.disabled && doc.app_name !== 'frappe'",
+   "fieldname": "disable_application",
+   "fieldtype": "Button",
+   "label": "Disable Application"
+  },
+  {
+   "depends_on": "eval:doc.disabled",
+   "fieldname": "enable_application",
+   "fieldtype": "Button",
+   "label": "Enable Application"
   }
  ],
  "grid_page_length": 50,
  "istable": 1,
  "links": [],
- "modified": "2026-08-03 12:00:00.000000",
+ "modified": "2026-08-04 12:40:02.195703",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Installed Application",

--- a/frappe/core/doctype/installed_application/installed_application.json
+++ b/frappe/core/doctype/installed_application/installed_application.json
@@ -8,7 +8,8 @@
   "app_version",
   "git_branch",
   "has_setup_wizard",
-  "is_setup_complete"
+  "is_setup_complete",
+  "disabled"
  ],
  "fields": [
   {
@@ -51,12 +52,21 @@
    "fieldtype": "Check",
    "in_list_view": 1,
    "label": "Is Setup Complete?"
+  },
+  {
+   "columns": 2,
+   "default": "0",
+   "fieldname": "disabled",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Disabled",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "istable": 1,
  "links": [],
- "modified": "2025-05-27 12:26:49.523690",
+ "modified": "2026-08-03 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Installed Application",

--- a/frappe/core/doctype/installed_application/installed_application.json
+++ b/frappe/core/doctype/installed_application/installed_application.json
@@ -1,6 +1,6 @@
 {
  "actions": [],
- "creation": "2026-08-03 21:14:17.680095",
+ "creation": "2020-05-11 17:44:54.674657",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [

--- a/frappe/core/doctype/installed_application/installed_application.py
+++ b/frappe/core/doctype/installed_application/installed_application.py
@@ -17,9 +17,9 @@ class InstalledApplication(Document):
 		from frappe.types import DF
 
 		app_name: DF.Data
-		app_version: DF.Data
+		app_version: DF.Data | None
 		disabled: DF.Check
-		git_branch: DF.Data
+		git_branch: DF.Data | None
 		has_setup_wizard: DF.Check
 		is_setup_complete: DF.Check
 		parent: DF.Data

--- a/frappe/core/doctype/installed_application/installed_application.py
+++ b/frappe/core/doctype/installed_application/installed_application.py
@@ -18,6 +18,7 @@ class InstalledApplication(Document):
 
 		app_name: DF.Data
 		app_version: DF.Data
+		disabled: DF.Check
 		git_branch: DF.Data
 		has_setup_wizard: DF.Check
 		is_setup_complete: DF.Check

--- a/frappe/core/doctype/installed_applications/installed_applications.js
+++ b/frappe/core/doctype/installed_applications/installed_applications.js
@@ -75,7 +75,7 @@ frappe.ui.form.on("Installed Application", {
 			callback() {
 				frappe.dom.unfreeze();
 				frappe.toast(__("{0} has been disabled", [row.app_name]));
-				cur_frm.reload_doc();
+				frm.reload_doc();
 			},
 		});
 	},
@@ -88,7 +88,7 @@ frappe.ui.form.on("Installed Application", {
 			callback() {
 				frappe.dom.unfreeze();
 				frappe.toast(__("{0} has been enabled", [row.app_name]));
-				cur_frm.reload_doc();
+				frm.reload_doc();
 			},
 		});
 	},

--- a/frappe/core/doctype/installed_applications/installed_applications.js
+++ b/frappe/core/doctype/installed_applications/installed_applications.js
@@ -65,3 +65,31 @@ frappe.ui.form.on("Installed Applications", {
 			});
 	},
 });
+
+frappe.ui.form.on("Installed Application", {
+	disable_application(frm, cdt, cdn) {
+		let row = locals[cdt][cdn];
+		frappe.call({
+			method: "frappe.core.doctype.installed_applications.installed_applications.set_app_state",
+			args: { app_name: row.app_name, disabled: 1 },
+			callback() {
+				frappe.dom.unfreeze();
+				frappe.toast(__("{0} has been disabled", [row.app_name]));
+				cur_frm.reload_doc();
+			},
+		});
+	},
+
+	enable_application(frm, cdt, cdn) {
+		let row = locals[cdt][cdn];
+		frappe.call({
+			method: "frappe.core.doctype.installed_applications.installed_applications.set_app_state",
+			args: { app_name: row.app_name, disabled: 0 },
+			callback() {
+				frappe.dom.unfreeze();
+				frappe.toast(__("{0} has been enabled", [row.app_name]));
+				cur_frm.reload_doc();
+			},
+		});
+	},
+});

--- a/frappe/core/doctype/installed_applications/installed_applications.py
+++ b/frappe/core/doctype/installed_applications/installed_applications.py
@@ -6,7 +6,7 @@ import json
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils.caching import redis_cache
+from frappe.utils import cint
 
 
 class InvalidAppOrder(frappe.ValidationError):
@@ -32,6 +32,7 @@ class InstalledApplications(Document):
 		self.reload_doc_if_required()
 
 		app_wise_setup_details = self.get_app_wise_setup_details()
+		disabled_apps = frappe.get_disabled_apps()
 
 		self.delete_key("installed_applications")
 		for app in frappe.utils.get_installed_apps_info():
@@ -56,6 +57,7 @@ class InstalledApplications(Document):
 					"git_branch": app.get("branch") or "UNVERSIONED",
 					"has_setup_wizard": has_setup_wizard,
 					"is_setup_complete": setup_complete,
+					"disabled": app.get("app_name") in disabled_apps,
 				},
 			)
 
@@ -83,6 +85,9 @@ class InstalledApplications(Document):
 		)
 
 	def reload_doc_if_required(self):
+		if frappe.db.has_column("Installed Application", "disabled"):
+			return
+
 		if frappe.db.has_column("Installed Application", "is_setup_complete"):
 			return
 
@@ -145,6 +150,19 @@ def _create_version_log_for_change(old, new):
 	version.flags.ignore_links = True  # This is a fake doctype
 	version.flags.ignore_permissions = True
 	version.insert()
+
+
+@frappe.whitelist()
+def set_app_state(app_name: str, disabled: bool | int | str):
+	"""Disable or enable an installed app on this site without touching its data."""
+	frappe.only_for("System Manager")
+
+	from frappe.installer import disable_app, enable_app
+
+	if cint(disabled):
+		disable_app(app_name)
+	else:
+		enable_app(app_name)
 
 
 @frappe.whitelist()

--- a/frappe/core/doctype/installed_applications/installed_applications.py
+++ b/frappe/core/doctype/installed_applications/installed_applications.py
@@ -88,9 +88,6 @@ class InstalledApplications(Document):
 		if frappe.db.has_column("Installed Application", "disabled"):
 			return
 
-		if frappe.db.has_column("Installed Application", "is_setup_complete"):
-			return
-
 		frappe.reload_doc("core", "doctype", "installed_application")
 		frappe.reload_doc("core", "doctype", "installed_applications")
 		frappe.reload_doc("integrations", "doctype", "webhook")

--- a/frappe/core/doctype/module_def/module_def.json
+++ b/frappe/core/doctype/module_def/module_def.json
@@ -34,7 +34,8 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "App Name",
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "fieldname": "restrict_to_domain",
@@ -139,7 +140,7 @@
    "link_fieldname": "module"
   }
  ],
- "modified": "2024-09-18 12:39:19.512528",
+ "modified": "2026-08-05 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Module Def",

--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
@@ -37,7 +37,8 @@
    "in_list_view": 1,
    "label": "Method",
    "read_only": 1,
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "default": "0",
@@ -117,8 +118,8 @@
    "link_fieldname": "scheduled_job_type"
   }
  ],
- "modified": "2025-12-17 12:02:56.228336",
- "modified_by": "Administrator",
+ "modified": "2026-08-03 21:30:28.554421",
+ "modified_by": "test@example.com",
  "module": "Core",
  "name": "Scheduled Job Type",
  "owner": "Administrator",

--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
@@ -358,12 +358,11 @@ def get_disabled_app_job_methods() -> list[str]:
 
 def get_permission_query_conditions(user):
 	"""Hide jobs belonging to apps that are disabled on this site."""
-	conditions = []
-	for app in frappe.get_disabled_apps():
-		prefix = frappe.db.escape(app.replace("_", r"\_") + ".%")
-		conditions.append(f"`tabScheduled Job Type`.`method` not like {prefix}")
+	methods = get_disabled_app_job_methods()
+	if not methods:
+		return None
 
-	return " and ".join(conditions)
+	return frappe.qb.DocType("Scheduled Job Type").method.notin(methods)
 
 
 def on_doctype_update():

--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
@@ -70,7 +70,15 @@ class ScheduledJobType(Document):
 					title=_("Bad Cron Expression"),
 				)
 
+	@property
+	def is_app_disabled(self) -> bool:
+		"""True when this job belongs to an app that is disabled on this site."""
+		return bool(self.method) and self.method.split(".", 1)[0] in frappe.get_disabled_apps()
+
 	def enqueue(self, force=False) -> bool:
+		if self.is_app_disabled:
+			return False
+
 		# enqueue event if last execution is done
 		if self.is_event_due() or force:
 			if not self.is_job_in_queue():
@@ -143,6 +151,9 @@ class ScheduledJobType(Document):
 		return parse_cron(self.cron_format).get_next(datetime, start_time=last_execution)
 
 	def execute(self):
+		if self.is_app_disabled:
+			return
+
 		if frappe.job:
 			frappe.job.frequency = self.frequency
 			frappe.job.cron_format = self.cron_format
@@ -206,6 +217,9 @@ def skip_next_execution(doc: str | dict):
 	frappe.only_for("System Manager")
 	doc = frappe.parse_json(doc)
 	doc: ScheduledJobType = frappe.get_doc("Scheduled Job Type", doc.get("name"))
+	if doc.is_app_disabled:
+		frappe.throw(_("Cannot modify a job of a disabled app"))
+
 	doc.last_execution = doc.next_execution
 	return doc.save()
 
@@ -222,9 +236,26 @@ def run_scheduled_job(scheduled_job_type: str, job_type: str | None = None):
 
 def sync_jobs(hooks: dict | None = None):
 	frappe.reload_doc("core", "doctype", "scheduled_job_type")
-	scheduler_events = hooks or frappe.get_hooks("scheduler_events")
+	scheduler_events = hooks or get_scheduler_events()
 	insert_events(scheduler_events)
 	clear_events(scheduler_events)
+
+
+def _collect_scheduler_events(apps: list[str]) -> dict:
+	"""Collect merged `scheduler_events` hooks from the given app list."""
+	hooks = {}
+	for app in apps:
+		frappe.append_hook(hooks, "events", frappe.get_hooks("scheduler_events", {}, app_name=app))
+	return hooks.get("events", {})
+
+
+def get_scheduler_events() -> dict:
+	"""Collect `scheduler_events` from every installed app, disabled ones included.
+
+	Disabled apps are skipped at enqueue time instead, so that a toggle does not delete
+	their job rows along with `stopped` and `last_execution`.
+	"""
+	return _collect_scheduler_events(frappe.get_installed_apps())
 
 
 def insert_events(scheduler_events: dict) -> list:
@@ -312,6 +343,27 @@ def clear_events(scheduler_events: dict):
 	for event in frappe.get_all("Scheduled Job Type", fields=["*"]):
 		if not event_exists(event):
 			frappe.delete_doc("Scheduled Job Type", event.name)
+
+
+def get_disabled_app_job_methods() -> list[str]:
+	methods = []
+	for jobs in _collect_scheduler_events(frappe.get_disabled_apps()).values():
+		if isinstance(jobs, dict):
+			for method_list in jobs.values():
+				methods.extend(method_list)
+		else:
+			methods.extend(jobs)
+	return methods
+
+
+def get_permission_query_conditions(user):
+	"""Hide jobs belonging to apps that are disabled on this site."""
+	conditions = []
+	for app in frappe.get_disabled_apps():
+		prefix = frappe.db.escape(app.replace("_", r"\_") + ".%")
+		conditions.append(f"`tabScheduled Job Type`.`method` not like {prefix}")
+
+	return " and ".join(conditions)
 
 
 def on_doctype_update():

--- a/frappe/core/doctype/user_invitation/user_invitation.py
+++ b/frappe/core/doctype/user_invitation/user_invitation.py
@@ -195,7 +195,7 @@ class UserInvitation(Document):
 
 	@staticmethod
 	def validate_app_name(app_name: str):
-		if app_name not in frappe.get_installed_apps():
+		if app_name not in frappe.get_active_apps():
 			frappe.throw(title=_("Invalid app"), msg=_("Application is not installed"))
 
 	@staticmethod
@@ -223,7 +223,7 @@ def mark_expired_invitations() -> None:
 def get_allowed_apps(user: Document | None) -> list[str]:
 	user_roles = set(get_user_roles(user))
 	allowed_apps: list[str] = []
-	for app in frappe.get_installed_apps():
+	for app in frappe.get_active_apps():
 		user_invitation_hooks = frappe.get_hooks("user_invitation", app_name=app)
 		if not isinstance(user_invitation_hooks, dict):
 			continue

--- a/frappe/custom/__init__.py
+++ b/frappe/custom/__init__.py
@@ -1,0 +1,67 @@
+import frappe
+from frappe import _
+
+# The customizations that an app can hide while the site disables the app. Each doctype
+# maps to the filter key that holds the doctype which the customization changes.
+CUSTOMIZATION_DOCTYPES = {
+	"Custom Field": "dt",
+	"Property Setter": "doc_type",
+	"Custom DocPerm": "parent",
+}
+
+
+def hide_customizations(customizations: dict[str, list[dict]]):
+	"""
+	Make Frappe ignore these customizations. The rows and their data stay in the database.
+
+	Use `unhide_customizations` to apply them again. Use this function for a temporary
+	state, for example when the site disables the app that owns them.
+
+	:param customizations: A dict. It maps a customization doctype to a list of row filters.
+
+	Example:
+
+	```
+	hide_customizations(
+	    {
+	        "Custom Field": [{"dt": "Address", "fieldname": "custom_a"}],
+	        "Custom DocPerm": [{"parent": "Project", "role": "HR User"}],
+	    }
+	)
+	```
+	"""
+	_set_is_app_disabled(customizations, 1)
+
+
+def unhide_customizations(customizations: dict[str, list[dict]]):
+	"""
+	Apply the customizations again. This undoes `hide_customizations`.
+
+	:param customizations: A dict. It maps a customization doctype to a list of row filters.
+	"""
+	_set_is_app_disabled(customizations, 0)
+
+
+def _set_is_app_disabled(customizations: dict[str, list[dict]], value: int):
+	changed_doctypes = set()
+
+	for doctype, rows in customizations.items():
+		target_key = CUSTOMIZATION_DOCTYPES.get(doctype)
+		if not target_key:
+			frappe.throw(_("{0} is not a customization doctype.").format(doctype))
+
+		# This column is new. A site that did not migrate yet does not have it.
+		if not frappe.db.has_column(doctype, "is_app_disabled"):
+			frappe.throw(_("{0} has no is_app_disabled column. Run bench migrate first.").format(doctype))
+
+		for filters in rows:
+			# Without one doctype name the update can change the rows of other doctypes.
+			if not isinstance(filters.get(target_key), str):
+				frappe.throw(_("{0} must be a doctype name in a {1} filter.").format(target_key, doctype))
+
+			frappe.db.set_value(doctype, filters, "is_app_disabled", value, update_modified=False)
+			changed_doctypes.add(filters[target_key])
+
+	# Clear only the doctypes that changed. This keeps a disable or an enable fast.
+	for doctype in changed_doctypes:
+		frappe.clear_cache(doctype=doctype)

--- a/frappe/custom/doctype/custom_field/custom_field.json
+++ b/frappe/custom/doctype/custom_field/custom_field.json
@@ -8,6 +8,7 @@
  "engine": "InnoDB",
  "field_order": [
   "is_system_generated",
+  "is_app_disabled",
   "dt",
   "module",
   "label",
@@ -480,6 +481,14 @@
   },
   {
    "default": "0",
+   "description": "Set while owner app is disabled.",
+   "fieldname": "is_app_disabled",
+   "fieldtype": "Check",
+   "label": "Is App Disabled",
+   "read_only": 1
+  },
+  {
+   "default": "0",
    "depends_on": "eval: doc.fieldtype === 'Select'",
    "fieldname": "sort_options",
    "fieldtype": "Check",
@@ -529,7 +538,7 @@
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-07-11 23:17:05.768689",
+ "modified": "2026-08-05 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Custom Field",

--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -97,6 +97,7 @@ class CustomField(Document):
 		in_preview: DF.Check
 		in_standard_filter: DF.Check
 		insert_after: DF.Literal[None]
+		is_app_disabled: DF.Check
 		is_system_generated: DF.Check
 		is_virtual: DF.Check
 		label: DF.Data | None

--- a/frappe/custom/doctype/property_setter/property_setter.json
+++ b/frappe/custom/doctype/property_setter/property_setter.json
@@ -7,6 +7,7 @@
  "engine": "InnoDB",
  "field_order": [
   "is_system_generated",
+  "is_app_disabled",
   "help",
   "sb0",
   "doctype_or_field",
@@ -111,13 +112,21 @@
    "fieldtype": "Check",
    "label": "Is System Generated",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "description": "Set while owner app is disabled.",
+   "fieldname": "is_app_disabled",
+   "fieldtype": "Check",
+   "label": "Is App Disabled",
+   "read_only": 1
   }
  ],
  "icon": "fa fa-glass",
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-23 16:03:35.631784",
+ "modified": "2026-08-05 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Property Setter",

--- a/frappe/custom/doctype/property_setter/property_setter.py
+++ b/frappe/custom/doctype/property_setter/property_setter.py
@@ -25,6 +25,7 @@ class PropertySetter(Document):
 			"", "DocField", "DocType", "DocType Link", "DocType Action", "DocType State"
 		]
 		field_name: DF.Data | None
+		is_app_disabled: DF.Check
 		is_system_generated: DF.Check
 		module: DF.Link | None
 		property: DF.Data

--- a/frappe/desk/desk_views.py
+++ b/frappe/desk/desk_views.py
@@ -4,6 +4,7 @@
 from functools import cached_property
 
 import frappe
+from frappe.app_state import get_disabled_modules
 from frappe.permissions import has_permission
 from frappe.query_builder import DocType
 from frappe.query_builder.functions import Count
@@ -250,5 +251,15 @@ class DeskViews:
 			non_permitted_reports = set(has_role.keys()) - permitted_names
 			for r in non_permitted_reports:
 				has_role.pop(r, None)
+
+		if disabled_modules := get_disabled_modules():
+			hidden = (
+				frappe.qb.from_(parentTable)
+				.select(parentTable.name)
+				.where(parentTable.module.isin(list(disabled_modules)))
+				.run(pluck=True)
+			)
+			for name in hidden:
+				has_role.pop(name, None)
 
 		return has_role

--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -7,6 +7,7 @@ from json import JSONDecodeError, dumps, loads
 
 import frappe
 from frappe import DoesNotExistError, ValidationError, _, _dict
+from frappe.app_state import get_disabled_modules
 from frappe.cache_manager import build_table_count_cache
 from frappe.core.doctype.custom_role.custom_role import get_custom_allowed_roles
 from frappe.desk.desk_views import DeskViews
@@ -454,12 +455,18 @@ def get_workspaces():
 	# adding None to allowed_domains to include pages without domain restriction
 	allowed_domains = [None, *frappe.get_active_domains()]
 
+	# a disabled app stays hidden even from Workspace Managers
+	disabled_modules = list(get_disabled_modules())
+
 	filters = {
 		"restrict_to_domain": ["in", allowed_domains],
 	}
 
 	if has_access:
-		filters = []
+		filters = {}
+
+	if disabled_modules:
+		filters["module"] = ["not in", disabled_modules]
 
 	# pages sorted based on sequence id
 	order_by = "sequence_id asc"
@@ -746,7 +753,7 @@ def update_onboarding_step(name: str | int, field: str, value: int | str):
 
 @frappe.whitelist()
 def get_installed_apps():
-	return frappe.get_installed_apps()
+	return frappe.get_active_apps()
 
 
 @frappe.whitelist()

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -156,7 +156,7 @@ def is_icon_permitted(icon, bootinfo, roles: list[str], icon_module: str | None)
 
 
 def _has_app_permission(icon) -> bool:
-	for a in frappe.get_installed_apps():
+	for a in frappe.get_active_apps():
 		# an app needn't declare `app_title`; asking for the hook by name returns [] instead
 		# of raising, so one such app can't abort the whole grid's permission check
 		app_title = (frappe.get_hooks("app_title", app_name=a) or [None])[0]

--- a/frappe/desk/doctype/global_search_settings/global_search_settings.py
+++ b/frappe/desk/doctype/global_search_settings/global_search_settings.py
@@ -64,7 +64,7 @@ def update_global_search_doctypes():
 	global_search_doctypes = []
 	show_message(1, _("Fetching default Global Search documents."))
 
-	installed_apps = [app for app in frappe.get_installed_apps() if app]
+	installed_apps = [app for app in frappe.get_active_apps() if app]
 	active_domains = [domain for domain in frappe.get_active_domains() if domain]
 	active_domains.append("Default")
 

--- a/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
+++ b/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
@@ -267,8 +267,14 @@ def create_workspace_sidebar_for_workspaces():
 @site_cache()
 def auto_generate_sidebar_from_module():
 	"""Auto generate sidebar from module"""
+	from frappe.app_state import get_disabled_modules
+
 	sidebars = []
+	disabled_modules = get_disabled_modules()
 	for module in frappe.get_all("Module Def", fields=["name", "app_name"]):
+		if module.name in disabled_modules:
+			continue
+
 		# Skip modules whose public workspace already carries authored sidebar items -- that
 		# workspace's sidebar is built from `Workspace.sidebar_items` (the source of truth), so a
 		# generated fallback would be redundant.

--- a/frappe/desk/form/meta.py
+++ b/frappe/desk/form/meta.py
@@ -4,6 +4,7 @@ import os
 
 import frappe
 from frappe import _
+from frappe.app_state import get_disabled_modules
 from frappe.build import scrub_html_template
 from frappe.model.meta import Meta
 from frappe.model.utils import render_include
@@ -142,10 +143,14 @@ class FormMeta(Meta):
 	def add_custom_script(self):
 		"""embed all require files"""
 		# custom script
+		filters = {"dt": self.name, "enabled": 1}
+		if disabled_modules := get_disabled_modules():
+			filters["module"] = ["not in", list(disabled_modules)]
+
 		client_scripts = (
 			frappe.get_all(
 				"Client Script",
-				filters={"dt": self.name, "enabled": 1},
+				filters=filters,
 				fields=["name", "script", "view"],
 				order_by="creation asc",
 			)
@@ -284,7 +289,7 @@ class FormMeta(Meta):
 
 def get_code_files_via_hooks(hook, name):
 	code_files = []
-	for app_name in frappe.get_installed_apps():
+	for app_name in frappe.get_active_apps():
 		code_hook = frappe.get_hooks(hook, default={}, app_name=app_name)
 		if not code_hook:
 			continue

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -18,7 +18,7 @@ from . import install_fixtures
 
 
 def site_requires_builtin_wizard() -> bool:
-	for app in frappe.get_installed_apps():
+	for app in frappe.get_active_apps():
 		hooks = frappe.get_hooks(app_name=app)
 		if hooks.get("setup_wizard_stages") or hooks.get("setup_wizard_complete"):
 			return True
@@ -282,8 +282,8 @@ def login_as_first_user(args):
 def get_stages_hooks(args):  # nosemgrep
 	stages = []
 
-	installed_apps = frappe.get_installed_apps(_ensure_on_bench=True)
-	for app_name in installed_apps:
+	active_apps = frappe.get_active_apps(_ensure_on_bench=True)
+	for app_name in active_apps:
 		setup_wizard_stages = frappe.get_hooks(app_name=app_name).get("setup_wizard_stages")
 		if not setup_wizard_stages:
 			continue

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import frappe
 from frappe import _
+from frappe.app_state import clear_cache_after_maintenance
 from frappe.core.doctype.installed_applications.installed_applications import get_setup_wizard_completed_apps
 from frappe.geo.country_info import get_country_info
 from frappe.permissions import AUTOMATIC_ROLES
@@ -221,6 +222,7 @@ def process_setup_stages(stages, user_input, is_background_task=False):
 		frappe.publish_realtime("setup_task", {"status": "ok"}, user=frappe.session.user)
 	finally:
 		frappe.flags.in_setup_wizard = False
+		clear_cache_after_maintenance()
 
 
 def set_missing_values(task):

--- a/frappe/desk/page/setup_wizard/test_setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/test_setup_wizard.py
@@ -24,6 +24,7 @@ class TestSetupWizardUrl(UnitTestCase):
 	def resolve(self, apps):
 		with (
 			patch.object(frappe, "get_installed_apps", return_value=list(apps)),
+			patch.object(frappe, "get_active_apps", return_value=list(apps)),
 			patch.object(frappe, "get_hooks", side_effect=fake_hooks(apps)),
 		):
 			url = setup_wizard.get_setup_wizard_url()

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -10,6 +10,7 @@ import frappe
 
 # Backward compatbility
 from frappe import _, bold, is_whitelisted
+from frappe.app_state import get_disabled_modules
 from frappe.database.schema import SPECIAL_CHAR_PATTERN
 from frappe.model.db_query import get_order_by
 from frappe.permissions import has_permission
@@ -264,6 +265,13 @@ def search_widget(
 		_relevance = {"IFNULL": [_relevance_expr, -9999], "as": "_relevance"}
 		formatted_fields.append(_relevance)
 		order_by = f"_relevance desc, {order_by}"
+
+	# DocType searches run with ignore_permissions, so exclude disabled apps explicitly
+	if doctype == "DocType" and (disabled_modules := get_disabled_modules()):
+		if isinstance(filters, dict):
+			filters["module"] = ["not in", list(disabled_modules)]
+		elif isinstance(filters, list):
+			filters.append(["module", "not in", list(disabled_modules)])
 
 	values = frappe.get_list(
 		doctype,

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -796,15 +796,24 @@ def trigger_daily_alerts():
 	trigger_notifications(None, "daily")
 
 
+def get_scheduled_notifications(events: tuple[str, ...]) -> list[dict]:
+	"""Return the enabled notifications for these events, minus those of a disabled app."""
+	from frappe.app_state import get_disabled_modules
+
+	filters = {"event": ("in", events), "enabled": 1}
+	if disabled_modules := get_disabled_modules():
+		filters["module"] = ("not in", list(disabled_modules))
+
+	return frappe.get_all("Notification", filters=filters)
+
+
 def trigger_notifications(doc, method=None):
 	if frappe.flags.in_import or frappe.flags.in_patch:
 		# don't send notifications while syncing or patching
 		return
 
 	if method == "daily":
-		doc_list = frappe.get_all(
-			"Notification", filters={"event": ("in", ("Days Before", "Days After")), "enabled": 1}
-		)
+		doc_list = get_scheduled_notifications(("Days Before", "Days After"))
 		for d in doc_list:
 			alert = frappe.get_doc("Notification", d.name)
 
@@ -814,9 +823,7 @@ def trigger_notifications(doc, method=None):
 				frappe.db.commit()  # nosemgrep
 
 	elif method == "offset":
-		doc_list = frappe.get_all(
-			"Notification", filters={"event": ("in", ("Minutes Before", "Minutes After")), "enabled": 1}
-		)
+		doc_list = get_scheduled_notifications(("Minutes Before", "Minutes After"))
 		for d in doc_list:
 			alert = frappe.get_doc("Notification", d.name)
 

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -74,6 +74,8 @@ def execute_cmd(cmd, from_async=False):
 
 	try:
 		method = get_attr(cmd)
+	except frappe.AppNotInstalledError:
+		raise
 	except Exception as e:
 		frappe.throw(_("Failed to get method for command {0} with {1}").format(cmd, str(e)))
 

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -105,15 +105,27 @@ pdf_generator = "frappe.utils.pdf.get_chrome_pdf"
 # permissions
 
 permission_query_conditions = {
-	"Report": "frappe.core.doctype.report.report.get_permission_query_conditions",
+	"Report": [
+		"frappe.core.doctype.report.report.get_permission_query_conditions",
+		"frappe.app_state.get_module_permission_query_conditions",
+	],
 	"Event": "frappe.desk.doctype.event.event.get_permission_query_conditions",
 	"ToDo": "frappe.desk.doctype.todo.todo.get_permission_query_conditions",
 	"User": "frappe.core.doctype.user.user.get_permission_query_conditions",
 	"Dashboard Settings": "frappe.desk.doctype.dashboard_settings.dashboard_settings.get_permission_query_conditions",
 	"Notification Log": "frappe.desk.doctype.notification_log.notification_log.get_permission_query_conditions",
-	"Dashboard": "frappe.desk.doctype.dashboard.dashboard.get_permission_query_conditions",
-	"Dashboard Chart": "frappe.desk.doctype.dashboard_chart.dashboard_chart.get_permission_query_conditions",
-	"Number Card": "frappe.desk.doctype.number_card.number_card.get_permission_query_conditions",
+	"Dashboard": [
+		"frappe.desk.doctype.dashboard.dashboard.get_permission_query_conditions",
+		"frappe.app_state.get_module_permission_query_conditions",
+	],
+	"Dashboard Chart": [
+		"frappe.desk.doctype.dashboard_chart.dashboard_chart.get_permission_query_conditions",
+		"frappe.app_state.get_module_permission_query_conditions",
+	],
+	"Number Card": [
+		"frappe.desk.doctype.number_card.number_card.get_permission_query_conditions",
+		"frappe.app_state.get_module_permission_query_conditions",
+	],
 	"Notification Settings": "frappe.desk.doctype.notification_settings.notification_settings.get_permission_query_conditions",
 	"Note": "frappe.desk.doctype.note.note.get_permission_query_conditions",
 	"Kanban Board": "frappe.desk.doctype.kanban_board.kanban_board.get_permission_query_conditions",
@@ -126,6 +138,17 @@ permission_query_conditions = {
 	"User Invitation": "frappe.core.doctype.user_invitation.user_invitation.get_permission_query_conditions",
 	"Document Template": "frappe.desk.doctype.document_template.document_template.get_permission_query_conditions",
 	"Tag Link": "frappe.desk.doctype.tag_link.tag_link.get_permission_query_conditions",
+	"Scheduled Job Type": "frappe.core.doctype.scheduled_job_type.scheduled_job_type.get_permission_query_conditions",
+	"DocType": "frappe.app_state.get_module_permission_query_conditions",
+	"Page": "frappe.app_state.get_module_permission_query_conditions",
+	"Workspace": "frappe.app_state.get_module_permission_query_conditions",
+	"Workspace Sidebar": "frappe.app_state.get_module_permission_query_conditions",
+	"Print Format": "frappe.app_state.get_module_permission_query_conditions",
+	"Notification": "frappe.app_state.get_module_permission_query_conditions",
+	"Web Form": "frappe.app_state.get_module_permission_query_conditions",
+	"Client Script": "frappe.app_state.get_module_permission_query_conditions",
+	"Server Script": "frappe.app_state.get_module_permission_query_conditions",
+	"Desktop Icon": "frappe.app_state.get_app_permission_query_conditions",
 }
 
 has_permission = {

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -16,6 +16,7 @@ import click
 from semantic_version import Version
 
 import frappe
+from frappe import _
 from frappe.defaults import _clear_cache
 from frappe.utils import cint, is_git_url
 from frappe.utils.dashboard import sync_dashboards
@@ -294,7 +295,10 @@ def install_app(name, verbose=False, set_as_patched=True, force=False):
 		raise Exception(f"App {name} not in apps.txt")
 
 	if not force and name in installed_apps:
-		click.secho(f"App {name} already installed", fg="yellow")
+		if name in frappe.get_disabled_apps():
+			enable_app(name)
+		else:
+			click.secho(f"App {name} already installed", fg="yellow")
 		return
 
 	print(f"\nInstalling {name}...")
@@ -381,6 +385,59 @@ def remove_from_installed_apps(app_name):
 		if frappe.flags.in_install:
 			post_install()
 		_sync_installed_apps_to_site_config()
+
+
+def set_app_disabled(app_name, disabled):
+	with filelock("toggle_app_state"):
+		frappe.local.request_cache and frappe.local.request_cache.clear()
+		disabled_apps = frappe.get_disabled_apps()
+
+		if disabled and app_name not in disabled_apps:
+			disabled_apps.append(app_name)
+		elif not disabled and app_name in disabled_apps:
+			disabled_apps.remove(app_name)
+		else:
+			return
+
+		frappe.db.set_global("disabled_apps", json.dumps(disabled_apps))
+		frappe.get_single("Installed Applications").update_versions()
+		frappe.db.commit()
+		frappe.clear_cache()
+		frappe.client_cache.erase_persistent_caches()
+
+
+def enable_app(app_name):
+	"""Bring back an app that was disabled, without re-syncing its schema."""
+	if app_name not in frappe.get_installed_apps():
+		frappe.throw(_("App {0} is not installed").format(app_name))
+
+	disabled_apps = frappe.get_disabled_apps()
+	for required_app in frappe.get_hooks("required_apps", app_name=app_name):
+		dependency = parse_app_name(required_app)
+		if dependency in disabled_apps:
+			frappe.throw(_("App {0} depends on {1}. Enable {1} first.").format(app_name, dependency))
+
+	set_app_disabled(app_name, False)
+	click.secho(f"App {app_name} enabled on Site {frappe.local.site}", fg="green")
+
+
+def disable_app(app_name):
+	"""Keep the app's schema and data, but stop it from taking effect on this site."""
+	if app_name == "frappe":
+		frappe.throw(_("App frappe cannot be disabled"))
+
+	if app_name not in frappe.get_installed_apps():
+		frappe.throw(_("App {0} is not installed").format(app_name))
+
+	for app in frappe.get_active_apps():
+		if app == app_name:
+			continue
+		required_apps = frappe.get_hooks("required_apps", app_name=app)
+		if any(app_name in required_app for required_app in required_apps):
+			frappe.throw(_("App {0} is a dependency of {1}. Disable {1} first.").format(app_name, app))
+
+	set_app_disabled(app_name, True)
+	click.secho(f"App {app_name} disabled on Site {frappe.local.site}", fg="green")
 
 
 def remove_app(app_name, dry_run=False, yes=False, no_backup=False, force=False):

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -418,7 +418,18 @@ def enable_app(app_name):
 		if dependency in disabled_apps:
 			frappe.throw(_("App {0} depends on {1}. Enable {1} first.").format(app_name, dependency))
 
-	set_app_disabled(app_name, False)
+	frappe.flags.in_app_toggle = True
+	try:
+		for before_enable in frappe.get_hooks("before_enable", app_name=app_name):
+			frappe.get_attr(before_enable)()
+
+		set_app_disabled(app_name, False)
+
+		for after_enable in frappe.get_hooks("after_enable", app_name=app_name):
+			frappe.get_attr(after_enable)()
+	finally:
+		frappe.flags.in_app_toggle = False
+
 	click.secho(f"App {app_name} enabled on Site {frappe.local.site}", fg="green")
 
 
@@ -437,7 +448,18 @@ def disable_app(app_name):
 		if any(app_name in required_app for required_app in required_apps):
 			frappe.throw(_("App {0} is a dependency of {1}. Disable {1} first.").format(app_name, app))
 
-	set_app_disabled(app_name, True)
+	frappe.flags.in_app_toggle = True
+	try:
+		for before_disable in frappe.get_hooks("before_disable", app_name=app_name):
+			frappe.get_attr(before_disable)()
+
+		set_app_disabled(app_name, True)
+
+		for after_disable in frappe.get_hooks("after_disable", app_name=app_name):
+			frappe.get_attr(after_disable)()
+	finally:
+		frappe.flags.in_app_toggle = False
+
 	click.secho(f"App {app_name} disabled on Site {frappe.local.site}", fg="green")
 
 

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -391,8 +391,8 @@ def remove_from_installed_apps(app_name):
 
 def set_app_disabled(app_name, disabled):
 	with filelock("toggle_app_state"):
-		frappe.local.request_cache and frappe.local.request_cache.clear()
-		disabled_apps = frappe.get_disabled_apps()
+		# read the global directly: `get_disabled_apps` is request cached and may be stale here
+		disabled_apps = json.loads(frappe.db.get_global("disabled_apps") or "[]")
 
 		if disabled and app_name not in disabled_apps:
 			disabled_apps.append(app_name)
@@ -400,6 +400,7 @@ def set_app_disabled(app_name, disabled):
 			disabled_apps.remove(app_name)
 
 		frappe.db.set_global("disabled_apps", json.dumps(disabled_apps))
+		frappe.local.request_cache and frappe.local.request_cache.clear()
 		frappe.get_single("Installed Applications").update_versions()
 		frappe.db.commit()
 		frappe.clear_cache()

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -380,6 +380,8 @@ def remove_from_installed_apps(app_name):
 		)
 		_clear_cache("__global")
 		frappe.local.doc_events_hooks = None
+		if app_name in frappe.get_disabled_apps():
+			set_app_disabled(app_name, False)
 		frappe.get_single("Installed Applications").update_versions()
 		frappe.db.commit()
 		if frappe.flags.in_install:

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -22,6 +22,8 @@ from frappe.utils import cint, is_git_url
 from frappe.utils.dashboard import sync_dashboards
 from frappe.utils.synchronization import filelock
 
+APP_STATE_LOCK = "toggle_app_state"
+
 
 def _is_scheduler_enabled(site) -> bool:
 	enable_scheduler = False
@@ -380,32 +382,33 @@ def remove_from_installed_apps(app_name):
 		)
 		_clear_cache("__global")
 		frappe.local.doc_events_hooks = None
-		if app_name in frappe.get_disabled_apps():
-			set_app_disabled(app_name, False)
-		frappe.get_single("Installed Applications").update_versions()
-		frappe.db.commit()
+		with filelock(APP_STATE_LOCK):
+			if app_name in frappe.get_disabled_apps():
+				set_app_disabled(app_name, False)
+			frappe.get_single("Installed Applications").update_versions()
+			frappe.db.commit()
 		if frappe.flags.in_install:
 			post_install()
 		_sync_installed_apps_to_site_config()
 
 
 def set_app_disabled(app_name, disabled):
-	with filelock("toggle_app_state"):
-		# read the global directly: `get_disabled_apps` is request cached and may be stale here
-		disabled_apps = json.loads(frappe.db.get_global("disabled_apps") or "[]")
+	"""Add the app to the `disabled_apps` global, or take it out again.
 
-		if disabled and app_name not in disabled_apps:
-			disabled_apps.append(app_name)
-		elif not disabled and app_name in disabled_apps:
-			disabled_apps.remove(app_name)
+	The caller holds the `APP_STATE_LOCK` and owns the commit, so that the read and
+	the write below cannot interleave with another toggle.
+	"""
+	# read the global directly: `get_disabled_apps` is request cached and may be stale here
+	disabled_apps = json.loads(frappe.db.get_global("disabled_apps") or "[]")
 
-		frappe.db.set_global("disabled_apps", json.dumps(disabled_apps))
-		frappe.local.request_cache and frappe.local.request_cache.clear()
-		frappe.get_single("Installed Applications").update_versions()
-		# the lock serialises this read and write, so the new list must be visible before it opens
-		frappe.db.commit()  # nosemgrep
-		frappe.clear_cache()
-		frappe.client_cache.erase_persistent_caches()
+	if disabled and app_name not in disabled_apps:
+		disabled_apps.append(app_name)
+	elif not disabled and app_name in disabled_apps:
+		disabled_apps.remove(app_name)
+
+	frappe.db.set_global("disabled_apps", json.dumps(disabled_apps))
+	frappe.local.request_cache and frappe.local.request_cache.clear()
+	frappe.get_single("Installed Applications").update_versions()
 
 
 def enable_app(app_name):
@@ -413,26 +416,31 @@ def enable_app(app_name):
 	if app_name not in frappe.get_installed_apps():
 		frappe.throw(_("App {0} is not installed").format(app_name))
 
-	disabled_apps = frappe.get_disabled_apps()
-	for required_app in frappe.get_hooks("required_apps", app_name=app_name):
-		dependency = parse_app_name(required_app)
-		if dependency in disabled_apps:
-			frappe.throw(_("App {0} depends on {1}. Enable {1} first.").format(app_name, dependency))
+	with filelock(APP_STATE_LOCK):
+		frappe.flags.in_app_toggle = True
+		try:
+			disabled_apps = frappe.get_disabled_apps()
+			for required_app in frappe.get_hooks("required_apps", app_name=app_name):
+				dependency = parse_app_name(required_app)
+				if dependency in disabled_apps:
+					frappe.throw(_("App {0} depends on {1}. Enable {1} first.").format(app_name, dependency))
 
-	frappe.flags.in_app_toggle = True
-	try:
-		for before_enable in frappe.get_hooks("before_enable", app_name=app_name):
-			frappe.get_attr(before_enable)()
+			for before_enable in frappe.get_hooks("before_enable", app_name=app_name):
+				frappe.get_attr(before_enable)()
 
-		set_app_disabled(app_name, False)
+			set_app_disabled(app_name, False)
 
-		for after_enable in frappe.get_hooks("after_enable", app_name=app_name):
-			frappe.get_attr(after_enable)()
+			for after_enable in frappe.get_hooks("after_enable", app_name=app_name):
+				frappe.get_attr(after_enable)()
 
-		# `set_app_disabled` commits before these hooks, and the CLI closes without a commit
-		frappe.db.commit()  # nosemgrep
-	finally:
-		frappe.flags.in_app_toggle = False
+			frappe.db.commit()  # nosemgrep
+		except Exception:
+			frappe.db.rollback()
+			raise
+		finally:
+			frappe.clear_cache()
+			frappe.client_cache.erase_persistent_caches()
+			frappe.flags.in_app_toggle = False
 
 	click.secho(f"App {app_name} enabled on Site {frappe.local.site}", fg="green")
 
@@ -445,27 +453,34 @@ def disable_app(app_name):
 	if app_name not in frappe.get_installed_apps():
 		frappe.throw(_("App {0} is not installed").format(app_name))
 
-	for app in frappe.get_active_apps():
-		if app == app_name:
-			continue
-		required_apps = frappe.get_hooks("required_apps", app_name=app)
-		if any(app_name in required_app for required_app in required_apps):
-			frappe.throw(_("App {0} is a dependency of {1}. Disable {1} first.").format(app_name, app))
+	with filelock(APP_STATE_LOCK):
+		frappe.flags.in_app_toggle = True
+		try:
+			for app in frappe.get_active_apps():
+				if app == app_name:
+					continue
+				required_apps = frappe.get_hooks("required_apps", app_name=app)
+				if any(app_name in required_app for required_app in required_apps):
+					frappe.throw(
+						_("App {0} is a dependency of {1}. Disable {1} first.").format(app_name, app)
+					)
 
-	frappe.flags.in_app_toggle = True
-	try:
-		for before_disable in frappe.get_hooks("before_disable", app_name=app_name):
-			frappe.get_attr(before_disable)()
+			for before_disable in frappe.get_hooks("before_disable", app_name=app_name):
+				frappe.get_attr(before_disable)()
 
-		set_app_disabled(app_name, True)
+			set_app_disabled(app_name, True)
 
-		for after_disable in frappe.get_hooks("after_disable", app_name=app_name):
-			frappe.get_attr(after_disable)()
+			for after_disable in frappe.get_hooks("after_disable", app_name=app_name):
+				frappe.get_attr(after_disable)()
 
-		# `set_app_disabled` commits before these hooks, and the CLI closes without a commit
-		frappe.db.commit()  # nosemgrep
-	finally:
-		frappe.flags.in_app_toggle = False
+			frappe.db.commit()  # nosemgrep
+		except Exception:
+			frappe.db.rollback()
+			raise
+		finally:
+			frappe.clear_cache()
+			frappe.client_cache.erase_persistent_caches()
+			frappe.flags.in_app_toggle = False
 
 	click.secho(f"App {app_name} disabled on Site {frappe.local.site}", fg="green")
 
@@ -645,7 +660,7 @@ def post_install(rebuild_website=False):
 		clear_website_cache()
 
 	init_singles()
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep
 	frappe.clear_cache()
 
 
@@ -655,7 +670,7 @@ def set_all_patches_as_completed(app):
 	patches = get_patches_from_app(app)
 	for patch in patches:
 		frappe.get_doc({"doctype": "Patch Log", "patch": patch}).insert(ignore_permissions=True)
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep
 
 
 def init_singles():

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -396,8 +396,6 @@ def set_app_disabled(app_name, disabled):
 			disabled_apps.append(app_name)
 		elif not disabled and app_name in disabled_apps:
 			disabled_apps.remove(app_name)
-		else:
-			return
 
 		frappe.db.set_global("disabled_apps", json.dumps(disabled_apps))
 		frappe.get_single("Installed Applications").update_versions()

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -427,6 +427,8 @@ def enable_app(app_name):
 
 		for after_enable in frappe.get_hooks("after_enable", app_name=app_name):
 			frappe.get_attr(after_enable)()
+
+		frappe.db.commit()
 	finally:
 		frappe.flags.in_app_toggle = False
 
@@ -457,6 +459,8 @@ def disable_app(app_name):
 
 		for after_disable in frappe.get_hooks("after_disable", app_name=app_name):
 			frappe.get_attr(after_disable)()
+
+		frappe.db.commit()
 	finally:
 		frappe.flags.in_app_toggle = False
 

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -402,7 +402,8 @@ def set_app_disabled(app_name, disabled):
 		frappe.db.set_global("disabled_apps", json.dumps(disabled_apps))
 		frappe.local.request_cache and frappe.local.request_cache.clear()
 		frappe.get_single("Installed Applications").update_versions()
-		frappe.db.commit()
+		# the lock serialises this read and write, so the new list must be visible before it opens
+		frappe.db.commit()  # nosemgrep
 		frappe.clear_cache()
 		frappe.client_cache.erase_persistent_caches()
 
@@ -428,7 +429,8 @@ def enable_app(app_name):
 		for after_enable in frappe.get_hooks("after_enable", app_name=app_name):
 			frappe.get_attr(after_enable)()
 
-		frappe.db.commit()
+		# `set_app_disabled` commits before these hooks, and the CLI closes without a commit
+		frappe.db.commit()  # nosemgrep
 	finally:
 		frappe.flags.in_app_toggle = False
 
@@ -460,7 +462,8 @@ def disable_app(app_name):
 		for after_disable in frappe.get_hooks("after_disable", app_name=app_name):
 			frappe.get_attr(after_disable)()
 
-		frappe.db.commit()
+		# `set_app_disabled` commits before these hooks, and the CLI closes without a commit
+		frappe.db.commit()  # nosemgrep
 	finally:
 		frappe.flags.in_app_toggle = False
 

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -467,6 +467,25 @@ def disable_app(app_name):
 	click.secho(f"App {app_name} disabled on Site {frappe.local.site}", fg="green")
 
 
+def reapply_disabled_app_state():
+	"""Run the `before_disable` hooks again for each app that the site disables.
+
+	A migration can create the customizations that an app hid. These hooks run more than
+	once, so they must give the same result each time.
+	"""
+	disabled_apps = frappe.get_disabled_apps()
+	if not disabled_apps:
+		return
+
+	frappe.flags.in_app_toggle = True
+	try:
+		for app_name in disabled_apps:
+			for before_disable in frappe.get_hooks("before_disable", app_name=app_name):
+				frappe.get_attr(before_disable)()
+	finally:
+		frappe.flags.in_app_toggle = False
+
+
 def remove_app(app_name, dry_run=False, yes=False, no_backup=False, force=False):
 	"""Remove app and all linked to the app's module with the app from a site."""
 

--- a/frappe/migrate.py
+++ b/frappe/migrate.py
@@ -16,6 +16,7 @@ import frappe
 import frappe.model.sync
 import frappe.modules.patch_handler
 import frappe.translate
+from frappe.app_state import clear_cache_after_maintenance
 from frappe.core.doctype.language.language import sync_languages
 from frappe.core.doctype.navbar_settings.navbar_settings import sync_standard_items
 from frappe.core.doctype.scheduled_job_type.scheduled_job_type import sync_jobs
@@ -115,6 +116,7 @@ class SiteMigration:
 		frappe.publish_realtime("version-update")
 		frappe.flags.touched_tables.clear()
 		frappe.flags.in_migrate = False
+		clear_cache_after_maintenance()
 
 	@atomic
 	def pre_schema_updates(self):

--- a/frappe/migrate.py
+++ b/frappe/migrate.py
@@ -22,6 +22,7 @@ from frappe.core.doctype.scheduled_job_type.scheduled_job_type import sync_jobs
 from frappe.database.schema import add_column
 from frappe.deferred_insert import save_to_db as flush_deferred_inserts
 from frappe.desk.notifications import clear_notifications
+from frappe.installer import reapply_disabled_app_state
 from frappe.modules.patch_handler import PatchType
 from frappe.modules.utils import sync_customizations
 from frappe.search.website_search import build_index_for_all_routes
@@ -201,6 +202,9 @@ class SiteMigration:
 		for app in frappe.get_installed_apps():
 			for fn in frappe.get_hooks("after_migrate", app_name=app):
 				frappe.get_attr(fn)()
+
+		print("Applying state of disabled apps again...")
+		reapply_disabled_app_state()
 
 	def required_services_running(self) -> bool:
 		"""Return True if all required services are running. Return False and print

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1726,11 +1726,16 @@ class Document(BaseDocument):
 
 		def _get_notifications():
 			"""Return enabled notifications for the current doctype."""
+			from frappe.app_state import get_disabled_modules
+
+			filters = {"enabled": 1, "document_type": self.doctype}
+			if disabled_modules := get_disabled_modules():
+				filters["module"] = ["not in", list(disabled_modules)]
 
 			return frappe.get_all(
 				"Notification",
 				fields=["name", "event", "method"],
-				filters={"enabled": 1, "document_type": self.doctype},
+				filters=filters,
 			)
 
 		notifications = frappe.client_cache.get_value(

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -24,6 +24,7 @@ import click
 
 import frappe
 from frappe import N_, _
+from frappe.app_state import is_module_disabled
 from frappe.model import (
 	NO_VALUE_FIELDS,
 	child_table_fields,
@@ -418,6 +419,8 @@ class Meta(Document):
 		if not custom_fields:
 			return
 
+		custom_fields = [field for field in custom_fields if not is_field_hidden_by_app(field)]
+
 		self.extend("fields", custom_fields)
 
 	def apply_property_setters(self):
@@ -433,6 +436,8 @@ class Meta(Document):
 
 		if not property_setters:
 			return
+
+		property_setters = [ps for ps in property_setters if not is_module_disabled(ps.module)]
 
 		for ps in property_setters:
 			if ps.doctype_or_field == "DocType":
@@ -849,6 +854,23 @@ class Meta(Document):
 
 
 #######
+
+
+def is_field_hidden_by_app(df) -> bool:
+	"""Return True for a customization belonging to, or pointing at, a disabled app.
+
+	A Link or Table field whose target is concealed cannot work, so it is hidden
+	regardless of which app declared it.
+	"""
+	from frappe.app_state import get_disabled_doctypes
+
+	if is_module_disabled(df.get("module")):
+		return True
+
+	return (
+		df.get("fieldtype") in ("Link", "Table", "Table MultiSelect")
+		and df.get("options") in get_disabled_doctypes()
+	)
 
 
 def get_parent_dt(dt):

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -24,7 +24,7 @@ import click
 
 import frappe
 from frappe import N_, _
-from frappe.app_state import is_module_disabled
+from frappe.app_state import is_disabled_app_filtering_active, is_module_disabled
 from frappe.model import (
 	NO_VALUE_FIELDS,
 	child_table_fields,
@@ -437,7 +437,12 @@ class Meta(Document):
 		if not property_setters:
 			return
 
-		property_setters = [ps for ps in property_setters if not is_module_disabled(ps.module)]
+		hide_disabled = is_disabled_app_filtering_active()
+		property_setters = [
+			ps
+			for ps in property_setters
+			if not ((hide_disabled and ps.get("is_app_disabled")) or is_module_disabled(ps.module))
+		]
 
 		for ps in property_setters:
 			if ps.doctype_or_field == "DocType":
@@ -650,6 +655,10 @@ class Meta(Document):
 				filters=dict(parent=self.name),
 				update=dict(doctype="Custom DocPerm"),
 			)
+
+			if is_disabled_app_filtering_active():
+				custom_perms = [d for d in custom_perms if not d.get("is_app_disabled")]
+
 			if custom_perms:
 				self.permissions = [Document(d) for d in custom_perms]
 
@@ -863,6 +872,10 @@ def is_field_hidden_by_app(df) -> bool:
 	regardless of which app declared it.
 	"""
 	from frappe.app_state import get_disabled_doctypes
+
+	# The app that owns this field sets the flag in its `before_disable` hook.
+	if df.get("is_app_disabled") and is_disabled_app_filtering_active():
+		return True
 
 	if is_module_disabled(df.get("module")):
 		return True

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -6,6 +6,7 @@ import functools
 import frappe
 import frappe.share
 from frappe import _, msgprint
+from frappe.app_state import is_module_disabled
 from frappe.core.doctype.permission_type.permission_type import get_doctype_ptype_map
 from frappe.query_builder import DocType
 from frappe.utils import cint, cstr
@@ -129,6 +130,10 @@ def has_permission(
 		)
 
 	meta = frappe.get_meta(doctype)
+
+	if is_module_disabled(meta.module):
+		debug and _debug_log(f"Not allowed because {meta.module} belongs to a disabled app")
+		return False
 
 	# docname == doctype for single doctypes
 	if not doc and meta.issingle:

--- a/frappe/realtime/__init__.py
+++ b/frappe/realtime/__init__.py
@@ -146,7 +146,7 @@ def get_socketio_secret():
 	return secret
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(allow_guest=True)  # nosemgrep
 def get_user_info():
 	user_type = frappe.session.data.user_type
 	trusted_secret = get_socketio_secret()

--- a/frappe/realtime/__init__.py
+++ b/frappe/realtime/__init__.py
@@ -159,7 +159,7 @@ def get_user_info():
 	return {
 		"user": frappe.session.user,
 		"user_type": user_type,
-		"installed_apps": frappe.get_installed_apps(),
+		"installed_apps": frappe.get_active_apps(),
 	}
 
 

--- a/frappe/search/website_search.py
+++ b/frappe/search/website_search.py
@@ -112,7 +112,7 @@ def slugs_with_web_view(_items_to_index):
 def get_static_pages_from_all_apps():
 	from glob import glob
 
-	apps = frappe.get_installed_apps()
+	apps = frappe.get_active_apps()
 
 	routes_to_index = []
 	for app in apps:

--- a/frappe/tests/test_app_state.py
+++ b/frappe/tests/test_app_state.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+from unittest.mock import patch
+
+import frappe
+from frappe.app_state import (
+	get_app_permission_query_conditions,
+	get_module_permission_query_conditions,
+)
+from frappe.model.db_query import DatabaseQuery
+from frappe.tests import IntegrationTestCase
+
+
+class TestDisabledAppPermissionConditions(IntegrationTestCase):
+	def test_no_condition_when_nothing_is_disabled(self):
+		with patch("frappe.app_state.get_disabled_modules", return_value=set()):
+			self.assertIsNone(get_module_permission_query_conditions("Administrator", doctype="Print Format"))
+
+		with patch("frappe.get_disabled_apps", return_value=[]):
+			self.assertIsNone(get_app_permission_query_conditions("Administrator", doctype="Desktop Icon"))
+
+	def test_disabled_module_records_are_hidden(self):
+		hidden = self.new_print_format(module="Core")
+		visible = self.new_print_format(module="Custom")
+
+		with patch("frappe.app_state.get_disabled_modules", return_value={"Core"}):
+			names = frappe.get_list("Print Format", pluck="name", limit_page_length=0)
+
+		self.assertNotIn(hidden, names)
+		self.assertIn(visible, names)
+
+	def test_records_without_a_module_stay_visible(self):
+		"""`module not in (...)` is NULL for an unset module, so the column needs an IFNULL guard."""
+		without_module = self.new_print_format(module=None)
+
+		with patch("frappe.app_state.get_disabled_modules", return_value={"Core"}):
+			names = frappe.get_list("Print Format", pluck="name", limit_page_length=0)
+			legacy = DatabaseQuery("Print Format").execute(fields=["name"], limit_page_length=0)
+
+		self.assertIn(without_module, names)
+		self.assertIn(without_module, [row.name for row in legacy])
+
+	def new_print_format(self, module: str | None) -> str:
+		print_format = frappe.get_doc(
+			doctype="Print Format", name=frappe.generate_hash(length=10), module=module, standard="No"
+		).insert()
+		return print_format.name

--- a/frappe/tests/test_app_state.py
+++ b/frappe/tests/test_app_state.py
@@ -1,14 +1,31 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+from contextlib import contextmanager
 from unittest.mock import patch
 
 import frappe
 from frappe.app_state import (
+	clear_cache_after_maintenance,
+	filter_out_disabled_doctypes,
 	get_app_permission_query_conditions,
+	get_disabled_doctypes,
+	get_disabled_modules,
 	get_module_permission_query_conditions,
+	is_disabled_app_filtering_active,
+	is_module_disabled,
 )
 from frappe.model.db_query import DatabaseQuery
 from frappe.tests import IntegrationTestCase
+
+MAINTENANCE_FLAGS = (
+	"in_install",
+	"in_migrate",
+	"in_patch",
+	"in_import",
+	"in_uninstall",
+	"in_setup_wizard",
+	"in_app_toggle",
+)
 
 
 class TestDisabledAppPermissionConditions(IntegrationTestCase):
@@ -45,3 +62,75 @@ class TestDisabledAppPermissionConditions(IntegrationTestCase):
 			doctype="Print Format", name=frappe.generate_hash(length=10), module=module, standard="No"
 		).insert()
 		return print_format.name
+
+
+class TestDisabledAppState(IntegrationTestCase):
+	"""`frappe` stands in for a disabled app here, because it owns modules on every site."""
+
+	def setUp(self):
+		super().setUp()
+		self.clear_request_cache()
+		self.addCleanup(self.clear_request_cache)
+
+	def clear_request_cache(self):
+		if getattr(frappe.local, "request_cache", None):
+			frappe.local.request_cache.clear()
+
+	@contextmanager
+	def disabled(self, *apps: str):
+		with patch("frappe.get_disabled_apps", return_value=list(apps)):
+			self.clear_request_cache()
+			try:
+				yield
+			finally:
+				self.clear_request_cache()
+
+	def test_modules_of_a_disabled_app_are_disabled(self):
+		with self.disabled("frappe"):
+			self.assertIn("Core", get_disabled_modules())
+
+	def test_no_module_is_disabled_when_no_app_is_disabled(self):
+		with self.disabled():
+			self.assertEqual(get_disabled_modules(), set())
+
+	def test_doctypes_of_a_disabled_module_are_disabled(self):
+		with self.disabled("frappe"):
+			self.assertIn("DocType", get_disabled_doctypes())
+
+	def test_is_module_disabled(self):
+		with self.disabled("frappe"):
+			self.assertTrue(is_module_disabled("Core"))
+			self.assertFalse(is_module_disabled("zzz Not A Module"))
+			self.assertFalse(is_module_disabled(""))
+			self.assertFalse(is_module_disabled(None))
+
+	def test_filter_out_disabled_doctypes(self):
+		with self.disabled("frappe"):
+			self.assertEqual(
+				filter_out_disabled_doctypes(["DocType", "zzz Not A DocType"]), ["zzz Not A DocType"]
+			)
+
+		with self.disabled():
+			self.assertEqual(filter_out_disabled_doctypes(["DocType"]), ["DocType"])
+
+	def test_a_maintenance_operation_stops_the_filtering(self):
+		"""A disabled app must take effect again while the site installs, migrates or imports."""
+		for flag in MAINTENANCE_FLAGS:
+			with self.subTest(flag=flag), self.disabled("frappe"):
+				self.assertTrue(is_disabled_app_filtering_active())
+				frappe.flags[flag] = True
+				try:
+					self.clear_request_cache()
+					self.assertFalse(is_disabled_app_filtering_active())
+					self.assertEqual(get_disabled_modules(), set())
+				finally:
+					frappe.flags[flag] = False
+
+	def test_cache_is_cleared_after_maintenance_only_when_an_app_is_disabled(self):
+		with self.disabled("frappe"), patch("frappe.clear_cache") as clear_cache:
+			clear_cache_after_maintenance()
+			clear_cache.assert_called_once()
+
+		with self.disabled(), patch("frappe.clear_cache") as clear_cache:
+			clear_cache_after_maintenance()
+			clear_cache.assert_not_called()

--- a/frappe/tests/test_app_toggle.py
+++ b/frappe/tests/test_app_toggle.py
@@ -1,0 +1,245 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+import json
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import frappe
+from frappe.installer import (
+	disable_app,
+	enable_app,
+	reapply_disabled_app_state,
+	remove_from_installed_apps,
+	set_app_disabled,
+)
+from frappe.tests import IntegrationTestCase
+
+FAKE_APP = "zzz_test_app"
+
+hook_calls = []
+
+
+class HookFailure(Exception):
+	pass
+
+
+def record_before_disable():
+	hook_calls.append("before_disable")
+
+
+def record_after_disable():
+	hook_calls.append("after_disable")
+
+
+def record_before_enable():
+	hook_calls.append("before_enable")
+
+
+def record_after_enable():
+	hook_calls.append("after_enable")
+
+
+def record_disabled_apps():
+	hook_calls.append(read_disabled_apps())
+
+
+def fail():
+	raise HookFailure("hook failed")
+
+
+def read_disabled_apps() -> list[str]:
+	"""Read the global from its row, past the defaults cache and the request cache."""
+	table = frappe.qb.DocType("DefaultValue")
+	rows = (
+		frappe.qb.from_(table)
+		.select(table.defvalue)
+		.where((table.defkey == "disabled_apps") & (table.parent == "__global"))
+		.run()
+	)
+	return json.loads(rows[0][0]) if rows and rows[0][0] else []
+
+
+def write_disabled_apps(apps: list[str]):
+	frappe.db.set_global("disabled_apps", json.dumps(apps))
+	frappe.db.commit()  # nosemgrep
+	frappe.clear_cache()
+	frappe.client_cache.erase_persistent_caches()
+
+
+@contextmanager
+def fake_app(hooks: dict | None = None):
+	"""Present FAKE_APP as installed, with only the hooks a test asks for.
+
+	`hooks` maps `(app_name, hook)` to a value. Any other hook of FAKE_APP is empty, and
+	every other app keeps its real hooks. `get_installed_apps_info` is pinned to the real
+	apps because it imports each app module to read a version.
+	"""
+	overrides = hooks or {}
+	real_get_hooks = frappe.get_hooks
+	installed = [*frappe.get_installed_apps(), FAKE_APP]
+	apps_info = frappe.utils.get_installed_apps_info()
+
+	def app_hooks(hook=None, default="_KEEP_DEFAULT_LIST", app_name=None):
+		if (app_name, hook) in overrides:
+			return overrides[(app_name, hook)]
+		if app_name == FAKE_APP:
+			return []
+		return real_get_hooks(hook, default, app_name)
+
+	with (
+		patch.object(frappe, "get_installed_apps", lambda *a, **k: installed),
+		patch.object(frappe, "get_hooks", app_hooks),
+		patch.object(frappe.utils, "get_installed_apps_info", lambda: apps_info),
+	):
+		yield
+
+
+class TestAppToggle(IntegrationTestCase):
+	def setUp(self):
+		super().setUp()
+		hook_calls.clear()
+		self.disabled_apps_before = read_disabled_apps()
+		self.installed_apps_before = frappe.db.get_global("installed_apps")
+		self.addCleanup(self.restore_globals)
+
+	def restore_globals(self):
+		"""A toggle commits, so put both globals back whatever the test did to them."""
+		frappe.db.set_global("installed_apps", self.installed_apps_before)
+		write_disabled_apps(self.disabled_apps_before)
+
+	def test_disable_adds_to_disabled_apps(self):
+		with fake_app():
+			disable_app(FAKE_APP)
+
+		self.assertIn(FAKE_APP, read_disabled_apps())
+		self.assertIn(FAKE_APP, frappe.get_disabled_apps())
+		self.assertNotIn(FAKE_APP, frappe.get_active_apps())
+
+	def test_enable_removes_from_disabled_apps(self):
+		write_disabled_apps([*self.disabled_apps_before, FAKE_APP])
+
+		with fake_app():
+			enable_app(FAKE_APP)
+
+		self.assertNotIn(FAKE_APP, read_disabled_apps())
+		self.assertNotIn(FAKE_APP, frappe.get_disabled_apps())
+
+	def test_disable_hooks_run_around_the_flip(self):
+		hooks = {
+			(FAKE_APP, "before_disable"): ["frappe.tests.test_app_toggle.record_before_disable"],
+			(FAKE_APP, "after_disable"): ["frappe.tests.test_app_toggle.record_after_disable"],
+		}
+		with fake_app(hooks):
+			disable_app(FAKE_APP)
+
+		self.assertEqual(hook_calls, ["before_disable", "after_disable"])
+
+	def test_enable_hooks_run_around_the_flip(self):
+		write_disabled_apps([*self.disabled_apps_before, FAKE_APP])
+		hooks = {
+			(FAKE_APP, "before_enable"): ["frappe.tests.test_app_toggle.record_before_enable"],
+			(FAKE_APP, "after_enable"): ["frappe.tests.test_app_toggle.record_after_enable"],
+		}
+		with fake_app(hooks):
+			enable_app(FAKE_APP)
+
+		self.assertEqual(hook_calls, ["before_enable", "after_enable"])
+
+	def test_before_disable_runs_while_the_app_is_still_active(self):
+		hooks = {(FAKE_APP, "before_disable"): ["frappe.tests.test_app_toggle.record_disabled_apps"]}
+		with fake_app(hooks):
+			disable_app(FAKE_APP)
+
+		self.assertNotIn(FAKE_APP, hook_calls[0])
+
+	def test_after_disable_runs_once_the_app_is_inactive(self):
+		hooks = {(FAKE_APP, "after_disable"): ["frappe.tests.test_app_toggle.record_disabled_apps"]}
+		with fake_app(hooks):
+			disable_app(FAKE_APP)
+
+		self.assertIn(FAKE_APP, hook_calls[0])
+
+	def test_failing_hook_leaves_the_database_unchanged(self):
+		hooks = {(FAKE_APP, "after_disable"): ["frappe.tests.test_app_toggle.fail"]}
+		with fake_app(hooks), self.assertRaises(HookFailure):
+			disable_app(FAKE_APP)
+
+		self.assertEqual(read_disabled_apps(), self.disabled_apps_before)
+
+	def test_failing_hook_leaves_the_cache_unchanged(self):
+		"""The flip is committed before the hooks, so a rollback has to drop the caches too."""
+		hooks = {(FAKE_APP, "after_disable"): ["frappe.tests.test_app_toggle.fail"]}
+		with fake_app(hooks), self.assertRaises(HookFailure):
+			disable_app(FAKE_APP)
+
+		self.assertNotIn(FAKE_APP, frappe.get_disabled_apps())
+		with self.secondary_connection():
+			self.assertNotIn(FAKE_APP, frappe.get_disabled_apps())
+
+	def test_a_hook_sees_the_flip_it_then_rolls_back(self):
+		"""Guards the test above: the flip must reach the database before the hook fails."""
+		hooks = {
+			(FAKE_APP, "after_disable"): [
+				"frappe.tests.test_app_toggle.record_disabled_apps",
+				"frappe.tests.test_app_toggle.fail",
+			]
+		}
+		with fake_app(hooks), self.assertRaises(HookFailure):
+			disable_app(FAKE_APP)
+
+		self.assertIn(FAKE_APP, hook_calls[0])
+		self.assertEqual(read_disabled_apps(), self.disabled_apps_before)
+
+	def test_cannot_disable_frappe(self):
+		with self.assertRaises(frappe.ValidationError):
+			disable_app("frappe")
+
+		self.assertNotIn("frappe", read_disabled_apps())
+
+	def test_cannot_disable_an_app_that_is_not_installed(self):
+		with self.assertRaises(frappe.ValidationError):
+			disable_app(FAKE_APP)
+
+	def test_cannot_enable_an_app_that_is_not_installed(self):
+		with self.assertRaises(frappe.ValidationError):
+			enable_app(FAKE_APP)
+
+	def test_cannot_disable_an_app_another_active_app_requires(self):
+		hooks = {("frappe", "required_apps"): [FAKE_APP]}
+		with fake_app(hooks), self.assertRaises(frappe.ValidationError):
+			disable_app(FAKE_APP)
+
+		self.assertNotIn(FAKE_APP, read_disabled_apps())
+
+	def test_cannot_enable_an_app_whose_dependency_is_disabled(self):
+		write_disabled_apps([*self.disabled_apps_before, FAKE_APP, "frappe"])
+		hooks = {(FAKE_APP, "required_apps"): ["frappe"]}
+		with fake_app(hooks), self.assertRaises(frappe.ValidationError):
+			enable_app(FAKE_APP)
+
+		self.assertIn(FAKE_APP, read_disabled_apps())
+
+	def test_uninstall_clears_the_disabled_state(self):
+		write_disabled_apps([*self.disabled_apps_before, FAKE_APP])
+
+		with fake_app():
+			remove_from_installed_apps(FAKE_APP)
+
+		self.assertNotIn(FAKE_APP, read_disabled_apps())
+
+	def test_reapply_runs_before_disable_again(self):
+		write_disabled_apps([*self.disabled_apps_before, FAKE_APP])
+		hooks = {(FAKE_APP, "before_disable"): ["frappe.tests.test_app_toggle.record_before_disable"]}
+		with fake_app(hooks):
+			reapply_disabled_app_state()
+
+		self.assertEqual(hook_calls, ["before_disable"])
+		self.assertIn(FAKE_APP, read_disabled_apps())
+
+	def test_set_app_disabled_does_not_commit(self):
+		"""The caller owns the commit, so the whole toggle can roll back as one unit."""
+		set_app_disabled(FAKE_APP, True)
+		self.assertIn(FAKE_APP, read_disabled_apps())
+
+		frappe.db.rollback()
+		self.assertNotIn(FAKE_APP, read_disabled_apps())

--- a/frappe/tests/test_customization_visibility.py
+++ b/frappe/tests/test_customization_visibility.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+from unittest.mock import patch
+
+import frappe
+from frappe.custom import hide_customizations, unhide_customizations
+from frappe.model.meta import is_field_hidden_by_app
+from frappe.tests import IntegrationTestCase
+
+
+class TestHideCustomizations(IntegrationTestCase):
+	def setUp(self):
+		super().setUp()
+		self.target = "ToDo"
+
+	def test_hide_and_unhide_a_custom_field(self):
+		fieldname = self.new_custom_field()
+		customizations = {"Custom Field": [{"dt": self.target, "fieldname": fieldname}]}
+
+		hide_customizations(customizations)
+		self.assertEqual(frappe.db.get_value("Custom Field", {"fieldname": fieldname}, "is_app_disabled"), 1)
+
+		unhide_customizations(customizations)
+		self.assertEqual(frappe.db.get_value("Custom Field", {"fieldname": fieldname}, "is_app_disabled"), 0)
+
+	def test_hide_and_unhide_a_property_setter(self):
+		name = self.new_property_setter()
+		customizations = {"Property Setter": [{"doc_type": self.target, "name": name}]}
+
+		hide_customizations(customizations)
+		self.assertEqual(frappe.db.get_value("Property Setter", name, "is_app_disabled"), 1)
+
+		unhide_customizations(customizations)
+		self.assertEqual(frappe.db.get_value("Property Setter", name, "is_app_disabled"), 0)
+
+	def test_hide_and_unhide_a_custom_docperm(self):
+		name = self.new_custom_docperm()
+		customizations = {"Custom DocPerm": [{"parent": self.target, "name": name}]}
+
+		hide_customizations(customizations)
+		self.assertEqual(frappe.db.get_value("Custom DocPerm", name, "is_app_disabled"), 1)
+
+		unhide_customizations(customizations)
+		self.assertEqual(frappe.db.get_value("Custom DocPerm", name, "is_app_disabled"), 0)
+
+	def test_rejects_a_doctype_that_is_not_a_customization(self):
+		with self.assertRaises(frappe.ValidationError):
+			hide_customizations({"ToDo": [{"dt": self.target}]})
+
+	def test_rejects_a_filter_without_a_doctype_name(self):
+		"""Without one doctype name the update would reach the rows of every other doctype."""
+		fieldname = self.new_custom_field()
+
+		with self.assertRaises(frappe.ValidationError):
+			hide_customizations({"Custom Field": [{"fieldname": fieldname}]})
+
+		with self.assertRaises(frappe.ValidationError):
+			hide_customizations({"Custom Field": [{"dt": ["like", "%"], "fieldname": fieldname}]})
+
+		self.assertEqual(frappe.db.get_value("Custom Field", {"fieldname": fieldname}, "is_app_disabled"), 0)
+
+	def new_custom_field(self) -> str:
+		"""`in_create_custom_fields` skips the schema sync, whose DDL would commit the row."""
+		fieldname = f"custom_{frappe.generate_hash(length=8)}"
+		frappe.flags.in_create_custom_fields = True
+		try:
+			frappe.get_doc(
+				doctype="Custom Field", dt=self.target, fieldname=fieldname, fieldtype="Data"
+			).insert()
+		finally:
+			frappe.flags.in_create_custom_fields = False
+		return fieldname
+
+	def new_property_setter(self) -> str:
+		property_setter = frappe.get_doc(
+			doctype="Property Setter",
+			doctype_or_field="DocType",
+			doc_type=self.target,
+			property="max_attachments",
+			value="2",
+			property_type="Int",
+		)
+		property_setter.flags.validate_fields_for_doctype = False
+		return property_setter.insert().name
+
+	def new_custom_docperm(self) -> str:
+		role = frappe.get_doc(
+			doctype="Role", role_name=f"zzz Test Role {frappe.generate_hash(length=6)}"
+		).insert()
+		return (
+			frappe.get_doc(doctype="Custom DocPerm", parent=self.target, role=role.name, read=1, permlevel=0)
+			.insert()
+			.name
+		)
+
+
+class TestFieldHiddenByApp(IntegrationTestCase):
+	def test_field_flagged_by_its_own_app_is_hidden(self):
+		self.assertTrue(is_field_hidden_by_app(frappe._dict(is_app_disabled=1)))
+		self.assertFalse(is_field_hidden_by_app(frappe._dict(is_app_disabled=0)))
+
+	def test_field_of_a_disabled_module_is_hidden(self):
+		with patch("frappe.model.meta.is_module_disabled", side_effect=lambda module: module == "Core"):
+			self.assertTrue(is_field_hidden_by_app(frappe._dict(module="Core")))
+			self.assertFalse(is_field_hidden_by_app(frappe._dict(module="Desk")))
+
+	def test_link_field_pointing_at_a_disabled_doctype_is_hidden(self):
+		"""A link to a concealed doctype cannot work, whichever app declared the field."""
+		with patch("frappe.app_state.get_disabled_doctypes", return_value={"ToDo"}):
+			for fieldtype in ("Link", "Table", "Table MultiSelect"):
+				with self.subTest(fieldtype=fieldtype):
+					self.assertTrue(is_field_hidden_by_app(frappe._dict(fieldtype=fieldtype, options="ToDo")))
+
+			self.assertFalse(is_field_hidden_by_app(frappe._dict(fieldtype="Link", options="Note")))
+			self.assertFalse(is_field_hidden_by_app(frappe._dict(fieldtype="Data", options="ToDo")))
+
+	def test_flagged_field_reappears_during_maintenance(self):
+		frappe.flags.in_migrate = True
+		try:
+			self.assertFalse(is_field_hidden_by_app(frappe._dict(is_app_disabled=1)))
+		finally:
+			frappe.flags.in_migrate = False

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -18,6 +18,7 @@ from contextlib import contextmanager, suppress
 from csv import reader, writer
 
 import frappe
+from frappe.app_state import filter_out_disabled_doctypes
 from frappe.query_builder import DocType, Field
 from frappe.utils import cstr, get_bench_path, get_build_version, is_html, strip, strip_html_tags, unique
 from frappe.utils.caching import http_cache
@@ -972,7 +973,7 @@ def get_translated_doctypes():
 	custom_dts = frappe.get_all(
 		"Property Setter", {"property": "translated_doctype", "value": "1"}, pluck="doc_type"
 	)
-	return unique(dts + custom_dts)
+	return filter_out_disabled_doctypes(unique(dts + custom_dts))
 
 
 @contextmanager

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -792,7 +792,7 @@ def get_installed_apps_info():
 			"version": version_details.get("branch_version") or version_details.get("version"),
 			"branch": version_details.get("branch"),
 		}
-		for app, version_details in get_versions().items()
+		for app, version_details in get_versions(include_disabled=True).items()
 	)
 	return out
 

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -522,6 +522,17 @@ use_json_request_body = True
 # before_uninstall = "{app_name}.uninstall.before_uninstall"
 # after_uninstall = "{app_name}.uninstall.after_uninstall"
 
+# Disable / Enable
+# ----------------
+# Called when this app is logically disabled or re-enabled on a site,
+# without uninstalling it. Use this to hide/restore fields this app adds
+# to other apps' doctypes.
+
+# before_disable = "{app_name}.uninstall.before_disable"
+# after_disable = "{app_name}.uninstall.after_disable"
+# before_enable = "{app_name}.install.before_enable"
+# after_enable = "{app_name}.install.after_enable"
+
 # Integration Setup
 # ------------------
 # To set up dependencies/integrations with other apps

--- a/frappe/utils/change_log.py
+++ b/frappe/utils/change_log.py
@@ -10,7 +10,7 @@ from semantic_version import SimpleSpec, Version
 
 import frappe
 from frappe import _, safe_decode
-from frappe.utils import cstr
+from frappe.utils import cint, cstr
 from frappe.utils.caching import redis_cache
 from frappe.utils.frappecloud import on_frappecloud
 
@@ -102,8 +102,10 @@ def update_last_known_versions():
 
 
 @frappe.whitelist()
-def get_versions():
-	"""Get versions of all installed apps.
+def get_versions(include_disabled: bool = False):
+	"""Get versions of apps active on this site.
+
+	:param include_disabled: Also return apps that are installed but disabled.
 
 	Example:
 
@@ -114,7 +116,12 @@ def get_versions():
 	                }
 	        }"""
 	versions = {}
-	for app in frappe.get_installed_apps(_ensure_on_bench=True):
+	apps = (
+		frappe.get_installed_apps(_ensure_on_bench=True)
+		if cint(include_disabled)
+		else frappe.get_active_apps(_ensure_on_bench=True)
+	)
+	for app in apps:
 		app_hooks = frappe.get_hooks(app_name=app)
 		app_color = app_hooks.get("app_color")
 

--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -49,7 +49,7 @@ def get_doctypes_with_global_search(with_child_tables=True):
 			if len(meta.get_global_search_fields()) > 0:
 				global_search_doctypes.append(d)
 
-		installed_apps = frappe.get_installed_apps()
+		installed_apps = frappe.get_active_apps()
 		module_app = frappe.local.module_app
 
 		doctypes = [
@@ -299,7 +299,7 @@ def update_global_search_for_all_web_pages():
 
 
 def get_routes_to_index():
-	apps = frappe.get_installed_apps()
+	apps = frappe.get_active_apps()
 
 	routes_to_index = []
 	for app in apps:

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -190,7 +190,7 @@ def _get_jloader():
 
 	apps = frappe.get_hooks("template_apps")
 	if not apps:
-		apps = list(reversed(frappe.get_installed_apps(_ensure_on_bench=True)))
+		apps = list(reversed(frappe.get_active_apps(_ensure_on_bench=True)))
 
 	if "frappe" not in apps:
 		apps.append("frappe")

--- a/frappe/utils/modules.py
+++ b/frappe/utils/modules.py
@@ -33,7 +33,7 @@ def get_modules_from_all_apps_for_user(user: str | None = None) -> list[dict]:
 
 def get_modules_from_all_apps():
 	modules_list = []
-	for app in frappe.get_installed_apps():
+	for app in frappe.get_active_apps():
 		modules_list += get_modules_from_app(app)
 	return modules_list
 

--- a/frappe/utils/scheduler.py
+++ b/frappe/utils/scheduler.py
@@ -133,8 +133,14 @@ def enqueue_events_for_site(site: str) -> None:
 
 def enqueue_events() -> list[str] | None:
 	if schedule_jobs_based_on_activity():
+		from frappe.core.doctype.scheduled_job_type.scheduled_job_type import get_disabled_app_job_methods
+
 		enqueued_jobs = []
-		all_jobs = frappe.get_docs("Scheduled Job Type", filters={"stopped": 0})
+		filters = {"stopped": 0}
+		if disabled_methods := get_disabled_app_job_methods():
+			filters["method"] = ["not in", disabled_methods]
+
+		all_jobs = frappe.get_docs("Scheduled Job Type", filters=filters)
 		random.shuffle(all_jobs)
 		for job_type in all_jobs:
 			try:

--- a/frappe/utils/user.py
+++ b/frappe/utils/user.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import frappe
 import frappe.share
 from frappe import _dict
+from frappe.app_state import get_disabled_modules
 from frappe.core.doctype.domain_settings.domain_settings import get_active_modules
 from frappe.desk.desk_views import DeskViews
 from frappe.permissions import AUTOMATIC_ROLES, get_rights, get_roles, get_valid_perms
@@ -77,6 +78,7 @@ class UserPermissions:
 		self.doctype_map = {}
 
 		active_domains = frappe.get_active_domains()
+		disabled_modules = get_disabled_modules()
 		all_doctypes = frappe.get_all(
 			"DocType",
 			fields=[
@@ -91,6 +93,9 @@ class UserPermissions:
 		)
 
 		for dt in all_doctypes:
+			if dt.module in disabled_modules:
+				continue
+
 			if not dt.restrict_to_domain or (dt.restrict_to_domain in active_domains):
 				self.doctype_map[dt["name"]] = dt
 

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -1201,4 +1201,4 @@ def get_link_options(
 
 @redis_cache(ttl=60 * 60)
 def get_published_web_forms() -> dict[str, str]:
-	return frappe.get_all("Web Form", ["name", "route", "modified"], {"published": 1})
+	return frappe.get_all("Web Form", ["name", "route", "modified", "module"], {"published": 1})

--- a/frappe/website/doctype/website_theme/website_theme.py
+++ b/frappe/website/doctype/website_theme/website_theme.py
@@ -187,7 +187,7 @@ def get_scss_paths():
 	import_path_list = []
 
 	scss_files = ["public/scss/website.scss", "public/scss/website.bundle.scss"]
-	for app in frappe.get_installed_apps():
+	for app in frappe.get_active_apps():
 		for scss_file in scss_files:
 			full_path = frappe.get_app_path(app, scss_file)
 			if path_exists(full_path):

--- a/frappe/website/page_renderers/static_page.py
+++ b/frappe/website/page_renderers/static_page.py
@@ -34,7 +34,7 @@ class StaticPage(BaseRenderer):
 		self.file_path = ""
 		if not self.is_valid_file_path():
 			return
-		for app in frappe.get_installed_apps():
+		for app in frappe.get_active_apps():
 			app_path = Path(frappe.get_app_path(app, "www"))
 			requested_path = (app_path / self.path).resolve()
 			if (

--- a/frappe/website/page_renderers/template_page.py
+++ b/frappe/website/page_renderers/template_page.py
@@ -50,7 +50,7 @@ class TemplatePage(BaseTemplatePage):
 		and /templates/pages folders and sets path if match is found
 		"""
 		folders = get_start_folders()
-		for app in reversed(frappe.get_installed_apps()):
+		for app in reversed(frappe.get_active_apps()):
 			app_path = frappe.get_app_path(app)
 
 			for dirname in folders:

--- a/frappe/website/router.py
+++ b/frappe/website/router.py
@@ -89,7 +89,7 @@ def get_pages(app=None):
 		if app:
 			apps = [app]
 		else:
-			apps = frappe.get_installed_apps()
+			apps = frappe.get_active_apps()
 
 		for app in apps:
 			app_path = frappe.get_app_path(app)
@@ -290,7 +290,7 @@ def get_doctypes_with_web_view():
 	"""Return doctypes with Has Web View or set via hooks"""
 
 	def _get():
-		installed_apps = frappe.get_installed_apps()
+		installed_apps = frappe.get_active_apps()
 		doctypes = frappe.get_hooks("website_generators")
 		doctypes_with_web_view = frappe.get_all(
 			"DocType", fields=["name", "module"], filters=dict(has_web_view=1)

--- a/frappe/website/router.py
+++ b/frappe/website/router.py
@@ -31,10 +31,16 @@ def get_page_info_from_web_page_with_dynamic_routes(path):
 
 def get_page_info_from_web_form(path):
 	"""Query published web forms and evaluate if the route matches"""
+	from frappe.app_state import get_disabled_modules
 	from frappe.website.doctype.web_form.web_form import get_published_web_forms
+
+	disabled_modules = get_disabled_modules()
 
 	for d in get_published_web_forms():
 		if not (path.startswith(f"{d.route}") or path.startswith(f"/{d.route}")):
+			continue
+
+		if d.module in disabled_modules:
 			continue
 
 		rules = []

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -10,6 +10,7 @@ import yaml
 from werkzeug.wrappers import Response
 
 import frappe
+from frappe.app_state import get_disabled_doctypes
 from frappe.apps import get_apps, get_default_path, is_desk_apps
 from frappe.model.document import Document
 from frappe.utils import (
@@ -466,8 +467,13 @@ def get_portal_sidebar_items():
 		roles = frappe.get_roles()
 		portal_settings = frappe.get_doc("Portal Settings", "Portal Settings")
 
+		disabled_doctypes = get_disabled_doctypes()
+
 		def add_items(sidebar_items, items):
 			for d in items:
+				if d.get("reference_doctype") in disabled_doctypes:
+					continue
+
 				if d.get("enabled") and ((not d.get("role")) or d.get("role") in roles):
 					sidebar_items.append(d.as_dict() if isinstance(d, Document) else d)
 

--- a/frappe/www/attribution.py
+++ b/frappe/www/attribution.py
@@ -15,7 +15,7 @@ def get_context(context):
 		frappe.throw(_("You need to be a system user to access this page."), frappe.PermissionError)
 
 	apps = []
-	for app in frappe.get_installed_apps():
+	for app in frappe.get_active_apps():
 		app_info = get_app_info(app)
 		if any([app_info.get("authors"), app_info.get("dependencies"), app_info.get("description")]):
 			apps.append(app_info)

--- a/hooks.md
+++ b/hooks.md
@@ -13,6 +13,20 @@
 1. `before_install` - method
 1. `after_install` - method
 
+#### Disable / Enable
+
+Called when the site disables the app, or enables it again. The app keeps its schema and its
+data, so these hooks only change what takes effect.
+
+1. `before_disable` - method, runs while the app still takes effect
+1. `after_disable` - method
+1. `before_enable` - method
+1. `after_enable` - method, runs after the app takes effect again
+
+An app hides its own customizations here, with `frappe.custom.hide_customizations` and
+`frappe.custom.unhide_customizations`. `bench migrate` runs `before_disable` again, so it must
+give the same result each time.
+
 
 #### Javascript / CSS Builds
 

--- a/hooks.md
+++ b/hooks.md
@@ -15,18 +15,16 @@
 
 #### Disable / Enable
 
-Called when the site disables the app, or enables it again. The app keeps its schema and its
-data, so these hooks only change what takes effect.
+The site runs these hooks when it disables an app, and when it enables the app again. The app keeps its schema and its data. These hooks change only what the app does on the site.
 
-1. `before_disable` - method, runs while the app still takes effect
-1. `after_disable` - method
-1. `before_enable` - method
-1. `after_enable` - method, runs after the app takes effect again
+1. `before_disable` - method, runs while the app is still active
+2. `after_disable` - method, runs after the app becomes inactive
+3. `before_enable` - method, runs while the app is still inactive
+4. `after_enable` - method, runs after the app becomes active again
 
-An app hides its own customizations here, with `frappe.custom.hide_customizations` and
-`frappe.custom.unhide_customizations`. `bench migrate` runs `before_disable` again, so it must
-give the same result each time.
+An app hides and shows its own customizations in these hooks. Call `frappe.custom.hide_customizations` from `before_disable`, and `frappe.custom.unhide_customizations` from `after_enable`. `bench migrate` runs `before_disable` again, so `before_disable` must give the same result each time.
 
+A disable or an enable is one transaction. If a hook fails, the site keeps the state that it had before, and nothing the hook wrote remains.
 
 #### Javascript / CSS Builds
 


### PR DESCRIPTION
Resolves https://github.com/frappe/frappe/issues/41481
Resolves https://github.com/frappe/frappe/issues/30936
Pilot changes : https://github.com/frappe/pilot/pull/356

This will allow to disable / enable app without uninstalling app.

Disabling an app
- will hide its apis, pages, workspaces, doctypes, module defs etc.
- stop scheduled job defined by the custom app
- dis-engage the hooks defined by the custom app
- hide custom fields created by the app also

Additional -
- Added `enable-app`, `disable-app` comand. Also can be disabled / enabled from `Installed Applications` table. 
  <img width="1018" height="458" alt="image" src="https://github.com/user-attachments/assets/d69a4a38-f2d2-42ac-905f-9335ff2dc521" />

- Added before_enable, after_enable, before_disable, after_disable hooks
- Add utility methods for enable/disable customization 
- Dont allow to disable app, if any app has dependency of that.

During migration, the custom app will be migrated also.