### PR TITLE
fix: send user-invitation expiry email to the invitee, not the inviter

### DIFF
--- a/frappe/core/doctype/user_invitation/user_invitation.py
+++ b/frappe/core/doctype/user_invitation/user_invitation.py
@@ -71,9 +71,8 @@ class UserInvitation(Document):
 		self.status = "Expired"
 		self.save()
 		email_title = self._get_email_title()
-		invited_by_user = frappe.get_doc("User", self.invited_by)
 		frappe.sendmail(
-			recipients=invited_by_user.email,
+			recipients=self.email,
 			subject=_("Invitation to join {0} expired").format(email_title),
 			template="user_invitation_expired",
 			args={"title": email_title},


### PR DESCRIPTION
The expired-invite email was going to the sender, but the wording is meant for the person who got invited. Changed it to go to the invitee, like the invite and cancel emails already do.


`no-docs`