### PR TITLE
fix(grid): keep search row aligned with sticky columns on resize

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -202,7 +202,7 @@ Cypress.Commands.add("fill_field", (fieldname, value, fieldtype = "Data") => {
 
 Cypress.Commands.add("get_field", (fieldname, fieldtype = "Data") => {
 	let field_element = fieldtype === "Select" ? "select" : "input";
-	let selector = `[data-fieldname="${fieldname}"] ${field_element}:visible`;
+	let selector = `[data-fieldname="${fieldname}"]:not(.search) ${field_element}:visible`;
 
 	if (fieldtype === "Text Editor") {
 		selector = `[data-fieldname="${fieldname}"] .ql-editor[contenteditable=true]:visible`;

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -906,9 +906,18 @@ export default class GridRow {
 		}
 		let input_class = this._get_fieldtype_class(df.fieldtype);
 
+		let add_class = "";
+		let add_style = `flex: 1 0 ${width}px; width: ${width}px;`;
+		if (df.sticky) {
+			add_class = " sticky-grid-col";
+			add_style += `left: ${this.grid.get_sticky_offset(df.fieldname)}px;`;
+		}
+
 		let $col = $(
-			`<div class="col grid-static-col search" style="flex: 1 0 ${width}px; width: ${width}px;"></div>`
-		).appendTo(this.row);
+			`<div class="col grid-static-col search${add_class}" style="${add_style}"></div>`
+		)
+			.attr("data-fieldname", df.fieldname)
+			.appendTo(this.row);
 
 		let $search_input = $(`
 			<input


### PR DESCRIPTION
- give search row cells of sticky columns the `sticky-grid-col` class and sticky `left` offset, same as `make_column`
- without it, `save_column_width`'s `left` patch lands on `position: relative` search cells (via the resize-handle CSS rule) and shifts the search inputs sideways after a column resize; search inputs also scrolled away from their pinned headers on horizontal scroll