### PR TITLE
fix: file manager breadcrumb shows undefined for nested folders

### DIFF
--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -97,6 +97,7 @@ frappe.router = {
 		image: "Image",
 		inbox: "Inbox",
 		file: "Home",
+		home: "Home",
 		map: "Map",
 	},
 	layout_mapped: {},

--- a/frappe/public/js/frappe/views/file/file_view.js
+++ b/frappe/public/js/frappe/views/file/file_view.js
@@ -57,15 +57,13 @@ frappe.views.FileView = class FileView extends frappe.views.ListView {
 	}
 
 	set_breadcrumbs() {
-		const route = frappe.get_route();
-		route.splice(-1);
-		const last_folder = route[route.length - 1];
-		if (last_folder === "File") return;
+		const route = frappe.get_route().slice(0, -1);
+		const at_home_folder = route[route.length - 1] === "File";
 
 		frappe.breadcrumbs.add({
 			type: "Custom",
-			label: __("Home"),
-			route: "/desk/List/File/Home",
+			label: at_home_folder ? this.page_title : __("Home"),
+			route: "/desk/file",
 		});
 	}
 
@@ -398,7 +396,10 @@ frappe.views.FileView = class FileView extends frappe.views.ListView {
 	}
 
 	get_route_url(file) {
-		return file.is_folder ? "/desk/List/File/" + file.name : this.get_form_link(file);
+		if (!file.is_folder) return this.get_form_link(file);
+
+		const folder_path = file.name.split("/").map(encodeURIComponent).join("/");
+		return "/desk/file/view/" + folder_path;
 	}
 
 	get_creation_date(file) {

--- a/frappe/public/js/frappe/views/file/file_view.js
+++ b/frappe/public/js/frappe/views/file/file_view.js
@@ -2,16 +2,6 @@ frappe.provide("frappe.views");
 
 frappe.views.FileView = class FileView extends frappe.views.ListView {
 	static load_last_view() {
-		const route = frappe.get_route();
-		if (route.length === 2) {
-			const view_user_settings = frappe.get_user_settings("File", "File");
-			frappe.set_route(
-				"List",
-				"File",
-				view_user_settings.last_folder || frappe.boot.home_folder
-			);
-			return true;
-		}
 		return redirect_to_home_if_invalid_route();
 	}
 
@@ -247,9 +237,6 @@ frappe.views.FileView = class FileView extends frappe.views.ListView {
 	before_render() {
 		super.before_render();
 		frappe.model.user_settings.save("File", "grid_view", frappe.views.FileView.grid_view);
-		this.save_view_user_settings({
-			last_folder: this.current_folder,
-		});
 	}
 
 	render() {


### PR DESCRIPTION
File Manager stores the current folder in the list route, but the router couldn't parse the `home` view it generated, so routes like `file/view/home/...` resolved with `route[2] === undefined`. That broke breadcrumbs and folder filtering, leaving folders empty on sites not relying on the doctype's default-view reroute. Adding a `home` route fixes parsing of the router's own URLs.

`set_breadcrumbs()` also mutated the live route returned by `frappe.get_route()`, shortening it on every render. This dropped the current folder from the breadcrumb and caused page cache collisions, rendering parent folder contents under child URLs.

Folder links now use proper Desk URLs with encoded path segments instead of `/app/List/File/...`, fixing unnecessary reroutes and an `href` injection issue. The Home folder also now displays a breadcrumb linking back to `/app/file`.

https://github.com/user-attachments/assets/fdcc63f4-d1ed-407a-8986-fb7224861d3a

The second commit removes dead `load_last_view()` code. Its last-folder branch is unreachable because `/app/file` is always rerouted to the default view before the factory runs.

For the backport, only the URL prefix differs (`/desk` vs `/app`); the dead-code removal is a behavioral no-op on v15/v16.

---

Ref: https://support.frappe.io/helpdesk/tickets/75386?view=VIEW-HD+Ticket-1252
