### PR TITLE
fix(print): resolve a letter head for beta formats like templates do

### DIFF
--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -6,6 +6,7 @@ from typing import ClassVar
 
 import frappe
 from frappe import _
+from frappe.utils.data import cint
 from frappe.utils.jinja_globals import is_rtl
 
 
@@ -218,12 +219,15 @@ def get_html(
 	style=None,
 	trigger_print=False,
 	settings=None,
+	no_letterhead=None,
 ):
 	from frappe.www.printview import validate_print
 
 	doc = frappe.get_doc(doctype, name)
 	validate_print(doc)
-	generator = PrintFormatGenerator(print_format, doc, letterhead, style=style, settings=settings)
+	generator = PrintFormatGenerator(
+		print_format, doc, letterhead, style=style, settings=settings, no_letterhead=no_letterhead
+	)
 	return generator.get_html_preview(action_banner=action_banner, trigger_print=trigger_print)
 
 
@@ -242,7 +246,7 @@ class PrintFormatGenerator:
 	}
 	_FIELD_RENDERERS: ClassVar[dict[str, str]] = {"HTML Editor": "HTML", "Markdown Editor": "Markdown"}
 
-	def __init__(self, print_format, doc, letterhead=None, style=None, settings=None):
+	def __init__(self, print_format, doc, letterhead=None, style=None, settings=None, no_letterhead=None):
 		self.print_format = (
 			print_format
 			if not isinstance(print_format, str)
@@ -253,14 +257,37 @@ class PrintFormatGenerator:
 		self.settings_override = settings or {}
 		self._header_absorbs_top_margin = False
 		self._logged_conditions = set()
-
-		if letterhead == _("No Letterhead"):
-			letterhead = None
-		self.letterhead = frappe.get_doc("Letter Head", letterhead) if letterhead else None
+		self.letterhead = None
 
 		self.build_context()
 		self.layout = self.get_layout(self.print_format)
 		self.context.layout = self.layout
+		self.letterhead = self.get_letterhead(letterhead, no_letterhead)
+		self.context.letterhead = self.letterhead
+
+	def get_letterhead(self, letterhead, no_letterhead):
+		"""Resolve the letter head to print, most specific choice first.
+
+		Mirrors ``printview.get_letter_head`` so a builder format prints the same
+		letter head a template one would, and adds the format's own choice: a layout
+		that names a letter head outranks the document's field. ``no_letterhead``
+		left unset falls back to the Print Settings toggle, as templates do.
+		"""
+		if no_letterhead is None:
+			no_letterhead = not cint(self.print_settings.with_letterhead)
+		if cint(no_letterhead) or letterhead == _("No Letterhead"):
+			return None
+
+		name = (
+			letterhead
+			or (self.layout or {}).get("letter_head")
+			or self.doc.get("letter_head")
+			or frappe.db.get_value("Letter Head", {"is_default": 1}, "name")
+		)
+		# a stale link shouldn't fail the render — templates degrade to no letter head too
+		if not name or not frappe.db.exists("Letter Head", name):
+			return None
+		return frappe.get_doc("Letter Head", name)
 
 	def build_context(self):
 		self.print_settings = frappe.get_doc("Print Settings")

--- a/frappe/utils/print_utils.py
+++ b/frappe/utils/print_utils.py
@@ -195,7 +195,9 @@ def attach_print(
 					validate_print_for_docstatus(doc_obj)
 					letterhead_name = letterhead if print_letterhead else None
 					pf = pf_doc or get_default_print_format(doc_obj.doctype)
-					generator = PrintFormatGenerator(pf, doc_obj, letterhead_name)
+					generator = PrintFormatGenerator(
+						pf, doc_obj, letterhead_name, no_letterhead=not print_letterhead
+					)
 					content = generator.render_pdf(password=password)
 				else:
 					kwargs["as_pdf"] = True

--- a/frappe/utils/test_print_format_generator.py
+++ b/frappe/utils/test_print_format_generator.py
@@ -479,6 +479,57 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 		html = generator._render_zone_section(section, todo)
 		self.assertFalse(html.strip())
 
+	def test_letterhead_resolution_precedence(self):
+		"""Beta renders resolve a letter head like templates do, with the layout's own choice on top."""
+		from frappe.utils.print_format_generator import PrintFormatGenerator
+
+		def make_lh(is_default=0):
+			lh = frappe.get_doc(
+				{
+					"doctype": "Letter Head",
+					"letter_head_name": f"_Test LH {frappe.generate_hash(length=6)}",
+					"source": "HTML",
+					"content": "<p>letterhead</p>",
+					"is_default": is_default,
+				}
+			).insert(ignore_permissions=True)
+			self.addCleanup(lh.delete, ignore_permissions=True)
+			return lh.name
+
+		site_default, from_layout, explicit = make_lh(is_default=1), make_lh(), make_lh()
+		pf = self._make_print_format()
+		todo = self._make_todo()
+
+		def resolved(**kwargs):
+			return (PrintFormatGenerator(pf.name, todo, **kwargs).letterhead or {}).get("name")
+
+		# nothing named anywhere: the site default, as templates do
+		self.assertEqual(resolved(no_letterhead=0), site_default)
+		self.assertIsNone(resolved(no_letterhead=1))
+
+		# the document's own field outranks the site default
+		todo.letter_head = from_layout
+		self.assertEqual(resolved(no_letterhead=0), from_layout)
+		todo.letter_head = None
+
+		# a layout that names one outranks the document
+		layout = json.loads(pf.format_data)
+		layout["letter_head"] = from_layout
+		pf.db_set("format_data", json.dumps(layout), update_modified=False)
+		frappe.clear_cache()
+		self.assertEqual(resolved(no_letterhead=0), from_layout)
+
+		# an explicit argument outranks everything, and "no" still wins
+		self.assertEqual(resolved(letterhead=explicit, no_letterhead=0), explicit)
+		self.assertIsNone(resolved(letterhead=explicit, no_letterhead=1))
+
+		# a deleted letter head degrades instead of raising
+		todo.letter_head = "_Test LH Deleted"
+		layout.pop("letter_head")
+		pf.db_set("format_data", json.dumps(layout), update_modified=False)
+		frappe.clear_cache()
+		self.assertIsNone(resolved(no_letterhead=0))
+
 	def test_section_background_in_html(self):
 		"""A section with a background color should have that style in the HTML output."""
 		from frappe.utils.print_format_generator import get_html

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -99,6 +99,7 @@ def get_context(context) -> PrintContext:
 			name=frappe.form_dict.name,
 			print_format=print_format,
 			letterhead=letterhead,
+			no_letterhead=frappe.form_dict.no_letterhead,
 			style=frappe.form_dict.style,
 			trigger_print=cint(frappe.form_dict.trigger_print),
 			action_banner=frappe.render_template("templates/print_formats/print_action_banner.html", context),
@@ -336,8 +337,9 @@ def get_html_and_style(
 		generator = PrintFormatGenerator(
 			print_format,
 			document,
-			None if no_letterhead else letterhead,
+			letterhead,
 			settings=frappe.parse_json(settings),
+			no_letterhead=no_letterhead,
 		)
 		html = generator.get_html_preview()
 	else:


### PR DESCRIPTION
Builder (beta) formats rendered with no letter head at all unless the caller named one. The template renderer falls back to `doc.letter_head` and then the site default; the beta one had no fallback, so `download_pdf?...&no_letterhead=0` lost the letter head, as did any document whose own `letter_head` field was set.

Resolution order, most specific first: explicit `letterhead` argument → the layout's own `letter_head` → `doc.letter_head` → site default. `no_letterhead` (or the Print Settings toggle) still wins over all of it.

- Resolves in `PrintFormatGenerator`, the single choke point for every beta render
- Threads `no_letterhead` through `printview`, `get_html` and `attach_print` instead of collapsing it into `letterhead=None`
- A deleted letter head degrades to none instead of raising, matching the template path