### PR TITLE
feat(pfb): add a justify option for section columns

### DIFF
--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -353,7 +353,8 @@ const preview_root = computed(() => {
 	if (df.fieldtype === "Repeater") return { classes: ["pfb-repeater"], style: custom };
 	if (df.fieldtype === "HTML") return { classes: ["custom-html"], style: custom };
 	if (df.fieldtype === "Field Template") return { classes: ["field-template"], style: custom };
-	if (df.fieldtype === "Spacer") return { classes: [], style: { height: "1em", ...custom } };
+	if (df.fieldtype === "Spacer")
+		return { classes: [], style: { height: df.height ? `${df.height}px` : "1em", ...custom } };
 	if (df.fieldtype === "Divider") {
 		return {
 			classes: [],

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -1,6 +1,6 @@
 <template>
 	<div
-		class="print-format-main"
+		class="print-format-main print-format"
 		data-theme="light"
 		:style="rootStyles"
 		:class="{
@@ -10,6 +10,7 @@
 		}"
 	>
 		<component :is="'style'" v-if="color_css">{{ color_css }}</component>
+		<component :is="'style'" v-if="print_format.css">{{ print_format.css }}</component>
 		<div v-if="!page_number_hidden" class="pfb-page-num" :style="page_number_style">
 			{{ __("1 of 2") }}
 		</div>

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -176,7 +176,7 @@ import { computed, inject } from "vue";
 import { useColumnResize } from "../../composables/useColumnResize";
 import {
 	DRAG_OPTIONS,
-	JUSTIFY_MODES,
+	JUSTIFY_CLASSES,
 	evaluate_visible_if,
 	parse_inline_style,
 	setDragging,
@@ -218,7 +218,7 @@ let is_grid = computed(() => !!props.section.field_borders);
 // Mirrors the row layout class print_format.html picks for right-aligned
 // columns; the server computes it for body sections only, never header/footer
 let row_layout = computed(() => {
-	if (JUSTIFY_MODES.includes(props.section.justify)) return `row-col-${props.section.justify}`;
+	if (JUSTIFY_CLASSES[props.section.justify]) return JUSTIFY_CLASSES[props.section.justify];
 	if (props.is_header) return "";
 	const cols = props.section.columns || [];
 	if (!cols.some((c) => c.align === "right")) return "";

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -217,6 +217,7 @@ let is_grid = computed(() => !!props.section.field_borders);
 // Mirrors the row layout class print_format.html picks for right-aligned
 // columns; the server computes it for body sections only, never header/footer
 let row_layout = computed(() => {
+	if (props.section.justify) return `row-col-${props.section.justify}`;
 	if (props.is_header) return "";
 	const cols = props.section.columns || [];
 	if (!cols.some((c) => c.align === "right")) return "";

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -176,6 +176,7 @@ import { computed, inject } from "vue";
 import { useColumnResize } from "../../composables/useColumnResize";
 import {
 	DRAG_OPTIONS,
+	JUSTIFY_MODES,
 	evaluate_visible_if,
 	parse_inline_style,
 	setDragging,
@@ -217,7 +218,7 @@ let is_grid = computed(() => !!props.section.field_borders);
 // Mirrors the row layout class print_format.html picks for right-aligned
 // columns; the server computes it for body sections only, never header/footer
 let row_layout = computed(() => {
-	if (props.section.justify) return `row-col-${props.section.justify}`;
+	if (JUSTIFY_MODES.includes(props.section.justify)) return `row-col-${props.section.justify}`;
 	if (props.is_header) return "";
 	const cols = props.section.columns || [];
 	if (!cols.some((c) => c.align === "right")) return "";

--- a/frappe/public/js/print_format_builder/components/inspector/FieldPropertiesPanel.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldPropertiesPanel.vue
@@ -110,6 +110,19 @@
 					@update:model-value="(v) => (selected_field.align = v)"
 				/>
 			</template>
+			<template v-else-if="is_spacer">
+				<StepperRow
+					:label="__('Height')"
+					:model-value="selected_field.height"
+					:base="16"
+					:step="4"
+					unit="px"
+					:placeholder="__('auto')"
+					allow-empty
+					@update:model-value="(v) => (selected_field.height = v)"
+				/>
+			</template>
+			<template v-else-if="is_divider"></template>
 			<template v-else>
 				<LabelField
 					v-model="selected_field.label"
@@ -205,6 +218,9 @@ const NON_TEXT_FIELDTYPES = new Set([
 let is_text_field = computed(() => !NON_TEXT_FIELDTYPES.has(selected_field.value?.fieldtype));
 
 let is_html_field = computed(() => selected_field.value?.fieldtype === "HTML");
+// a spacer prints a gap and a divider a rule — neither carries a label to align
+let is_spacer = computed(() => selected_field.value?.fieldtype === "Spacer");
+let is_divider = computed(() => selected_field.value?.fieldtype === "Divider");
 let is_image_element = computed(
 	() => selected_field.value?.fieldtype === "Image" && selected_field.value?.custom
 );

--- a/frappe/public/js/print_format_builder/components/inspector/SectionPropertiesPanel.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/SectionPropertiesPanel.vue
@@ -74,7 +74,7 @@
 					@change="set_justify($event.target.value)"
 				>
 					<option value="">{{ __("Normal") }}</option>
-					<option v-for="mode in JUSTIFY_MODES" :key="mode" :value="mode">
+					<option v-for="mode in Object.keys(JUSTIFY_CLASSES)" :key="mode" :value="mode">
 						{{ justify_labels[mode] }}
 					</option>
 				</select>
@@ -137,7 +137,7 @@ import StyleSection from "./StyleSection.vue";
 import ToggleRow from "./ToggleRow.vue";
 import VisibilitySection from "./VisibilitySection.vue";
 import { mountColorControl } from "./useColorControl";
-import { JUSTIFY_MODES } from "../../utils";
+import { JUSTIFY_CLASSES } from "../../utils";
 
 let store = inject("$store");
 

--- a/frappe/public/js/print_format_builder/components/inspector/SectionPropertiesPanel.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/SectionPropertiesPanel.vue
@@ -66,6 +66,20 @@
 		</InspectorSection>
 
 		<InspectorSection :label="__('Layout')" :init-open="false">
+			<div class="pfb-insp-row">
+				<span class="pfb-insp-label">{{ __("Justify") }}</span>
+				<select
+					class="pfb-insp-select"
+					:value="section_justify"
+					@change="set_justify($event.target.value)"
+				>
+					<option value="">{{ __("Normal") }}</option>
+					<option value="space-between">{{ __("Space Between") }}</option>
+					<option value="space-evenly">{{ __("Space Evenly") }}</option>
+					<option value="center">{{ __("Center") }}</option>
+					<option value="right-end">{{ __("Right") }}</option>
+				</select>
+			</div>
 			<SegmentedRow
 				:label="__('Mode')"
 				:model-value="section_field_borders"
@@ -134,6 +148,16 @@ const spacing_props = [
 	{ key: "margin", label: __("Margin") },
 ];
 let preview_doc = computed(() => store.preview_doc.value);
+
+let section_justify = computed(() => selected_section.value?.justify ?? "");
+
+function set_justify(value) {
+	if (value) {
+		selected_section.value.justify = value;
+	} else {
+		delete selected_section.value.justify;
+	}
+}
 
 let section_orientation = computed(() => selected_section.value?.field_orientation ?? "");
 let section_gap = computed(() => selected_section.value?.gap ?? 20);

--- a/frappe/public/js/print_format_builder/components/inspector/SectionPropertiesPanel.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/SectionPropertiesPanel.vue
@@ -74,10 +74,9 @@
 					@change="set_justify($event.target.value)"
 				>
 					<option value="">{{ __("Normal") }}</option>
-					<option value="space-between">{{ __("Space Between") }}</option>
-					<option value="space-evenly">{{ __("Space Evenly") }}</option>
-					<option value="center">{{ __("Center") }}</option>
-					<option value="right-end">{{ __("Right") }}</option>
+					<option v-for="mode in JUSTIFY_MODES" :key="mode" :value="mode">
+						{{ justify_labels[mode] }}
+					</option>
 				</select>
 			</div>
 			<SegmentedRow
@@ -138,6 +137,7 @@ import StyleSection from "./StyleSection.vue";
 import ToggleRow from "./ToggleRow.vue";
 import VisibilitySection from "./VisibilitySection.vue";
 import { mountColorControl } from "./useColorControl";
+import { JUSTIFY_MODES } from "../../utils";
 
 let store = inject("$store");
 
@@ -148,6 +148,13 @@ const spacing_props = [
 	{ key: "margin", label: __("Margin") },
 ];
 let preview_doc = computed(() => store.preview_doc.value);
+
+const justify_labels = {
+	"space-between": __("Space Between"),
+	"space-evenly": __("Space Evenly"),
+	center: __("Center"),
+	"right-end": __("Right"),
+};
 
 let section_justify = computed(() => selected_section.value?.justify ?? "");
 

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -37,6 +37,9 @@ export function write_json(key, value) {
 // Blocks the builder invents — they never map to a docfield on the document type
 export const BLOCK_FIELDTYPES = new Set(["Spacer", "Divider", "Repeater"]);
 
+// Mirrors PrintFormatGenerator.JUSTIFY_MODES — each names a row-col-* class
+export const JUSTIFY_MODES = ["space-between", "space-evenly", "center", "right-end"];
+
 // Mirrors print_format_generator.is_qr_barcode_options: a Barcode docfield whose
 // options ask for a qr code — "qrcode"/"qr" or JSON like {"format": "qrcode"}
 export function is_qr_barcode_options(options) {

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -37,8 +37,14 @@ export function write_json(key, value) {
 // Blocks the builder invents — they never map to a docfield on the document type
 export const BLOCK_FIELDTYPES = new Set(["Spacer", "Divider", "Repeater"]);
 
-// Mirrors PrintFormatGenerator.JUSTIFY_MODES — each names a row-col-* class
-export const JUSTIFY_MODES = ["space-between", "space-evenly", "center", "right-end"];
+// Mirrors PrintFormatGenerator.JUSTIFY_MODES; the class names are spelled out so
+// both surfaces can be grepped for them
+export const JUSTIFY_CLASSES = {
+	"space-between": "row-col-space-between",
+	"space-evenly": "row-col-space-evenly",
+	center: "row-col-center",
+	"right-end": "row-col-right-end",
+};
 
 // Mirrors print_format_generator.is_qr_barcode_options: a Barcode docfield whose
 // options ask for a qr code — "qrcode"/"qr" or JSON like {"format": "qrcode"}

--- a/frappe/templates/print_format/macros/Spacer.html
+++ b/frappe/templates/print_format/macros/Spacer.html
@@ -1,2 +1,2 @@
-<div style="height: 1em;{{ df.custom_style|e if df.custom_style }}">
+<div style="height: {{ (df.height|int|string + 'px') if df.height else '1em' }};{{ df.custom_style|e if df.custom_style }}">
 </div>

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -1,4 +1,11 @@
 {% import "templates/print_format/macros.html" as macros %}
+{#- A section's justify names one of these classes and nothing else -#}
+{%- set justify_classes = {
+	'space-between': 'row-col-space-between',
+	'space-evenly': 'row-col-space-evenly',
+	'center': 'row-col-center',
+	'right-end': 'row-col-right-end',
+} -%}
 
 <!DOCTYPE html>
 <html lang="{{ lang or 'en' }}"{% if layout_direction %} dir="{{ layout_direction }}"{% endif %}>
@@ -40,7 +47,7 @@
 	{%- if ns_h.has_fields -%}
 	{%- set col_gap = (layout.header.gap if layout.header.gap is defined and layout.header.gap != None else 20)|string + 'px' -%}
 	<div class="section document-header-content">
-	<div class="section-columns row{{ ' row-col-' + layout.header.justify if layout.header.justify else '' }}" style="gap:{{ col_gap }}">
+	<div class="section-columns row {{ justify_classes.get(layout.header.justify, '') }}" style="gap:{{ col_gap }}">
 	{%- for column in layout.header.columns %}
 	<div class="column col"{% if column.width %} style="flex: {{ column.width|float }} 1 0%"{% endif %}>
 	{%- for df in column.fields %}{{ macros.render_field(df, doc) }}{%- endfor %}
@@ -115,8 +122,8 @@
 		{#- The section's own justify wins; a right-aligned column is the older way to ask -#}
 		{%- set ns2 = namespace(has_right=false) -%}
 		{%- for col in section.columns -%}{%- if col.align == 'right' -%}{%- set ns2.has_right = true -%}{%- endif -%}{%- endfor -%}
-		{%- if section.justify -%}
-			{%- set row_layout = 'row-col-' + section.justify -%}
+		{%- if section.justify in justify_classes -%}
+			{%- set row_layout = justify_classes[section.justify] -%}
 		{%- elif ns2.has_right and section.columns | length == 1 -%}
 			{%- set row_layout = 'row-col-right-end' -%}
 		{%- elif ns2.has_right -%}
@@ -153,7 +160,7 @@
 	{%- if ns_f.has_fields -%}
 	{%- set col_gap_f = (layout.footer.gap if layout.footer.gap is defined and layout.footer.gap != None else 20)|string + 'px' -%}
 	<div class="section document-footer-content">
-	<div class="section-columns row{{ ' row-col-' + layout.footer.justify if layout.footer.justify else '' }}" style="gap:{{ col_gap_f }}">
+	<div class="section-columns row {{ justify_classes.get(layout.footer.justify, '') }}" style="gap:{{ col_gap_f }}">
 	{%- for column in layout.footer.columns %}
 	<div class="column col"{% if column.width %} style="flex: {{ column.width|float }} 1 0%"{% endif %}>
 	{%- for df in column.fields %}{{ macros.render_field(df, doc) }}{%- endfor %}

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -112,10 +112,12 @@
 		<div class="section-label">{{ _(section.label)|e }}</div>
 		{% endif %}
 
-		{#- Detect right-aligned columns to pick the right row layout class -#}
+		{#- The section's own justify wins; a right-aligned column is the older way to ask -#}
 		{%- set ns2 = namespace(has_right=false) -%}
 		{%- for col in section.columns -%}{%- if col.align == 'right' -%}{%- set ns2.has_right = true -%}{%- endif -%}{%- endfor -%}
-		{%- if ns2.has_right and section.columns | length == 1 -%}
+		{%- if section.justify -%}
+			{%- set row_layout = 'row-col-' + section.justify -%}
+		{%- elif ns2.has_right and section.columns | length == 1 -%}
 			{%- set row_layout = 'row-col-right-end' -%}
 		{%- elif ns2.has_right -%}
 			{%- set row_layout = 'row-col-space-between' -%}

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -40,7 +40,7 @@
 	{%- if ns_h.has_fields -%}
 	{%- set col_gap = (layout.header.gap if layout.header.gap is defined and layout.header.gap != None else 20)|string + 'px' -%}
 	<div class="section document-header-content">
-	<div class="section-columns row" style="gap:{{ col_gap }}">
+	<div class="section-columns row{{ ' row-col-' + layout.header.justify if layout.header.justify else '' }}" style="gap:{{ col_gap }}">
 	{%- for column in layout.header.columns %}
 	<div class="column col"{% if column.width %} style="flex: {{ column.width|float }} 1 0%"{% endif %}>
 	{%- for df in column.fields %}{{ macros.render_field(df, doc) }}{%- endfor %}
@@ -153,7 +153,7 @@
 	{%- if ns_f.has_fields -%}
 	{%- set col_gap_f = (layout.footer.gap if layout.footer.gap is defined and layout.footer.gap != None else 20)|string + 'px' -%}
 	<div class="section document-footer-content">
-	<div class="section-columns row" style="gap:{{ col_gap_f }}">
+	<div class="section-columns row{{ ' row-col-' + layout.footer.justify if layout.footer.justify else '' }}" style="gap:{{ col_gap_f }}">
 	{%- for column in layout.footer.columns %}
 	<div class="column col"{% if column.width %} style="flex: {{ column.width|float }} 1 0%"{% endif %}>
 	{%- for df in column.fields %}{{ macros.render_field(df, doc) }}{%- endfor %}

--- a/frappe/templates/print_format/print_format_doc.css
+++ b/frappe/templates/print_format/print_format_doc.css
@@ -452,13 +452,23 @@
 	justify-content: space-between !important;
 }
 
-.print-format-doc .row-col-space-between .col {
-	flex: none !important;
-	max-width: 48% !important;
+.print-format-doc .row-col-space-evenly {
+	justify-content: space-evenly !important;
+}
+
+.print-format-doc .row-col-center {
+	justify-content: center !important;
 }
 
 .print-format-doc .row-col-right-end {
 	justify-content: flex-end !important;
+}
+
+.print-format-doc .row-col-space-between .col,
+.print-format-doc .row-col-space-evenly .col,
+.print-format-doc .row-col-center .col {
+	flex: none !important;
+	max-width: 48% !important;
 }
 
 .print-format-doc .row-col-right-end .col {

--- a/frappe/templates/print_format/print_format_doc.css
+++ b/frappe/templates/print_format/print_format_doc.css
@@ -437,17 +437,8 @@
 	}
 }
 
-/*
- * Column right-align layout modes
- *
- * row-col-space-between (2+ cols, at least one right-aligned):
- *   Columns sit at natural content width. justify-content:space-between
- *   pushes the leftmost to the left edge and rightmost to the right edge.
- *   No empty-box spacer needed.
- *
- * row-col-right-end (1 col, right-aligned):
- *   Single column is pushed to the right edge with justify-content:flex-end.
- */
+/* How a section distributes its columns — set by the section's justify, or by a
+   right-aligned column on formats that predate it. */
 .print-format-doc .row-col-space-between {
 	justify-content: space-between !important;
 }
@@ -464,16 +455,15 @@
 	justify-content: flex-end !important;
 }
 
+/* The grid gives every column `width: 100%`, so a row has no free space for
+   justify-content to distribute. These take their content width instead, and
+   still shrink when the row runs out of room — so any column count behaves. */
 .print-format-doc .row-col-space-between .col,
 .print-format-doc .row-col-space-evenly .col,
-.print-format-doc .row-col-center .col {
-	flex: none !important;
-	max-width: 48% !important;
-}
-
+.print-format-doc .row-col-center .col,
 .print-format-doc .row-col-right-end .col {
-	flex: none !important;
-	max-width: 50% !important;
+	flex: 0 1 auto !important;
+	width: auto !important;
 }
 
 /* Keep letterhead images from overflowing their box. The .letter-head selector

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -245,6 +245,9 @@ class PrintFormatGenerator:
 		"bottom_right": "right",
 	}
 	_FIELD_RENDERERS: ClassVar[dict[str, str]] = {"HTML Editor": "HTML", "Markdown Editor": "Markdown"}
+	JUSTIFY_MODES: ClassVar[frozenset[str]] = frozenset(
+		{"space-between", "space-evenly", "center", "right-end"}
+	)
 
 	def __init__(self, print_format, doc, letterhead=None, style=None, settings=None, no_letterhead=None):
 		self.print_format = (
@@ -604,7 +607,11 @@ class PrintFormatGenerator:
 				for col in zone.get("columns") or []
 				if isinstance(col, dict)
 			]
-			return {**zone, "columns": columns}
+			cleaned = {**zone, "columns": columns}
+			# justify names a CSS class, so only the modes we ship may reach the markup
+			if cleaned.get("justify") not in self.JUSTIFY_MODES:
+				cleaned.pop("justify", None)
+			return cleaned
 
 		def clean_field(df):
 			if "table_columns" not in df:

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -479,7 +479,7 @@ class PrintFormatGenerator:
 {%- for col in section.columns -%}{%- for df in col.get('fields', []) -%}{%- set ns.has_fields = true -%}{%- endfor -%}{%- endfor -%}
 {%- if ns.has_fields -%}
 {%- set col_gap = (section.gap if section.gap is defined and section.gap is not none else 20)|string + 'px' -%}
-<div class="section section-columns row" style="gap:{{ col_gap }}">
+<div class="section section-columns row{{ ' row-col-' + section.justify if section.get('justify') else '' }}" style="gap:{{ col_gap }}">
 {%- for column in section.columns %}
 <div class="column col"{% if column.get('width') %} style="flex: {{ column.get('width')|float }} 1 0%"{% endif %}>
 {%- for df in column.get('fields', []) -%}

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -505,11 +505,12 @@ class PrintFormatGenerator:
 		return "\n".join(parts) or None
 
 	_ZONE_SECTION_TEMPLATE = """\
+{%- set justify_classes = {'space-between': 'row-col-space-between', 'space-evenly': 'row-col-space-evenly', 'center': 'row-col-center', 'right-end': 'row-col-right-end'} -%}
 {%- set ns = namespace(has_fields=false) -%}
 {%- for col in section.columns -%}{%- for df in col.get('fields', []) -%}{%- set ns.has_fields = true -%}{%- endfor -%}{%- endfor -%}
 {%- if ns.has_fields -%}
 {%- set col_gap = (section.gap if section.gap is defined and section.gap is not none else 20)|string + 'px' -%}
-<div class="section section-columns row{{ ' row-col-' + section.justify if section.get('justify') else '' }}" style="gap:{{ col_gap }}">
+<div class="section section-columns row {{ justify_classes.get(section.get('justify'), '') }}" style="gap:{{ col_gap }}">
 {%- for column in section.columns %}
 <div class="column col"{% if column.get('width') %} style="flex: {{ column.get('width')|float }} 1 0%"{% endif %}>
 {%- for df in column.get('fields', []) -%}

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -514,7 +514,7 @@ class PrintFormatGenerator:
 {%- if df.fieldtype == 'HTML' and df.html -%}
 <div class="custom-html">{{ frappe.render_template(df.html, {'doc': doc}) }}</div>
 {%- elif df.fieldtype == 'Spacer' -%}
-<div style="height:12px"></div>
+<div style="height:{{ (df.height|int|string + 'px') if df.get('height') else '1em' }}"></div>
 {%- elif df.fieldtype == 'Divider' -%}
 <hr style="border-top:1px solid #e5e7eb;margin:4px 0"/>
 {%- elif df.fieldtype == 'Image' -%}

--- a/frappe/utils/test_print_format_generator.py
+++ b/frappe/utils/test_print_format_generator.py
@@ -530,6 +530,27 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 		frappe.clear_cache()
 		self.assertIsNone(resolved(no_letterhead=0))
 
+	def test_section_justify_only_emits_known_modes(self):
+		"""justify names a CSS class, so a layout can't smuggle markup through it."""
+		from frappe.utils.print_format_generator import get_html
+
+		layout = {
+			"sections": [
+				{"justify": 'x" onmouseover="alert(1)', "columns": [{"fields": []}]},
+				{
+					"justify": "space-between",
+					"columns": [{"fields": [{"fieldtype": "Data", "fieldname": "description"}]}],
+				},
+			],
+			"header": {"justify": 'x" onmouseover="alert(1)', "columns": [{"fields": []}]},
+			"footer": {"columns": [{"fields": []}]},
+		}
+		pf = self._make_print_format(format_data=json.dumps(layout))
+		html = get_html("ToDo", self._make_todo().name, pf.name)
+
+		self.assertNotIn("onmouseover", html)
+		self.assertIn("row-col-space-between", html)
+
 	def test_section_background_in_html(self):
 		"""A section with a background color should have that style in the HTML output."""
 		from frappe.utils.print_format_generator import get_html

--- a/frappe/utils/test_print_format_parity.py
+++ b/frappe/utils/test_print_format_parity.py
@@ -31,7 +31,8 @@ SERVER_SOURCES = [
 ]
 
 BUILDER_DIR = APP_PATH / "public" / "js" / "print_format_builder"
-CANVAS_SOURCES = sorted(BUILDER_DIR.rglob("*.vue"))
+# utils.js holds class names the components render from, so it speaks the markup too
+CANVAS_SOURCES = [*sorted(BUILDER_DIR.rglob("*.vue")), BUILDER_DIR / "utils.js"]
 
 # Classes that legitimately exist on only one surface.
 SERVER_ONLY_CLASSES = {


### PR DESCRIPTION
Sections can now push their columns apart, plus three builder fixes found alongside it.

**Justify** (Section → Layout): Normal (default), Space Between, Space Evenly, Center, Right. The renderers already understood these row layouts but nothing could set them — `column.align` was read by the print template and the canvas, yet no control ever wrote it. Applies to header and footer zones too, so a two-item header can sit left/right. A section that names no justify renders exactly as before, and the older `column.align == "right"` layout still wins when no justify is set. Since the value names a CSS class, `normalise_layout` drops anything outside the shipped modes, so a hand-edited `format_data` cannot reach the markup.

Justified columns now take their content width (`flex: 0 1 auto; width: auto`) instead of the fixed `max-width: 48%/50%` the old rules used — that cap only existed to undo the grid’s `width: 100%`, and it broke at three or more columns.

**Custom CSS on the canvas**: a format’s Custom CSS was emitted for print but never for the builder, and the canvas lacked the `.print-format` wrapper that printview wraps the body in — so rules written against print output could not match while editing. The canvas now emits the CSS and carries the class.

**Spacer**: had Label and Align controls that no renderer reads, and no height control at all, so every spacer printed a fixed 1em. It now takes a height, honoured by the body macro, the zone template and the canvas alike; the zone template’s hardcoded `12px` is gone. Divider drops the same dead controls.

no-docs