### PR TITLE
fix(qb_query): preserve explicit unlimited page length for virtual dt

### DIFF
--- a/frappe/model/qb_query.py
+++ b/frappe/model/qb_query.py
@@ -333,7 +333,7 @@ class DatabaseQuery:
 		if not isinstance(or_filters, Filters):
 			or_filters = Filters(or_filters, doctype=self.doctype)
 
-		_page_length = page_length or limit or limit_page_length or 20
+		_page_length = next((x for x in (page_length, limit, limit_page_length) if x is not None), 20)
 		kwargs = {
 			"fields": fields,
 			"filters": filters,

--- a/frappe/tests/test_virtual_doctype.py
+++ b/frappe/tests/test_virtual_doctype.py
@@ -163,6 +163,28 @@ class TestVirtualDoctypes(IntegrationTestCase):
 	def test_get_count(self):
 		self.assertIsInstance(VirtualDoctypeTest.get_count(), int)
 
+	def test_get_all_preserves_unlimited_page_length(self):
+		from frappe.model.base_document import get_controller
+
+		controller = get_controller(TEST_DOCTYPE_NAME)
+		captured = {}
+
+		def spy_get_list(*args, **kwargs):
+			captured.update(kwargs)
+			return []
+
+		with patch.object(controller, "get_list", side_effect=spy_get_list):
+			frappe.get_all(TEST_DOCTYPE_NAME, limit_page_length=0)
+
+		self.assertEqual(captured.get("limit_page_length"), 0)
+		self.assertEqual(captured.get("page_length"), 0)
+
+		captured.clear()
+		with patch.object(controller, "get_list", side_effect=spy_get_list):
+			frappe.get_list(TEST_DOCTYPE_NAME)
+
+		self.assertEqual(captured.get("limit_page_length"), 20)
+
 	def test_delete_doc(self):
 		doc = frappe.get_doc(doctype=TEST_DOCTYPE_NAME).insert()
 


### PR DESCRIPTION
closes: https://github.com/frappe/frappe/issues/40763

Credits: @tushardev-365

preserve explicit unlimited page length for virtual doctypes

Only apply the default when no limit argument was passed at all.