### PR TITLE
fix: raise error with actual reason of denial

### DIFF
--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -54,7 +54,8 @@ def print_has_permission_check_logs(func):
 		# print only if access denied
 		# and if user is checking their own permission
 		if not result and self_perm_check and print_logs:
-			msgprint(("<br>").join(frappe.flags.get("has_permission_check_logs", [])))
+			if logs := frappe.flags.get("has_permission_check_logs"):
+				msgprint(("<br>").join(logs))
 
 		if print_logs:
 			frappe.flags.pop("has_permission_check_logs", None)
@@ -143,12 +144,13 @@ def has_permission(
 			debug and _debug_log(
 				"Permission check failed from role permission system. Check if user's role grant them permission to the document."
 			)
-			msg = _("User {0} does not have access to this document").format(frappe.bold(user))
-			if meta.issingle:
-				msg += f": {_(doc.doctype)}"
-			elif has_permission(doc.doctype):
-				msg += f": {_(doc.doctype)} - {doc.name}"
-			push_perm_check_log(msg, debug=debug)
+			if not frappe.flags.get("has_permission_check_logs"):
+				msg = _("User {0} does not have access to this document").format(frappe.bold(user))
+				if meta.issingle:
+					msg += f": {_(doc.doctype)}"
+				elif has_permission(doc.doctype, print_logs=False):
+					msg += f": {_(doc.doctype)} - {doc.name}"
+				push_perm_check_log(msg, debug=debug)
 	else:
 		if ptype == "submit" and not cint(meta.is_submittable):
 			push_perm_check_log(_("Document Type is not submittable"), debug=debug)

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -116,6 +116,18 @@ class TestPermissions(IntegrationTestCase):
 		self.assertTrue(post1.has_permission("read"))
 		self.assertTrue(get_doc_permissions(post1).get("read"))
 
+	def test_user_permission_denial_is_explained(self):
+		add_user_permission("Test Blog Category", "_Test Blog Category 1", "test2@example.com")
+
+		with self.set_user("test2@example.com"):
+			frappe.local.message_log = []
+			post = frappe.get_doc("Test Blog Post", "_Test Blog Post")
+			self.assertRaises(frappe.PermissionError, post.check_permission, "read")
+
+			message = frappe.local.message_log[-1]["message"]
+			self.assertIn("Test Blog Category", message)
+			self.assertIn("_Test Blog Category", message)
+
 	def test_user_permissions_in_report(self):
 		add_user_permission("Test Blog Category", "_Test Blog Category 1", "test2@example.com")
 


### PR DESCRIPTION
Every document-level permission denial showed only the generic message from `raise_no_permission_to`, even when the actual cause was a User Permission restriction. As a result, users were told they needed a permission they already had, with no indication of what actually blocked access.

The reason was already being computed but discarded. A nested `has_permission(doc.doctype)` call reset `has_permission_check_logs`, clearing the outer permission check's buffer before it could be displayed. This also caused the blank **Message** dialogs.

This change:
- passes `print_logs=False` to the nested `has_permission()` call so the caller's buffer is preserved,
- skips `msgprint` when there are no permission logs, and
- treats the generic "does not have access to this document" message as a fallback instead of appending it when a more specific reason exists.

Permission denials now show the actual cause before the generic permission requirement.

<img width="636" height="253" alt="Screenshot 2026-08-04 at 5 25 50 PM" src="https://github.com/user-attachments/assets/326b44cd-ae3f-4226-b974-789b8417d921" />


Closes #41575 