### PR TITLE
fix(ui): resolve @framework/ui's own deps against the host app

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -47,12 +47,7 @@ The `paths` key must match the package name `@framework/ui` (also the key under
 The host app must already provide the peers (`vue`, `vue-router`, `frappe-ui`) — every
 Frappe frontend does.
 
-### 3. Dedupe shared singletons — `vite.config.js`
-
-`@framework/ui` ships raw source compiled in place by the host bundler, so its bare
-imports of shared singletons (`vue`, `vue-router`, `frappe-ui`, `reka-ui`, `dompurify`)
-resolve by realpath into a _second_ copy unless deduped — breaking provide/inject
-context (reka-ui especially) and doubling Vue. Add the bundled plugin:
+### 3. Add the bundled Vite plugin — `vite.config.js`
 
 ```js
 import frameworkUI from "@framework/ui/vite";
@@ -61,6 +56,18 @@ export default defineConfig({
   plugins: [frameworkUI()], // pass { dedupe: [...] } to add app-specific singletons
 });
 ```
+
+The plugin does two things, both consequences of raw source compiled in place by the
+host bundler:
+
+- **Dedupes shared singletons.** Bare imports of `vue`, `vue-router`, `frappe-ui`,
+  `reka-ui` and `dompurify` resolve by realpath into a _second_ copy unless deduped —
+  breaking provide/inject context (reka-ui especially) and doubling Vue.
+- **Resolves this package's own dependencies against the host app.** `leaflet`,
+  `cropperjs` and the rest are declared in this package's `package.json`, but a bench
+  installs `node_modules` beside the host frontend and never beside the frappe repo,
+  so walking up from this package's realpath finds nothing. The plugin re-runs the
+  host's resolver for bare specifiers Vite could not resolve itself.
 
 ## Usage
 
@@ -86,6 +93,11 @@ Subpaths work too (via the `./*` export), e.g. `import { FormLayout } from '@fra
 - **"Failed to resolve import '@framework/ui'"** after a rename or fresh link: re-run
   `yarn install` and restart the dev server so the new symlink enters Vite's module graph.
   Also confirm the import specifier matches the package name `@framework/ui`.
+- **A build that fails on an asset import** from one of this package's own dependencies
+  (e.g. leaflet's marker images) while the dev server passes: the host app is missing the
+  plugin from step 3, and only a stray `apps/frappe/ui/node_modules` was hiding it. Vite
+  keeps a project-root resolution fallback for JS but not for `css` and `?url` asset
+  imports, so those are the first to break on a fresh setup.
 - **`vue`/`vue-router`/`frappe-ui` imports inside this package** are resolved by the host
   app (peers + `resolve.dedupe`), so the package cannot be built or type-checked in
   isolation — work on it from within a consuming app.

--- a/ui/vite/index.js
+++ b/ui/vite/index.js
@@ -9,24 +9,46 @@
 // Opt-in: add `frameworkUI()` to a consuming app's vite `plugins`. Apps that do
 // not use @framework/ui need not add it. Pass `{ dedupe: [...] }` to extend the
 // list with app-specific raw-source singletons.
-//
-// Note: genuinely external deps @framework/ui owns (leaflet, vuedraggable, …)
-// are NOT listed here — they ship in this package's own node_modules and resolve
-// by realpath, so they must NOT be deduped to the host (the host does not have
-// them). frappe-ui notably does not ship vuedraggable, so it lives in this
-// package's dependencies, not the host's.
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const SINGLETONS = ["vue", "vue-router", "frappe-ui", "reka-ui", "dompurify"];
+
+const packageRoot = path.resolve(fileURLToPath(import.meta.url), "../..");
+const packageSource = path.join(packageRoot, "src");
 
 export default function frameworkUI(options = {}) {
 	const extra = options.dedupe ?? [];
 	const dedupe = [...new Set([...SINGLETONS, ...extra])];
+	return [
+		{
+			name: "framework-ui-dedupe",
+			config() {
+				return {
+					resolve: { dedupe },
+				};
+			},
+		},
+		resolveOwnDependencies(),
+	];
+}
+
+// This package's deps (leaflet, cropperjs, …) live beside the host app: a bench
+// installs node_modules there, never beside this repo's source.
+function resolveOwnDependencies() {
+	let hostImporter;
 	return {
-		name: "framework-ui-dedupe",
-		config() {
-			return {
-				resolve: { dedupe },
-			};
+		name: "framework-ui-deps",
+		configResolved(config) {
+			hostImporter = path.join(config.root, "index.html");
+		},
+		// Unenforced, so vite resolves first and this only sees what the walk up
+		// from this package's realpath missed. Bare specifiers only.
+		resolveId(source, importer) {
+			if (!importer?.startsWith(packageSource)) return null;
+			if (/^[./]/.test(source)) return null;
+			return this.resolve(source, hostImporter);
 		},
 	};
 }


### PR DESCRIPTION
## Problem

`@framework/ui` ships raw source that the host app's bundler compiles in place. Its own
dependencies (`leaflet`, `cropperjs`, …) are declared in `ui/package.json`, but a bench
installs `node_modules` beside the host frontend and never beside the frappe repo — so
walking up from this package's realpath finds nothing on a fresh setup.

CRM's `frontend2` build died on Frappe Cloud at leaflet's marker images while passing
locally, where a stray `apps/frappe/ui/node_modules` happened to exist.

Vite 5 masked this by retrying resolution from the project root. Vite 8 keeps that
fallback for JS but not for `css` and `?url` asset imports, which is why only the leaflet
assets failed.

## Fix

The bundled `@framework/ui/vite` plugin now re-runs the host's resolver for bare
specifiers imported from this package's source. The hook is unenforced, so Vite resolves
first and the plugin only sees what Vite could not resolve itself. This covers both JS
and asset imports.

Studio solves the same problem from the other end, with an `install-framework-ui` script
that populates this repo's `node_modules`. That copy is what makes the dedupe list
necessary; resolving against the host instead leaves one tree.

## Docs

`ui/README.md` now describes both jobs the plugin does, and adds a troubleshooting entry
for the asset-import build failure that follows from leaving the plugin out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)