### PR TITLE
fix: regression in keyboard navigation in popup

### DIFF
--- a/frappe/public/js/frappe/ui/messages.js
+++ b/frappe/public/js/frappe/ui/messages.js
@@ -87,6 +87,9 @@ frappe.warn = function (
 		minimizable: is_minimizable,
 	});
 
+	// flag, used to bind "okay" on enter
+	d.confirm_dialog = true;
+
 	d.$body.append(`<div class="frappe-confirm-message">${message_html}</div>`);
 	// destructive confirm: the es-button red theme replaces the old
 	// btn-primary → btn-danger class swap


### PR DESCRIPTION
Regression: https://github.com/frappe/frappe/pull/41444

`Enter` and `Esc` should take primary and secondary action respectively in popup modal