### PR TITLE
feat: rebuild address & contact cards and add quick entry

### DIFF
--- a/frappe/contacts/address_and_contact.py
+++ b/frappe/contacts/address_and_contact.py
@@ -17,8 +17,8 @@ def load_address_and_contact(doc, key=None) -> None:
 
 
 @frappe.whitelist()
-def delink_party(doctype: str, name: str, link_doctype: str, link_name: str) -> None:
-	"""Remove the link between an Address or Contact and the given party."""
+def remove_link(doctype: str, name: str, link_doctype: str, link_name: str) -> None:
+	"""Remove the link between an Address or Contact and the document it is linked to."""
 	if doctype not in ("Address", "Contact"):
 		frappe.throw(_("Can only unlink an Address or a Contact"))
 
@@ -38,7 +38,7 @@ def delink_party(doctype: str, name: str, link_doctype: str, link_name: str) -> 
 
 
 def clear_stale_primary_link(doctype: str, name: str, link_doctype: str, link_name: str) -> None:
-	"""Clear the party's primary Address/Contact field when it points at a record it no longer links to."""
+	"""Clear the document's primary Address/Contact field when it points at a record it no longer links to."""
 	meta = frappe.get_meta(link_doctype)
 	primary_fields = [df.fieldname for df in get_primary_link_fields(meta, doctype)]
 	if not primary_fields:
@@ -60,7 +60,7 @@ def clear_stale_primary_link(doctype: str, name: str, link_doctype: str, link_na
 
 
 def get_primary_link_fields(meta, doctype: str) -> list:
-	"""Party fields that hold its primary Address or Contact, by the same name convention the form uses."""
+	"""Document fields that hold its primary Address or Contact, by the same name convention the form uses."""
 	return [
 		df
 		for df in meta.get("fields", {"fieldtype": "Link", "options": doctype})

--- a/frappe/contacts/address_and_contact.py
+++ b/frappe/contacts/address_and_contact.py
@@ -34,6 +34,39 @@ def delink_party(doctype: str, name: str, link_doctype: str, link_name: str) -> 
 	doc.links = remaining
 	doc.save()
 
+	clear_stale_primary_link(doctype, name, link_doctype, link_name)
+
+
+def clear_stale_primary_link(doctype: str, name: str, link_doctype: str, link_name: str) -> None:
+	"""Clear the party's primary Address/Contact field when it points at a record it no longer links to."""
+	meta = frappe.get_meta(link_doctype)
+	primary_fields = [df.fieldname for df in get_primary_link_fields(meta, doctype)]
+	if not primary_fields:
+		return
+
+	values = frappe.db.get_value(link_doctype, link_name, primary_fields, as_dict=True) or {}
+	stale_fields = [fieldname for fieldname in primary_fields if values.get(fieldname) == name]
+	if not stale_fields:
+		return
+
+	frappe.has_permission(link_doctype, "write", doc=link_name, throw=True)
+
+	updates = dict.fromkeys(stale_fields)
+	for df in meta.fields:
+		if df.fetch_from and df.fetch_from.split(".")[0] in stale_fields:
+			updates[df.fieldname] = None
+
+	frappe.db.set_value(link_doctype, link_name, updates)
+
+
+def get_primary_link_fields(meta, doctype: str) -> list:
+	"""Party fields that hold its primary Address or Contact, by the same name convention the form uses."""
+	return [
+		df
+		for df in meta.get("fields", {"fieldtype": "Link", "options": doctype})
+		if "primary" in df.fieldname.lower()
+	]
+
 
 def has_permission(doc, ptype, user):
 	links = get_permitted_and_not_permitted_links(doc.doctype)

--- a/frappe/contacts/address_and_contact.py
+++ b/frappe/contacts/address_and_contact.py
@@ -26,9 +26,7 @@ def delink_party(doctype: str, name: str, link_doctype: str, link_name: str) -> 
 	doc.check_permission("write")
 
 	remaining = [
-		link
-		for link in doc.links
-		if not (link.link_doctype == link_doctype and link.link_name == link_name)
+		link for link in doc.links if not (link.link_doctype == link_doctype and link.link_name == link_name)
 	]
 	if len(remaining) == len(doc.links):
 		return

--- a/frappe/contacts/address_and_contact.py
+++ b/frappe/contacts/address_and_contact.py
@@ -16,6 +16,27 @@ def load_address_and_contact(doc, key=None) -> None:
 	doc.set_onload("contact_list", get_contact_display_list(doc.doctype, doc.name))
 
 
+@frappe.whitelist()
+def delink_party(doctype: str, name: str, link_doctype: str, link_name: str) -> None:
+	"""Remove the link between an Address or Contact and the given party."""
+	if doctype not in ("Address", "Contact"):
+		frappe.throw(_("Can only unlink an Address or a Contact"))
+
+	doc = frappe.get_doc(doctype, name)
+	doc.check_permission("write")
+
+	remaining = [
+		link
+		for link in doc.links
+		if not (link.link_doctype == link_doctype and link.link_name == link_name)
+	]
+	if len(remaining) == len(doc.links):
+		return
+
+	doc.links = remaining
+	doc.save()
+
+
 def has_permission(doc, ptype, user):
 	links = get_permitted_and_not_permitted_links(doc.doctype)
 	if not links.get("not_permitted_links"):

--- a/frappe/contacts/doctype/address/address.json
+++ b/frappe/contacts/doctype/address/address.json
@@ -77,6 +77,7 @@
    "label": "County"
   },
   {
+   "allow_in_quick_entry": 1,
    "fieldname": "state",
    "fieldtype": "Data",
    "label": "State/Province"
@@ -92,6 +93,7 @@
    "search_index": 1
   },
   {
+   "allow_in_quick_entry": 1,
    "fieldname": "pincode",
    "fieldtype": "Data",
    "label": "Postal Code",
@@ -153,7 +155,7 @@
  "icon": "fa fa-map-marker",
  "idx": 5,
  "links": [],
- "modified": "2026-06-20 16:01:27.068028",
+ "modified": "2026-07-31 16:01:27.068028",
  "modified_by": "Administrator",
  "module": "Contacts",
  "name": "Address",
@@ -222,6 +224,7 @@
    "write": 1
   }
  ],
+ "quick_entry": 1,
  "search_fields": "country, state",
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/frappe/contacts/doctype/contact/contact.json
+++ b/frappe/contacts/doctype/contact/contact.json
@@ -48,6 +48,7 @@
    "options": "fa fa-user"
   },
   {
+   "allow_in_quick_entry": 1,
    "fieldname": "first_name",
    "fieldtype": "Data",
    "in_global_search": 1,
@@ -56,6 +57,7 @@
    "oldfieldtype": "Data"
   },
   {
+   "allow_in_quick_entry": 1,
    "bold": 1,
    "fieldname": "last_name",
    "fieldtype": "Data",
@@ -158,6 +160,7 @@
    "label": "Department"
   },
   {
+   "allow_in_quick_entry": 1,
    "fieldname": "designation",
    "fieldtype": "Data",
    "label": "Designation"
@@ -240,6 +243,7 @@
    "read_only": 1
   },
   {
+   "allow_in_quick_entry": 1,
    "fieldname": "company_name",
    "fieldtype": "Data",
    "label": "Company Name"
@@ -257,7 +261,7 @@
  "image_field": "image",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-23 16:01:30.937045",
+ "modified": "2026-07-31 16:01:30.937045",
  "modified_by": "Administrator",
  "module": "Contacts",
  "name": "Contact",
@@ -390,6 +394,7 @@
    "write": 1
   }
  ],
+ "quick_entry": 1,
  "show_title_field_in_link": 1,
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -479,12 +479,10 @@ def get_full_name(
 
 
 def get_contact_display_list(doctype: str, name: str) -> list[dict]:
-	from frappe.contacts.doctype.address.address import get_condensed_address
-
 	if not frappe.has_permission("Contact", "read"):
 		return []
 
-	contact_list = frappe.get_list(
+	return frappe.get_list(
 		"Contact",
 		filters=[
 			["Dynamic Link", "link_doctype", "=", doctype],
@@ -494,27 +492,3 @@ def get_contact_display_list(doctype: str, name: str) -> list[dict]:
 		fields=["*"],
 		order_by="is_primary_contact DESC, creation ASC",
 	)
-
-	for contact in contact_list:
-		contact["email_ids"] = frappe.get_all(
-			"Contact Email",
-			filters={"parenttype": "Contact", "parent": contact.name, "is_primary": 0},
-			fields=["email_id"],
-		)
-
-		contact["phone_nos"] = frappe.get_all(
-			"Contact Phone",
-			filters={
-				"parenttype": "Contact",
-				"parent": contact.name,
-				"is_primary_phone": 0,
-				"is_primary_mobile_no": 0,
-			},
-			fields=["phone"],
-		)
-
-		if contact.address and frappe.has_permission("Address", "read"):
-			address = frappe.get_doc("Address", contact.address)
-			contact["address"] = get_condensed_address(address)
-
-	return contact_list

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -515,7 +515,6 @@ def get_contact_display_list(doctype: str, name: str) -> list[dict]:
 
 		if contact.address and frappe.has_permission("Address", "read"):
 			address = frappe.get_doc("Address", contact.address)
-			contact["address_name"] = address.name
 			contact["address"] = get_condensed_address(address)
 
 	return contact_list

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -515,6 +515,7 @@ def get_contact_display_list(doctype: str, name: str) -> list[dict]:
 
 		if contact.address and frappe.has_permission("Address", "read"):
 			address = frappe.get_doc("Address", contact.address)
+			contact["address_name"] = address.name
 			contact["address"] = get_condensed_address(address)
 
 	return contact_list

--- a/frappe/contacts/test_address_and_contact.py
+++ b/frappe/contacts/test_address_and_contact.py
@@ -2,7 +2,7 @@
 # License: MIT. See LICENSE
 
 import frappe
-from frappe.contacts.address_and_contact import delink_party
+from frappe.contacts.address_and_contact import remove_link
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 from frappe.tests import IntegrationTestCase
 
@@ -24,7 +24,7 @@ PRIMARY_FIELDS = {
 }
 
 
-class TestDelinkParty(IntegrationTestCase):
+class TestRemoveLink(IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls):
 		super().setUpClass()
@@ -38,9 +38,9 @@ class TestDelinkParty(IntegrationTestCase):
 		frappe.clear_cache(doctype="ToDo")
 
 	def setUp(self):
-		self.party = frappe.get_doc({"doctype": "ToDo", "description": "_Test Delink Party"}).insert()
-		self.other_party = frappe.get_doc(
-			{"doctype": "ToDo", "description": "_Test Delink Other Party"}
+		self.document = frappe.get_doc({"doctype": "ToDo", "description": "_Test Remove Link"}).insert()
+		self.other_document = frappe.get_doc(
+			{"doctype": "ToDo", "description": "_Test Remove Link Other"}
 		).insert()
 
 	def create_address(self, links):
@@ -59,55 +59,55 @@ class TestDelinkParty(IntegrationTestCase):
 	def link_to(self, doc):
 		return {"link_doctype": doc.doctype, "link_name": doc.name}
 
-	def test_removes_only_the_given_party(self):
-		address = self.create_address([self.link_to(self.party), self.link_to(self.other_party)])
+	def test_removes_only_the_given_document(self):
+		address = self.create_address([self.link_to(self.document), self.link_to(self.other_document)])
 
-		delink_party("Address", address.name, self.party.doctype, self.party.name)
+		remove_link("Address", address.name, self.document.doctype, self.document.name)
 
 		address.reload()
 		self.assertEqual(
 			[(link.link_doctype, link.link_name) for link in address.links],
-			[(self.other_party.doctype, self.other_party.name)],
+			[(self.other_document.doctype, self.other_document.name)],
 		)
 
 	def test_keeps_the_address_itself(self):
-		address = self.create_address([self.link_to(self.party)])
+		address = self.create_address([self.link_to(self.document)])
 
-		delink_party("Address", address.name, self.party.doctype, self.party.name)
+		remove_link("Address", address.name, self.document.doctype, self.document.name)
 
 		self.assertTrue(frappe.db.exists("Address", address.name))
 		self.assertEqual(frappe.get_doc("Address", address.name).links, [])
 
-	def test_unknown_party_is_a_no_op(self):
-		address = self.create_address([self.link_to(self.party)])
+	def test_unknown_document_is_a_no_op(self):
+		address = self.create_address([self.link_to(self.document)])
 		modified_before = frappe.db.get_value("Address", address.name, "modified")
 
-		delink_party("Address", address.name, self.other_party.doctype, self.other_party.name)
+		remove_link("Address", address.name, self.other_document.doctype, self.other_document.name)
 
 		address.reload()
 		self.assertEqual(len(address.links), 1)
 		self.assertEqual(frappe.db.get_value("Address", address.name, "modified"), modified_before)
 
-	def test_clears_the_partys_primary_link(self):
-		address = self.create_address([self.link_to(self.party)])
-		self.party.db_set({"primary_address": address.name, "primary_city": "_Test City"})
+	def test_clears_the_documents_primary_link(self):
+		address = self.create_address([self.link_to(self.document)])
+		self.document.db_set({"primary_address": address.name, "primary_city": "_Test City"})
 
-		delink_party("Address", address.name, self.party.doctype, self.party.name)
+		remove_link("Address", address.name, self.document.doctype, self.document.name)
 
-		self.party.reload()
-		self.assertIsNone(self.party.primary_address)
-		self.assertIsNone(self.party.primary_city)
+		self.document.reload()
+		self.assertIsNone(self.document.primary_address)
+		self.assertIsNone(self.document.primary_city)
 
 	def test_keeps_a_primary_link_to_another_record(self):
-		address = self.create_address([self.link_to(self.party)])
-		other_address = self.create_address([self.link_to(self.party)])
-		self.party.db_set("primary_address", other_address.name)
+		address = self.create_address([self.link_to(self.document)])
+		other_address = self.create_address([self.link_to(self.document)])
+		self.document.db_set("primary_address", other_address.name)
 
-		delink_party("Address", address.name, self.party.doctype, self.party.name)
+		remove_link("Address", address.name, self.document.doctype, self.document.name)
 
-		self.party.reload()
-		self.assertEqual(self.party.primary_address, other_address.name)
+		self.document.reload()
+		self.assertEqual(self.document.primary_address, other_address.name)
 
 	def test_rejects_other_doctypes(self):
 		with self.assertRaises(frappe.ValidationError):
-			delink_party("ToDo", self.party.name, self.party.doctype, self.party.name)
+			remove_link("ToDo", self.document.name, self.document.doctype, self.document.name)

--- a/frappe/contacts/test_address_and_contact.py
+++ b/frappe/contacts/test_address_and_contact.py
@@ -3,10 +3,40 @@
 
 import frappe
 from frappe.contacts.address_and_contact import delink_party
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 from frappe.tests import IntegrationTestCase
+
+PRIMARY_FIELDS = {
+	"ToDo": [
+		{
+			"fieldname": "primary_address",
+			"label": "Primary Address",
+			"fieldtype": "Link",
+			"options": "Address",
+		},
+		{
+			"fieldname": "primary_city",
+			"label": "Primary City",
+			"fieldtype": "Data",
+			"fetch_from": "primary_address.city",
+		},
+	]
+}
 
 
 class TestDelinkParty(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		create_custom_fields(PRIMARY_FIELDS)
+		cls.addClassCleanup(cls.drop_primary_fields)
+
+	@staticmethod
+	def drop_primary_fields():
+		for field in PRIMARY_FIELDS["ToDo"]:
+			frappe.delete_doc("Custom Field", f"ToDo-{field['fieldname']}", force=True)
+		frappe.clear_cache(doctype="ToDo")
+
 	def setUp(self):
 		self.party = frappe.get_doc({"doctype": "ToDo", "description": "_Test Delink Party"}).insert()
 		self.other_party = frappe.get_doc(
@@ -57,6 +87,26 @@ class TestDelinkParty(IntegrationTestCase):
 		address.reload()
 		self.assertEqual(len(address.links), 1)
 		self.assertEqual(frappe.db.get_value("Address", address.name, "modified"), modified_before)
+
+	def test_clears_the_partys_primary_link(self):
+		address = self.create_address([self.link_to(self.party)])
+		self.party.db_set({"primary_address": address.name, "primary_city": "_Test City"})
+
+		delink_party("Address", address.name, self.party.doctype, self.party.name)
+
+		self.party.reload()
+		self.assertIsNone(self.party.primary_address)
+		self.assertIsNone(self.party.primary_city)
+
+	def test_keeps_a_primary_link_to_another_record(self):
+		address = self.create_address([self.link_to(self.party)])
+		other_address = self.create_address([self.link_to(self.party)])
+		self.party.db_set("primary_address", other_address.name)
+
+		delink_party("Address", address.name, self.party.doctype, self.party.name)
+
+		self.party.reload()
+		self.assertEqual(self.party.primary_address, other_address.name)
 
 	def test_rejects_other_doctypes(self):
 		with self.assertRaises(frappe.ValidationError):

--- a/frappe/contacts/test_address_and_contact.py
+++ b/frappe/contacts/test_address_and_contact.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+
+import frappe
+from frappe.contacts.address_and_contact import delink_party
+from frappe.tests import IntegrationTestCase
+
+
+class TestDelinkParty(IntegrationTestCase):
+	def setUp(self):
+		self.party = frappe.get_doc({"doctype": "ToDo", "description": "_Test Delink Party"}).insert()
+		self.other_party = frappe.get_doc(
+			{"doctype": "ToDo", "description": "_Test Delink Other Party"}
+		).insert()
+
+	def create_address(self, links):
+		return frappe.get_doc(
+			{
+				"doctype": "Address",
+				"address_title": "_Test Delink Address",
+				"address_type": "Billing",
+				"address_line1": "_Test Address Line 1",
+				"city": "_Test City",
+				"country": "India",
+				"links": links,
+			}
+		).insert()
+
+	def link_to(self, doc):
+		return {"link_doctype": doc.doctype, "link_name": doc.name}
+
+	def test_removes_only_the_given_party(self):
+		address = self.create_address([self.link_to(self.party), self.link_to(self.other_party)])
+
+		delink_party("Address", address.name, self.party.doctype, self.party.name)
+
+		address.reload()
+		self.assertEqual(
+			[(link.link_doctype, link.link_name) for link in address.links],
+			[(self.other_party.doctype, self.other_party.name)],
+		)
+
+	def test_keeps_the_address_itself(self):
+		address = self.create_address([self.link_to(self.party)])
+
+		delink_party("Address", address.name, self.party.doctype, self.party.name)
+
+		self.assertTrue(frappe.db.exists("Address", address.name))
+		self.assertEqual(frappe.get_doc("Address", address.name).links, [])
+
+	def test_unknown_party_is_a_no_op(self):
+		address = self.create_address([self.link_to(self.party)])
+		modified_before = frappe.db.get_value("Address", address.name, "modified")
+
+		delink_party("Address", address.name, self.other_party.doctype, self.other_party.name)
+
+		address.reload()
+		self.assertEqual(len(address.links), 1)
+		self.assertEqual(frappe.db.get_value("Address", address.name, "modified"), modified_before)
+
+	def test_rejects_other_doctypes(self):
+		with self.assertRaises(frappe.ValidationError):
+			delink_party("ToDo", self.party.name, self.party.doctype, self.party.name)

--- a/frappe/public/js/desk.bundle.js
+++ b/frappe/public/js/desk.bundle.js
@@ -91,7 +91,6 @@ import "./frappe/utils/datetime.js";
 import "./frappe/utils/number_format.js";
 import "./frappe/utils/help.js";
 import "./frappe/utils/help_links.js";
-import "./frappe/utils/address_and_contact.js";
 import "./frappe/utils/preview_email.js";
 import "./frappe/utils/file_manager.js";
 import "./frappe/utils/diffview";

--- a/frappe/public/js/form.bundle.js
+++ b/frappe/public/js/form.bundle.js
@@ -13,5 +13,6 @@ import "./frappe/form/templates/users_in_sidebar.html";
 import "./frappe/views/formview.js";
 import "./frappe/views/render_preview.js";
 import "./frappe/form/form.js";
+import "./frappe/utils/address_and_contact.js";
 import "./frappe/meta_tag.js";
 import "./frappe/doctype/";

--- a/frappe/public/js/frappe/form/templates/address_list.html
+++ b/frappe/public/js/frappe/form/templates/address_list.html
@@ -11,7 +11,7 @@
 		<div class="box-header flex items-center flex-wrap gap-2">
 			<span class="text-base-semibold text-ink-gray-8">{%= frappe.utils.escape_html(addr.address_title) %}</span>
 			{% if (addr.name === primary_name) { %}
-				{%= frappe.ui.badge.html({ label: __("Primary"), theme: "blue", size: "sm" }) %}
+				{%= frappe.ui.badge.html({ label: __("Primary"), size: "sm" }) %}
 			{% } %}
 		</div>
 		{% const tags = [addr.address_type !== "Other" ? frappe.utils.escape_html(__(addr.address_type)) : null, addr.is_shipping_address ? __("Shipping") : null, addr.disabled ? __("Disabled") : null].filter(Boolean).join(" · "); %}

--- a/frappe/public/js/frappe/form/templates/address_list.html
+++ b/frappe/public/js/frappe/form/templates/address_list.html
@@ -1,7 +1,7 @@
 {% if (addr_list.length) { %}
-	<p>
+	<div class="card-list-actions">
 		{%= frappe.ui.button.html({ label: __("Address"), icon: "plus", size: "sm", css_class: "btn-address" }) %}
-	</p>
+	</div>
 {% } %}
 
 <div class="clearfix"></div>
@@ -16,9 +16,9 @@
 		</div>
 		{% const tags = [addr.address_type !== "Other" ? frappe.utils.escape_html(__(addr.address_type)) : null, addr.is_shipping_address ? __("Shipping") : null, addr.disabled ? __("Disabled") : null].filter(Boolean).join(" · "); %}
 		{% if (tags) { %}
-			<p class="box-subtitle text-sm text-ink-gray-5">{%= tags %}</p>
+			<div class="box-subtitle text-sm text-ink-gray-5">{%= tags %}</div>
 		{% } %}
-		<p class="text-ink-gray-7">{%= addr.display %}</p>
+		<div class="address-display text-ink-gray-7">{%= addr.display %}</div>
 	</div>
 {% } %}
 

--- a/frappe/public/js/frappe/form/templates/address_list.html
+++ b/frappe/public/js/frappe/form/templates/address_list.html
@@ -1,45 +1,25 @@
 <p>
-	<button class="btn btn-xs btn-default btn-address">
-		{{ __("New Address") }}
-	</button>
+	{%= frappe.ui.button.html({ label: __("New Address"), icon: "plus", size: "sm", css_class: "btn-address" }) %}
 </p>
 
 <div class="clearfix"></div>
 {% for (const addr of addr_list) { %}
-	<div class="address-box">
-		<a
-			href="{%= frappe.utils.get_form_link('Address', addr.name) %}"
-			class="btn btn-xs btn-default edit-btn"
-			title="{%= __('Edit') %}"
-		>
-			<svg class="icon icon-xs">
-				<use href="#icon-pencil"></use>
-			</svg>
-		</a>
-		<p class="h6 flex flex-wrap">
-			<span>{%= addr.address_title %}</span>
-			{% if (addr.address_type !== "Other") { %}
-				&nbsp;&#183;&nbsp;
-				<span class="text-muted">{%= __(addr.address_type) %}</span>
-			{% } %}
+	<div class="address-box" data-name="{%= frappe.utils.escape_html(addr.name) %}">
+		{%= frappe.ui.button.html({ icon: "ellipsis", variant: "ghost", size: "sm", title: __("Options"), css_class: "card-menu-btn" }) %}
+		<div class="box-header flex items-center flex-wrap gap-2">
+			<span class="text-base-semibold text-ink-gray-8">{%= addr.address_title %}</span>
 			{% if (addr.is_primary_address) { %}
-				&nbsp;&#183;&nbsp;
-				<span class="text-muted">{%= __("Primary Address") %}</span>
+				{%= frappe.ui.badge.html({ label: __("Primary"), theme: "blue" }) %}
 			{% } %}
-			{% if (addr.is_shipping_address) { %}
-				&nbsp;&#183;&nbsp;
-				<span class="text-muted">{%= __("Shipping Address") %}</span>
-			{% } %}
-			{% if (addr.disabled) { %}
-				&nbsp;&#183;&nbsp;
-				<span class="text-muted">{%= __("Disabled") %}</span>
-			{% } %}
-		</p>
-		<p>{%= addr.display %}</p>
+		</div>
+		{% const tags = [addr.address_type !== "Other" ? __(addr.address_type) : null, addr.is_shipping_address ? __("Shipping") : null, addr.disabled ? __("Disabled") : null].filter(Boolean).join(" · "); %}
+		{% if (tags) { %}
+			<p class="box-subtitle text-sm text-ink-gray-5">{%= tags %}</p>
+		{% } %}
+		<p class="text-ink-gray-7">{%= addr.display %}</p>
 	</div>
 {% } %}
 
 {% if (!addr_list.length) { %}
-	<p class="text-muted small">{%= __("No address added yet.") %}</p>
+	{%= frappe.ui.empty_state.html({ icon: "map-pin", title: __("No addresses added yet") }) %}
 {% } %}
-

--- a/frappe/public/js/frappe/form/templates/address_list.html
+++ b/frappe/public/js/frappe/form/templates/address_list.html
@@ -1,6 +1,8 @@
-<p>
-	{%= frappe.ui.button.html({ label: __("New Address"), icon: "plus", size: "sm", css_class: "btn-address" }) %}
-</p>
+{% if (addr_list.length) { %}
+	<p>
+		{%= frappe.ui.button.html({ label: __("Address"), icon: "plus", size: "sm", css_class: "btn-address" }) %}
+	</p>
+{% } %}
 
 <div class="clearfix"></div>
 {% for (const addr of addr_list) { %}
@@ -9,7 +11,7 @@
 		<div class="box-header flex items-center flex-wrap gap-2">
 			<span class="text-base-semibold text-ink-gray-8">{%= addr.address_title %}</span>
 			{% if (addr.name === primary_name) { %}
-				{%= frappe.ui.badge.html({ label: __("Primary"), theme: "blue" }) %}
+				{%= frappe.ui.badge.html({ label: __("Primary"), theme: "blue", size: "sm" }) %}
 			{% } %}
 		</div>
 		{% const tags = [addr.address_type !== "Other" ? __(addr.address_type) : null, addr.is_shipping_address ? __("Shipping") : null, addr.disabled ? __("Disabled") : null].filter(Boolean).join(" · "); %}
@@ -21,5 +23,9 @@
 {% } %}
 
 {% if (!addr_list.length) { %}
-	{%= frappe.ui.empty_state.html({ icon: "map-pin", title: __("No addresses added yet") }) %}
+	{%= frappe.ui.empty_state.html({
+		icon: "map-pin",
+		title: __("No addresses added yet"),
+		actions: [{ label: __("New Address"), icon: "plus", css_class: "btn-address" }],
+	}) %}
 {% } %}

--- a/frappe/public/js/frappe/form/templates/address_list.html
+++ b/frappe/public/js/frappe/form/templates/address_list.html
@@ -8,7 +8,7 @@
 		{%= frappe.ui.button.html({ icon: "ellipsis", variant: "ghost", size: "sm", title: __("Options"), css_class: "card-menu-btn" }) %}
 		<div class="box-header flex items-center flex-wrap gap-2">
 			<span class="text-base-semibold text-ink-gray-8">{%= addr.address_title %}</span>
-			{% if (addr.is_primary_address) { %}
+			{% if (addr.name === primary_name) { %}
 				{%= frappe.ui.badge.html({ label: __("Primary"), theme: "blue" }) %}
 			{% } %}
 		</div>

--- a/frappe/public/js/frappe/form/templates/address_list.html
+++ b/frappe/public/js/frappe/form/templates/address_list.html
@@ -9,12 +9,12 @@
 	<div class="address-box" data-name="{%= frappe.utils.escape_html(addr.name) %}">
 		{%= frappe.ui.button.html({ icon: "ellipsis", variant: "ghost", size: "sm", title: __("Options"), css_class: "card-menu-btn" }) %}
 		<div class="box-header flex items-center flex-wrap gap-2">
-			<span class="text-base-semibold text-ink-gray-8">{%= addr.address_title %}</span>
+			<span class="text-base-semibold text-ink-gray-8">{%= frappe.utils.escape_html(addr.address_title) %}</span>
 			{% if (addr.name === primary_name) { %}
 				{%= frappe.ui.badge.html({ label: __("Primary"), theme: "blue", size: "sm" }) %}
 			{% } %}
 		</div>
-		{% const tags = [addr.address_type !== "Other" ? __(addr.address_type) : null, addr.is_shipping_address ? __("Shipping") : null, addr.disabled ? __("Disabled") : null].filter(Boolean).join(" · "); %}
+		{% const tags = [addr.address_type !== "Other" ? frappe.utils.escape_html(__(addr.address_type)) : null, addr.is_shipping_address ? __("Shipping") : null, addr.disabled ? __("Disabled") : null].filter(Boolean).join(" · "); %}
 		{% if (tags) { %}
 			<p class="box-subtitle text-sm text-ink-gray-5">{%= tags %}</p>
 		{% } %}

--- a/frappe/public/js/frappe/form/templates/contact_list.html
+++ b/frappe/public/js/frappe/form/templates/contact_list.html
@@ -11,7 +11,7 @@
 		<div class="box-header flex items-center flex-wrap gap-2">
 			<span class="text-base-semibold text-ink-gray-8">{%= frappe.utils.escape_html(contact.first_name) %} {%= frappe.utils.escape_html(contact.last_name) %}</span>
 			{% if (contact.name === primary_name) { %}
-				{%= frappe.ui.badge.html({ label: __("Primary"), theme: "blue", size: "sm" }) %}
+				{%= frappe.ui.badge.html({ label: __("Primary"), size: "sm" }) %}
 			{% } %}
 		</div>
 		{% if (contact.is_billing_contact) { %}

--- a/frappe/public/js/frappe/form/templates/contact_list.html
+++ b/frappe/public/js/frappe/form/templates/contact_list.html
@@ -1,7 +1,7 @@
 {% if (contact_list.length) { %}
-	<p>
+	<div class="card-list-actions">
 		{%= frappe.ui.button.html({ label: __("Contact"), icon: "plus", size: "sm", css_class: "btn-contact" }) %}
-	</p>
+	</div>
 {% } %}
 
 <div class="clearfix"></div>
@@ -15,35 +15,35 @@
 			{% } %}
 		</div>
 		{% if (contact.is_billing_contact) { %}
-			<p class="box-subtitle text-sm text-ink-gray-5">{%= __("Billing") %}</p>
+			<div class="box-subtitle text-sm text-ink-gray-5">{%= __("Billing") %}</div>
 		{% } %}
 		{% let mobile_no = contact.mobile_no !== contact.phone ? contact.mobile_no : ""; %}
 		{% if (contact.designation) { %}
-			<p class="contact-line flex items-center gap-2 text-ink-gray-7" title="{%= __("Designation") %}">
+			<div class="contact-line flex items-center gap-2 text-ink-gray-7" title="{%= __("Designation") %}">
 				{%= frappe.utils.icon("briefcase", "sm", "", "", "text-ink-gray-5", true) %}
 				<span>{%= frappe.utils.escape_html(contact.designation) %}</span>
-			</p>
+			</div>
 		{% } %}
 		{% if (contact.phone) { %}
-			<p class="contact-line flex items-center gap-2 text-ink-gray-7">
+			<div class="contact-line flex items-center gap-2 text-ink-gray-7">
 				{%= frappe.utils.icon("phone", "sm", "", "", "text-ink-gray-5", true) %}
 				<a href="tel:{%= frappe.utils.escape_html(contact.phone) %}" title="{%= __("Primary Phone") %}">{%= frappe.utils.escape_html(contact.phone) %}</a>
-			</p>
+			</div>
 		{% } %}
 		{% if (mobile_no) { %}
-			<p class="contact-line flex items-center gap-2 text-ink-gray-7">
+			<div class="contact-line flex items-center gap-2 text-ink-gray-7">
 				{%= frappe.utils.icon("smartphone", "sm", "", "", "text-ink-gray-5", true) %}
 				<a href="tel:{%= frappe.utils.escape_html(mobile_no) %}" title="{%= __("Primary Mobile") %}">{%= frappe.utils.escape_html(mobile_no) %}</a>
-			</p>
+			</div>
 		{% } %}
 		{% if (contact.email_id) { %}
-			<p class="contact-line flex items-center gap-2 text-ink-gray-7">
+			<div class="contact-line flex items-center gap-2 text-ink-gray-7">
 				{%= frappe.utils.icon("mail", "sm", "", "", "text-ink-gray-5", true) %}
 				<a href="mailto:{%= frappe.utils.escape_html(contact.email_id) %}" title="{%= __("Primary Email") %}">{%= frappe.utils.escape_html(contact.email_id) %}</a>
-			</p>
+			</div>
 		{% } %}
 		{% if (!contact.designation && !contact.phone && !mobile_no && !contact.email_id) { %}
-			<p class="contact-line text-sm text-ink-gray-4">{%= __("No contact details") %}</p>
+			<div class="contact-line text-sm text-ink-gray-4">{%= __("No contact details") %}</div>
 		{% } %}
 	</div>
 {% } %}

--- a/frappe/public/js/frappe/form/templates/contact_list.html
+++ b/frappe/public/js/frappe/form/templates/contact_list.html
@@ -9,7 +9,7 @@
 	<div class="contact-box" data-name="{%= frappe.utils.escape_html(contact.name) %}">
 		{%= frappe.ui.button.html({ icon: "ellipsis", variant: "ghost", size: "sm", title: __("Options"), css_class: "card-menu-btn" }) %}
 		<div class="box-header flex items-center flex-wrap gap-2">
-			<span class="text-base-semibold text-ink-gray-8">{%= contact.first_name %} {%= contact.last_name %}</span>
+			<span class="text-base-semibold text-ink-gray-8">{%= frappe.utils.escape_html(contact.first_name) %} {%= frappe.utils.escape_html(contact.last_name) %}</span>
 			{% if (contact.name === primary_name) { %}
 				{%= frappe.ui.badge.html({ label: __("Primary"), theme: "blue", size: "sm" }) %}
 			{% } %}
@@ -21,7 +21,7 @@
 		{% if (contact.designation) { %}
 			<p class="contact-line flex items-center gap-2 text-ink-gray-7" title="{%= __("Designation") %}">
 				{%= frappe.utils.icon("briefcase", "sm", "", "", "text-ink-gray-5", true) %}
-				<span>{%= contact.designation %}</span>
+				<span>{%= frappe.utils.escape_html(contact.designation) %}</span>
 			</p>
 		{% } %}
 		{% if (contact.phone) { %}

--- a/frappe/public/js/frappe/form/templates/contact_list.html
+++ b/frappe/public/js/frappe/form/templates/contact_list.html
@@ -1,6 +1,8 @@
-<p>
-	{%= frappe.ui.button.html({ label: __("New Contact"), icon: "plus", size: "sm", css_class: "btn-contact" }) %}
-</p>
+{% if (contact_list.length) { %}
+	<p>
+		{%= frappe.ui.button.html({ label: __("Contact"), icon: "plus", size: "sm", css_class: "btn-contact" }) %}
+	</p>
+{% } %}
 
 <div class="clearfix"></div>
 {% for (const contact of contact_list) { %}
@@ -9,7 +11,7 @@
 		<div class="box-header flex items-center flex-wrap gap-2">
 			<span class="text-base-semibold text-ink-gray-8">{%= contact.first_name %} {%= contact.last_name %}</span>
 			{% if (contact.name === primary_name) { %}
-				{%= frappe.ui.badge.html({ label: __("Primary"), theme: "blue" }) %}
+				{%= frappe.ui.badge.html({ label: __("Primary"), theme: "blue", size: "sm" }) %}
 			{% } %}
 		</div>
 		{% if (contact.is_billing_contact) { %}
@@ -47,5 +49,9 @@
 {% } %}
 
 {% if (!contact_list.length) { %}
-	{%= frappe.ui.empty_state.html({ icon: "user", title: __("No contacts added yet") }) %}
+	{%= frappe.ui.empty_state.html({
+		icon: "user",
+		title: __("No contacts added yet"),
+		actions: [{ label: __("New Contact"), icon: "plus", css_class: "btn-contact" }],
+	}) %}
 {% } %}

--- a/frappe/public/js/frappe/form/templates/contact_list.html
+++ b/frappe/public/js/frappe/form/templates/contact_list.html
@@ -8,14 +8,20 @@
 		{%= frappe.ui.button.html({ icon: "ellipsis", variant: "ghost", size: "sm", title: __("Options"), css_class: "card-menu-btn" }) %}
 		<div class="box-header flex items-center flex-wrap gap-2">
 			<span class="text-base-semibold text-ink-gray-8">{%= contact.first_name %} {%= contact.last_name %}</span>
-			{% if (contact.is_primary_contact) { %}
+			{% if (contact.name === primary_name) { %}
 				{%= frappe.ui.badge.html({ label: __("Primary"), theme: "blue" }) %}
 			{% } %}
-			{% if (contact.is_billing_contact) { %}
-				{%= frappe.ui.badge.html({ label: __("Billing"), theme: "green" }) %}
-			{% } %}
 		</div>
+		{% if (contact.is_billing_contact) { %}
+			<p class="box-subtitle text-sm text-ink-gray-5">{%= __("Billing") %}</p>
+		{% } %}
 		{% let mobile_no = contact.mobile_no !== contact.phone ? contact.mobile_no : ""; %}
+		{% if (contact.designation) { %}
+			<p class="contact-line flex items-center gap-2 text-ink-gray-7" title="{%= __("Designation") %}">
+				{%= frappe.utils.icon("briefcase", "sm", "", "", "text-ink-gray-5", true) %}
+				<span>{%= contact.designation %}</span>
+			</p>
+		{% } %}
 		{% if (contact.phone) { %}
 			<p class="contact-line flex items-center gap-2 text-ink-gray-7">
 				{%= frappe.utils.icon("phone", "sm", "", "", "text-ink-gray-5", true) %}
@@ -34,13 +40,7 @@
 				<a href="mailto:{%= frappe.utils.escape_html(contact.email_id) %}" title="{%= __("Primary Email") %}">{%= frappe.utils.escape_html(contact.email_id) %}</a>
 			</p>
 		{% } %}
-		{% if (contact.address_name) { %}
-			<p class="contact-line flex items-center gap-2 text-ink-gray-7" title="{%= __("Address") %}">
-				{%= frappe.utils.icon("map-pin", "sm", "", "", "text-ink-gray-5", true) %}
-				<span>{%= frappe.utils.escape_html(contact.address_name) %}</span>
-			</p>
-		{% } %}
-		{% if (!contact.phone && !mobile_no && !contact.email_id && !contact.address_name) { %}
+		{% if (!contact.designation && !contact.phone && !mobile_no && !contact.email_id) { %}
 			<p class="contact-line text-sm text-ink-gray-4">{%= __("No contact details") %}</p>
 		{% } %}
 	</div>

--- a/frappe/public/js/frappe/form/templates/contact_list.html
+++ b/frappe/public/js/frappe/form/templates/contact_list.html
@@ -1,92 +1,51 @@
 <p>
-	<button class="btn btn-xs btn-default btn-contact">
-		{{ __("New Contact") }}
-	</button>
+	{%= frappe.ui.button.html({ label: __("New Contact"), icon: "plus", size: "sm", css_class: "btn-contact" }) %}
 </p>
 
 <div class="clearfix"></div>
 {% for (const contact of contact_list) { %}
-	<div class="contact-box">
-		<a
-			href="{%= frappe.utils.get_form_link('Contact', contact.name) %}"
-			class="btn btn-xs btn-default edit-btn"
-			title="{%= __('Edit') %}"
-		>
-			<svg class="icon icon-xs">
-				<use href="#icon-pencil"></use>
-			</svg>
-		</a>
-		<p class="h6 flex flex-wrap">
-			<span>{%= contact.first_name %} {%= contact.last_name %}</span>
+	<div class="contact-box" data-name="{%= frappe.utils.escape_html(contact.name) %}">
+		{%= frappe.ui.button.html({ icon: "ellipsis", variant: "ghost", size: "sm", title: __("Options"), css_class: "card-menu-btn" }) %}
+		<div class="box-header flex items-center flex-wrap gap-2">
+			<span class="text-base-semibold text-ink-gray-8">{%= contact.first_name %} {%= contact.last_name %}</span>
 			{% if (contact.is_primary_contact) { %}
-				&nbsp;&#183;&nbsp;
-				<span class="text-muted">{%= __("Primary Contact") %}</span>
+				{%= frappe.ui.badge.html({ label: __("Primary"), theme: "blue" }) %}
 			{% } %}
 			{% if (contact.is_billing_contact) { %}
-				&nbsp;&#183;&nbsp;
-				<span class="text-muted">{%= __("Billing Contact") %}</span>
+				{%= frappe.ui.badge.html({ label: __("Billing"), theme: "green" }) %}
 			{% } %}
-			{% if (contact.designation){ %}
-				&nbsp;&#183;&nbsp;
-				<span class="text-muted"> {%= contact.designation %}</span>
-			{% } %}
-		</p>
-		{% if (contact.phone || contact.mobile_no || contact.phone_nos.length > 0) { %}
-		<p>
-			{% if (contact.phone) { %}
-				<a href="tel:{%= frappe.utils.escape_html(contact.phone) %}">
-					{%= frappe.utils.escape_html(contact.phone) %}
-				</a>
-				&#183;
-				<span class="text-muted">{%= __("Primary Phone") %}</span>
-				<br>
-			{% endif %}
-			{% if (contact.mobile_no) { %}
-				<a href="tel:{%= frappe.utils.escape_html(contact.mobile_no) %}">
-					{%= frappe.utils.escape_html(contact.mobile_no) %}
-				</a>
-				&#183;
-				<span class="text-muted">{%= __("Primary Mobile") %}</span>
-				<br>
-			{% endif %}
-			{% if (contact.phone_nos) { %}
-				{% for (const phone_no of contact.phone_nos) { %}
-					<a href="tel:{%= frappe.utils.escape_html(phone_no.phone) %}">
-						{%= frappe.utils.escape_html(phone_no.phone) %}
-					</a>
-					<br>
-				{% } %}
-			{% endif %}
-		</p>
-		{% endif %}
-		{% if (contact.email_id || contact.email_ids.length > 0) { %}
-		<p>
-			{% if (contact.email_id) { %}
-				<a href="mailto:{%= frappe.utils.escape_html(contact.email_id) %}">
-					{%= frappe.utils.escape_html(contact.email_id) %}
-				</a>
-				&#183;
-				<span class="text-muted">{%= __("Primary Email") %}</span>
-				<br>
-			{% endif %}
-			{% if (contact.email_ids) { %}
-				{% for (const email_id of contact.email_ids) { %}
-					<a href="mailto:{%= frappe.utils.escape_html(email_id.email_id) %}">
-						{%= frappe.utils.escape_html(email_id.email_id) %}
-					</a>
-					<br>
-				{% } %}
-			{% endif %}
-		</p>
-		{% endif %}
-		{% if (contact.address) { %}
-		<p>
-			{%= contact.address %}
-		</p>
-		{% endif %}
+		</div>
+		{% let mobile_no = contact.mobile_no !== contact.phone ? contact.mobile_no : ""; %}
+		{% if (contact.phone) { %}
+			<p class="contact-line flex items-center gap-2 text-ink-gray-7">
+				{%= frappe.utils.icon("phone", "sm", "", "", "text-ink-gray-5", true) %}
+				<a href="tel:{%= frappe.utils.escape_html(contact.phone) %}" title="{%= __("Primary Phone") %}">{%= frappe.utils.escape_html(contact.phone) %}</a>
+			</p>
+		{% } %}
+		{% if (mobile_no) { %}
+			<p class="contact-line flex items-center gap-2 text-ink-gray-7">
+				{%= frappe.utils.icon("smartphone", "sm", "", "", "text-ink-gray-5", true) %}
+				<a href="tel:{%= frappe.utils.escape_html(mobile_no) %}" title="{%= __("Primary Mobile") %}">{%= frappe.utils.escape_html(mobile_no) %}</a>
+			</p>
+		{% } %}
+		{% if (contact.email_id) { %}
+			<p class="contact-line flex items-center gap-2 text-ink-gray-7">
+				{%= frappe.utils.icon("mail", "sm", "", "", "text-ink-gray-5", true) %}
+				<a href="mailto:{%= frappe.utils.escape_html(contact.email_id) %}" title="{%= __("Primary Email") %}">{%= frappe.utils.escape_html(contact.email_id) %}</a>
+			</p>
+		{% } %}
+		{% if (contact.address_name) { %}
+			<p class="contact-line flex items-center gap-2 text-ink-gray-7" title="{%= __("Address") %}">
+				{%= frappe.utils.icon("map-pin", "sm", "", "", "text-ink-gray-5", true) %}
+				<span>{%= frappe.utils.escape_html(contact.address_name) %}</span>
+			</p>
+		{% } %}
+		{% if (!contact.phone && !mobile_no && !contact.email_id && !contact.address_name) { %}
+			<p class="contact-line text-sm text-ink-gray-4">{%= __("No contact details") %}</p>
+		{% } %}
 	</div>
 {% } %}
 
 {% if (!contact_list.length) { %}
-	<p class="text-muted small">{%= __("No contacts added yet.") %}</p>
+	{%= frappe.ui.empty_state.html({ icon: "user", title: __("No contacts added yet") }) %}
 {% } %}

--- a/frappe/public/js/frappe/utils/address_and_contact.js
+++ b/frappe/public/js/frappe/utils/address_and_contact.js
@@ -78,7 +78,7 @@ frappe.ui.form.ContactQuickEntryForm = class ContactQuickEntryForm extends (
 	}
 };
 
-const PARTY_LINK_SECTIONS = [
+const ADDRESS_CONTACT_GROUPS = [
 	{
 		doctype: "Address",
 		wrapper_field: "address_html",
@@ -97,7 +97,7 @@ const PARTY_LINK_SECTIONS = [
 	},
 ];
 
-class PartyLinkSection {
+class AddressContactController {
 	constructor(
 		frm,
 		{ doctype, wrapper_field, onload_key, template, button_selector, primary_flag }
@@ -255,19 +255,19 @@ class PartyLinkSection {
 
 	unlink(record) {
 		const record_label = frappe.utils.bold(record.name);
-		const party_label = frappe.utils.bold(this.frm.docname);
+		const document_label = frappe.utils.bold(this.frm.docname);
 		const message = __("Unlink {0} {1} from {2}?", [
 			__(this.doctype),
 			record_label,
-			party_label,
+			document_label,
 		]);
 
-		frappe.confirm(message, () => this.delink_party(record));
+		frappe.confirm(message, () => this.remove_link(record));
 	}
 
-	delink_party(record) {
+	remove_link(record) {
 		return frappe
-			.xcall("frappe.contacts.address_and_contact.delink_party", {
+			.xcall("frappe.contacts.address_and_contact.remove_link", {
 				doctype: this.doctype,
 				name: record.name,
 				link_doctype: this.frm.doctype,
@@ -291,9 +291,9 @@ $.extend(frappe.contacts, {
 	},
 
 	render_address_and_contact: function (frm) {
-		for (const options of PARTY_LINK_SECTIONS) {
-			const section = new PartyLinkSection(frm, options);
-			if (section.is_loaded) section.render();
+		for (const options of ADDRESS_CONTACT_GROUPS) {
+			const controller = new AddressContactController(frm, options);
+			if (controller.is_loaded) controller.render();
 		}
 	},
 

--- a/frappe/public/js/frappe/utils/address_and_contact.js
+++ b/frappe/public/js/frappe/utils/address_and_contact.js
@@ -1,7 +1,9 @@
 frappe.provide("frappe.contacts");
 frappe.provide("frappe.ui.form");
 
-frappe.ui.form.AddressQuickEntryForm = class AddressQuickEntryForm extends frappe.ui.form.QuickEntryForm {
+frappe.ui.form.AddressQuickEntryForm = class AddressQuickEntryForm extends (
+	frappe.ui.form.QuickEntryForm
+) {
 	insert() {
 		if (this.source_frm) {
 			this.dialog.doc.links = [
@@ -17,7 +19,9 @@ frappe.ui.form.AddressQuickEntryForm = class AddressQuickEntryForm extends frapp
 	}
 };
 
-frappe.ui.form.ContactQuickEntryForm = class ContactQuickEntryForm extends frappe.ui.form.AddressQuickEntryForm {
+frappe.ui.form.ContactQuickEntryForm = class ContactQuickEntryForm extends (
+	frappe.ui.form.AddressQuickEntryForm
+) {
 	render_dialog() {
 		const fields = this.get_detail_fields().map(
 			({ table, value_field, primary_flag, ...field }) => field
@@ -215,9 +219,11 @@ class PartyLinkSection {
 				record.name
 			);
 		} else {
-			const previous = this.primary_name;
-			if (previous && previous !== record.name) {
-				await frappe.db.set_value(this.doctype, previous, this.primary_flag, 0);
+			const previously_primary = this.records.filter(
+				(other) => other[this.primary_flag] && other.name !== record.name
+			);
+			for (const previous of previously_primary) {
+				await frappe.db.set_value(this.doctype, previous.name, this.primary_flag, 0);
 			}
 			await frappe.db.set_value(this.doctype, record.name, this.primary_flag, 1);
 		}

--- a/frappe/public/js/frappe/utils/address_and_contact.js
+++ b/frappe/public/js/frappe/utils/address_and_contact.js
@@ -1,25 +1,23 @@
 frappe.provide("frappe.contacts");
 frappe.provide("frappe.ui.form");
 
-class PartyQuickEntryForm extends frappe.ui.form.QuickEntryForm {
+frappe.ui.form.AddressQuickEntryForm = class AddressQuickEntryForm extends frappe.ui.form.QuickEntryForm {
 	insert() {
-		if (this.party_frm) {
+		if (this.source_frm) {
 			this.dialog.doc.links = [
-				{ link_doctype: this.party_frm.doctype, link_name: this.party_frm.docname },
+				{ link_doctype: this.source_frm.doctype, link_name: this.source_frm.docname },
 			];
 		}
 		return super.insert();
 	}
 
 	open_form_if_not_list() {
-		if (!this.party_frm) return super.open_form_if_not_list();
-		this.party_frm.reload_doc();
+		if (!this.source_frm) return super.open_form_if_not_list();
+		this.source_frm.reload_doc();
 	}
-}
+};
 
-frappe.ui.form.AddressQuickEntryForm = class AddressQuickEntryForm extends PartyQuickEntryForm {};
-
-frappe.ui.form.ContactQuickEntryForm = class ContactQuickEntryForm extends PartyQuickEntryForm {
+frappe.ui.form.ContactQuickEntryForm = class ContactQuickEntryForm extends frappe.ui.form.AddressQuickEntryForm {
 	render_dialog() {
 		const fields = this.get_detail_fields().map(
 			({ table, value_field, primary_flag, ...field }) => field
@@ -204,7 +202,7 @@ class PartyLinkSection {
 				after_insert: () => frm.reload_doc(),
 			}).show();
 		} else {
-			frappe.new_doc(doctype, null, (quick_entry) => (quick_entry.party_frm = frm));
+			frappe.new_doc(doctype, null, (quick_entry) => (quick_entry.source_frm = frm));
 		}
 	}
 

--- a/frappe/public/js/frappe/utils/address_and_contact.js
+++ b/frappe/public/js/frappe/utils/address_and_contact.js
@@ -8,33 +8,44 @@ $.extend(frappe.contacts, {
 	},
 
 	render_address_and_contact: function (frm) {
-		const items = [
+		const sections = [
 			{
+				doctype: "Address",
 				field: "address_html",
 				data: "addr_list",
 				template: "address_list",
 				btn: ".btn-address",
-				doctype: "Address",
+				primary_flag: "is_primary_address",
 			},
 			{
+				doctype: "Contact",
 				field: "contact_html",
 				data: "contact_list",
 				template: "contact_list",
 				btn: ".btn-contact",
-				doctype: "Contact",
+				primary_flag: "is_primary_contact",
 			},
 		];
 
-		for (const item of items) {
-			// render address or contact
-			const field_wrapper = frm.fields_dict[item.field]?.wrapper;
+		for (const section of sections) {
+			const field_wrapper = frm.fields_dict[section.field]?.wrapper;
+			if (!field_wrapper || !frm.doc.__onload || !(section.data in frm.doc.__onload)) continue;
 
-			if (field_wrapper && frm.doc.__onload && item.data in frm.doc.__onload) {
-				$(field_wrapper)
-					.html(frappe.render_template(item.template, frm.doc.__onload))
-					.find(item.btn)
-					.on("click", () => new_record(item.doctype, frm));
-			}
+			const $wrapper = $(field_wrapper).html(
+				frappe.render_template(section.template, frm.doc.__onload)
+			);
+			$wrapper.find(section.btn).on("click", () => new_record(section.doctype, frm));
+			const records = frm.doc.__onload[section.data] || [];
+			const by_name = Object.fromEntries(records.map((r) => [r.name, r]));
+			$wrapper.find(".card-menu-btn").each(function () {
+				const record = by_name[this.closest("[data-name]")?.dataset.name];
+				if (!record) return;
+				new frappe.ui.Dropdown({
+					trigger: this,
+					options: card_menu(frm, section, record, records),
+					align: "end",
+				});
+			});
 		}
 	},
 
@@ -98,4 +109,60 @@ function new_record(doctype, frm) {
 	} else {
 		frappe.new_doc(doctype);
 	}
+}
+
+function card_menu(frm, section, record, records) {
+	const { doctype } = section;
+	return [
+		{
+			label: __("Edit"),
+			icon: "pen",
+			onclick: () => frappe.set_route("Form", doctype, record.name),
+		},
+		{
+			label: __("Set as Primary"),
+			icon: "star",
+			condition: () => !record[section.primary_flag],
+			onclick: () => set_primary(frm, section, record, records),
+		},
+		{
+			label: __("Delete"),
+			icon: "trash-2",
+			theme: "red",
+			onclick: () => delete_record(frm, doctype, record.name),
+		},
+	];
+}
+
+function get_primary_field(frm, doctype) {
+	return (frm.meta.fields || []).find(
+		(df) => df.fieldtype === "Link" && df.options === doctype && /primary/i.test(df.fieldname)
+	)?.fieldname;
+}
+
+function set_primary(frm, section, record, records) {
+	const { doctype, primary_flag } = section;
+	const primary_field = get_primary_field(frm, doctype);
+	const previous = records.find((r) => r.name !== record.name && r[primary_flag]);
+	const jobs = [];
+
+	if (previous) jobs.push(frappe.db.set_value(doctype, previous.name, primary_flag, 0));
+
+	if (primary_field) {
+		jobs.push(frappe.db.set_value(frm.doctype, frm.docname, primary_field, record.name));
+	} else {
+		jobs.push(frappe.db.set_value(doctype, record.name, primary_flag, 1));
+	}
+
+	Promise.all(jobs).then(() => frm.reload_doc());
+}
+
+function delete_record(frm, doctype, name) {
+	const label = `<b>${frappe.utils.escape_html(name)}</b>`;
+	frappe.confirm(__("Delete {0} {1}?", [__(doctype), label]), () => {
+		frappe.db.delete_doc(doctype, name).then(() => {
+			frappe.show_alert({ message: __("{0} deleted", [__(doctype)]), indicator: "green" });
+			frm.reload_doc();
+		});
+	});
 }

--- a/frappe/public/js/frappe/utils/address_and_contact.js
+++ b/frappe/public/js/frappe/utils/address_and_contact.js
@@ -1,4 +1,98 @@
 frappe.provide("frappe.contacts");
+frappe.provide("frappe.ui.form");
+
+/**
+ * Quick entry for records that belong to a party, such as Address and Contact.
+ *
+ * When the dialog is opened from a party's form, the new record is linked back to
+ * that party and the user stays on the form instead of being sent to the record
+ * that was just created. "Edit Full Form" still opens the full page.
+ */
+class PartyQuickEntryForm extends frappe.ui.form.QuickEntryForm {
+	insert() {
+		const link = this.get_party_link();
+		if (link) {
+			this.dialog.doc.links = [link];
+		}
+		return super.insert();
+	}
+
+	/**
+	 * The party is only linked while its form is the open one, so a stale
+	 * frappe.dynamic_link from an earlier visit cannot leak into a record created
+	 * somewhere else.
+	 */
+	get_party_link() {
+		const link = frappe.dynamic_link;
+		if (!link?.doc) return null;
+
+		const route = frappe.get_route();
+		const link_name = link.doc[link.fieldname];
+		const is_party_form_open =
+			route[0] === "Form" && route[1] === link.doctype && route[2] === link_name;
+
+		return is_party_form_open ? { link_doctype: link.doctype, link_name } : null;
+	}
+
+	open_form_if_not_list() {
+		if (frappe.get_route()?.[0] === "Form") {
+			cur_frm?.reload_doc();
+		}
+	}
+}
+
+frappe.ui.form.AddressQuickEntryForm = class AddressQuickEntryForm extends PartyQuickEntryForm {};
+
+frappe.ui.form.ContactQuickEntryForm = class ContactQuickEntryForm extends PartyQuickEntryForm {
+	render_dialog() {
+		const fields = this.get_phone_fields().map(({ primary_flag, ...field }) => field);
+		this.docfields = this.docfields.concat({ fieldtype: "Column Break" }, ...fields);
+		super.render_dialog();
+	}
+
+	update_doc() {
+		const doc = super.update_doc();
+		const phone_nos = [];
+
+		for (const { fieldname, primary_flag } of this.get_phone_fields()) {
+			if (doc[fieldname]) {
+				phone_nos.push({ phone: doc[fieldname], [primary_flag]: 1 });
+			}
+			delete doc[fieldname];
+		}
+
+		if (phone_nos.length) {
+			doc.phone_nos = phone_nos;
+		}
+		return doc;
+	}
+
+	/**
+	 * Contact.phone and Contact.mobile_no are read only values that validate()
+	 * derives from the phone_nos table. Reusing those fieldnames here would make
+	 * the form layout replace these inputs with the read only definitions and hide
+	 * them, so the numbers are collected under dialog specific fieldnames and
+	 * written to phone_nos on save.
+	 */
+	get_phone_fields() {
+		return [
+			{
+				fieldname: "contact_phone",
+				label: __("Phone"),
+				fieldtype: "Data",
+				options: "Phone",
+				primary_flag: "is_primary_phone",
+			},
+			{
+				fieldname: "contact_mobile_no",
+				label: __("Mobile No"),
+				fieldtype: "Data",
+				options: "Phone",
+				primary_flag: "is_primary_mobile_no",
+			},
+		];
+	}
+};
 
 $.extend(frappe.contacts, {
 	clear_address_and_contact: function (frm) {

--- a/frappe/public/js/frappe/utils/address_and_contact.js
+++ b/frappe/public/js/frappe/utils/address_and_contact.js
@@ -122,6 +122,7 @@ function new_record(doctype, frm) {
 
 function card_menu(frm, section, record, primary_name) {
 	const { doctype } = section;
+	const is_primary = record.name === primary_name;
 	return [
 		{
 			label: __("Edit"),
@@ -131,19 +132,19 @@ function card_menu(frm, section, record, primary_name) {
 		{
 			label: __("Set as Primary"),
 			icon: "star",
-			condition: () => record.name !== primary_name,
+			condition: () => !is_primary,
 			onclick: () => set_primary(frm, section, record),
 		},
 		{
-			label: __("Unlink from {0}", [__(frm.doctype)]),
-			icon: "unlink",
-			onclick: () => delink_record(frm, doctype, record.name),
+			label: __("Unset as Primary"),
+			icon: "star-off",
+			condition: () => is_primary,
+			onclick: () => unset_primary(frm, section, record),
 		},
 		{
-			label: __("Delete"),
-			icon: "trash-2",
-			theme: "red",
-			onclick: () => delete_record(frm, doctype, record.name),
+			label: __("Unlink {0}", [__(doctype)]),
+			icon: "unlink",
+			onclick: () => delink_record(frm, doctype, record.name),
 		},
 	];
 }
@@ -160,6 +161,12 @@ function get_primary_name(frm, section, records) {
 	return records.find((r) => r[section.primary_flag])?.name;
 }
 
+function get_dependent_fields(frm, primary_field) {
+	return (frm.meta.fields || [])
+		.filter((df) => df.fetch_from?.split(".")[0] === primary_field)
+		.map((df) => df.fieldname);
+}
+
 async function set_primary(frm, section, record) {
 	const primary_field = get_primary_field(frm, section.doctype);
 
@@ -172,10 +179,27 @@ async function set_primary(frm, section, record) {
 	frm.reload_doc();
 }
 
+async function unset_primary(frm, section, record) {
+	const primary_field = get_primary_field(frm, section.doctype);
+
+	if (primary_field) {
+		const updates = { [primary_field]: null };
+		for (const fieldname of get_dependent_fields(frm, primary_field)) {
+			updates[fieldname] = null;
+		}
+		await frappe.db.set_value(frm.doctype, frm.docname, updates);
+	} else {
+		await frappe.db.set_value(section.doctype, record.name, section.primary_flag, 0);
+	}
+
+	frm.reload_doc();
+}
+
 function delink_record(frm, doctype, name) {
 	const label = `<b>${frappe.utils.escape_html(name)}</b>`;
+	const party_label = `<b>${frappe.utils.escape_html(frm.docname)}</b>`;
 	frappe.confirm(
-		__("Unlink {0} {1} from {2}?", [__(doctype), label, __(frm.doctype)]),
+		__("Unlink {0} {1} from {2}?", [__(doctype), label, party_label]),
 		() => {
 			frappe
 				.xcall("frappe.contacts.address_and_contact.delink_party", {
@@ -193,14 +217,4 @@ function delink_record(frm, doctype, name) {
 				});
 		}
 	);
-}
-
-function delete_record(frm, doctype, name) {
-	const label = `<b>${frappe.utils.escape_html(name)}</b>`;
-	frappe.confirm(__("Delete {0} {1}?", [__(doctype), label]), () => {
-		frappe.db.delete_doc(doctype, name).then(() => {
-			frappe.show_alert({ message: __("{0} deleted", [__(doctype)]), indicator: "green" });
-			frm.reload_doc();
-		});
-	});
 }

--- a/frappe/public/js/frappe/utils/address_and_contact.js
+++ b/frappe/public/js/frappe/utils/address_and_contact.js
@@ -217,6 +217,10 @@ class PartyLinkSection {
 				record.name
 			);
 		} else {
+			const previous = this.primary_name;
+			if (previous && previous !== record.name) {
+				await frappe.db.set_value(this.doctype, previous, this.primary_flag, 0);
+			}
 			await frappe.db.set_value(this.doctype, record.name, this.primary_flag, 1);
 		}
 

--- a/frappe/public/js/frappe/utils/address_and_contact.js
+++ b/frappe/public/js/frappe/utils/address_and_contact.js
@@ -31,18 +31,20 @@ $.extend(frappe.contacts, {
 			const field_wrapper = frm.fields_dict[section.field]?.wrapper;
 			if (!field_wrapper || !frm.doc.__onload || !(section.data in frm.doc.__onload)) continue;
 
+			const records = frm.doc.__onload[section.data] || [];
+			const primary_name = get_primary_name(frm, section, records);
+
 			const $wrapper = $(field_wrapper).html(
-				frappe.render_template(section.template, frm.doc.__onload)
+				frappe.render_template(section.template, { ...frm.doc.__onload, primary_name })
 			);
 			$wrapper.find(section.btn).on("click", () => new_record(section.doctype, frm));
-			const records = frm.doc.__onload[section.data] || [];
 			const by_name = Object.fromEntries(records.map((r) => [r.name, r]));
 			$wrapper.find(".card-menu-btn").each(function () {
 				const record = by_name[this.closest("[data-name]")?.dataset.name];
 				if (!record) return;
 				new frappe.ui.Dropdown({
 					trigger: this,
-					options: card_menu(frm, section, record, records),
+					options: card_menu(frm, section, record, primary_name),
 					align: "end",
 				});
 			});
@@ -111,7 +113,7 @@ function new_record(doctype, frm) {
 	}
 }
 
-function card_menu(frm, section, record, records) {
+function card_menu(frm, section, record, primary_name) {
 	const { doctype } = section;
 	return [
 		{
@@ -122,8 +124,13 @@ function card_menu(frm, section, record, records) {
 		{
 			label: __("Set as Primary"),
 			icon: "star",
-			condition: () => !record[section.primary_flag],
-			onclick: () => set_primary(frm, section, record, records),
+			condition: () => record.name !== primary_name,
+			onclick: () => set_primary(frm, section, record),
+		},
+		{
+			label: __("Unlink from {0}", [__(frm.doctype)]),
+			icon: "unlink",
+			onclick: () => delink_record(frm, doctype, record.name),
 		},
 		{
 			label: __("Delete"),
@@ -140,21 +147,45 @@ function get_primary_field(frm, doctype) {
 	)?.fieldname;
 }
 
-function set_primary(frm, section, record, records) {
-	const { doctype, primary_flag } = section;
-	const primary_field = get_primary_field(frm, doctype);
-	const previous = records.find((r) => r.name !== record.name && r[primary_flag]);
-	const jobs = [];
+function get_primary_name(frm, section, records) {
+	const primary_field = get_primary_field(frm, section.doctype);
+	if (primary_field) return frm.doc[primary_field];
+	return records.find((r) => r[section.primary_flag])?.name;
+}
 
-	if (previous) jobs.push(frappe.db.set_value(doctype, previous.name, primary_flag, 0));
+async function set_primary(frm, section, record) {
+	const primary_field = get_primary_field(frm, section.doctype);
 
 	if (primary_field) {
-		jobs.push(frappe.db.set_value(frm.doctype, frm.docname, primary_field, record.name));
+		await frappe.db.set_value(frm.doctype, frm.docname, primary_field, record.name);
 	} else {
-		jobs.push(frappe.db.set_value(doctype, record.name, primary_flag, 1));
+		await frappe.db.set_value(section.doctype, record.name, section.primary_flag, 1);
 	}
 
-	Promise.all(jobs).then(() => frm.reload_doc());
+	frm.reload_doc();
+}
+
+function delink_record(frm, doctype, name) {
+	const label = `<b>${frappe.utils.escape_html(name)}</b>`;
+	frappe.confirm(
+		__("Unlink {0} {1} from {2}?", [__(doctype), label, __(frm.doctype)]),
+		() => {
+			frappe
+				.xcall("frappe.contacts.address_and_contact.delink_party", {
+					doctype,
+					name,
+					link_doctype: frm.doctype,
+					link_name: frm.docname,
+				})
+				.then(() => {
+					frappe.show_alert({
+						message: __("{0} unlinked", [__(doctype)]),
+						indicator: "green",
+					});
+					frm.reload_doc();
+				});
+		}
+	);
 }
 
 function delete_record(frm, doctype, name) {

--- a/frappe/public/js/frappe/utils/address_and_contact.js
+++ b/frappe/public/js/frappe/utils/address_and_contact.js
@@ -1,13 +1,7 @@
 frappe.provide("frappe.contacts");
 frappe.provide("frappe.ui.form");
 
-/**
- * Quick entry for records that belong to a party, such as Address and Contact.
- *
- * When the dialog is opened from a party's form, the new record is linked back to
- * that party and the user stays on the form instead of being sent to the record
- * that was just created. "Edit Full Form" still opens the full page.
- */
+// Links the new record to the party it was created from, and stays on that form.
 class PartyQuickEntryForm extends frappe.ui.form.QuickEntryForm {
 	insert() {
 		const link = this.get_party_link();
@@ -17,11 +11,7 @@ class PartyQuickEntryForm extends frappe.ui.form.QuickEntryForm {
 		return super.insert();
 	}
 
-	/**
-	 * The party is only linked while its form is the open one, so a stale
-	 * frappe.dynamic_link from an earlier visit cannot leak into a record created
-	 * somewhere else.
-	 */
+	// Route check keeps a stale frappe.dynamic_link out of unrelated records.
 	get_party_link() {
 		const link = frappe.dynamic_link;
 		if (!link?.doc) return null;
@@ -67,13 +57,8 @@ frappe.ui.form.ContactQuickEntryForm = class ContactQuickEntryForm extends Party
 		return doc;
 	}
 
-	/**
-	 * Contact.phone and Contact.mobile_no are read only values that validate()
-	 * derives from the phone_nos table. Reusing those fieldnames here would make
-	 * the form layout replace these inputs with the read only definitions and hide
-	 * them, so the numbers are collected under dialog specific fieldnames and
-	 * written to phone_nos on save.
-	 */
+	// Not named phone/mobile_no: those are read only on Contact, so the layout
+	// would swap in the read only definitions and hide the inputs.
 	get_phone_fields() {
 		return [
 			{
@@ -94,61 +79,216 @@ frappe.ui.form.ContactQuickEntryForm = class ContactQuickEntryForm extends Party
 	}
 };
 
+const PARTY_LINK_SECTIONS = [
+	{
+		doctype: "Address",
+		wrapper_field: "address_html",
+		onload_key: "addr_list",
+		template: "address_list",
+		button_selector: ".btn-address",
+		primary_flag: "is_primary_address",
+	},
+	{
+		doctype: "Contact",
+		wrapper_field: "contact_html",
+		onload_key: "contact_list",
+		template: "contact_list",
+		button_selector: ".btn-contact",
+		primary_flag: "is_primary_contact",
+	},
+];
+
+// One card list on a party's form: either its addresses or its contacts.
+class PartyLinkSection {
+	constructor(frm, { doctype, wrapper_field, onload_key, template, button_selector, primary_flag }) {
+		this.frm = frm;
+		this.doctype = doctype;
+		this.wrapper_field = wrapper_field;
+		this.onload_key = onload_key;
+		this.template = template;
+		this.button_selector = button_selector;
+		this.primary_flag = primary_flag;
+	}
+
+	// A missing onload key means the party does not track this link at all.
+	get is_loaded() {
+		const has_wrapper = Boolean(this.frm.fields_dict[this.wrapper_field]);
+		return has_wrapper && this.onload_key in (this.frm.doc.__onload || {});
+	}
+
+	get records() {
+		return this.frm.doc.__onload[this.onload_key] || [];
+	}
+
+	// The party's own link field, such as Customer.customer_primary_address.
+	get primary_field() {
+		return (this.frm.meta.fields || []).find(
+			(df) =>
+				df.fieldtype === "Link" && df.options === this.doctype && /primary/i.test(df.fieldname)
+		)?.fieldname;
+	}
+
+	get primary_name() {
+		if (this.primary_field) return this.frm.doc[this.primary_field];
+		return this.records.find((record) => record[this.primary_flag])?.name;
+	}
+
+	render() {
+		const primary_name = this.primary_name;
+		const records = [...this.records].sort(
+			(first, second) => (second.name === primary_name) - (first.name === primary_name)
+		);
+
+		const $wrapper = $(this.frm.fields_dict[this.wrapper_field].wrapper).html(
+			frappe.render_template(this.template, {
+				...this.frm.doc.__onload,
+				[this.onload_key]: records,
+				primary_name,
+			})
+		);
+
+		$wrapper.find(this.button_selector).on("click", () => this.create_record());
+		this.bind_card_menus($wrapper);
+	}
+
+	bind_card_menus($wrapper) {
+		const by_name = Object.fromEntries(this.records.map((record) => [record.name, record]));
+
+		$wrapper.find(".card-menu-btn").each((index, trigger) => {
+			const record = by_name[trigger.closest("[data-name]")?.dataset.name];
+			if (!record) return;
+			new frappe.ui.Dropdown({
+				trigger,
+				options: this.get_menu_options(record),
+				align: "end",
+			});
+		});
+	}
+
+	get_menu_options(record) {
+		const is_primary = record.name === this.primary_name;
+		return [
+			{
+				label: __("Edit"),
+				icon: "pen",
+				onclick: () => frappe.set_route("Form", this.doctype, record.name),
+			},
+			{
+				label: __("Set as Primary"),
+				icon: "star",
+				condition: () => !is_primary,
+				onclick: () => this.set_primary(record),
+			},
+			{
+				label: __("Unset as Primary"),
+				icon: "star-off",
+				condition: () => is_primary,
+				onclick: () => this.unset_primary(record),
+			},
+			{
+				label: __("Unlink {0}", [__(this.doctype)]),
+				icon: "unlink",
+				onclick: () => this.unlink(record),
+			},
+		];
+	}
+
+	create_record() {
+		const { frm, doctype } = this;
+		frappe.dynamic_link = { doctype: frm.doc.doctype, doc: frm.doc, fieldname: "name" };
+
+		if (frappe.boot.enable_address_autocompletion === 1 && doctype === "Address") {
+			new frappe.ui.AddressAutocompleteDialog({
+				title: __("New Address"),
+				link_doctype: frm.doc.doctype,
+				link_name: frm.doc.name,
+				after_insert: () => frm.reload_doc(),
+			}).show();
+		} else {
+			frappe.new_doc(doctype);
+		}
+	}
+
+	async set_primary(record) {
+		if (this.primary_field) {
+			await frappe.db.set_value(
+				this.frm.doctype,
+				this.frm.docname,
+				this.primary_field,
+				record.name
+			);
+		} else {
+			await frappe.db.set_value(this.doctype, record.name, this.primary_flag, 1);
+		}
+
+		this.frm.reload_doc();
+	}
+
+	async unset_primary(record) {
+		const primary_field = this.primary_field;
+
+		if (primary_field) {
+			const updates = { [primary_field]: null };
+			for (const fieldname of this.get_dependent_fields(primary_field)) {
+				updates[fieldname] = null;
+			}
+			await frappe.db.set_value(this.frm.doctype, this.frm.docname, updates);
+		} else {
+			await frappe.db.set_value(this.doctype, record.name, this.primary_flag, 0);
+		}
+
+		this.frm.reload_doc();
+	}
+
+	// Cleared with the primary link, else hooks like Customer.create_primary_contact
+	// see the stale fetched values and recreate the record.
+	get_dependent_fields(primary_field) {
+		return (this.frm.meta.fields || [])
+			.filter((df) => df.fetch_from?.split(".")[0] === primary_field)
+			.map((df) => df.fieldname);
+	}
+
+	unlink(record) {
+		const record_label = frappe.utils.bold(record.name);
+		const party_label = frappe.utils.bold(this.frm.docname);
+		const message = __("Unlink {0} {1} from {2}?", [
+			__(this.doctype),
+			record_label,
+			party_label,
+		]);
+
+		frappe.confirm(message, () => this.delink_party(record));
+	}
+
+	delink_party(record) {
+		return frappe
+			.xcall("frappe.contacts.address_and_contact.delink_party", {
+				doctype: this.doctype,
+				name: record.name,
+				link_doctype: this.frm.doctype,
+				link_name: this.frm.docname,
+			})
+			.then(() => {
+				frappe.show_alert({
+					message: __("{0} unlinked", [__(this.doctype)]),
+					indicator: "green",
+				});
+				this.frm.reload_doc();
+			});
+	}
+}
+
 $.extend(frappe.contacts, {
 	clear_address_and_contact: function (frm) {
-		for (const field of ["address_html", "contact_html"]) {
-			$(frm.fields_dict[field]?.wrapper)?.html("");
+		for (const wrapper_field of ["address_html", "contact_html"]) {
+			$(frm.fields_dict[wrapper_field]?.wrapper)?.html("");
 		}
 	},
 
 	render_address_and_contact: function (frm) {
-		const sections = [
-			{
-				doctype: "Address",
-				field: "address_html",
-				data: "addr_list",
-				template: "address_list",
-				btn: ".btn-address",
-				primary_flag: "is_primary_address",
-			},
-			{
-				doctype: "Contact",
-				field: "contact_html",
-				data: "contact_list",
-				template: "contact_list",
-				btn: ".btn-contact",
-				primary_flag: "is_primary_contact",
-			},
-		];
-
-		for (const section of sections) {
-			const field_wrapper = frm.fields_dict[section.field]?.wrapper;
-			if (!field_wrapper || !frm.doc.__onload || !(section.data in frm.doc.__onload)) continue;
-
-			const records = frm.doc.__onload[section.data] || [];
-			const primary_name = get_primary_name(frm, section, records);
-			const sorted = [...records].sort(
-				(a, b) => (b.name === primary_name) - (a.name === primary_name)
-			);
-
-			const $wrapper = $(field_wrapper).html(
-				frappe.render_template(section.template, {
-					...frm.doc.__onload,
-					[section.data]: sorted,
-					primary_name,
-				})
-			);
-			$wrapper.find(section.btn).on("click", () => new_record(section.doctype, frm));
-			const by_name = Object.fromEntries(records.map((r) => [r.name, r]));
-			$wrapper.find(".card-menu-btn").each(function () {
-				const record = by_name[this.closest("[data-name]")?.dataset.name];
-				if (!record) return;
-				new frappe.ui.Dropdown({
-					trigger: this,
-					options: card_menu(frm, section, record, primary_name),
-					align: "end",
-				});
-			});
+		for (const options of PARTY_LINK_SECTIONS) {
+			const section = new PartyLinkSection(frm, options);
+			if (section.is_loaded) section.render();
 		}
 	},
 
@@ -192,123 +332,3 @@ $.extend(frappe.contacts, {
 			.then((address_display) => frm.set_value(_display_field, address_display));
 	},
 });
-
-function new_record(doctype, frm) {
-	frappe.dynamic_link = {
-		doctype: frm.doc.doctype,
-		doc: frm.doc,
-		fieldname: "name",
-	};
-
-	if (frappe.boot.enable_address_autocompletion === 1 && doctype === "Address") {
-		new frappe.ui.AddressAutocompleteDialog({
-			title: __("New Address"),
-			link_doctype: frm.doc.doctype,
-			link_name: frm.doc.name,
-			after_insert: function (doc) {
-				frm.reload_doc();
-			},
-		}).show();
-	} else {
-		frappe.new_doc(doctype);
-	}
-}
-
-function card_menu(frm, section, record, primary_name) {
-	const { doctype } = section;
-	const is_primary = record.name === primary_name;
-	return [
-		{
-			label: __("Edit"),
-			icon: "pen",
-			onclick: () => frappe.set_route("Form", doctype, record.name),
-		},
-		{
-			label: __("Set as Primary"),
-			icon: "star",
-			condition: () => !is_primary,
-			onclick: () => set_primary(frm, section, record),
-		},
-		{
-			label: __("Unset as Primary"),
-			icon: "star-off",
-			condition: () => is_primary,
-			onclick: () => unset_primary(frm, section, record),
-		},
-		{
-			label: __("Unlink {0}", [__(doctype)]),
-			icon: "unlink",
-			onclick: () => delink_record(frm, doctype, record.name),
-		},
-	];
-}
-
-function get_primary_field(frm, doctype) {
-	return (frm.meta.fields || []).find(
-		(df) => df.fieldtype === "Link" && df.options === doctype && /primary/i.test(df.fieldname)
-	)?.fieldname;
-}
-
-function get_primary_name(frm, section, records) {
-	const primary_field = get_primary_field(frm, section.doctype);
-	if (primary_field) return frm.doc[primary_field];
-	return records.find((r) => r[section.primary_flag])?.name;
-}
-
-function get_dependent_fields(frm, primary_field) {
-	return (frm.meta.fields || [])
-		.filter((df) => df.fetch_from?.split(".")[0] === primary_field)
-		.map((df) => df.fieldname);
-}
-
-async function set_primary(frm, section, record) {
-	const primary_field = get_primary_field(frm, section.doctype);
-
-	if (primary_field) {
-		await frappe.db.set_value(frm.doctype, frm.docname, primary_field, record.name);
-	} else {
-		await frappe.db.set_value(section.doctype, record.name, section.primary_flag, 1);
-	}
-
-	frm.reload_doc();
-}
-
-async function unset_primary(frm, section, record) {
-	const primary_field = get_primary_field(frm, section.doctype);
-
-	if (primary_field) {
-		const updates = { [primary_field]: null };
-		for (const fieldname of get_dependent_fields(frm, primary_field)) {
-			updates[fieldname] = null;
-		}
-		await frappe.db.set_value(frm.doctype, frm.docname, updates);
-	} else {
-		await frappe.db.set_value(section.doctype, record.name, section.primary_flag, 0);
-	}
-
-	frm.reload_doc();
-}
-
-function delink_record(frm, doctype, name) {
-	const label = `<b>${frappe.utils.escape_html(name)}</b>`;
-	const party_label = `<b>${frappe.utils.escape_html(frm.docname)}</b>`;
-	frappe.confirm(
-		__("Unlink {0} {1} from {2}?", [__(doctype), label, party_label]),
-		() => {
-			frappe
-				.xcall("frappe.contacts.address_and_contact.delink_party", {
-					doctype,
-					name,
-					link_doctype: frm.doctype,
-					link_name: frm.docname,
-				})
-				.then(() => {
-					frappe.show_alert({
-						message: __("{0} unlinked", [__(doctype)]),
-						indicator: "green",
-					});
-					frm.reload_doc();
-				});
-		}
-	);
-}

--- a/frappe/public/js/frappe/utils/address_and_contact.js
+++ b/frappe/public/js/frappe/utils/address_and_contact.js
@@ -1,7 +1,6 @@
 frappe.provide("frappe.contacts");
 frappe.provide("frappe.ui.form");
 
-// Links the new record to the party it was created from, and stays on that form.
 class PartyQuickEntryForm extends frappe.ui.form.QuickEntryForm {
 	insert() {
 		const link = this.get_party_link();
@@ -11,7 +10,6 @@ class PartyQuickEntryForm extends frappe.ui.form.QuickEntryForm {
 		return super.insert();
 	}
 
-	// Route check keeps a stale frappe.dynamic_link out of unrelated records.
 	get_party_link() {
 		const link = frappe.dynamic_link;
 		if (!link?.doc) return null;
@@ -35,37 +33,36 @@ frappe.ui.form.AddressQuickEntryForm = class AddressQuickEntryForm extends Party
 
 frappe.ui.form.ContactQuickEntryForm = class ContactQuickEntryForm extends PartyQuickEntryForm {
 	render_dialog() {
-		const fields = this.get_phone_fields().map(({ primary_flag, ...field }) => field);
+		const fields = this.get_detail_fields().map(
+			({ table, value_field, primary_flag, ...field }) => field
+		);
 		this.docfields = this.docfields.concat({ fieldtype: "Column Break" }, ...fields);
 		super.render_dialog();
 	}
 
 	update_doc() {
 		const doc = super.update_doc();
-		const phone_nos = [];
 
-		for (const { fieldname, primary_flag } of this.get_phone_fields()) {
-			if (doc[fieldname]) {
-				phone_nos.push({ phone: doc[fieldname], [primary_flag]: 1 });
-			}
+		for (const { fieldname, table, value_field, primary_flag } of this.get_detail_fields()) {
+			const value = doc[fieldname];
 			delete doc[fieldname];
+			if (!value) continue;
+
+			doc[table] = doc[table] || [];
+			doc[table].push({ [value_field]: value, [primary_flag]: 1 });
 		}
 
-		if (phone_nos.length) {
-			doc.phone_nos = phone_nos;
-		}
 		return doc;
 	}
-
-	// Not named phone/mobile_no: those are read only on Contact, so the layout
-	// would swap in the read only definitions and hide the inputs.
-	get_phone_fields() {
+	get_detail_fields() {
 		return [
 			{
 				fieldname: "contact_phone",
 				label: __("Phone"),
 				fieldtype: "Data",
 				options: "Phone",
+				table: "phone_nos",
+				value_field: "phone",
 				primary_flag: "is_primary_phone",
 			},
 			{
@@ -73,7 +70,18 @@ frappe.ui.form.ContactQuickEntryForm = class ContactQuickEntryForm extends Party
 				label: __("Mobile No"),
 				fieldtype: "Data",
 				options: "Phone",
+				table: "phone_nos",
+				value_field: "phone",
 				primary_flag: "is_primary_mobile_no",
+			},
+			{
+				fieldname: "contact_email",
+				label: __("Email"),
+				fieldtype: "Data",
+				options: "Email",
+				table: "email_ids",
+				value_field: "email_id",
+				primary_flag: "is_primary",
 			},
 		];
 	}
@@ -98,7 +106,6 @@ const PARTY_LINK_SECTIONS = [
 	},
 ];
 
-// One card list on a party's form: either its addresses or its contacts.
 class PartyLinkSection {
 	constructor(frm, { doctype, wrapper_field, onload_key, template, button_selector, primary_flag }) {
 		this.frm = frm;
@@ -110,7 +117,6 @@ class PartyLinkSection {
 		this.primary_flag = primary_flag;
 	}
 
-	// A missing onload key means the party does not track this link at all.
 	get is_loaded() {
 		const has_wrapper = Boolean(this.frm.fields_dict[this.wrapper_field]);
 		return has_wrapper && this.onload_key in (this.frm.doc.__onload || {});
@@ -120,7 +126,6 @@ class PartyLinkSection {
 		return this.frm.doc.__onload[this.onload_key] || [];
 	}
 
-	// The party's own link field, such as Customer.customer_primary_address.
 	get primary_field() {
 		return (this.frm.meta.fields || []).find(
 			(df) =>
@@ -240,8 +245,6 @@ class PartyLinkSection {
 		this.frm.reload_doc();
 	}
 
-	// Cleared with the primary link, else hooks like Customer.create_primary_contact
-	// see the stale fetched values and recreate the record.
 	get_dependent_fields(primary_field) {
 		return (this.frm.meta.fields || [])
 			.filter((df) => df.fetch_from?.split(".")[0] === primary_field)

--- a/frappe/public/js/frappe/utils/address_and_contact.js
+++ b/frappe/public/js/frappe/utils/address_and_contact.js
@@ -3,29 +3,17 @@ frappe.provide("frappe.ui.form");
 
 class PartyQuickEntryForm extends frappe.ui.form.QuickEntryForm {
 	insert() {
-		const link = this.get_party_link();
-		if (link) {
-			this.dialog.doc.links = [link];
+		if (this.party_frm) {
+			this.dialog.doc.links = [
+				{ link_doctype: this.party_frm.doctype, link_name: this.party_frm.docname },
+			];
 		}
 		return super.insert();
 	}
 
-	get_party_link() {
-		const link = frappe.dynamic_link;
-		if (!link?.doc) return null;
-
-		const route = frappe.get_route();
-		const link_name = link.doc[link.fieldname];
-		const is_party_form_open =
-			route[0] === "Form" && route[1] === link.doctype && route[2] === link_name;
-
-		return is_party_form_open ? { link_doctype: link.doctype, link_name } : null;
-	}
-
 	open_form_if_not_list() {
-		if (frappe.get_route()?.[0] === "Form") {
-			cur_frm?.reload_doc();
-		}
+		if (!this.party_frm) return super.open_form_if_not_list();
+		this.party_frm.reload_doc();
 	}
 }
 
@@ -54,6 +42,7 @@ frappe.ui.form.ContactQuickEntryForm = class ContactQuickEntryForm extends Party
 
 		return doc;
 	}
+
 	get_detail_fields() {
 		return [
 			{
@@ -107,7 +96,10 @@ const PARTY_LINK_SECTIONS = [
 ];
 
 class PartyLinkSection {
-	constructor(frm, { doctype, wrapper_field, onload_key, template, button_selector, primary_flag }) {
+	constructor(
+		frm,
+		{ doctype, wrapper_field, onload_key, template, button_selector, primary_flag }
+	) {
 		this.frm = frm;
 		this.doctype = doctype;
 		this.wrapper_field = wrapper_field;
@@ -129,7 +121,9 @@ class PartyLinkSection {
 	get primary_field() {
 		return (this.frm.meta.fields || []).find(
 			(df) =>
-				df.fieldtype === "Link" && df.options === this.doctype && /primary/i.test(df.fieldname)
+				df.fieldtype === "Link" &&
+				df.options === this.doctype &&
+				/primary/i.test(df.fieldname)
 		)?.fieldname;
 	}
 
@@ -210,7 +204,7 @@ class PartyLinkSection {
 				after_insert: () => frm.reload_doc(),
 			}).show();
 		} else {
-			frappe.new_doc(doctype);
+			frappe.new_doc(doctype, null, (quick_entry) => (quick_entry.party_frm = frm));
 		}
 	}
 

--- a/frappe/public/js/frappe/utils/address_and_contact.js
+++ b/frappe/public/js/frappe/utils/address_and_contact.js
@@ -33,9 +33,16 @@ $.extend(frappe.contacts, {
 
 			const records = frm.doc.__onload[section.data] || [];
 			const primary_name = get_primary_name(frm, section, records);
+			const sorted = [...records].sort(
+				(a, b) => (b.name === primary_name) - (a.name === primary_name)
+			);
 
 			const $wrapper = $(field_wrapper).html(
-				frappe.render_template(section.template, { ...frm.doc.__onload, primary_name })
+				frappe.render_template(section.template, {
+					...frm.doc.__onload,
+					[section.data]: sorted,
+					primary_name,
+				})
 			);
 			$wrapper.find(section.btn).on("click", () => new_record(section.doctype, frm));
 			const by_name = Object.fromEntries(records.map((r) => [r.name, r]));

--- a/frappe/public/scss/common/controls.scss
+++ b/frappe/public/scss/common/controls.scss
@@ -169,6 +169,10 @@ select.form-control {
 		background-color: var(--surface-base);
 	}
 
+	.card-list-actions {
+		margin-bottom: var(--margin-sm);
+	}
+
 	.address-box,
 	.contact-box {
 		background-color: var(--card-bg);
@@ -179,13 +183,19 @@ select.form-control {
 		word-wrap: break-word;
 		position: relative;
 
-		p:last-child {
+		> :last-child {
 			margin-bottom: 0;
 		}
 
 		.box-header {
 			padding-inline-end: 1.5rem;
 			margin-bottom: var(--margin-sm);
+		}
+
+		.box-subtitle,
+		.contact-line,
+		.address-display {
+			line-height: 1.4;
 		}
 
 		.box-subtitle {
@@ -198,11 +208,6 @@ select.form-control {
 			top: var(--padding-sm);
 			inset-inline-end: var(--padding-sm);
 		}
-	}
-
-	.address-box p,
-	.contact-box p {
-		line-height: 1.4;
 	}
 
 	.contact-box .contact-line {

--- a/frappe/public/scss/common/controls.scss
+++ b/frappe/public/scss/common/controls.scss
@@ -171,8 +171,8 @@ select.form-control {
 
 	.address-box,
 	.contact-box {
-		background-color: var(--control-bg);
-		padding: var(--padding-sm);
+		background-color: var(--card-bg);
+		padding: var(--padding-md);
 		margin-bottom: var(--margin-sm);
 		border: 1px solid var(--border-color);
 		border-radius: var(--radius);
@@ -183,19 +183,33 @@ select.form-control {
 			margin-bottom: 0;
 		}
 
-		.edit-btn {
+		.box-header {
+			padding-inline-end: 1.5rem;
+			margin-bottom: var(--margin-xs);
+		}
+
+		.box-subtitle {
+			margin-bottom: var(--margin-sm);
+		}
+
+		.card-menu-btn {
 			position: absolute;
-			top: 0px;
-			right: 0px;
-			display: flex;
-			justify-content: center;
-			align-items: center;
-			padding: var(--padding-sm);
+			top: var(--padding-sm);
+			inset-inline-end: var(--padding-sm);
 		}
 	}
 
 	.contact-box p {
 		line-height: 1.1;
+	}
+
+	.contact-box .contact-line {
+		margin-bottom: var(--margin-xs);
+
+		svg.icon {
+			flex-shrink: 0;
+			margin: 0;
+		}
 	}
 
 	.action-btn {

--- a/frappe/public/scss/common/controls.scss
+++ b/frappe/public/scss/common/controls.scss
@@ -185,10 +185,11 @@ select.form-control {
 
 		.box-header {
 			padding-inline-end: 1.5rem;
-			margin-bottom: var(--margin-xs);
+			margin-bottom: var(--margin-sm);
 		}
 
 		.box-subtitle {
+			margin-top: calc(-1 * var(--margin-xs));
 			margin-bottom: var(--margin-sm);
 		}
 
@@ -199,8 +200,9 @@ select.form-control {
 		}
 	}
 
+	.address-box p,
 	.contact-box p {
-		line-height: 1.1;
+		line-height: 1.4;
 	}
 
 	.contact-box .contact-line {


### PR DESCRIPTION
Rebuilds the Address & Contact cards on a party's form using espresso
components, and enables quick entry for both doctypes.

_**Before:**_

<img width="2936" height="1670" alt="image" src="https://github.com/user-attachments/assets/e8192758-0ae6-426f-b04b-d0750d24500e" />


**_After:_**

https://github.com/user-attachments/assets/b4d0ec03-5588-4f22-a9f1-1665a389766f




- Cards use the espresso button, badge, dropdown and empty state, with a kebab
  menu in place of the edit pencil.
- Contact cards are trimmed to the primary details, and status now shows as
  badges and a subtitle instead of interpuncts.
- Unlink replaces Delete, so a record shared with other parties survives.
- Address and Contact can be created from a quick entry dialog. A record created
  from a party's form is linked back to it, and the user stays on that form
  after saving.

Depends On: https://github.com/frappe/erpnext/pull/57838

no-docs
