### PR TITLE
feat: add depreacted flag for doctype

### DIFF
--- a/frappe/core/doctype/doctype/doctype.js
+++ b/frappe/core/doctype/doctype/doctype.js
@@ -50,6 +50,7 @@ frappe.ui.form.on("DocType", {
 			frm.toggle_enable("custom", 0);
 			frm.toggle_enable("is_virtual", 0);
 			frm.toggle_enable("beta", 0);
+			frm.toggle_enable("deprecated", 0);
 		}
 
 		if (!frm.is_new() && !frm.doc.istable) {

--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -42,6 +42,7 @@
   "track_views",
   "custom",
   "beta",
+  "deprecated",
   "is_virtual",
   "queue_in_background",
   "description",
@@ -206,6 +207,14 @@
    "fieldname": "beta",
    "fieldtype": "Check",
    "label": "Beta"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:!doc.istable",
+   "description": "Marks this DocType as deprecated. It will continue to work, but users will be warned against using it.",
+   "fieldname": "deprecated",
+   "fieldtype": "Check",
+   "label": "Deprecated"
   },
   {
    "fieldname": "fields",
@@ -803,7 +812,7 @@
    "link_fieldname": "document_type"
   }
  ],
- "modified": "2026-05-26 16:07:46.949040",
+ "modified": "2026-07-30 13:10:20.823749",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocType",

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -116,6 +116,7 @@ class DocType(Document):
 		default_email_template: DF.Link | None
 		default_print_format: DF.Data | None
 		default_view: DF.Literal[None]
+		deprecated: DF.Check
 		description: DF.SmallText | None
 		document_type: DF.Literal["", "Document", "Setup", "System", "Other"]
 		documentation: DF.Data | None

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.json
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.json
@@ -4,6 +4,7 @@
  "allow_rename": 1,
  "autoname": "field:label",
  "creation": "2016-02-22 03:47:45.387068",
+ "deprecated": 1,
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
@@ -151,7 +152,7 @@
   }
  ],
  "links": [],
- "modified": "2026-02-04 13:59:30.578370",
+ "modified": "2026-07-30 13:29:53.139874",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Desktop Icon",

--- a/frappe/desk/doctype/desktop_layout/desktop_layout.json
+++ b/frappe/desk/doctype/desktop_layout/desktop_layout.json
@@ -3,6 +3,7 @@
  "allow_rename": 1,
  "autoname": "field:user",
  "creation": "2026-01-18 02:17:17.304705",
+ "deprecated": 1,
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
@@ -27,7 +28,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-01-25 15:30:12.805037",
+ "modified": "2026-08-05 12:50:00.903099",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Desktop Layout",

--- a/frappe/desk/doctype/desktop_layout/test_desktop_layout.py
+++ b/frappe/desk/doctype/desktop_layout/test_desktop_layout.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026, Frappe Technologies and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class IntegrationTestDesktopLayout(IntegrationTestCase):
+	"""
+	Integration tests for DesktopLayout.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.json
+++ b/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.json
@@ -3,6 +3,7 @@
  "allow_rename": 1,
  "autoname": "field:title",
  "creation": "2025-08-12 12:06:45.016314",
+ "deprecated": 1,
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
@@ -79,7 +80,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-02-20 15:19:27.520469",
+ "modified": "2026-08-05 12:49:37.185845",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Workspace Sidebar",

--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -44,6 +44,15 @@
 				}) %}
 			</div>
 			{% endif %}
+			{% if frm.meta.deprecated %}
+			<div class="pt-1">
+				{%= frappe.ui.badge.html({
+					label: __("Deprecated"),
+					theme: "red",
+					title: __("This feature is deprecated and may be removed in a future release"),
+				}) %}
+			</div>
+			{% endif %}
 			{% if (title && title !== frm.doc.name) { %}
 			<div class="form-name-container mt-1 flex justify-between form-name-copy" data-copy="{%= frappe.utils.escape_html(frappe.utils.html2text(frm.doc.name)) %}" title="{%= frappe.utils.escape_html(frappe.utils.html2text(frm.doc.name)) %}" >
 				<span class="ellipsis mr-3">{%= frappe.utils.escape_html(frappe.utils.html2text(frm.doc.name)) %}</span>

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -185,6 +185,21 @@ frappe.views.BaseList = class BaseList {
 
 	set_title() {
 		this.page.set_title(this.page_title, null, true, "", this.meta?.description);
+		this.set_deprecated_badge();
+	}
+
+	set_deprecated_badge() {
+		this.page.$title_area.find(".deprecated-badge").remove();
+		if (!this.meta?.deprecated) return;
+
+		frappe.ui
+			.badge({
+				label: __("Deprecated"),
+				theme: "red",
+				title: __("This DocType is deprecated and may be removed in a future release"),
+				css_class: "deprecated-badge",
+			})
+			.appendTo(this.page.$title_area);
 	}
 
 	setup_view_menu() {

--- a/frappe/public/scss/desk/page.scss
+++ b/frappe/public/scss/desk/page.scss
@@ -40,6 +40,11 @@
 		display: inline-flex;
 		align-items: center;
 
+		.deprecated-badge {
+			margin-left: var(--margin-sm);
+			flex-shrink: 0;
+		}
+
 		.page-indicator-pill {
 			margin-left: var(--margin-sm);
 


### PR DESCRIPTION
Mimics how experimental is shown as a badge

<img width="1165" height="900" alt="Screenshot 2026-08-05 at 12 11 00 PM" src="https://github.com/user-attachments/assets/eb0b0872-7943-4cbb-aac2-1bf82d0271ce" />

`no-docs` very self explanatory.