### PR TITLE
fix: Return `Self | None` type from `doc.get_latest()`

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1864,7 +1864,7 @@ class Document(BaseDocument):
 	def load_doc_before_save(self, *, raise_exception: bool = False):
 		"""load existing document from db before saving"""
 
-		self._doc_before_save = None
+		self._doc_before_save: "Self | None" = None
 
 		if self.is_new():
 			return


### PR DESCRIPTION
`Document.get_latest()` was returning `Document | None` even in contexts where the return type should obviously be a specific known doctype.

closes https://github.com/frappe/frappe/issues/24811 (my own issue)