### PR TITLE
fix: form does not render when form sidebar is disabled (backport #40708)

### DIFF
--- a/cypress/integration/form_web_link.js
+++ b/cypress/integration/form_web_link.js
@@ -1,0 +1,43 @@
+context("Form Web Link", () => {
+	const route = "cypress-web-link-page";
+
+	const set_form_sidebar = (value) => {
+		cy.window()
+			.its("frappe")
+			.then((frappe) => {
+				cy.set_value("User", frappe.session.user, { form_sidebar: value });
+			});
+	};
+
+	before(() => {
+		cy.login();
+		cy.visit("/app/website");
+		cy.insert_doc(
+			"Web Page",
+			{
+				title: "Cypress Web Link Page",
+				route: route,
+				published: 1,
+				content_type: "HTML",
+				main_section_html: "<p>Cypress</p>",
+			},
+			true
+		);
+		set_form_sidebar(0);
+	});
+
+	after(() => {
+		cy.login();
+		cy.visit("/app/website");
+		set_form_sidebar(1);
+		cy.remove_doc("Web Page", route);
+	});
+
+	it("renders a published website page when the form sidebar is disabled", () => {
+		cy.login();
+		cy.visit(`/app/web-page/${route}`);
+
+		cy.get('.frappe-control[data-fieldname="title"]').should("be.visible");
+		cy.get('.frappe-control[data-fieldname="route"]').should("be.visible");
+	});
+});

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1156,6 +1156,8 @@ frappe.ui.form.Form = class FrappeForm {
 	}
 
 	add_web_link(path, label) {
+		if (!this.sidebar) return;
+
 		label = __(label) || __("See on Website");
 		this.web_link = this.sidebar
 			.add_user_action(__(label), function () {})


### PR DESCRIPTION
## Summary

Manual backport of #40708, merged to develop and carried to version-16-hotfix as #40715. The v15 backport never happened, so version-15-hotfix still has the bug.

Opening a published Web Page, Web Form or any other website generator document with the form sidebar turned off renders an empty form. `render_form` only builds `this.sidebar` when the `form_sidebar` user setting is on, but `add_web_link` assumes it exists, so `show_web_link` throws a TypeError out of `refresh_header`. The exception rejects the `render_form` promise chain before `refresh_fields()` runs, leaving the body blank.

Guarding `add_web_link` on the sidebar lets the chain finish. With no sidebar there is nowhere to put the link, so skipping it is the expected behaviour, and nothing changes when the sidebar is on. `show_report_bug_link` goes through the same path for beta doctypes.

Cypress spec is the one from #40708, adapted to v15 routes and to v15's `remove_doc`, which takes no ignore flag and asserts a 202; the doc is inserted with `ignore_duplicate` instead and removed in `after`.

## v15 broken 

<img width="1366" height="858" alt="Screenshot 2026-08-05 at 3 10 28 PM" src="https://github.com/user-attachments/assets/c5056402-2bb7-4ffe-8476-7e7ec8a6aea6" />

## v15 fixed

<img width="1347" height="869" alt="Screenshot 2026-08-05 at 3 12 00 PM" src="https://github.com/user-attachments/assets/77e61472-2a29-47cd-9951-a4f28d2b2eb8" />

