### PR TITLE
refactor(defaults): share sys default helpers with web bundle

### DIFF
--- a/frappe/public/js/frappe-web.bundle.js
+++ b/frappe/public/js/frappe-web.bundle.js
@@ -5,6 +5,7 @@ import "./frappe/provide.js";
 import "./frappe/translate.js";
 import "./frappe/form/formatters.js";
 import "./frappe/format.js";
+import "./frappe/sys_defaults.js";
 import "./frappe/utils/number_format.js";
 import "./frappe/utils/utils.js";
 

--- a/frappe/public/js/frappe/defaults.js
+++ b/frappe/public/js/frappe/defaults.js
@@ -1,7 +1,9 @@
 // Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 // MIT License. See license.txt
 
-frappe.defaults = {
+import "./sys_defaults.js";
+
+Object.assign(frappe.defaults, {
 	get_user_default: function (key) {
 		let defaults = frappe.boot.user.defaults;
 		let d = defaults[key];
@@ -57,19 +59,6 @@ frappe.defaults = {
 		// filter out values which are not permitted to the user
 		d = d.filter((item) => frappe.defaults.in_user_permission(key, item));
 		return d;
-	},
-	get_global_default: function (key) {
-		var d = frappe.sys_defaults[key];
-		if ($.isArray(d)) d = d[0];
-		return d;
-	},
-	get_global_defaults: function (key) {
-		var d = frappe.sys_defaults[key];
-		if (!$.isArray(d)) d = [d];
-		return d;
-	},
-	is_enabled: function (key) {
-		return cint(this.get_global_default(key)) === 1;
 	},
 	set_user_default_local: function (key, value) {
 		frappe.boot.user.defaults[key] = value;
@@ -137,4 +126,4 @@ frappe.defaults = {
 			frappe.defaults.update_user_permissions();
 		}
 	},
-};
+});

--- a/frappe/public/js/frappe/sys_defaults.js
+++ b/frappe/public/js/frappe/sys_defaults.js
@@ -1,0 +1,20 @@
+// Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+// MIT License. See license.txt
+
+frappe.provide("frappe.defaults");
+
+Object.assign(frappe.defaults, {
+	get_global_default: function (key) {
+		var d = frappe.sys_defaults[key];
+		if ($.isArray(d)) d = d[0];
+		return d;
+	},
+	get_global_defaults: function (key) {
+		var d = frappe.sys_defaults[key];
+		if (!$.isArray(d)) d = [d];
+		return d;
+	},
+	is_enabled: function (key) {
+		return cint(this.get_global_default(key)) === 1;
+	},
+});


### PR DESCRIPTION
**Problem:** After moving checkboxes to `frappe.defaults.is_enabled`, website pages broke because `defaults.js` is desk-only. `number_format.js` (and anything else that calls `is_enabled`) runs in `frappe-web.bundle.js`, where `frappe.defaults` was undefined.

**Fix:** Move the sys-default helpers (`get_global_default`, `get_global_defaults`, `is_enabled`) into `sys_defaults.js`, import that from both `defaults.js` and `frappe-web.bundle.js`, so the same helpers are available on desk and web.