### PR TITLE
fix: Virtulization and pagination issue due to variable card height

### DIFF
--- a/cypress/integration/kanban.js
+++ b/cypress/integration/kanban.js
@@ -182,6 +182,32 @@ context("Kanban Board", () => {
 		cy.get("@open-cards").find(".kanban-card .kanban-card-doc").should("not.contain", "ID:");
 	});
 
+	it("Shows fieldtype icons when labels are hidden", () => {
+		cy.call("frappe.desk.doctype.kanban_board.kanban_board.save_settings", {
+			board_name: "ToDo Kanban",
+			settings: { fields: ["status", "priority"], show_labels: 0 },
+		});
+
+		visit_todo_kanban();
+		cy.get('.kanban-column[data-column-value="Open"] .kanban-cards').as("open-cards");
+		cy.get("@open-cards")
+			.find(".kanban-card .kanban-card-doc")
+			.first()
+			.as("card-doc")
+			.should("not.contain", "Status:")
+			.and("not.contain", "Priority:");
+		cy.get("@card-doc")
+			.find(".kanban-doc-icon")
+			.should("have.length.at.least", 1)
+			.first()
+			.should("have.attr", "title")
+			.and("not.be.empty");
+		cy.get("@card-doc")
+			.find(".kanban-doc-icon")
+			.first()
+			.should("have.attr", "title", "Status");
+	});
+
 	const test_column_page_prefetch = () => {
 		cy.call("frappe.tests.ui_test_helpers.create_multiple_todo_records");
 		cy.intercept(

--- a/frappe/public/js/frappe/views/kanban/kanban_board.bundle.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_board.bundle.js
@@ -520,16 +520,8 @@ if (frappe.views.KanbanView) {
 				}, show_empty_state)
 			);
 
-			// Order sync on load is expensive for large boards (10k+ DB lookups server-side).
-			// saved card server-side) and, on corrupt orders, re-saves cards and
-			// triggers TimestampMismatch errors.
 			requestAnimationFrame(() => {
-				const cols = store.cur_list?.board?.columns || [];
-				if (!cols.length) return;
-				const total_saved = cols.reduce((n, col) => n + parse_column_order(col).length, 0);
-				if (total_saved <= LARGE_BOARD_ORDER_SYNC_LIMIT) {
-					store.update_order();
-				}
+				store.update_order();
 			});
 		}
 
@@ -1378,7 +1370,6 @@ if (frappe.views.KanbanView) {
 		return self;
 	};
 
-	// Fieldtype → lucide icon, shown in place of the label when labels are hidden.
 	const FIELD_TYPE_ICONS = {
 		Data: "type",
 		"Small Text": "text-align-start",
@@ -1430,8 +1421,6 @@ if (frappe.views.KanbanView) {
 				disable_click: card._disable_click ? "disable-click" : "",
 				creation: card.creation,
 				doc_content: get_doc_content(card),
-				// Show the image as a fixed-size avatar beside the title only when the
-				// card actually has one — the title row height is fixed either way.
 				avatar_html: image_url
 					? frappe.ui.avatar.html({
 							label: title,
@@ -1451,8 +1440,6 @@ if (frappe.views.KanbanView) {
 			}
 		}
 
-		// Render every configured field on its own single line (missing values show
-		// "-") so all cards in a board have the same number of rows and height.
 		function get_doc_content(card) {
 			let fields = [];
 			const show_labels = get_kanban_board_show_labels();
@@ -1484,7 +1471,6 @@ if (frappe.views.KanbanView) {
 						</div>
 					`);
 				} else {
-					// Label hidden → show a fieldtype icon (tooltip = label) then value.
 					const label = frappe.utils.escape_html(__(field.label, null, field.parent));
 					const icon = frappe.utils.icon(get_field_icon(field), "sm");
 					fields.push(`

--- a/frappe/public/js/frappe/views/kanban/kanban_board.bundle.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_board.bundle.js
@@ -521,8 +521,13 @@ if (frappe.views.KanbanView) {
 			);
 
 			// Order sync on load is expensive for large boards (10k+ DB lookups server-side).
+			// saved card server-side) and, on corrupt orders, re-saves cards and
+			// triggers TimestampMismatch errors.
 			requestAnimationFrame(() => {
-				if (store.cards.length <= LARGE_BOARD_ORDER_SYNC_LIMIT) {
+				const cols = store.cur_list?.board?.columns || [];
+				if (!cols.length) return;
+				const total_saved = cols.reduce((n, col) => n + parse_column_order(col).length, 0);
+				if (total_saved <= LARGE_BOARD_ORDER_SYNC_LIMIT) {
 					store.update_order();
 				}
 			});
@@ -1373,6 +1378,40 @@ if (frappe.views.KanbanView) {
 		return self;
 	};
 
+	// Fieldtype → lucide icon, shown in place of the label when labels are hidden.
+	const FIELD_TYPE_ICONS = {
+		Data: "type",
+		"Small Text": "text-align-start",
+		Text: "text-align-start",
+		"Long Text": "text-align-start",
+		"Text Editor": "text-align-start",
+		Code: "code",
+		Link: "link",
+		"Dynamic Link": "link",
+		Select: "list",
+		Date: "calendar",
+		Datetime: "calendar-clock",
+		Time: "clock",
+		Currency: "banknote",
+		Float: "hash",
+		Int: "hash",
+		Percent: "percent",
+		Check: "square-check",
+		Phone: "phone",
+		Rating: "star",
+		Color: "palette",
+		Duration: "timer",
+		Attach: "paperclip",
+		"Attach Image": "image",
+		Geolocation: "map-pin",
+	};
+
+	function get_field_icon(field) {
+		if (field.fieldtype === "Data" && field.options === "Email") return "mail";
+		if (field.fieldtype === "Data" && field.options === "Phone") return "phone";
+		return FIELD_TYPE_ICONS[field.fieldtype] || "info";
+	}
+
 	frappe.views.KanbanBoardCard = function (card, wrapper) {
 		var self = {};
 
@@ -1383,13 +1422,24 @@ if (frappe.views.KanbanView) {
 		}
 
 		function make_dom() {
+			const title = frappe.utils.escape_html(frappe.utils.html2text(card.title));
+			const image_url = cur_list.get_image_url(card);
 			var opts = {
 				name: card.name,
-				title: frappe.utils.escape_html(frappe.utils.html2text(card.title)),
+				title: title,
 				disable_click: card._disable_click ? "disable-click" : "",
 				creation: card.creation,
 				doc_content: get_doc_content(card),
-				image_url: cur_list.get_image_url(card),
+				// Show the image as a fixed-size avatar beside the title only when the
+				// card actually has one — the title row height is fixed either way.
+				avatar_html: image_url
+					? frappe.ui.avatar.html({
+							label: title,
+							image: image_url,
+							size: "lg",
+							shape: "square",
+					  })
+					: "",
 				form_link: frappe.utils.get_form_link(card.doctype, card.name),
 			};
 
@@ -1401,8 +1451,11 @@ if (frappe.views.KanbanView) {
 			}
 		}
 
+		// Render every configured field on its own single line (missing values show
+		// "-") so all cards in a board have the same number of rows and height.
 		function get_doc_content(card) {
 			let fields = [];
+			const show_labels = get_kanban_board_show_labels();
 			const field_names = get_kanban_board_fields();
 			for (let field_name of field_names) {
 				const fieldname =
@@ -1412,20 +1465,35 @@ if (frappe.views.KanbanView) {
 					frappe.meta.docfield_map[card.doctype]?.[fieldname] ||
 					frappe.model.get_std_field(fieldname);
 				if (!field) continue;
-				let label = get_kanban_board_show_labels()
-					? `<span>${__(field.label, null, field.parent)}: </span>`
-					: "";
-				let rendered_value = card.doc[fieldname];
+
+				let raw = card.doc[fieldname];
 				if (field.fieldtype === "Data") {
-					rendered_value = frappe.utils.escape_html(rendered_value);
+					raw = frappe.utils.escape_html(raw);
 				}
-				let value = frappe.format(rendered_value, field);
-				fields.push(`
-					<div class="text-muted text-truncate">
-						${label}
-						<span>${value}</span>
-					</div>
-				`);
+				let value =
+					raw === null || raw === undefined || raw === ""
+						? ""
+						: frappe.format(raw, field);
+				if (value === "" || value == null) value = "-";
+
+				if (show_labels) {
+					fields.push(`
+						<div class="kanban-doc-field truncate text-muted">
+							<span>${__(field.label, null, field.parent)}: </span>
+							<span>${value}</span>
+						</div>
+					`);
+				} else {
+					// Label hidden → show a fieldtype icon (tooltip = label) then value.
+					const label = frappe.utils.escape_html(__(field.label, null, field.parent));
+					const icon = frappe.utils.icon(get_field_icon(field), "sm");
+					fields.push(`
+						<div class="kanban-doc-field flex items-center text-muted">
+							<span class="kanban-doc-icon shrink-0" title="${label}">${icon}</span>
+							<span class="truncate">${value}</span>
+						</div>
+					`);
+				}
 			}
 
 			return fields.join("");
@@ -1471,18 +1539,11 @@ if (frappe.views.KanbanView) {
 			`;
 
 			if (card.color && frappe.ui.color.validate_hex(card.color)) {
-				const $div = $("<div>");
-				$("<div></div>")
-					.css({
-						width: "30px",
-						height: "4px",
-						borderRadius: "2px",
-						marginBottom: "8px",
-						backgroundColor: card.color,
-					})
-					.appendTo($div);
-
-				self.$card.find(".kanban-card .kanban-title-area").prepend($div);
+				// Left accent border — does not change card height (unlike a bar).
+				self.$card
+					.find(".kanban-card")
+					.addClass("has-color")
+					.css("--kanban-card-accent", card.color);
 			}
 
 			self.$card
@@ -1883,7 +1944,9 @@ if (frappe.views.KanbanView) {
 		}
 	}
 
-	/** Full column order for drag/save — saved order plus loaded cards not in it yet. */
+	/** Full column order for drag/save — saved order plus loaded cards not in it yet.
+	 * Deduplicated so a corrupt saved order (same card listed twice) is never
+	 * re-persisted or rendered twice. */
 	function get_column_full_order(column, cards_index) {
 		const saved = parse_column_order(column);
 		const column_cards = cards_index?.by_column[column.title] || [];
@@ -1891,22 +1954,26 @@ if (frappe.views.KanbanView) {
 		if (!saved.length) {
 			return column_cards.map((card) => card.name);
 		}
-		if (!column_cards.length) {
-			return saved.slice();
+
+		const seen = new Set();
+		const ordered_names = [];
+		for (let i = 0; i < saved.length; i++) {
+			if (!seen.has(saved[i])) {
+				seen.add(saved[i]);
+				ordered_names.push(saved[i]);
+			}
 		}
-
-		const saved_set = new Set(saved);
-		const ordered_names = saved.slice();
-
 		for (let i = 0; i < column_cards.length; i++) {
-			if (!saved_set.has(column_cards[i].name)) {
+			if (!seen.has(column_cards[i].name)) {
+				seen.add(column_cards[i].name);
 				ordered_names.push(column_cards[i].name);
 			}
 		}
 		return ordered_names;
 	}
 
-	/** Column card order for display / sync — saved order first, then cards missing from it. */
+	/** Column card order for display / sync — saved order first, then cards missing
+	 * from it. Deduplicated so a duplicated saved order never renders a card twice. */
 	function get_column_display_order(column, cards_index) {
 		const column_cards = cards_index?.by_column[column.title] || [];
 		if (!column_cards.length) return [];
@@ -1915,14 +1982,18 @@ if (frappe.views.KanbanView) {
 		if (!saved.length) return column_cards.map((card) => card.name);
 
 		const names_in_column = new Set(column_cards.map((card) => card.name));
-		const saved_set = new Set(saved);
+		const seen = new Set();
 		const ordered_names = [];
 
 		for (let i = 0; i < saved.length; i++) {
-			if (names_in_column.has(saved[i])) ordered_names.push(saved[i]);
+			if (names_in_column.has(saved[i]) && !seen.has(saved[i])) {
+				seen.add(saved[i]);
+				ordered_names.push(saved[i]);
+			}
 		}
 		for (let i = 0; i < column_cards.length; i++) {
-			if (!saved_set.has(column_cards[i].name)) {
+			if (!seen.has(column_cards[i].name)) {
+				seen.add(column_cards[i].name);
 				ordered_names.push(column_cards[i].name);
 			}
 		}

--- a/frappe/public/js/frappe/views/kanban/kanban_card.html
+++ b/frappe/public/js/frappe/views/kanban/kanban_card.html
@@ -2,10 +2,10 @@
 	<div class="kanban-card content">
 		<div class="kanban-card-body">
 			<div class="kanban-title-area">
-				<div class="kanban-card-header flex items-center">
+				<div class="kanban-card-header">
 					{{ avatar_html }}
-					<a href="{{ form_link }}" class="kanban-card-title-link min-w-0 flex-1">
-						<div class="kanban-card-title ellipsis truncate" title="{{title}}">
+					<a href="{{ form_link }}" class="kanban-card-title-link">
+						<div class="kanban-card-title ellipsis" title="{{title}}">
 							{{ title }}
 						</div>
 					</a>
@@ -16,7 +16,7 @@
 				</div>
 				{% } %}
 			</div>
-			<div class="kanban-card-meta flex items-center">
+			<div class="kanban-card-meta">
 			</div>
 		</div>
 	</div>

--- a/frappe/public/js/frappe/views/kanban/kanban_card.html
+++ b/frappe/public/js/frappe/views/kanban/kanban_card.html
@@ -1,23 +1,22 @@
 <div class="kanban-card-wrapper {{ disable_click }}" data-name="{{encodeURIComponent(name)}}">
 	<div class="kanban-card content">
-		{% if(image_url) { %}
-		<div class="kanban-image">
-			<img  src="{{image_url}}" alt="{{title}}">
-		</div>
-		{% } %}
 		<div class="kanban-card-body">
 			<div class="kanban-title-area">
-				<a href="{{ form_link }}">
-					<div class="kanban-card-title ellipsis" title="{{title}}">
-						{{ title }}
-					</div>
-				</a>
-				<br>
+				<div class="kanban-card-header flex items-center">
+					{{ avatar_html }}
+					<a href="{{ form_link }}" class="kanban-card-title-link min-w-0 flex-1">
+						<div class="kanban-card-title ellipsis truncate" title="{{title}}">
+							{{ title }}
+						</div>
+					</a>
+				</div>
+				{% if(doc_content) { %}
 				<div class="kanban-card-doc text-muted">
 					{{ doc_content }}
 				</div>
+				{% } %}
 			</div>
-			<div class="kanban-card-meta">
+			<div class="kanban-card-meta flex items-center">
 			</div>
 		</div>
 	</div>

--- a/frappe/public/js/frappe/views/kanban/kanban_pagination.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_pagination.js
@@ -33,8 +33,12 @@ export const kanban_pagination = {
 	},
 
 	rebuild_column_loaded_names(column, field_name) {
+		// Callers pass either a mapped board column (has `title`) or a raw Kanban
+		// Board child row (has `column_name`); resolve either so `loaded_names` is
+		// rebuilt correctly. If this stays empty the memory cap never engages.
+		const column_title = column.title ?? column.column_name;
 		const saved = this.parse_column_order(column.order);
-		const in_column = (this.data || []).filter((d) => d[field_name] === column.title);
+		const in_column = (this.data || []).filter((d) => d[field_name] === column_title);
 		const in_set = new Set(in_column.map((d) => d.name));
 		const names = [];
 

--- a/frappe/public/scss/desk/kanban.scss
+++ b/frappe/public/scss/desk/kanban.scss
@@ -170,43 +170,63 @@
 					margin-bottom: var(--margin-xl);
 				}
 
+				// Every card is the same fixed height so virtual scrolling stays
+				// glitch-free. Content that does not fit is truncated.
 				.kanban-card {
-					@include flex(flex, space-between, null, column);
+					@include flex(flex, flex-start, null, column);
 					margin-top: var(--margin-sm);
-					min-height: 100px;
+					overflow: hidden;
 					@include card($padding: 0, $background-color: var(--kanban-card-bg));
 					box-shadow: none;
 					border: 1px solid var(--border-color);
 
-					.kanban-image {
-						height: 125px;
-
-						img {
-							border-radius: var(--radius) var(--radius) 0 0;
-							object-position: top;
-							object-fit: cover;
-							margin: 0 auto;
-							height: 100%;
-							width: 100%;
-							min-width: 100%;
-							color: transparent;
-							position: relative;
-						}
+					&.has-color {
+						border-left: 3px solid var(--kanban-card-accent);
 					}
 
 					.kanban-card-body {
 						cursor: grab;
 						padding: var(--padding-md);
+						width: 100%;
+						display: flex;
+						flex-direction: column;
+						gap: var(--margin-xs);
 
+						// Kept as a wrapper for backward compatibility (customizations
+						// hook onto it); stays layout-neutral.
 						.kanban-title-area {
-							margin-bottom: 12px;
-							width: 100%;
-							max-width: 100%;
-							font-size: var(--text-md);
-							font-weight: 500;
+							display: flex;
+							flex-direction: column;
+							gap: var(--margin-xs);
+							min-width: 0;
+						}
 
-							.kanban-card-title,
-							.kanban-card-doc {
+						// Avatar (image or initials) + title on one fixed-height row so
+						// 1-line and 2-line titles reserve the same space.
+						.kanban-card-header {
+							display: flex;
+							align-items: flex-start;
+							gap: var(--margin-sm);
+							height: 42px;
+							overflow: hidden;
+
+							.es-avatar {
+								flex: 0 0 auto;
+							}
+
+							.kanban-card-title-link {
+								flex: 1 1 auto;
+								min-width: 0;
+								color: var(--text-color);
+
+								&:hover {
+									text-decoration: none;
+								}
+							}
+
+							.kanban-card-title {
+								font-size: var(--text-md);
+								font-weight: 500;
 								white-space: normal !important;
 								display: -webkit-box;
 								-webkit-box-orient: vertical;
@@ -216,48 +236,82 @@
 								text-overflow: ellipsis;
 								word-break: break-word;
 							}
+						}
 
-							.kanban-card-doc {
-								.text-muted div {
-									display: inline;
+						// Each configured field on its own single, truncated line so
+						// every card in a board has the same number of rows (missing
+						// values render "-").
+						.kanban-card-doc {
+							display: flex;
+							flex-direction: column;
+							gap: 2px;
+							font-size: var(--text-md);
+
+							.kanban-doc-field {
+								min-width: 0;
+								line-height: 1.5;
+
+								.kanban-doc-icon {
+									display: inline-flex;
+									align-items: center;
+									margin-right: var(--margin-xs);
+									color: var(--text-muted);
+
+									.icon {
+										width: 13px;
+										height: 13px;
+									}
 								}
-							}
 
-							.kanban-card-creation {
-								font-size: var(--text-md);
-								color: var(--text-muted);
-								margin-top: var(--margin-xs);
+								.truncate {
+									flex: 1 1 auto;
+									min-width: 0;
+								}
 							}
 						}
 
+						// Single fixed-height row: tags on the left, like + assignees right.
 						.kanban-card-meta {
+							flex: 0 0 auto;
+							display: flex;
+							align-items: center;
+							gap: var(--margin-xs);
+							min-height: 24px;
+
 							.list-comment-count {
-								width: 30px;
+								flex: 0 0 auto;
 							}
 
-							.like-action:not(.liked) {
-								.icon use {
+							.like-action {
+								order: -1; // like on the left, assignees pushed right
+
+								&:not(.liked) .icon use {
 									stroke: var(--text-muted);
 								}
 							}
 
 							.kanban-tags {
 								@include get_textstyle("sm", "regular");
-								margin-bottom: 8px;
+								display: flex;
+								flex-wrap: nowrap;
+								overflow: hidden;
+								min-width: 0;
 
 								.tag-pill {
 									border-radius: 100px;
 									height: 22px;
 									width: auto;
 									padding: 2px 8px;
-									margin-bottom: var(--margin-xs);
 									margin-right: var(--margin-xs);
+									white-space: nowrap;
+									flex: 0 0 auto;
 								}
 							}
 
 							.kanban-assignments {
 								display: flex;
-								float: right;
+								margin-left: auto;
+								flex: 0 0 auto;
 
 								.avatar {
 									cursor: default;

--- a/frappe/public/scss/desk/kanban.scss
+++ b/frappe/public/scss/desk/kanban.scss
@@ -170,8 +170,6 @@
 					margin-bottom: var(--margin-xl);
 				}
 
-				// Every card is the same fixed height so virtual scrolling stays
-				// glitch-free. Content that does not fit is truncated.
 				.kanban-card {
 					@include flex(flex, flex-start, null, column);
 					margin-top: var(--margin-sm);
@@ -201,8 +199,6 @@
 							min-width: 0;
 						}
 
-						// Avatar (image or initials) + title on one fixed-height row so
-						// 1-line and 2-line titles reserve the same space.
 						.kanban-card-header {
 							display: flex;
 							align-items: flex-start;
@@ -238,9 +234,6 @@
 							}
 						}
 
-						// Each configured field on its own single, truncated line so
-						// every card in a board has the same number of rows (missing
-						// values render "-").
 						.kanban-card-doc {
 							display: flex;
 							flex-direction: column;
@@ -270,7 +263,6 @@
 							}
 						}
 
-						// Single fixed-height row: tags on the left, like + assignees right.
 						.kanban-card-meta {
 							flex: 0 0 auto;
 							display: flex;


### PR DESCRIPTION
### Problem

On the Kanban board, some cards had a picture and some didn't. The ones with pictures were taller. Since the board only draws the cards you can see (to stay fast), it needs every card to be the same height to know where things are. Mismatched heights broke that math — so scrolling felt glitchy, and when you scrolled down it would stop loading more cards, so you couldn't reach everything.

On top of that, the same card sometimes showed up twice, and every time the board opened it did a huge amount of unnecessary work on the server, which threw errors like "this record was modified after you opened it."

### Solve by
We made all cards the same height. The image now shows as a small avatar next to the title (only when there actually is one), and every card shows the same set of info fields — with a "-" when a value is empty and a little icon for each field type. Same layout on every card = same height = smooth scrolling and reliable loading all the way down.

`.kanban-image` was removed in favor of the avatar next to the title; other card class names are unchanged so existing customizations keep working.

<img width="1463" height="856" alt="image" src="https://github.com/user-attachments/assets/f3ae04a2-ecdd-4be5-b9b3-8f5e84762784" />
