### PR TITLE
perf: reuse cached web form doc when building link options

### DIFF
--- a/frappe/website/doctype/web_form/test_web_form.py
+++ b/frappe/website/doctype/web_form/test_web_form.py
@@ -14,6 +14,7 @@ from frappe.website.doctype.web_form.web_form import (
 	get_form_data,
 	get_link_options,
 	get_web_form_list,
+	process_link_field,
 )
 from frappe.website.serve import get_response_content
 
@@ -983,6 +984,20 @@ class TestWebForm(IntegrationTestCase):
 
 		with self.assertRaises(frappe.ValidationError):
 			web_form.save()
+
+	def test_link_options_do_not_reload_web_form_per_field(self):
+		self.add_web_form_link_field()
+
+		def link_field():
+			return frappe._dict(
+				{"fieldname": "reference_doctype", "fieldtype": "Link", "options": "Salutation"}
+			)
+
+		process_link_field(link_field(), "manage-events")
+
+		with self.assertQueryCount(6):
+			for _ in range(5):
+				process_link_field(link_field(), "manage-events")
 
 	def test_get_link_options_blocked_for_unauthorized_link_on_guest_key_form(self):
 		self.set_web_form_settings(key_required=1, login_required=0)

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -721,7 +721,7 @@ def get_context(context):
 
 
 def process_link_field(field, web_form_name, web_form_request_key=None, docname=None):
-	web_form = frappe.get_lazy_doc("Web Form", web_form_name)
+	web_form = frappe.get_cached_doc("Web Form", web_form_name)
 	ensure_guest_key_link_doctype_allowed(web_form, field.options)
 
 	field.fieldtype = "Autocomplete"
@@ -1150,7 +1150,7 @@ def get_link_options(
 	web_form_request_key=None,
 	docname=None,
 ):
-	web_form: WebForm = frappe.get_lazy_doc("Web Form", web_form_name)
+	web_form: WebForm = frappe.get_cached_doc("Web Form", web_form_name)
 
 	if web_form.login_required and frappe.session.user == "Guest":
 		frappe.throw(_("You must be logged in to use this form."), frappe.PermissionError)


### PR DESCRIPTION
`get_link_options` runs once per Link field, and both it and `process_link_field` reloaded the same Web Form document even though they only read it. That resulted in four queries per Link field, with only one fetching the actual options.

Switching to `get_cached_doc` removes the redundant loads. On a form with 25 Link fields, query count drops from **105 to 30** (warm cache). The cached document is read-only in these paths, and saving a Web Form already invalidates the cache.

This only removes redundant queries; the option fetches themselves are unchanged.