### PR TITLE
fix: expose only read-only request attributes to sandboxed templates

### DIFF
--- a/frappe/tests/test_safe_exec.py
+++ b/frappe/tests/test_safe_exec.py
@@ -307,6 +307,27 @@ class TestSafeDoc(IntegrationTestCase):
 		)
 		self.assertEqual(result.strip(), expected)
 
+	def test_request_in_template_exposes_only_safe_attributes(self):
+		from werkzeug.wrappers import Request
+
+		from frappe.utils import set_request
+
+		original = getattr(frappe.local, "request", None)
+		try:
+			set_request(method="GET", path="/app/todo?q=1")
+			request = get_safe_globals()["frappe"]["request"]
+
+			# a plain read-only view, not the live Werkzeug request
+			self.assertNotIsInstance(request, Request)
+			self.assertEqual(request.path, "/app/todo")
+			self.assertEqual(request.method, "GET")
+			self.assertEqual(request.args.get("q"), "1")
+			# uploads / stream / environ are not reachable from templates
+			self.assertIsNone(request.get("files"))
+			self.assertIsNone(request.get("environ"))
+		finally:
+			frappe.local.request = original
+
 
 class TestNoSafeExec(IntegrationTestCase):
 	def test_safe_exec_disabled_by_default(self):

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -400,6 +400,23 @@ def make_safe_get_request(url: str, **kwargs):
 	return frappe.integrations.utils.make_get_request(url, **kwargs)
 
 
+def get_safe_request():
+	"""Read-only view of the request for sandboxed templates.
+
+	Only exposes plain path/method/query attributes; the raw request object is kept out so
+	template code cannot reach uploads, the stream or the WSGI environ.
+	"""
+	request = getattr(frappe.local, "request", None)
+	if not request:
+		return frappe._dict()
+
+	return frappe._dict(
+		path=request.path,
+		method=request.method,
+		args=frappe._dict(request.args.to_dict()),
+	)
+
+
 def render_safe_globals():
 	"""Safer subset of globals for rendering ops."""
 	datautils = frappe._dict()
@@ -463,7 +480,7 @@ def render_safe_globals():
 			full_name=frappe.local.session.data.full_name
 			if getattr(frappe.local, "session", None) and getattr(frappe.local.session, "data", None)
 			else "Guest",
-			request=getattr(frappe.local, "request", {}),
+			request=get_safe_request(),
 			session=frappe._dict(
 				user=user,
 				csrf_token=frappe.local.session.data.csrf_token


### PR DESCRIPTION
- Sandboxed templates received the live Werkzeug request as `frappe.request`, exposing uploads (`request.files`), the raw stream and the WSGI environ to template code.
- Replaces it with a small read-only view exposing just `path`, `method` and query `args`; template params were already available via `frappe.form_dict`/`frappe.args`, and no core template reads the raw object.
- Added a test asserting the exposed request is a plain read-only dict without `files`/`environ`.