### PR TITLE
chore: drop cryptography and pyOpenSSL from exclude-newer-package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,7 +225,7 @@ nixpkgs-deps = [
 
 [tool.uv]
 exclude-newer = "7 days"
-exclude-newer-package = { cryptography = false, pyOpenSSL = false } # drop cryptography and pyOpenSSL after 2026-08-08
+exclude-newer-package = { }
 
 [tool.mypy]
 strict = false


### PR DESCRIPTION
Merge after 2026-08-08 when releases are older than 7 days

Introduced in https://github.com/frappe/frappe/pull/41589