### PR TITLE
fix: print the doctype default format when the requested name does not resolve

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -742,10 +742,10 @@ frappe.ui.form.PrintView = class {
 				doctype: this.frm.doc.doctype,
 				name: this.frm.doc.name,
 				letterhead: this.get_letterhead(),
+				// "Standard" when the selector is cleared: an omitted format means
+				// the doctype's default, the same as everywhere else in printing
+				print_format: this.selected_format(),
 			});
-			if (print_format.name) {
-				params.append("print_format", print_format.name);
-			}
 			if (this.additional_settings && Object.keys(this.additional_settings).length) {
 				params.append("settings", JSON.stringify(this.additional_settings));
 			}

--- a/frappe/tests/test_printview.py
+++ b/frappe/tests/test_printview.py
@@ -50,3 +50,36 @@ class PrintViewTest(IntegrationTestCase):
 
 		self.assertEqual(note.print_heading, note.name)
 		self.assertTrue(note.flags.in_print)
+
+	def test_unresolvable_format_falls_back_to_the_doctype_default(self):
+		"""Callers interpolate a missing name into the url ("format=None"), and formats
+		get renamed — either way the doctype's default wins over the built-in one."""
+		from frappe.custom.doctype.property_setter.property_setter import make_property_setter
+		from frappe.www.printview import get_print_format_doc
+
+		default = frappe.get_doc(
+			doctype="Print Format",
+			name=f"_Test Default {frappe.generate_hash(length=6)}",
+			doc_type="Note",
+			custom_format=1,
+			html="<div>default</div>",
+		).insert()
+
+		def drop_default():
+			frappe.db.delete("Property Setter", {"doc_type": "Note", "property": "default_print_format"})
+			frappe.clear_cache(doctype="Note")
+
+		self.addCleanup(drop_default)
+		make_property_setter("Note", None, "default_print_format", default.name, "Data", for_doctype=True)
+		frappe.clear_cache(doctype="Note")
+		meta = frappe.get_meta("Note")
+
+		self.assertEqual(get_print_format_doc("None", meta).name, default.name)
+		self.assertEqual(get_print_format_doc("_No Such Format ZZZ", meta).name, default.name)
+		self.assertEqual(get_print_format_doc(None, meta).name, default.name)
+		# an explicit "Standard" still means the built-in format
+		self.assertIsNone(get_print_format_doc("Standard", meta))
+
+		# without a doctype default it still degrades to the built-in format
+		drop_default()
+		self.assertIsNone(get_print_format_doc("None", frappe.get_meta("Note")))

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -37,25 +37,18 @@ def download_pdf(
 	letterhead: str | None = None,
 	settings: str | dict | None = None,
 ):
-	from frappe.printing.doctype.print_format.classic_converter import (
-		get_default_print_format,
-		uses_beta_renderer,
-	)
-	from frappe.www.printview import set_link_titles, validate_print
+	from frappe.www.printview import resolve_print_format, set_link_titles, validate_print
 
 	doc = frappe.get_doc(doctype, name)
 	validate_print(doc)
 	set_link_titles(doc)
-	if not print_format or print_format == "Standard":
-		print_format = get_default_print_format(doctype)
-	else:
-		pf_doc = frappe.get_doc("Print Format", print_format)
-		if not uses_beta_renderer(pf_doc):
-			# jinja formats have no layout for the generator — hand off to the
-			# legacy pipeline, which reads the format's template
-			from frappe.utils.print_format import download_pdf as download_jinja_pdf
+	print_format, is_beta = resolve_print_format(print_format, doc.meta)
+	if not is_beta:
+		# jinja formats have no layout for the generator — hand off to the
+		# legacy pipeline, which reads the format's template
+		from frappe.utils.print_format import download_pdf as download_jinja_pdf
 
-			return download_jinja_pdf(doctype, name, format=print_format, letterhead=letterhead)
+		return download_jinja_pdf(doctype, name, format=print_format.name, letterhead=letterhead)
 	generator = PrintFormatGenerator(print_format, doc, letterhead, settings=frappe.parse_json(settings))
 	pdf = generator.render_pdf()
 

--- a/frappe/utils/test_print_format_generator.py
+++ b/frappe/utils/test_print_format_generator.py
@@ -530,6 +530,43 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 		frappe.clear_cache()
 		self.assertIsNone(resolved(no_letterhead=0))
 
+	def test_download_pdf_without_format_uses_the_doctype_default(self):
+		"""An omitted print_format means the doctype's default, matching
+		frappe.utils.print_format.download_pdf; "Standard" means the built-in one."""
+		from unittest.mock import patch
+
+		from frappe.custom.doctype.property_setter.property_setter import make_property_setter
+		from frappe.utils.print_format_generator import PrintFormatGenerator, download_pdf
+
+		todo = self._make_todo()
+		classic = frappe.get_doc(
+			{
+				"doctype": "Print Format",
+				"name": f"_Test Default Classic {frappe.generate_hash(length=6)}",
+				"doc_type": "ToDo",
+				"custom_format": 1,
+				"html": "<div>classic</div>",
+			}
+		).insert()
+		self.addCleanup(frappe.delete_doc, "Print Format", classic.name, force=True)
+		ps = make_property_setter(
+			"ToDo", None, "default_print_format", classic.name, "Data", for_doctype=True
+		)
+		self.addCleanup(frappe.delete_doc, "Property Setter", ps.name, force=True)
+		self.addCleanup(frappe.clear_cache, doctype="ToDo")
+		frappe.clear_cache(doctype="ToDo")
+
+		with patch("frappe.utils.print_format.download_pdf") as jinja:
+			download_pdf("ToDo", todo.name)
+		self.assertEqual(jinja.call_args.kwargs["format"], classic.name)
+
+		with (
+			patch("frappe.utils.print_format.download_pdf") as jinja,
+			patch.object(PrintFormatGenerator, "render_pdf", return_value=b""),
+		):
+			download_pdf("ToDo", todo.name, print_format="Standard")
+		jinja.assert_not_called()
+
 	def test_section_justify_only_emits_known_modes(self):
 		"""justify names a CSS class, so a layout can't smuggle markup through it."""
 		from frappe.utils.print_format_generator import get_html

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -140,12 +140,21 @@ def get_print_format_doc(print_format_name: str, meta: "Meta") -> "PrintFormat" 
 
 	if print_format_name == "Standard":
 		return None
-	else:
+
+	def fetch(name):
 		try:
-			return frappe.get_doc("Print Format", print_format_name)
+			return frappe.get_doc("Print Format", name)
 		except frappe.DoesNotExistError:
-			# if old name, return standard!
+			frappe.clear_last_message()
 			return None
+
+	# a renamed or deleted format — or a caller interpolating a missing name into
+	# the url — resolves to the doctype's default, like an omitted name does
+	if doc := fetch(print_format_name):
+		return doc
+	if meta.default_print_format in (None, "", "Standard", print_format_name):
+		return None
+	return fetch(meta.default_print_format)
 
 
 def resolve_print_format(print_format_name: "str | None", meta: "Meta") -> tuple["PrintFormat", bool]:


### PR DESCRIPTION
Two ways the same document printed through a different format than the one the site had chosen as its default.

- `printview.get_print_format_doc` swallowed a failed lookup and dropped straight to the built-in Standard, skipping the doctype's default. A renamed or deleted format hit this, and so does any caller that interpolates an empty value into the url — press builds `...&format={self.meta.default_print_format}`, which sends the literal `format=None` when that field is unset
- `print_format_generator.download_pdf` ignored the doctype default when `print_format` was omitted, while `print_format.download_pdf` honoured it — it now resolves through `printview.resolve_print_format`, the same choke point printview and `get_print` use
- the desk PDF button now sends `print_format=Standard` explicitly, so clearing the selector still means the built-in format

An explicit `Standard`, and a doctype with no default at all, both still get the built-in format.

Measured on a doctype whose default is a custom format, reading the marker out of the returned PDF:

| request | before | after |
| --- | --- | --- |
| `print_format.download_pdf&format=None` | built-in Standard | doctype default |
| `print_format.download_pdf` (no format) | doctype default | doctype default |
| `print_format.download_pdf&format=Standard` | built-in Standard | built-in Standard |
| `print_format_generator.download_pdf` (no format) | built-in Standard | doctype default |
| `print_format_generator.download_pdf&print_format=None` | 404 | doctype default |
| either, with an explicit format name | that format | that format |
