### PR TITLE
fix: honour the doctype default print format in generator downloads

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -742,10 +742,10 @@ frappe.ui.form.PrintView = class {
 				doctype: this.frm.doc.doctype,
 				name: this.frm.doc.name,
 				letterhead: this.get_letterhead(),
+				// "Standard" when the selector is cleared: an omitted format means
+				// the doctype's default, the same as everywhere else in printing
+				print_format: this.selected_format(),
 			});
-			if (print_format.name) {
-				params.append("print_format", print_format.name);
-			}
 			if (this.additional_settings && Object.keys(this.additional_settings).length) {
 				params.append("settings", JSON.stringify(this.additional_settings));
 			}

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -37,25 +37,18 @@ def download_pdf(
 	letterhead: str | None = None,
 	settings: str | dict | None = None,
 ):
-	from frappe.printing.doctype.print_format.classic_converter import (
-		get_default_print_format,
-		uses_beta_renderer,
-	)
-	from frappe.www.printview import set_link_titles, validate_print
+	from frappe.www.printview import resolve_print_format, set_link_titles, validate_print
 
 	doc = frappe.get_doc(doctype, name)
 	validate_print(doc)
 	set_link_titles(doc)
-	if not print_format or print_format == "Standard":
-		print_format = get_default_print_format(doctype)
-	else:
-		pf_doc = frappe.get_doc("Print Format", print_format)
-		if not uses_beta_renderer(pf_doc):
-			# jinja formats have no layout for the generator — hand off to the
-			# legacy pipeline, which reads the format's template
-			from frappe.utils.print_format import download_pdf as download_jinja_pdf
+	print_format, is_beta = resolve_print_format(print_format, doc.meta)
+	if not is_beta:
+		# jinja formats have no layout for the generator — hand off to the
+		# legacy pipeline, which reads the format's template
+		from frappe.utils.print_format import download_pdf as download_jinja_pdf
 
-			return download_jinja_pdf(doctype, name, format=print_format, letterhead=letterhead)
+		return download_jinja_pdf(doctype, name, format=print_format.name, letterhead=letterhead)
 	generator = PrintFormatGenerator(print_format, doc, letterhead, settings=frappe.parse_json(settings))
 	pdf = generator.render_pdf()
 

--- a/frappe/utils/test_print_format_generator.py
+++ b/frappe/utils/test_print_format_generator.py
@@ -530,6 +530,43 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 		frappe.clear_cache()
 		self.assertIsNone(resolved(no_letterhead=0))
 
+	def test_download_pdf_without_format_uses_the_doctype_default(self):
+		"""An omitted print_format means the doctype's default, matching
+		frappe.utils.print_format.download_pdf; "Standard" means the built-in one."""
+		from unittest.mock import patch
+
+		from frappe.custom.doctype.property_setter.property_setter import make_property_setter
+		from frappe.utils.print_format_generator import PrintFormatGenerator, download_pdf
+
+		todo = self._make_todo()
+		classic = frappe.get_doc(
+			{
+				"doctype": "Print Format",
+				"name": f"_Test Default Classic {frappe.generate_hash(length=6)}",
+				"doc_type": "ToDo",
+				"custom_format": 1,
+				"html": "<div>classic</div>",
+			}
+		).insert()
+		self.addCleanup(frappe.delete_doc, "Print Format", classic.name, force=True)
+		ps = make_property_setter(
+			"ToDo", None, "default_print_format", classic.name, "Data", for_doctype=True
+		)
+		self.addCleanup(frappe.delete_doc, "Property Setter", ps.name, force=True)
+		self.addCleanup(frappe.clear_cache, doctype="ToDo")
+		frappe.clear_cache(doctype="ToDo")
+
+		with patch("frappe.utils.print_format.download_pdf") as jinja:
+			download_pdf("ToDo", todo.name)
+		self.assertEqual(jinja.call_args.kwargs["format"], classic.name)
+
+		with (
+			patch("frappe.utils.print_format.download_pdf") as jinja,
+			patch.object(PrintFormatGenerator, "render_pdf", return_value=b""),
+		):
+			download_pdf("ToDo", todo.name, print_format="Standard")
+		jinja.assert_not_called()
+
 	def test_section_justify_only_emits_known_modes(self):
 		"""justify names a CSS class, so a layout can't smuggle markup through it."""
 		from frappe.utils.print_format_generator import get_html


### PR DESCRIPTION
`print_format_generator.download_pdf` resolved an omitted `print_format` straight to the built-in Standard, while `print_format.download_pdf` resolves it to the doctype's default — the same document printed differently through the two endpoints.

- resolve through `printview.resolve_print_format`, the same choke point printview and `get_print` already use
- the desk PDF button now sends `print_format=Standard` explicitly, so clearing the selector still means the built-in format rather than the doctype default

This changes what an omitted `print_format` means on a whitelisted endpoint, so it ships with the client change rather than on its own.

Measured in `bench console`, calling both functions with no format argument and reading a marker out of each PDF:

| doctype default | `print_format.download_pdf` | `print_format_generator.download_pdf` |
| --- | --- | --- |
| set | doctype default | built-in Standard → **doctype default** |
| not set | built-in Standard | built-in Standard |
