### PR TITLE
fix: print the doctype default when a print format name does not resolve

### DIFF
--- a/frappe/tests/test_printview.py
+++ b/frappe/tests/test_printview.py
@@ -50,3 +50,36 @@ class PrintViewTest(IntegrationTestCase):
 
 		self.assertEqual(note.print_heading, note.name)
 		self.assertTrue(note.flags.in_print)
+
+	def test_unresolvable_format_falls_back_to_the_doctype_default(self):
+		"""Callers interpolate a missing name into the url ("format=None"), and formats
+		get renamed — either way the doctype's default wins over the built-in one."""
+		from frappe.custom.doctype.property_setter.property_setter import make_property_setter
+		from frappe.www.printview import get_print_format_doc
+
+		default = frappe.get_doc(
+			doctype="Print Format",
+			name=f"_Test Default {frappe.generate_hash(length=6)}",
+			doc_type="Note",
+			custom_format=1,
+			html="<div>default</div>",
+		).insert()
+
+		def drop_default():
+			frappe.db.delete("Property Setter", {"doc_type": "Note", "property": "default_print_format"})
+			frappe.clear_cache(doctype="Note")
+
+		self.addCleanup(drop_default)
+		make_property_setter("Note", None, "default_print_format", default.name, "Data", for_doctype=True)
+		frappe.clear_cache(doctype="Note")
+		meta = frappe.get_meta("Note")
+
+		self.assertEqual(get_print_format_doc("None", meta).name, default.name)
+		self.assertEqual(get_print_format_doc("_No Such Format ZZZ", meta).name, default.name)
+		self.assertEqual(get_print_format_doc(None, meta).name, default.name)
+		# an explicit "Standard" still means the built-in format
+		self.assertIsNone(get_print_format_doc("Standard", meta))
+
+		# without a doctype default it still degrades to the built-in format
+		drop_default()
+		self.assertIsNone(get_print_format_doc("None", frappe.get_meta("Note")))

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -140,12 +140,21 @@ def get_print_format_doc(print_format_name: str, meta: "Meta") -> "PrintFormat" 
 
 	if print_format_name == "Standard":
 		return None
-	else:
+
+	def fetch(name):
 		try:
-			return frappe.get_doc("Print Format", print_format_name)
+			return frappe.get_doc("Print Format", name)
 		except frappe.DoesNotExistError:
-			# if old name, return standard!
+			frappe.clear_last_message()
 			return None
+
+	# a renamed or deleted format — or a caller interpolating a missing name into
+	# the url — resolves to the doctype's default, like an omitted name does
+	if doc := fetch(print_format_name):
+		return doc
+	if meta.default_print_format in (None, "", "Standard", print_format_name):
+		return None
+	return fetch(meta.default_print_format)
 
 
 def resolve_print_format(print_format_name: "str | None", meta: "Meta") -> tuple["PrintFormat", bool]:


### PR DESCRIPTION
`get_print_format_doc` falls back to the doctype's default when no format name is given, but drops straight to the built-in Standard when a name is given and does not resolve — so a stale name silently prints a different document than the site's chosen default.

- retry the doctype's default before giving up, so both paths agree
- covers renamed and deleted formats, and callers that interpolate a missing value into the url (`format=None`)

An explicit `Standard`, and a doctype with no default at all, still get the built-in format.

| request | before | after |
| --- | --- | --- |
| `format=<renamed or deleted>` | built-in Standard | doctype default |
| `format=None` | built-in Standard | doctype default |
| no format param | doctype default | doctype default |
| `format=Standard` | built-in Standard | built-in Standard |
| `format=None`, no doctype default | built-in Standard | built-in Standard |
