### PR TITLE
fix(safe_exec): remove request from render globals & place in exec globals

### DIFF
--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -463,7 +463,6 @@ def render_safe_globals():
 			full_name=frappe.local.session.data.full_name
 			if getattr(frappe.local, "session", None) and getattr(frappe.local.session, "data", None)
 			else "Guest",
-			request=getattr(frappe.local, "request", {}),
 			session=frappe._dict(
 				user=user,
 				csrf_token=frappe.local.session.data.csrf_token
@@ -601,7 +600,9 @@ def exec_safe_globals():
 			),
 		),
 	)
-	return _update_namespace(render_safe, exec_safe)
+	result = _update_namespace(render_safe, exec_safe)
+	result["frappe"]["request"] = getattr(frappe.local, "request", {})
+	return result
 
 
 def get_keys_for_autocomplete(


### PR DESCRIPTION
Doubt anyone uses this, but including in exec_safe_globals just in case, no need for this to exist in render_safe_globals imo.

also related (in part) to closing Ticket 75110 as a DiD.

Thanks to @Crypto-Cat for reporting this.