### PR TITLE
Datepicker

### DIFF
--- a/cypress/integration/control_date.js
+++ b/cypress/integration/control_date.js
@@ -72,7 +72,7 @@ context("Date Control", () => {
 		cy.get_field("date", "Date").click();
 
 		//Clicking on "Today" button
-		cy.get(".datepicker--button").click();
+		cy.get('.datepicker--button[data-action="today"]').click();
 
 		//Verifying if clicking on "Today" button matches today's date
 		cy.window().then((win) => {

--- a/frappe/public/js/frappe/form/controls/date.js
+++ b/frappe/public/js/frappe/form/controls/date.js
@@ -59,6 +59,8 @@ frappe.ui.form.ControlDate = class ControlDate extends frappe.ui.form.ControlDat
 			sysdefaults && sysdefaults.date_format ? sysdefaults.date_format : "yyyy-mm-dd";
 
 		this.today_text = __("Today");
+		this.yesterday_text = __("Yesterday");
+		this.tomorrow_text = __("Tomorrow");
 		this.date_format = frappe.defaultDateFormat;
 		this.datepicker_options = {
 			language: lang,
@@ -77,7 +79,7 @@ frappe.ui.form.ControlDate = class ControlDate extends frappe.ui.form.ControlDat
 			},
 			onShow: () => {
 				this.datepicker.$datepicker
-					.find(".datepicker--button:visible")
+					.find('[data-action="today"]:visible')
 					.text(this.today_text);
 
 				this.update_datepicker_position();
@@ -111,6 +113,33 @@ frappe.ui.form.ControlDate = class ControlDate extends frappe.ui.form.ControlDat
 			this.datepicker.selectDate(this.get_now_date());
 			this.datepicker.hide();
 		});
+
+		this.add_yesterday_tomorrow_buttons();
+	}
+	add_yesterday_tomorrow_buttons() {
+		if (this.timepicker_only) return;
+
+		let $today_button = this.datepicker.$datepicker.find('[data-action="today"]');
+		if (!$today_button.length) return;
+
+		$(`<span class="datepicker--button" data-action="yesterday">${this.yesterday_text}</span>`)
+			.insertBefore($today_button)
+			.on("click", () => {
+				this.datepicker.selectDate(this.get_offset_date(-1));
+				this.datepicker.hide();
+			});
+
+		$(`<span class="datepicker--button" data-action="tomorrow">${this.tomorrow_text}</span>`)
+			.insertAfter($today_button)
+			.on("click", () => {
+				this.datepicker.selectDate(this.get_offset_date(1));
+				this.datepicker.hide();
+			});
+	}
+	get_offset_date(offset) {
+		let date = this.get_now_date();
+		date.setDate(date.getDate() + offset);
+		return date;
 	}
 	update_datepicker_position() {
 		// show datepicker above or below the input


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

This PR adds **Yesterday** and **Tomorrow** quick-select buttons to the Date field's calendar popup, alongside the existing **Today** button.

> Explain the **details** for making this change. What existing problem does the pull request solve?

The date field's calendar (`frappe.ui.form.ControlDate`, backed by the vendored air-datepicker library) only exposed a "Today" quick-select button. Users who frequently need to enter yesterday's or tomorrow's date had to either navigate the calendar manually or use the "t" keyboard shortcut (which only sets today's date). This adds explicit Yesterday/Tomorrow buttons to the same button row for faster, more discoverable date entry.

Changes in `frappe/public/js/frappe/form/controls/date.js`:
- Added translated `yesterday_text` / `tomorrow_text` alongside `today_text`.
- Added `add_yesterday_tomorrow_buttons()`, which inserts Yesterday/Tomorrow buttons before/after the existing Today button and binds them to select `now ± 1 day`.
- Added `get_offset_date(offset)` helper to compute an offset date from "now".
- Fixed the `onShow` label-translation logic to target `[data-action="today"]` specifically instead of all `.datepicker--button` elements, since the old selector would have overwritten the new buttons' labels with "Today" every time the picker opened.

No server-side logic involved — this is a client-side UI addition only.

> Screenshots/GIFs

before:
<img width="728" height="551" alt="image" src="https://github.com/user-attachments/assets/2c90a5e4-2296-4902-ad01-c61318290374" />


After:
<img width="728" height="551" alt="image" src="https://github.com/user-attachments/assets/62a4d98e-65c5-47ef-b16a-47fe69318169" />


_(add a screenshot/GIF of the calendar popup showing Yesterday | Today | Tomorrow)_