### PR TITLE
fix(file): hardening zip file uploads

### DIFF
--- a/frappe/core/api/file.py
+++ b/frappe/core/api/file.py
@@ -87,6 +87,14 @@ def get_max_file_size() -> int:
 	)
 
 
+def get_max_extract_size() -> int:
+	return (
+		cint(frappe.get_system_settings("max_zip_extract_size")) * 1024 * 1024
+		or cint(frappe.conf.get("max_zip_extract_size"))
+		or 25 * 1024 * 1024
+	)
+
+
 def get_file_chunk_size() -> int:
 	return cint(frappe.conf.get("file_chunk_size")) or 25 * 1024 * 1024
 

--- a/frappe/core/api/file.py
+++ b/frappe/core/api/file.py
@@ -4,7 +4,7 @@ from frappe.core.doctype.file.utils import setup_folder_path
 from frappe.utils import cint, cstr
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def unzip_file(name: str):
 	"""Unzip the given file and make file records for each of the extracted files"""
 	file: File = frappe.get_doc("File", name)

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -710,31 +710,37 @@ class File(Document):
 					)
 				)
 
-			for file in members:
-				filename = os.path.basename(file.filename)
+			try:
+				for file in members:
+					filename = os.path.basename(file.filename)
 
-				file_doc = frappe.new_doc("File")
-				try:
-					content = z.read(file.filename)
-				except zipfile.BadZipFile:
-					frappe.throw(_("{0} is a not a valid zip file").format(self.file_name))
+					file_doc = frappe.new_doc("File")
+					try:
+						content = z.read(file.filename)
+					except zipfile.BadZipFile:
+						frappe.throw(_("{0} is a not a valid zip file").format(self.file_name))
 
-				total_extracted_size += len(content)
-				if total_extracted_size > max_extracted_size:
-					frappe.throw(
-						_("Zip file extracts to more than the maximum allowed size of {0} MB").format(
-							max_extracted_size // 1048576
+					total_extracted_size += len(content)
+					if total_extracted_size > max_extracted_size:
+						frappe.throw(
+							_("Zip file extracts to more than the maximum allowed size of {0} MB").format(
+								max_extracted_size // 1048576
+							)
 						)
-					)
 
-				file_doc.content = content
-				file_doc.file_name = filename
-				file_doc.folder = self.folder
-				file_doc.is_private = self.is_private
-				file_doc.attached_to_doctype = self.attached_to_doctype
-				file_doc.attached_to_name = self.attached_to_name
-				file_doc.save()
-				files.append(file_doc)
+					file_doc.content = content
+					file_doc.file_name = filename
+					file_doc.folder = self.folder
+					file_doc.is_private = self.is_private
+					file_doc.attached_to_doctype = self.attached_to_doctype
+					file_doc.attached_to_name = self.attached_to_name
+					file_doc.save()
+					files.append(file_doc)
+			except Exception:
+				# roll back any children already persisted before the failure
+				for file_doc in files:
+					frappe.delete_doc("File", file_doc.name, ignore_permissions=True, force=True)
+				raise
 
 		frappe.delete_doc("File", self.name)
 		return files

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -681,28 +681,53 @@ class File(Document):
 
 	def unzip(self) -> list["File"]:
 		"""Unzip current file and replace it by its children"""
+		from frappe.core.api.file import get_max_file_size
+
 		if not self.file_url.endswith(".zip"):
 			frappe.throw(_("{0} is not a zip file").format(self.file_name))
 
 		zip_path = self.get_full_path()
+		max_extracted_size = get_max_file_size()
 
 		files = []
+		total_extracted_size = 0
 		with zipfile.ZipFile(zip_path) as z:
-			for file in z.filelist:
-				if file.is_dir() or file.filename.startswith("__MACOSX/"):
-					# skip directories and macos hidden directory
-					continue
+			# skip directories, macos hidden directory & hidden files
+			members = [
+				file
+				for file in z.filelist
+				if not (file.is_dir() or file.filename.startswith("__MACOSX/"))
+				and not os.path.basename(file.filename).startswith(".")
+			]
 
+			# Reject on declared (central directory) sizes before reading any member,
+			# so a small, highly compressible archive can't force large reads/writes.
+			declared_total_size = sum(file.file_size for file in members)
+			if declared_total_size > max_extracted_size:
+				frappe.throw(
+					_("Zip file extracts to more than the maximum allowed size of {0} MB").format(
+						max_extracted_size // 1048576
+					)
+				)
+
+			for file in members:
 				filename = os.path.basename(file.filename)
-				if filename.startswith("."):
-					# skip hidden files
-					continue
 
 				file_doc = frappe.new_doc("File")
 				try:
-					file_doc.content = z.read(file.filename)
+					content = z.read(file.filename)
 				except zipfile.BadZipFile:
 					frappe.throw(_("{0} is a not a valid zip file").format(self.file_name))
+
+				total_extracted_size += len(content)
+				if total_extracted_size > max_extracted_size:
+					frappe.throw(
+						_("Zip file extracts to more than the maximum allowed size of {0} MB").format(
+							max_extracted_size // 1048576
+						)
+					)
+
+				file_doc.content = content
 				file_doc.file_name = filename
 				file_doc.folder = self.folder
 				file_doc.is_private = self.is_private

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -681,13 +681,13 @@ class File(Document):
 
 	def unzip(self) -> list["File"]:
 		"""Unzip current file and replace it by its children"""
-		from frappe.core.api.file import get_max_file_size
+		from frappe.core.api.file import get_max_extract_size
 
 		if not self.file_url.endswith(".zip"):
 			frappe.throw(_("{0} is not a zip file").format(self.file_name))
 
 		zip_path = self.get_full_path()
-		max_extracted_size = get_max_file_size()
+		max_extracted_size = get_max_extract_size()
 
 		files = []
 		total_extracted_size = 0

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -6,6 +6,7 @@ import shutil
 import tempfile
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import frappe
 from frappe import _
@@ -646,6 +647,33 @@ class TestFile(IntegrationTestCase):
 			}
 		).insert(ignore_permissions=True)
 		self.assertRaisesRegex(ValidationError, "not a zip file", test_file.unzip)
+
+	@IntegrationTestCase.change_settings("System Settings", {"max_file_size": 0})
+	def test_file_unzip_exceeding_max_file_size(self):
+		file_path = frappe.get_app_path("frappe", "www/_test/assets/file.zip")
+		public_file_path = frappe.get_site_path("public", "files")
+		try:
+			shutil.copy(file_path, public_file_path)
+		except Exception:
+			pass
+
+		test_file = frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_url": "/files/file.zip",
+			}
+		).insert(ignore_permissions=True)
+		self.addCleanup(test_file.delete)
+
+		file_count_before = frappe.db.count("File")
+
+		# file.zip's extracted contents (~158 KB) exceed this limit, so extraction must be rejected
+		with patch.dict(frappe.conf, {"max_file_size": 1000}):
+			self.assertRaisesRegex(ValidationError, "maximum allowed size", test_file.unzip)
+
+		# original zip must survive a rejected extraction, no children left behind
+		self.assertTrue(frappe.db.exists("File", test_file.name))
+		self.assertEqual(frappe.db.count("File"), file_count_before)
 
 	def test_create_file_without_file_url(self):
 		test_file = frappe.get_doc(

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -4,6 +4,7 @@ import base64
 import os
 import shutil
 import tempfile
+import zipfile
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 from unittest.mock import patch
@@ -674,6 +675,46 @@ class TestFile(IntegrationTestCase):
 		# original zip must survive a rejected extraction, no children left behind
 		self.assertTrue(frappe.db.exists("File", test_file.name))
 		self.assertEqual(frappe.db.count("File"), file_count_before)
+
+	def test_file_unzip_rolls_back_children_on_mid_extraction_failure(self):
+		fixture_dir = tempfile.mkdtemp()
+		zip_path = os.path.join(fixture_dir, "corrupt.zip")
+		with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_STORED) as zf:
+			zf.writestr("a.txt", "hello-a")
+			zf.writestr("b.txt", "hello-b")
+			zf.writestr("c.txt", "hello-c")
+
+		# flip a byte in the last member's stored (uncompressed) data so it fails
+		# its CRC check on read, without touching the central directory metadata
+		with open(zip_path, "rb") as f:
+			data = bytearray(f.read())
+		corrupt_offset = data.rfind(b"hello-c")
+		self.assertNotEqual(corrupt_offset, -1)
+		data[corrupt_offset] ^= 0xFF
+		with open(zip_path, "wb") as f:
+			f.write(data)
+
+		public_file_path = frappe.get_site_path("public", "files")
+		shutil.copy(zip_path, public_file_path)
+
+		test_file = frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_url": "/files/corrupt.zip",
+			}
+		).insert(ignore_permissions=True)
+		self.addCleanup(test_file.delete)
+
+		file_count_before = frappe.db.count("File")
+
+		# a.txt and b.txt extract fine and get saved before c.txt fails its CRC check;
+		# the whole call must still roll back to a clean no-op
+		self.assertRaisesRegex(ValidationError, "not a valid zip file", test_file.unzip)
+
+		self.assertTrue(frappe.db.exists("File", test_file.name))
+		self.assertEqual(frappe.db.count("File"), file_count_before)
+		self.assertFalse(frappe.db.exists("File", {"file_name": "a.txt"}))
+		self.assertFalse(frappe.db.exists("File", {"file_name": "b.txt"}))
 
 	def test_create_file_without_file_url(self):
 		test_file = frappe.get_doc(

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -649,8 +649,8 @@ class TestFile(IntegrationTestCase):
 		).insert(ignore_permissions=True)
 		self.assertRaisesRegex(ValidationError, "not a zip file", test_file.unzip)
 
-	@IntegrationTestCase.change_settings("System Settings", {"max_file_size": 0})
-	def test_file_unzip_exceeding_max_file_size(self):
+	@IntegrationTestCase.change_settings("System Settings", {"max_zip_extract_size": 0})
+	def test_file_unzip_respects_dedicated_extract_size_setting(self):
 		file_path = frappe.get_app_path("frappe", "www/_test/assets/file.zip")
 		public_file_path = frappe.get_site_path("public", "files")
 		try:
@@ -668,11 +668,11 @@ class TestFile(IntegrationTestCase):
 
 		file_count_before = frappe.db.count("File")
 
-		# file.zip's extracted contents (~158 KB) exceed this limit, so extraction must be rejected
-		with patch.dict(frappe.conf, {"max_file_size": 1000}):
+		# a dedicated, tighter zip-extraction budget must be enforced even though
+		# max_file_size (used for ordinary uploads) stays at its generous default
+		with patch.dict(frappe.conf, {"max_zip_extract_size": 1000}):
 			self.assertRaisesRegex(ValidationError, "maximum allowed size", test_file.unzip)
 
-		# original zip must survive a rejected extraction, no children left behind
 		self.assertTrue(frappe.db.exists("File", test_file.name))
 		self.assertEqual(frappe.db.count("File"), file_count_before)
 

--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -82,6 +82,7 @@
   "files_tab",
   "files_section",
   "max_file_size",
+  "max_zip_extract_size",
   "allow_guests_to_upload_files",
   "force_web_capture_mode_for_uploads",
   "strip_exif_metadata_from_uploaded_images",
@@ -842,12 +843,19 @@
    "fieldname": "sync_in_batch",
    "fieldtype": "Check",
    "label": "Sync In Batches"
+  },
+  {
+   "description": "Maximum total size a ZIP archive is allowed to expand to when extracted.",
+   "fieldname": "max_zip_extract_size",
+   "fieldtype": "Int",
+   "label": "Max Zip Extract Size (MB)",
+   "non_negative": 1
   }
  ],
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2026-08-03 11:12:47.811078",
+ "modified": "2026-08-06 17:22:18.039321",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -81,6 +81,7 @@ class SystemSettings(Document):
 		max_file_size: DF.Int
 		max_report_rows: DF.Int
 		max_signups_allowed_per_hour: DF.Int
+		max_zip_extract_size: DF.Int
 		minimum_password_score: DF.Literal["1", "2", "3", "4"]
 		number_format: DF.Literal[
 			"#,###.##",


### PR DESCRIPTION
This PR hardens Zip file uploads (bunch of stuff done is enlisted below):
1. Restricted unzip_file RPC to `POST` only.
2. Check Total child sizes (cumulative) alongside the pre-existing `File` record sizes.
3. Rollback on failure: if extraction fails partway (size cap or corrupt member), delete any children already saved so the call is a clean no-op instead of leaving orphaned File docs/blobs.
4. Test Coverage

closes Ticket 75545