### PR TITLE
fix(chromium): Make headless_shell executable on linux arm64

### DIFF
--- a/frappe/tests/test_chromium_download.py
+++ b/frappe/tests/test_chromium_download.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+import io
+import os
+import tempfile
+import zipfile
+from unittest.mock import MagicMock, patch
+
+from frappe.tests import UnitTestCase
+from frappe.utils.chromium.download import download_chromium
+
+
+def _archive_containing(*names: str) -> bytes:
+	"""Build a Chromium-like zip. Recorded permissions do not matter — zipfile.extractall()
+	drops them and writes every member as 0o644."""
+	buffer = io.BytesIO()
+	with zipfile.ZipFile(buffer, "w") as archive:
+		for name in names:
+			archive.writestr(name, b"not a real binary")
+	return buffer.getvalue()
+
+
+def _streamed_response(payload: bytes) -> MagicMock:
+	response = MagicMock()
+	response.headers = {"content-length": str(len(payload))}
+	response.iter_content.return_value = [payload]
+	return MagicMock(__enter__=MagicMock(return_value=response), __exit__=MagicMock(return_value=False))
+
+
+class TestChromiumDownload(UnitTestCase):
+	def download(self, payload: bytes) -> str:
+		"""Run download_chromium() against a throwaway bench and return the expected executable path."""
+		bench_path = tempfile.mkdtemp()
+		with (
+			patch("frappe.utils.get_bench_path", return_value=bench_path),
+			patch("platform.system", return_value="Linux"),
+			patch(
+				"frappe.utils.chromium.download.get_chromium_download_url",
+				return_value="https://example.com/chromium.zip",
+			),
+			patch("requests.get", return_value=_streamed_response(payload)),
+		):
+			download_chromium()
+
+		return os.path.join(bench_path, "chromium", "chrome-linux", "headless_shell")
+
+	def test_linux_arm64_archive_leaves_headless_shell_executable(self):
+		"""The arm64 build already unpacks to chrome-linux/headless_shell and skips the rename branch."""
+		executable = self.download(_archive_containing("chrome-linux/headless_shell"))
+
+		self.assertTrue(os.path.exists(executable), f"{executable} was not extracted")
+		self.assertTrue(os.access(executable, os.X_OK), f"{executable} is not executable")
+
+	def test_linux_x86_64_archive_is_renamed_and_left_executable(self):
+		executable = self.download(_archive_containing("chrome-headless-shell-linux64/chrome-headless-shell"))
+
+		self.assertTrue(os.path.exists(executable), f"{executable} was not extracted")
+		self.assertTrue(os.access(executable, os.X_OK), f"{executable} is not executable")

--- a/frappe/utils/chromium/download.py
+++ b/frappe/utils/chromium/download.py
@@ -130,9 +130,11 @@ def download_chromium():
 					os.rename(executable_shell, os.path.join(renamed_dir, "headless_shell"))
 				else:
 					raise RuntimeError("Failed to rename executable. Expected chrome-headless-shell.")
-			# Make the `headless_shell` executable
-			exec_path = os.path.join(renamed_dir, executable_path[1])
-			make_chromium_executable(exec_path)
+
+		# zipfile.extractall() does not restore permissions, so the binary always needs a chmod.
+		# Keep this outside the rename branch: the linux-arm64 build already extracts to
+		# chrome-linux/headless_shell and would otherwise be left non-executable.
+		make_chromium_executable(os.path.join(chromium_dir, *executable_path))
 
 		click.echo(f"Chromium is ready to use at: {chromium_dir}")
 	except requests.Timeout:


### PR DESCRIPTION
## Problem

On linux arm64, `bench setup-chrome` leaves `chromium/chrome-linux/headless_shell` at mode `0644`, so Chromium can never start. Callers see:

```
TimeoutError: Chromium took too long to start.
```

with the binary sitting exactly where it is expected — which makes it look like a missing shared library rather than a permissions problem.

## Cause

Two things combine in `download_chromium()`:

1. `zipfile.extractall()` does not restore Unix permissions. Both archives land on disk as `0644` regardless of the mode recorded in the zip.
2. The `chmod` only ran inside the `if extracted != chrome_folder_name:` rename branch.

The x86_64 chrome-for-testing archive unpacks to `chrome-headless-shell-linux64/`, so it takes the rename branch and gets chmod-ed. The arm64 Playwright archive already unpacks to `chrome-linux/headless_shell`, skips the branch entirely, and is left non-executable.

Reproduced against the real archives that `get_chromium_download_url()` resolves to:

```
arm64 (playwright):        top-level=['chrome-linux']                  zip-mode=0o755  after-extractall=0o644  X_OK=False
x64 (chrome-for-testing):  top-level=['chrome-headless-shell-linux64'] zip-mode=0o644  after-extractall=0o644  X_OK=False
```

## Fix

Move `make_chromium_executable()` out of the rename branch so it always runs after extraction. Doing it here rather than at the arm64 call site, since `extractall()` never restores permissions for either build.

Note `find_or_download_chromium_executable()` chmods on the *already exists* path, so a second call self-heals — but `bench setup-chrome` itself still returns a broken binary, which matters when it runs at Docker build time and the result is baked into an image.

## Tests

`frappe/tests/test_chromium_download.py` covers both archive layouts. The arm64 case fails on `develop` and passes with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)