### PR TITLE
fix: better handling of required app names

### DIFF
--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -271,6 +271,30 @@ def parse_app_name(name: str) -> str:
 	return repo
 
 
+def parse_required_app_name(requirement: str) -> str:
+	"""Parse the app name out of a `required_apps` entry.
+
+	Entries can be `erpnext`, `frappe/erpnext`, a git URL or any of those with an `@branch`.
+	Unlike `parse_app_name`, this resolves the name locally, so it is safe to call for an app
+	that is not present on the bench.
+	"""
+	name = requirement.rstrip("/").split("#")[0]
+	name = name.rsplit("/", 1)[-1].rsplit(":", 1)[-1]
+	return name.split("@")[0].removesuffix(".git")
+
+
+def is_required_by(app_name: str, dependent_app: str) -> bool:
+	"""Check if `dependent_app` declares `app_name` in its `required_apps` hook.
+
+	Entries are parsed before comparing. Matching the raw string instead would flag any app whose
+	name happens to be a substring of a requirement, e.g. `appe` against `frappe/erpnext`.
+	"""
+	return any(
+		app_name == parse_required_app_name(required_app)
+		for required_app in frappe.get_hooks("required_apps", app_name=dependent_app)
+	)
+
+
 def install_app(name, verbose=False, set_as_patched=True, force=False):
 	from frappe.core.doctype.scheduled_job_type.scheduled_job_type import sync_jobs
 	from frappe.model.sync import sync_for
@@ -421,7 +445,7 @@ def enable_app(app_name):
 		try:
 			disabled_apps = frappe.get_disabled_apps()
 			for required_app in frappe.get_hooks("required_apps", app_name=app_name):
-				dependency = parse_app_name(required_app)
+				dependency = parse_required_app_name(required_app)
 				if dependency in disabled_apps:
 					frappe.throw(_("App {0} depends on {1}. Enable {1} first.").format(app_name, dependency))
 
@@ -459,8 +483,7 @@ def disable_app(app_name):
 			for app in frappe.get_active_apps():
 				if app == app_name:
 					continue
-				required_apps = frappe.get_hooks("required_apps", app_name=app)
-				if any(app_name in required_app for required_app in required_apps):
+				if is_required_by(app_name, app):
 					frappe.throw(
 						_("App {0} is a dependency of {1}. Disable {1} first.").format(app_name, app)
 					)
@@ -518,11 +541,9 @@ def remove_app(app_name, dry_run=False, yes=False, no_backup=False, force=False)
 
 	# Don't allow uninstalling if we have dependent apps installed
 	for app in frappe.get_installed_apps():
-		if app != app_name:
-			hooks = frappe.get_hooks(app_name=app)
-			if hooks.required_apps and any(app_name in required_app for required_app in hooks.required_apps):
-				click.secho(f"App {app_name} is a dependency of {app}. Uninstall {app} first.", fg="yellow")
-				return
+		if app != app_name and is_required_by(app_name, app):
+			click.secho(f"App {app_name} is a dependency of {app}. Uninstall {app} first.", fg="yellow")
+			return
 
 	print(f"Uninstalling App {app_name} from Site {site}...")
 

--- a/frappe/tests/test_app_toggle.py
+++ b/frappe/tests/test_app_toggle.py
@@ -8,13 +8,16 @@ import frappe
 from frappe.installer import (
 	disable_app,
 	enable_app,
+	parse_required_app_name,
 	reapply_disabled_app_state,
 	remove_from_installed_apps,
 	set_app_disabled,
 )
-from frappe.tests import IntegrationTestCase
+from frappe.tests import IntegrationTestCase, UnitTestCase
 
 FAKE_APP = "zzz_test_app"
+# sits inside the requirement string `frappe/erpnext` without being the app it names
+COLLIDING_APP = "next"
 
 hook_calls = []
 
@@ -67,22 +70,22 @@ def write_disabled_apps(apps: list[str]):
 
 
 @contextmanager
-def fake_app(hooks: dict | None = None):
-	"""Present FAKE_APP as installed, with only the hooks a test asks for.
+def fake_app(hooks: dict | None = None, name: str = FAKE_APP):
+	"""Present `name` as an installed app, with only the hooks a test asks for.
 
-	`hooks` maps `(app_name, hook)` to a value. Any other hook of FAKE_APP is empty, and
+	`hooks` maps `(app_name, hook)` to a value. Any other hook of the fake app is empty, and
 	every other app keeps its real hooks. `get_installed_apps_info` is pinned to the real
 	apps because it imports each app module to read a version.
 	"""
 	overrides = hooks or {}
 	real_get_hooks = frappe.get_hooks
-	installed = [*frappe.get_installed_apps(), FAKE_APP]
+	installed = [*frappe.get_installed_apps(), name]
 	apps_info = frappe.utils.get_installed_apps_info()
 
 	def app_hooks(hook=None, default="_KEEP_DEFAULT_LIST", app_name=None):
 		if (app_name, hook) in overrides:
 			return overrides[(app_name, hook)]
-		if app_name == FAKE_APP:
+		if app_name == name:
 			return []
 		return real_get_hooks(hook, default, app_name)
 
@@ -92,6 +95,26 @@ def fake_app(hooks: dict | None = None):
 		patch.object(frappe.utils, "get_installed_apps_info", lambda: apps_info),
 	):
 		yield
+
+
+class TestRequiredAppName(UnitTestCase):
+	def test_every_spelling_of_a_requirement_resolves_to_the_app(self):
+		requirements = [
+			"erpnext",
+			"frappe/erpnext",
+			"frappe/erpnext@version-15",
+			"https://github.com/frappe/erpnext.git",
+			"https://github.com/frappe/erpnext.git#develop",
+			"git@github.com:frappe/erpnext.git",
+			"/home/frappe/frappe-bench/apps/erpnext/",
+		]
+		for requirement in requirements:
+			with self.subTest(requirement=requirement):
+				self.assertEqual(parse_required_app_name(requirement), "erpnext")
+
+	def test_an_app_off_the_bench_resolves_without_a_remote_lookup(self):
+		"""`parse_app_name` asks GitHub for a name it cannot place; a dependency check must not."""
+		self.assertEqual(parse_required_app_name(FAKE_APP), FAKE_APP)
 
 
 class TestAppToggle(IntegrationTestCase):
@@ -210,6 +233,22 @@ class TestAppToggle(IntegrationTestCase):
 			disable_app(FAKE_APP)
 
 		self.assertNotIn(FAKE_APP, read_disabled_apps())
+
+	def test_cannot_disable_an_app_a_qualified_requirement_names(self):
+		"""A `required_apps` entry may be spelled `org/repo`; the dependency is the repo."""
+		hooks = {("frappe", "required_apps"): [f"frappe/{FAKE_APP}"]}
+		with fake_app(hooks), self.assertRaises(frappe.ValidationError):
+			disable_app(FAKE_APP)
+
+		self.assertNotIn(FAKE_APP, read_disabled_apps())
+
+	def test_can_disable_an_app_whose_name_is_only_a_substring_of_a_requirement(self):
+		"""`next` is inside `frappe/erpnext` but is not it, so it must not count as a dependency."""
+		hooks = {("frappe", "required_apps"): ["frappe/erpnext"]}
+		with fake_app(hooks, name=COLLIDING_APP):
+			disable_app(COLLIDING_APP)
+
+		self.assertIn(COLLIDING_APP, read_disabled_apps())
 
 	def test_cannot_enable_an_app_whose_dependency_is_disabled(self):
 		write_disabled_apps([*self.disabled_apps_before, FAKE_APP, "frappe"])


### PR DESCRIPTION
Required app name hook for hrms contains frappe/erpnext and an app named next want to wants to be uninstalled. The bug is the check thinks hrms is dependant on the app next
