### PR TITLE
feat(ui): move telemetry, onboarding, TrialBanner and DataImport into @framework/ui

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -75,6 +75,7 @@
     "vuedraggable": "^4.1.0"
   },
   "peerDependencies": {
+    "@vueuse/core": ">=10.4.1",
     "frappe-ui": ">=1.0.0-beta.16",
     "vue": ">=3.3.0",
     "vue-router": "^4.1.5"

--- a/ui/src/components/DataImport/DataImport.vue
+++ b/ui/src/components/DataImport/DataImport.vue
@@ -1,0 +1,181 @@
+<template>
+	<header
+		class="sticky flex items-center justify-between space-x-28 top-0 z-10 border-b bg-surface-base px-3 py-2.5 sm:px-5"
+	>
+		<Breadcrumbs :items="breadcrumbs" />
+		<ImportSteps
+			class="flex-1 hidden lg:flex"
+			v-if="step != 'list'"
+			:data="data"
+			:step="step"
+			@updateStep="updateStep"
+		/>
+	</header>
+	<div>
+		<ImportSteps
+			class="flex-1 lg:hidden w-[90%] mx-auto mt-5"
+			v-if="step != 'list'"
+			:data="data"
+			:step="step"
+			@updateStep="updateStep"
+		/>
+
+		<DataImportList
+			v-if="step === 'list'"
+			:dataImports="dataImports"
+			@updateStep="updateStep"
+		/>
+
+		<UploadStep
+			v-else-if="step === 'upload'"
+			:dataImports="dataImports"
+			:doctype="doctype || data?.reference_doctype"
+			:fields="fields"
+			:data="data"
+			@updateStep="updateStep"
+		/>
+
+		<MappingStep
+			v-else-if="step === 'map'"
+			:dataImports="dataImports"
+			:data="data as DataImport"
+			:fields="fields"
+			@updateStep="updateStep"
+		/>
+
+		<PreviewStep
+			v-else-if="step === 'preview'"
+			:dataImports="dataImports"
+			:data="data as DataImport"
+			:fields="fields"
+			:doctypeMap="
+				doctypeMap as Record<
+					string,
+					{ title: string; listRoute?: string; pageRoute?: string }
+				>
+			"
+			:socket="socket"
+			@updateStep="updateStep"
+		/>
+	</div>
+</template>
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from "vue";
+import type { DataImportProps, DataImport } from "./types";
+import { Breadcrumbs, createListResource, createResource } from "frappe-ui";
+import { useRoute } from "vue-router";
+import type { RouteLocationRaw } from "vue-router";
+import DataImportList from "./DataImportList.vue";
+import ImportSteps from "./ImportSteps.vue";
+import MappingStep from "./MappingStep.vue";
+import PreviewStep from "./PreviewStep.vue";
+import UploadStep from "./UploadStep.vue";
+
+const route = useRoute();
+const step = ref<"upload" | "map" | "list" | "preview">("list");
+const data = ref<DataImport | null>(null);
+
+const props = defineProps<Partial<DataImportProps>>();
+
+const dataImports = createListResource({
+	doctype: "Data Import",
+	fields: [
+		"name",
+		"reference_doctype",
+		"import_type",
+		"status",
+		"creation",
+		"mute_emails",
+		"import_file",
+		"google_sheets_url",
+		"template_options",
+	],
+	auto: true,
+	orderBy: "modified desc",
+});
+
+const fields = createResource({
+	url: "frappe.desk.form.load.getdoctype",
+	makeParams: (values: { doctype: string }) => {
+		return {
+			doctype: values.doctype,
+			with_parent: 1,
+		};
+	},
+	auto: false,
+});
+
+const updateData = () => {
+	data.value = dataImports.data?.find((di: DataImport) => di.name === props.importName) || null;
+};
+
+watch(
+	() => [route.params, props, dataImports.data],
+	() => {
+		if (props.doctype) {
+			step.value = "upload";
+			fields.reload({
+				doctype: route.params.doctype,
+			});
+		} else if (props.importName) {
+			updateData();
+			if (!data.value?.import_file && !data.value?.google_sheets_url) {
+				step.value = "upload";
+			} else if (step.value == "upload" && route.query.step == "map") {
+				step.value = route.query.step;
+			} else {
+				step.value = "preview";
+			}
+			if (data.value?.reference_doctype) {
+				fields.reload({
+					doctype: data.value?.reference_doctype,
+				});
+			}
+		}
+	},
+	{ immediate: true }
+);
+
+watch(
+	() => route.query,
+	() => {
+		if (route.query.step == "list") {
+			step.value = "list";
+		}
+	}
+);
+
+const updateStep = (newStep: "list" | "upload" | "map" | "preview", newData: DataImport) => {
+	step.value = newStep;
+	if (newData) {
+		data.value = newData;
+	}
+};
+
+const doctypeTitle = computed(() => {
+	let doctype = props.doctype || data.value?.reference_doctype;
+	return props.doctypeMap?.[doctype || ""]?.title || doctype || "";
+});
+
+const breadcrumbs = computed(() => {
+	let crumbs: { label: string; route?: RouteLocationRaw }[] = [
+		{
+			label: "Data Import",
+			route: {
+				name: "DataImportList",
+				query: {
+					step: "list",
+				},
+			},
+		},
+	];
+
+	if (step.value !== "list") {
+		crumbs.push({
+			label: `Importing ${doctypeTitle.value}`,
+		});
+	}
+
+	return crumbs;
+});
+</script>

--- a/ui/src/components/DataImport/DataImportList.vue
+++ b/ui/src/components/DataImport/DataImportList.vue
@@ -1,0 +1,165 @@
+<template>
+	<div class="flex min-h-0 flex-col text-base py-5 w-[90%] lg:w-[700px] mx-auto">
+		<div class="flex items-center justify-between">
+			<div>
+				<div class="text-lg font-semibold mb-1 text-ink-gray-9">Data Import</div>
+				<div class="text-ink-gray-6 leading-5">
+					Import data into your system using CSV files.
+				</div>
+			</div>
+			<Button variant="solid" @click="showModal = true">
+				<template #prefix>
+					<FeatherIcon name="plus" class="size-4 stroke-1.5" />
+				</template>
+				Import
+			</Button>
+		</div>
+
+		<div class="flex items-center space-x-2 my-5">
+			<FormControl
+				v-model="search"
+				placeholder="Search imported files"
+				type="text"
+				class="flex-1"
+			/>
+			<FormControl v-model="importStatus" type="select" :options="importOptions" />
+		</div>
+
+		<div v-if="dataImports.data?.length" class="overflow-y-scroll">
+			<div class="divide-y">
+				<div
+					class="grid grid-cols-[75%,20%] lg:grid-cols-[85%,20%] items-center text-sm text-ink-gray-5 py-1.5 mx-2 my-0.5 px-1"
+				>
+					<div>Name</div>
+					<div class="pl-1">Status</div>
+				</div>
+				<div
+					v-for="dataImport in dataImports.data"
+					@click="() => redirectToImport(dataImport.name!)"
+					class="grid grid-cols-[75%,20%] lg:grid-cols-[85%,20%] items-center cursor-pointer py-2.5 px-1 mx-2"
+				>
+					<div class="space-y-1">
+						<div class="text-ink-gray-7">
+							{{ dataImport.reference_doctype }}
+						</div>
+						<div class="text-ink-gray-5">
+							{{ dayjs(dataImport.creation).fromNow() }}
+						</div>
+					</div>
+					<Badge
+						:label="dataImport.status"
+						:theme="getBadgeColor(dataImport.status) as BadgeProps['theme']"
+						class="w-fit"
+					/>
+				</div>
+			</div>
+			<div class="my-5 flex justify-center">
+				<Button v-if="props.dataImports.hasNextPage" @click="props.dataImports.next?.()">
+					<template #prefix>
+						<FeatherIcon name="refresh-cw" class="size-4 stroke-1.5" />
+					</template>
+					Load More
+				</Button>
+			</div>
+		</div>
+		<div v-else class="text-sm italic text-ink-gray-5 mt-5">No data imports found.</div>
+		<Dialog
+			v-model="showModal"
+			:options="{
+				title: 'New Data Import',
+				actions: [
+					{
+						label: 'Continue',
+						variant: 'solid',
+						onClick({ close }) {
+							createDataImport(close);
+						},
+					},
+				],
+			}"
+		>
+			<template #body-content>
+				<div>
+					<Link
+						v-model="doctypeForImport"
+						doctype="DocType"
+						:filters="{
+							allow_import: 1,
+						}"
+						label="Choose a Document Type to import"
+					/>
+				</div>
+			</template>
+		</Dialog>
+	</div>
+</template>
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import { useRouter } from "vue-router";
+import type { DataImports, DataImport } from "./types";
+import { Badge, Button, Dialog, FeatherIcon, FormControl, dayjs, toast } from "frappe-ui";
+import type { BadgeProps } from "frappe-ui";
+import { Link } from "../Link";
+import { getBadgeColor } from "./dataImport";
+
+const search = ref("");
+const importStatus = ref("All");
+const showModal = ref(false);
+const doctypeForImport = ref<string | null>(null);
+const emit = defineEmits(["updateStep"]);
+const router = useRouter();
+
+const props = defineProps<{
+	dataImports: DataImports;
+}>();
+
+const importOptions = computed(() => {
+	const options = ["All", "Pending", "Success", "Partial Success", "Error", "Timed Out"];
+	return options.map((option) => ({ label: option, value: option }));
+});
+
+watch([search, importStatus], ([newSearch, newStatus]) => {
+	props.dataImports.update({
+		filters: [
+			newSearch ? [["name", "like", `%${newSearch}%`]] : [],
+			newStatus !== "All" ? [["status", "=", newStatus]] : [],
+		].flat(),
+	});
+	props.dataImports.reload();
+});
+
+const createDataImport = (close: () => void) => {
+	props.dataImports.insert.submit(
+		{
+			reference_doctype: doctypeForImport.value!,
+			import_type: "Insert New Records",
+			mute_emails: true,
+			status: "Pending",
+		},
+		{
+			onSuccess(data: DataImport) {
+				router.replace({
+					name: "DataImport",
+					params: {
+						importName: data.name,
+					},
+				});
+				close();
+			},
+			onError(error: any) {
+				console.error(error);
+				toast.error(error.messages?.[0] || error);
+			},
+		}
+	);
+};
+
+const redirectToImport = (importName: string) => {
+	router.replace({
+		name: "DataImport",
+		params: {
+			importName,
+		},
+	});
+};
+</script>

--- a/ui/src/components/DataImport/ImportSteps.vue
+++ b/ui/src/components/DataImport/ImportSteps.vue
@@ -1,0 +1,136 @@
+<template>
+	<div class="flex items-center space-x-3 lg:space-x-10 text-xs lg:text-base">
+		<div
+			class="flex items-center space-x-1 lg:space-x-2 text-ink-gray-5 cursor-pointer"
+			:class="{
+				'text-ink-gray-9 font-semibold': onUploadStep,
+			}"
+			@click="emit('updateStep', 'upload', { ...data })"
+		>
+			<FeatherIcon
+				v-if="uploadStepCompleted"
+				name="check"
+				class="size-5 text-sm border rounded-[5px] p-0.5"
+				:class="{
+					'text-ink-base bg-surface-gray-10': onUploadStep,
+				}"
+			/>
+			<div
+				v-else
+				class="text-sm border rounded-[5px] px-1.5 py-0.5"
+				:class="{
+					'text-ink-base bg-surface-gray-10': onUploadStep,
+				}"
+			>
+				<span> 1 </span>
+			</div>
+			<div>Upload File</div>
+		</div>
+		<div
+			class="flex items-center space-x-1 lg:space-x-2 text-ink-gray-5"
+			:class="{
+				'text-ink-gray-9 font-semibold': onMapStep,
+				'cursor-pointer': uploadStepCompleted,
+			}"
+			@click="moveToMapStep()"
+		>
+			<FeatherIcon
+				v-if="mapStepCompleted"
+				name="check"
+				class="size-5 text-sm border rounded-[5px] p-0.5"
+				:class="{
+					'text-ink-base bg-surface-gray-10': onMapStep,
+				}"
+			/>
+			<div
+				v-else
+				class="text-sm border rounded-[5px] px-1.5 py-0.5"
+				:class="{
+					'text-ink-base bg-surface-gray-10': onMapStep,
+				}"
+			>
+				<span> 2 </span>
+			</div>
+			<div>Map Data</div>
+		</div>
+		<div
+			class="flex items-center space-x-1 lg:space-x-2 text-ink-gray-5"
+			:class="{
+				'text-ink-gray-9 font-semibold': onPreviewStep,
+				'cursor-pointer': uploadStepCompleted,
+			}"
+			@click="moveToPreviewStep()"
+		>
+			<FeatherIcon
+				v-if="previewStepCompleted"
+				name="check"
+				class="size-5 text-sm border rounded-[5px] p-0.5"
+				:class="{
+					'text-ink-base bg-surface-gray-10': onPreviewStep,
+				}"
+			/>
+			<div
+				v-else
+				class="text-sm border rounded-[5px] px-1.5 py-0.5"
+				:class="{
+					'text-ink-base bg-surface-gray-10': onPreviewStep,
+				}"
+			>
+				<span> 3 </span>
+			</div>
+			<div>Review & Import</div>
+		</div>
+	</div>
+</template>
+<script setup lang="ts">
+import type { DataImport } from "./types";
+import { computed } from "vue";
+import { FeatherIcon } from "frappe-ui";
+
+const emit = defineEmits(["updateStep"]);
+
+const props = defineProps<{
+	data: DataImport | null;
+	step: "list" | "upload" | "map" | "preview";
+}>();
+
+const onUploadStep = computed(() => {
+	return props.step === "upload";
+});
+
+const uploadStepCompleted = computed(() => {
+	return props.data?.import_file || props.data?.google_sheets_url;
+});
+
+const onMapStep = computed(() => {
+	return props.step === "map";
+});
+
+const mapStepCompleted = computed(() => {
+	return (
+		props.data &&
+		props.data?.template_options &&
+		JSON.parse(props.data.template_options).column_to_field_map
+	);
+});
+
+const onPreviewStep = computed(() => {
+	return props.step === "preview";
+});
+
+const previewStepCompleted = computed(() => {
+	return props.data?.status === "Success";
+});
+
+const moveToMapStep = () => {
+	if (uploadStepCompleted.value) {
+		emit("updateStep", "map", { ...props.data });
+	}
+};
+
+const moveToPreviewStep = () => {
+	if (uploadStepCompleted.value) {
+		emit("updateStep", "preview", { ...props.data });
+	}
+};
+</script>

--- a/ui/src/components/DataImport/MappingStep.vue
+++ b/ui/src/components/DataImport/MappingStep.vue
@@ -1,0 +1,187 @@
+<template>
+	<div class="w-[85%] lg:w-[700px] mx-auto py-12 space-y-8 text-base">
+		<div class="flex justify-between">
+			<div class="space-y-2">
+				<div class="text-md font-semibold text-ink-gray-9">
+					<span> Map Data </span>
+					<Badge v-if="data?.status" :theme="getBadgeColor(data?.status)">
+						{{ data?.status }}
+					</Badge>
+				</div>
+				<div class="leading-5 text-ink-gray-7">
+					Change the mapping of columns from your file to fields in the system
+				</div>
+			</div>
+
+			<div class="flex flex-col lg:flex-row space-y-2 lg:space-x-2 lg:space-y-0">
+				<Button v-if="mappingUpdated" label="Reset Mapping" @click="resetMapping" />
+				<Button label="Continue" variant="solid" @click="$emit('updateStep', 'preview')" />
+			</div>
+		</div>
+
+		<div v-if="Object.keys(columnMappings).length" class="border rounded-md space-y-8">
+			<div class="grid grid-cols-2 text-ink-gray-5 border-b py-2 px-4">
+				<div>Fields in File</div>
+				<div>Fields in System</div>
+			</div>
+			<div class="grid grid-cols-2 py-2 px-4 gap-y-8">
+				<template v-for="i in columnsFromFile.length" :key="i">
+					<div class="text-ink-gray-7">{{ columnsFromFile[i - 1] }}</div>
+					<Combobox
+						:model-value="columnMappings[columnsFromFile[i - 1]]"
+						:options="columnsFromSystem"
+						placeholder="Select field"
+						@update:selected-option="
+							(option: ComboboxOption | null) => updateColumnMappings(i, option)
+						"
+					/>
+				</template>
+			</div>
+		</div>
+	</div>
+</template>
+<script setup lang="ts">
+import type { DataImport, DataImports } from "./types";
+import { fieldsToIgnore, getBadgeColor, getPreviewData } from "./dataImport";
+import { computed, nextTick, onMounted, ref } from "vue";
+import { Badge, Button, Combobox, toast } from "frappe-ui";
+import type { ComboboxOption } from "frappe-ui";
+
+const previewData = ref<any>(null);
+const emit = defineEmits(["updateStep"]);
+const columnMappings = ref<Record<string, string>>({});
+const mappingUpdated = ref(false);
+
+const props = defineProps<{
+	dataImports: DataImports;
+	data: DataImport;
+	fields: any;
+}>();
+
+onMounted(async () => {
+	previewData.value = await getPreviewData(
+		props.data.name!,
+		props.data.import_file,
+		props.data.google_sheets_url
+	);
+	initializeColumnMappings();
+});
+
+const initializeColumnMappings = () => {
+	const mappings: Record<string, string> = {};
+	let columnToFieldMap = [];
+	if (props.data?.template_options)
+		columnToFieldMap = JSON.parse(props.data?.template_options)?.["column_to_field_map"];
+
+	if (Object.keys(columnToFieldMap).length > 0) mappingUpdated.value = true;
+
+	columnsFromFile.value.forEach((col: string, index: number) => {
+		// A mapped column holds the target fieldname; an unmapped one falls back
+		// to the file's own header, which Combobox shows verbatim because no
+		// option matches it.
+		if (columnToFieldMap && columnToFieldMap[index]) mappings[col] = columnToFieldMap[index];
+		else mappings[col] = col;
+	});
+
+	columnMappings.value = mappings;
+};
+
+const updateColumnMappings = (index: number, value: ComboboxOption | null) => {
+	// Only a plain selectable option carries a `value`; custom rows and group
+	// headers do not, and this combobox renders neither.
+	if (!value || typeof value === "string" || !("value" in value)) return;
+	mappingUpdated.value = true;
+	let templateOptions = props.data?.template_options
+		? JSON.parse(props.data?.template_options)
+		: {};
+	let columnToFieldMap = templateOptions["column_to_field_map"] || {};
+	columnToFieldMap[index - 1] = value.value;
+
+	props.dataImports.setValue.submit(
+		{
+			...props.data,
+			template_options: JSON.stringify({
+				...templateOptions,
+				column_to_field_map: columnToFieldMap,
+			}),
+		},
+		{
+			onSuccess: (data: DataImport) => {
+				emit("updateStep", "map", { ...data });
+				nextTick(() => {
+					initializeColumnMappings();
+				});
+			},
+			onError: (error: any) => {
+				toast.error(error.messages?.[0] || error);
+				console.error("Error updating column mappings:", error);
+			},
+		}
+	);
+};
+
+const columnsFromFile = computed(() => {
+	const columns: string[] = [];
+	previewData.value?.columns.forEach((col: any) => {
+		if (col.header_title != "Sr. No") columns.push(col.header_title);
+	});
+	return columns;
+});
+
+const columnsFromSystem = computed(() => {
+	const parent = props.data!.reference_doctype;
+	const docs = props.fields.data?.docs || [];
+
+	return docs
+		.map((doc: any) => {
+			const isParent = doc.name === parent;
+
+			const columns = doc.fields
+				.filter((f: any) => !fieldsToIgnore.includes(f.fieldtype))
+				.map((f: any) => ({
+					value: f.fieldname,
+					label: isParent
+						? f.label
+						: `${f.label} (${getChildTableName(parent, doc.name)})`,
+				}));
+
+			return [{ value: "name", label: "ID" }, ...columns];
+		})
+		.flat();
+});
+
+const resetMapping = () => {
+	let templateOptions = props.data?.template_options
+		? JSON.parse(props.data?.template_options)
+		: {};
+	props.dataImports.setValue.submit(
+		{
+			...props.data,
+			template_options: JSON.stringify({
+				...templateOptions,
+				column_to_field_map: {},
+			}),
+		},
+		{
+			onSuccess: (data: DataImport) => {
+				emit("updateStep", "map", { ...data });
+				nextTick(() => {
+					initializeColumnMappings();
+				});
+			},
+			onError: (error: any) => {
+				toast.error(error.messages?.[0] || error);
+				console.error("Error resetting column mappings:", error);
+			},
+		}
+	);
+};
+
+const getChildTableName = (parent: string, child: string) => {
+	let parentFields =
+		props.fields.data?.docs.find((doc: any) => doc.name == parent)?.fields || [];
+
+	let childField = parentFields.filter((field: any) => field.options == child)[0];
+	return childField?.label || child;
+};
+</script>

--- a/ui/src/components/DataImport/PreviewStep.vue
+++ b/ui/src/components/DataImport/PreviewStep.vue
@@ -170,7 +170,7 @@
 </template>
 <script setup lang="ts">
 import { getPreviewData, getBadgeColor } from "./dataImport";
-import { computed, nextTick, onMounted, ref, watch } from "vue";
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import type { DataImport, DataImports, DataImportSocket } from "./types";
 import { Badge, Button, FeatherIcon, HoverCard, TabButtons, call } from "frappe-ui";
 
@@ -188,13 +188,15 @@ const props = defineProps<{
 	socket?: DataImportSocket;
 }>();
 
+const onImportRefresh = (data: { data_import: string }) => {
+	reloadPreviewData(data.data_import);
+};
+
 onMounted(async () => {
 	// The host owns the socket connection, the same way `useNotifications` takes
 	// one. Without it the table still loads; it just does not refresh itself
 	// while the import runs.
-	props.socket?.on("data_import_refresh", (data: { data_import: string }) => {
-		reloadPreviewData(data.data_import);
-	});
+	props.socket?.on("data_import_refresh", onImportRefresh);
 
 	if (!props.data?.name) return;
 	preview.value = await getPreviewData(
@@ -205,6 +207,11 @@ onMounted(async () => {
 	if (props.data.status != "Pending") {
 		getImportLogs();
 	}
+});
+
+onBeforeUnmount(() => {
+	// The socket is the host's and outlives this screen, so drop our listener.
+	props.socket?.off("data_import_refresh", onImportRefresh);
 });
 
 const reloadPreviewData = (dataImport: string) => {

--- a/ui/src/components/DataImport/PreviewStep.vue
+++ b/ui/src/components/DataImport/PreviewStep.vue
@@ -1,0 +1,377 @@
+<template>
+	<div class="text-base h-full flex flex-col w-[90%] lg:w-[700px] mx-auto py-12 space-y-10">
+		<div class="flex flex-col space-y-1">
+			<div class="flex items-center justify-between text-ink-gray-7">
+				<div class="flex items-center space-x-2 text-md font-semibold text-ink-gray-9">
+					<span> Review and Import </span>
+
+					<Badge :theme="getBadgeColor(data.status)">
+						{{ data.status }}
+					</Badge>
+				</div>
+				<Button
+					v-if="data.status != 'Success'"
+					:label="data.status != 'Pending' ? 'Retry' : 'Import'"
+					variant="solid"
+					@click="startImport"
+				/>
+				<Button v-else-if="listRoute" label="Done" @click="redirectToList()" />
+			</div>
+			<div class="leading-5 text-ink-gray-7">
+				Verify the data before starting the import process
+			</div>
+		</div>
+
+		<div v-if="mapping.length" class="space-y-2">
+			<div class="text-ink-gray-5 text-sm">Column Mapping</div>
+			<div class="border rounded-md bg-surface-gray-2 p-4 space-y-4 text-sm text-ink-gray-7">
+				<div
+					v-for="map in mapping"
+					class="grid grid-cols-[40%,10%,40%] lg:grid-cols-3 space-x-3 items-center"
+				>
+					<div class="">
+						{{ map[0] }}
+					</div>
+					<div class="flex justify-end">
+						<FeatherIcon name="arrow-right" class="inline size-4 text-ink-gray-5" />
+					</div>
+					<div>
+						{{ map[1] }}
+					</div>
+				</div>
+			</div>
+		</div>
+
+		<div v-if="warnings.length" class="space-y-2">
+			<div class="text-ink-gray-5 text-sm">Warnings</div>
+			<div class="rounded-md bg-surface-amber-2 p-2 space-y-2 text-xs">
+				<div v-for="warning in warnings" class="flex items-center space-x-2">
+					<FeatherIcon name="alert-circle" class="size-3 text-ink-amber-6" />
+					<div v-html="warning.message" class="text-ink-amber-6"></div>
+				</div>
+			</div>
+		</div>
+
+		<div v-if="preview?.data?.length" class="border rounded-md overflow-x-auto">
+			<table class="divide-y">
+				<thead class="rounded-t-md">
+					<tr>
+						<th
+							v-for="column in previewColumns"
+							:key="column.key"
+							:style="{ minWidth: column.width, textAlign: column.align }"
+							class="p-2 text-left text-sm text-ink-gray-5"
+							:class="{
+								'border-r':
+									column.key != previewColumns[previewColumns.length - 1].key,
+								'w-full':
+									column.key == previewColumns[previewColumns.length - 1].key,
+							}"
+						>
+							{{ column.label }}
+						</th>
+					</tr>
+				</thead>
+				<tbody class="bg-surface-base divide-y divide-surface-gray-2">
+					<tr v-for="(row, rowIndex) in previewData" :key="rowIndex">
+						<td
+							v-for="column in previewColumns"
+							:key="column.key"
+							:style="{ minWidth: column.width, textAlign: column.align }"
+							class="px-3 py-2 text-sm text-ink-gray-7 align-top"
+							:class="{
+								'border-r':
+									column.key != previewColumns[previewColumns.length - 1].key,
+							}"
+						>
+							<div class="leading-5 text-sm">
+								{{ row[column.key] }}
+							</div>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+
+		<div v-if="data.status != 'Pending' && importLogs.length" class="space-y-4">
+			<div class="font-semibold text-ink-gray-9">Import Logs</div>
+
+			<div class="rounded-md p-2" :class="importBannerClass">
+				{{ importSuccessCount }} {{ importSuccessCount == 1 ? "row" : "rows" }} imported
+				successfully, {{ importErrorCount }}
+				{{ importErrorCount == 1 ? "row" : "rows" }} failed.
+			</div>
+
+			<TabButtons :buttons="tabButtons" v-model="activeTab" class="w-fit" />
+
+			<div v-if="filteredLogs.length" class="border rounded-md overflow-x-auto">
+				<table class="table-fixed w-full divide-y">
+					<thead class="rounded-t-md">
+						<tr>
+							<th
+								class="p-2 text-left text-sm text-ink-gray-5 w-20 border-r text-center"
+							>
+								Row no.
+							</th>
+							<th class="p-2 text-left text-sm text-ink-gray-5 w-[80%]">Message</th>
+						</tr>
+					</thead>
+					<tbody class="bg-surface-base divide-y divide-surface-gray-2">
+						<tr v-for="(row, rowIndex) in filteredLogs" :key="rowIndex" class="group">
+							<td class="px-3 py-2 text-sm text-ink-gray-7 border-r">
+								<div class="flex items-center justify-center space-x-2">
+									<div
+										v-if="row.success"
+										class="size-1.5 bg-surface-green-3 rounded"
+									></div>
+									<div v-else class="size-1.5 bg-surface-red-7 rounded"></div>
+									<div>
+										{{ JSON.parse(row["row_indexes"])[0] - 1 }}
+									</div>
+								</div>
+							</td>
+
+							<td class="px-3 py-2 text-sm text-ink-gray-7 w-full">
+								<span v-if="rowMessage(row)" v-html="rowMessage(row)"> </span>
+								<span v-else-if="!rowMessage(row) && !row.success">
+									Failed to import
+								</span>
+								<span v-else-if="row.success">
+									Successfully imported
+									<span
+										@click="redirectToPage(row.docname)"
+										:class="{
+											'cursor-pointer underline': pageRoute,
+										}"
+									>
+										{{ row.docname }}
+									</span>
+								</span>
+							</td>
+							<td
+								class="px-3 py-2 text-ink-gray-5 float-right invisible group-hover:visible"
+							>
+								<HoverCard v-if="row.exception" side="left" align="start">
+									<template #trigger>
+										<FeatherIcon name="info" class="size-4" />
+									</template>
+									<div class="w-[500px] p-2 text-xs leading-5 font-mono">
+										{{ row.exception }}
+									</div>
+								</HoverCard>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+			<div v-else class="text-ink-gray-5 text-sm">No logs to display.</div>
+		</div>
+	</div>
+</template>
+<script setup lang="ts">
+import { getPreviewData, getBadgeColor } from "./dataImport";
+import { computed, nextTick, onMounted, ref, watch } from "vue";
+import type { DataImport, DataImports, DataImportSocket } from "./types";
+import { Badge, Button, FeatherIcon, HoverCard, TabButtons, call } from "frappe-ui";
+
+const preview = ref<any>(null);
+const emit = defineEmits(["updateStep"]);
+const importLogs = ref<any[]>([]);
+const filteredLogs = ref<any[]>([]);
+const activeTab = ref("all");
+
+const props = defineProps<{
+	dataImports: DataImports;
+	data: DataImport;
+	fields: any;
+	doctypeMap: Record<string, { title: string; listRoute?: string; pageRoute?: string }>;
+	socket?: DataImportSocket;
+}>();
+
+onMounted(async () => {
+	// The host owns the socket connection, the same way `useNotifications` takes
+	// one. Without it the table still loads; it just does not refresh itself
+	// while the import runs.
+	props.socket?.on("data_import_refresh", (data: { data_import: string }) => {
+		reloadPreviewData(data.data_import);
+	});
+
+	if (!props.data?.name) return;
+	preview.value = await getPreviewData(
+		props.data.name,
+		props.data.import_file,
+		props.data.google_sheets_url
+	);
+	if (props.data.status != "Pending") {
+		getImportLogs();
+	}
+});
+
+const reloadPreviewData = (dataImport: string) => {
+	if (dataImport != props.data.name) return;
+	nextTick(() => {
+		props.dataImports.reload();
+		nextTick(async () => {
+			let updatedData = props.dataImports.data?.find((d) => d.name === props.data.name);
+			emit("updateStep", "preview", { ...updatedData });
+			getImportLogs();
+		});
+	});
+};
+
+const previewColumns = computed(() => {
+	const columns: any[] = [];
+	preview.value?.columns.forEach((col: any, index: number) => {
+		let align = "left";
+		let width = "300px";
+		if (index == 0) {
+			col.header_title = "No";
+			align = "center";
+			width = "60px";
+		} else if (col.header_title == "ID") {
+			width = "150px";
+		}
+		columns.push({
+			key: col.header_title,
+			label: col.header_title,
+			width: width,
+			align: align,
+		});
+	});
+	return columns;
+});
+
+const previewData = computed(() => {
+	const data: Record<string, any>[] = [];
+	preview.value?.data.forEach((row: any) => {
+		const dataMap: Record<string, any> = {};
+		Object.keys(row).forEach((key: any, index: number) => {
+			let columnLabel = getColumnLabel(index);
+			let mappedFieldIndex = getMappedColumnName(index);
+			if (columnLabel == "No") {
+				dataMap[columnLabel] = row[key] - 1;
+			} else if (mappedFieldIndex) {
+				dataMap[columnLabel] = row[mappedFieldIndex];
+			} else {
+				dataMap[columnLabel] = row[key];
+			}
+		});
+		data.push(dataMap);
+	});
+	return data;
+});
+
+const getColumnLabel = (index: number) => {
+	return preview.value?.columns[index]?.header_title || `Column ${index + 1}`;
+};
+
+const getMappedColumnName = (index: number) => {
+	let mappedColumn = preview.value?.columns[index]?.map_to_field;
+	if (!mappedColumn) return null;
+	let mappedColumnLabel = preview.value?.columns[index]?.df?.label;
+	let mappedColumnIndex = preview.value?.columns.filter(
+		(col: any) => col.header_title == mappedColumnLabel
+	)[0]?.column_number;
+	return mappedColumnIndex;
+};
+
+const startImport = () => {
+	call("frappe.core.doctype.data_import.data_import.form_start_import", {
+		data_import: props.data.name,
+	});
+};
+
+const getImportLogs = () => {
+	call("frappe.core.doctype.data_import.data_import.get_import_logs", {
+		data_import: props.data.name,
+	}).then((data: any) => {
+		importLogs.value = data;
+		filteredLogs.value = data;
+	});
+};
+
+const updateImportLogs = () => {
+	if (activeTab.value == "all") {
+		filteredLogs.value = importLogs.value;
+	} else if (activeTab.value == "successful") {
+		filteredLogs.value = importLogs.value.filter((log) => log.success);
+	} else if (activeTab.value == "failed") {
+		filteredLogs.value = importLogs.value.filter((log) => !log.success);
+	}
+};
+
+watch(activeTab, () => {
+	updateImportLogs();
+});
+
+const importSuccessCount = computed(() => {
+	if (!importLogs.value.length) return 0;
+	return importLogs.value.filter((log) => log.success).length;
+});
+
+const importErrorCount = computed(() => {
+	if (!importLogs.value.length) return 0;
+	return importLogs.value.filter((log) => !log.success).length;
+});
+
+const importBannerClass = computed(() => {
+	if (importErrorCount.value == 0) {
+		return "bg-surface-green-2 text-ink-green-6";
+	} else if (importSuccessCount.value == 0) {
+		return "bg-surface-red-2 text-ink-red-6";
+	} else {
+		return "bg-surface-amber-2 text-ink-amber-6";
+	}
+});
+
+const mapping = computed(() => {
+	let warningMap: string[][] = [];
+	if (!preview.value?.warnings?.length) return [];
+	preview.value.warnings.forEach((warning: any) => {
+		if (warning.type == "info") {
+			const regex = /<strong>(.*?)<\/strong>/g;
+			let match;
+			const fields = [];
+			while ((match = regex.exec(warning.message)) !== null) {
+				fields.push(match[1]);
+			}
+			warningMap.push(fields);
+		}
+	});
+	return warningMap;
+});
+
+const warnings = computed(() => {
+	return preview.value?.warnings?.filter((warning: any) => warning.type != "info") || [];
+});
+
+const listRoute = computed(() => {
+	return props.doctypeMap[props.data.reference_doctype]?.listRoute;
+});
+
+const redirectToList = () => {
+	if (!listRoute.value) return;
+	window.location.href = listRoute.value;
+};
+
+const pageRoute = computed(() => {
+	return props.doctypeMap[props.data.reference_doctype]?.pageRoute;
+});
+
+const redirectToPage = (docname: string) => {
+	if (!pageRoute.value) return;
+	window.location.href = pageRoute.value.replace("docname", docname);
+};
+
+const tabButtons = computed(() => {
+	return [
+		{ label: "All", value: "all" },
+		{ label: "Successful", value: "successful" },
+		{ label: "Failed", value: "failed" },
+	];
+});
+
+const rowMessage = (row: any) => {
+	return JSON.parse(row.messages)?.[0]?.message;
+};
+</script>

--- a/ui/src/components/DataImport/TemplateModal.vue
+++ b/ui/src/components/DataImport/TemplateModal.vue
@@ -1,0 +1,238 @@
+<template>
+	<Dialog
+		v-model="show"
+		:options="{
+			title: 'Export Data',
+			size: '2xl',
+		}"
+	>
+		<template #body-content>
+			<div class="text-base space-y-5">
+				<div class="grid grid-cols-2 gap-5">
+					<FormControl
+						label="File Type"
+						v-model="fileType"
+						:options="['Excel', 'CSV']"
+						type="select"
+					/>
+				</div>
+				<div class="border-t">
+					<p class="mt-2 text-ink-gray-5">
+						Select the fields you want to include in the template.
+					</p>
+					<div class="space-x-2 mt-2 mb-5">
+						<Button label="Select All" @click="selectAllFields" />
+						<Button label="Select Mandatory Fields" @click="selectMandatoryFields" />
+						<Button label="Unselect All" @click="unselectAllFields" />
+					</div>
+					<div class="space-y-8">
+						<div
+							v-for="doctype in Object.keys(fields.data)"
+							:key="doctype"
+							class="flex flex-col space-y-2"
+						>
+							<div class="text-ink-gray-5">
+								{{ doctype }}
+							</div>
+							<div class="grid grid-cols-2 gap-5">
+								<div
+									v-for="field in fields.data[doctype]"
+									:key="field.fieldname"
+									class="flex items-center space-x-2"
+								>
+									<Checkbox
+										:id="`checkbox-${doctype}-${field.fieldname}`"
+										:checked="fieldSelection[doctype][field.fieldname]"
+										@change="
+											(e: Event) =>
+												(fieldSelection[doctype][field.fieldname] = (
+													e.target as HTMLInputElement
+												).checked)
+										"
+									/>
+									<label
+										:for="`checkbox-${doctype}-${field.fieldname}`"
+										:class="{
+											'text-ink-red-6': field.reqd,
+										}"
+									>
+										{{ field.label || field.fieldname }}
+									</label>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</template>
+		<template #actions="{ close }">
+			<div class="flex justify-end space-x-2">
+				<Button label="Export" variant="solid" @click="handleExport" />
+				<Button label="Cancel" @click="close" />
+			</div>
+		</template>
+	</Dialog>
+</template>
+<script setup lang="ts">
+import { ref } from "vue";
+import type { DocField } from "./types";
+import { Button, Checkbox, Dialog, FormControl, createResource } from "frappe-ui";
+import { fieldsToIgnore, getChildTableName } from "./dataImport";
+
+const show = defineModel<boolean>({ required: true, default: false });
+const fileType = ref<"Excel" | "CSV">("CSV");
+const exportType = ref<"All Records" | "5 Records" | "Blank Template">("Blank Template");
+const fieldSelection = ref<Record<string, Record<string, boolean>>>({});
+const doctypeMeta = ref<any>(null);
+
+const props = defineProps<{
+	doctype: string;
+}>();
+
+const fields = createResource({
+	url: "frappe.desk.form.load.getdoctype",
+	params: {
+		doctype: props.doctype,
+		with_parent: 1,
+	},
+	auto: true,
+	transform(data: any) {
+		doctypeMeta.value = data.docs;
+		return transformFields(data);
+	},
+});
+
+const transformFields = (data: any) => {
+	let doctypeMap: Record<string, { fieldname: string; label: string; reqd: number }[]> = {};
+
+	prepareDoctypeMap(data.docs, doctypeMap);
+	addIDField(doctypeMap);
+	updateFieldSelection(doctypeMap);
+
+	return doctypeMap;
+};
+
+const prepareDoctypeMap = (
+	docs: any[],
+	doctypeMap: Record<string, { fieldname: string; label: string; reqd: number }[]>
+) => {
+	docs.forEach((doc: any) => {
+		doctypeMap[doc.name] = doc.fields
+			.filter((field: DocField) => {
+				return !fieldsToIgnore.includes(field.fieldtype);
+			})
+			.map((field: DocField) => {
+				return {
+					fieldname: field.fieldname,
+					label: field.label,
+					reqd: field.reqd,
+					disabled: doc.name == props.doctype && field.reqd ? true : false,
+				};
+			});
+	});
+};
+
+const addIDField = (
+	doctypeMap: Record<string, { fieldname: string; label: string; reqd: number }[]>
+) => {
+	Object.keys(doctypeMap).forEach((doctype: string) => {
+		doctypeMap[doctype].unshift({
+			fieldname: "name",
+			label: "ID",
+			reqd: 1,
+		} as { fieldname: string; label: string; reqd: number });
+	});
+};
+
+const updateFieldSelection = (
+	doctypeMap: Record<string, { fieldname: string; label: string; reqd: number }[]>
+) => {
+	Object.keys(doctypeMap).forEach((doctype: string) => {
+		if (!fieldSelection.value[doctype]) {
+			fieldSelection.value[doctype] = {};
+			if (doctype == props.doctype) {
+				doctypeMap[doctype].forEach((field) => {
+					if (field.reqd) {
+						fieldSelection.value[doctype][field.fieldname] = true;
+					}
+				});
+			}
+		}
+	});
+};
+
+const getExportURL = () => {
+	let doctype = props.doctype;
+	let exportFields = getExportFields();
+	let exportRecords = getExportType();
+	let exportPageLength = exportType.value == "5 Records" ? 5 : "";
+
+	return `/api/method/frappe.core.doctype.data_import.data_import.download_template
+        ?doctype=${encodeURIComponent(doctype)}
+        &export_fields=${encodeURIComponent(JSON.stringify(exportFields))}
+        &export_records=${encodeURIComponent(exportRecords)}
+        &file_type=${encodeURIComponent(fileType.value)}
+        &export_page_length=${exportPageLength}`.replace(/\s+/g, "");
+};
+
+const handleExport = async () => {
+	let url = getExportURL();
+	const response = await fetch(url);
+	const blob = await response.blob();
+	const link = document.createElement("a");
+
+	link.href = URL.createObjectURL(blob);
+	link.download = props.doctype + (fileType.value === "CSV" ? ".csv" : ".xlsx");
+	document.body.appendChild(link);
+
+	link.click();
+	document.body.removeChild(link);
+};
+
+const getExportFields = () => {
+	let exportFields: Record<string, string[]> = {};
+	Object.keys(fieldSelection.value).forEach((doctype: string) => {
+		let doctypeName =
+			doctype == props.doctype
+				? doctype
+				: getChildTableName(doctype, props.doctype, doctypeMeta.value);
+		exportFields[doctypeName] = Object.keys(fieldSelection.value[doctype]).filter(
+			(fieldname: string) => fieldSelection.value[doctype][fieldname]
+		);
+	});
+	return exportFields;
+};
+
+const getExportType = () => {
+	if (exportType.value == "Blank Template") return "blank_template";
+	if (exportType.value == "5 Records") return "5_records";
+	return "all";
+};
+
+const selectAllFields = () => {
+	Object.keys(fields.data).forEach((doctype: string) => {
+		fields.data[doctype].forEach((field: DocField) => {
+			if (!fieldSelection.value[doctype]) {
+				fieldSelection.value[doctype] = {};
+			}
+			fieldSelection.value[doctype][field.fieldname] = true;
+		});
+	});
+};
+
+const selectMandatoryFields = () => {
+	Object.keys(fields.data).forEach((doctype: string) => {
+		fields.data[doctype].forEach((field: DocField) => {
+			fieldSelection.value[doctype][field.fieldname] = field.reqd ? true : false;
+		});
+	});
+};
+
+const unselectAllFields = () => {
+	Object.keys(fields.data).forEach((doctype: string) => {
+		fields.data[doctype].forEach((field: DocField) => {
+			fieldSelection.value[doctype][field.fieldname] = false;
+		});
+	});
+};
+</script>

--- a/ui/src/components/DataImport/UploadStep.vue
+++ b/ui/src/components/DataImport/UploadStep.vue
@@ -1,0 +1,462 @@
+<template>
+	<div class="text-base h-full flex flex-col w-[85%] lg:w-[700px] mx-auto pt-12 space-y-8">
+		<div class="flex flex-col space-y-1 text-ink-gray-7">
+			<div class="flex items-center justify-between">
+				<div class="flex items-center space-x-2 text-lg font-semibold text-ink-gray-9">
+					<span> Choose Import </span>
+					<Badge v-if="data?.status" :theme="getBadgeColor(data?.status)">
+						{{ data?.status }}
+					</Badge>
+				</div>
+				<Button variant="solid" @click="saveImport" :disabled="disableContinueButton">
+					Continue
+				</Button>
+			</div>
+			<div class="leading-5">
+				Import data into your system using CSV files or Google Sheets.
+			</div>
+		</div>
+
+		<div class="space-y-4">
+			<div
+				v-if="showFileSelector && !importFile"
+				@dragover.prevent
+				@drop.prevent="(e) => uploadFile(e)"
+				class="h-[300px] flex items-center justify-center bg-surface-gray-1 border border-dashed border-outline-gray-3 rounded-md"
+			>
+				<div v-if="showFileSelector && !uploading" class="w-4/5 lg:w-2/5 text-center">
+					<FeatherIcon
+						name="upload-cloud"
+						class="size-6 stroke-1.5 text-ink-gray-6 mx-auto mb-2.5"
+					/>
+					<input
+						ref="fileInput"
+						type="file"
+						accept=".csv"
+						class="hidden"
+						@change="(e) => uploadFile(e)"
+					/>
+					<div class="leading-5 text-ink-gray-9">
+						Drag and drop a CSV file, or upload from your
+						<span
+							@click="openFileSelector"
+							class="cursor-pointer font-semibold hover:underline"
+							>Device</span
+						>
+						or
+						<span
+							@click="openSheetSelector"
+							class="cursor-pointer font-semibold hover:underline"
+						>
+							Google Sheet
+						</span>
+					</div>
+				</div>
+				<div
+					v-else-if="showFileSelector && uploading"
+					class="w-4/5 lg:w-2/5 bg-surface-base border rounded-md p-2"
+				>
+					<div class="space-y-2">
+						<div class="font-medium">
+							{{ uploadingdFile.name }}
+						</div>
+						<div class="text-ink-gray-6">
+							{{ convertToKB(uploaded) }} of {{ convertToKB(total) }}
+						</div>
+					</div>
+					<div class="w-full bg-surface-gray-1 h-1 rounded-full mt-3">
+						<div
+							class="bg-surface-gray-10 h-1 rounded-full transition-all duration-500 ease-in-out"
+							:style="`width: ${uploadProgress}%`"
+						></div>
+					</div>
+				</div>
+			</div>
+			<div
+				v-else-if="importFile"
+				class="h-[300px] flex items-center justify-center bg-surface-gray-1 border border-dashed border-outline-gray-3 rounded-md"
+			>
+				<div
+					class="w-4/5 lg:w-2/5 bg-surface-base border rounded-md p-2 flex items-center justify-between items-center"
+				>
+					<div class="space-y-2">
+						<div class="font-medium leading-5 text-ink-gray-9">
+							{{ importFile.file_name || importFile.split("/").pop() }}
+						</div>
+						<div v-if="importFile.file_size" class="text-ink-gray-6">
+							{{ convertToKB(importFile.file_size) }}
+						</div>
+					</div>
+					<FeatherIcon
+						name="trash-2"
+						class="size-4 stroke-1.5 text-ink-red-6 cursor-pointer"
+						@click="deleteFile"
+					/>
+				</div>
+			</div>
+
+			<div
+				v-else-if="showSheetSelector"
+				class="flex flex-col h-[300px] p-4 border border-dashed border-outline-gray-3 rounded-md"
+			>
+				<div class="flex items-center space-x-2 text-ink-gray-7">
+					<FeatherIcon
+						name="chevron-left"
+						class="size-4 cursor-pointer"
+						@click="backToFileSelector"
+					/>
+					<div>Google Sheet</div>
+				</div>
+				<div
+					class="flex-1 flex flex-col items-center justify-center w-[95%] lg:w-[400px] mx-auto space-y-3"
+				>
+					<input
+						v-model="googleSheet"
+						type="text"
+						class="w-full border border-outline-gray-2 rounded-md px-2.5 text-base"
+						placeholder="Add Google Sheets Link"
+					/>
+					<div class="text-ink-gray-5">
+						Make sure the link is publically accessible to fetch the data.
+					</div>
+				</div>
+			</div>
+
+			<div class="flex justify-end">
+				<Dropdown
+					:options="[
+						{
+							label: 'Mandatory Fields',
+							onClick() {
+								exportTemplate('mandatory');
+							},
+						},
+						{
+							label: 'All Fields',
+							onClick() {
+								exportTemplate('all');
+							},
+						},
+						{
+							label: 'Custom Template',
+							onClick() {
+								showTemplateModal = true;
+							},
+						},
+					]"
+				>
+					<template v-slot="{ open }">
+						<Button variant="ghost">
+							<template #prefix>
+								<FeatherIcon name="download" class="size-4 stroke-1.5" />
+							</template>
+							Download CSV Template
+							<template #suffix>
+								<FeatherIcon
+									name="chevron-down"
+									:class="[
+										'w-4 h-4 stroke-1.5 ml-1 transform transition-transform',
+										open ? 'rotate-180' : '',
+									]"
+								/>
+							</template>
+						</Button>
+					</template>
+				</Dropdown>
+			</div>
+		</div>
+
+		<TemplateModal
+			v-if="props.doctype || props.data?.reference_doctype"
+			v-model="showTemplateModal"
+			:doctype="props.doctype || (props.data?.reference_doctype as string)"
+		/>
+	</div>
+</template>
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from "vue";
+import { useRouter } from "vue-router";
+import type { DataImports, DataImport, DocField, DocType } from "./types";
+import { Badge, Button, Dropdown, FeatherIcon, FileUploadHandler, toast } from "frappe-ui";
+import { fieldsToIgnore, getChildTableName, getBadgeColor } from "./dataImport";
+import TemplateModal from "./TemplateModal.vue";
+
+const emit = defineEmits(["updateStep"]);
+const importFile = ref<any | null>(null);
+const googleSheet = ref<string>("");
+const uploading = ref(false);
+const uploadingdFile = ref<any | null>(null);
+const uploaded = ref(0);
+const total = ref(0);
+const showTemplateModal = ref(false);
+const fileInput = ref<HTMLInputElement | null>(null);
+const showFileSelector = ref(true);
+const showSheetSelector = ref(false);
+const showLibrarySelector = ref(false);
+const router = useRouter();
+
+const props = defineProps<{
+	dataImports: DataImports;
+	doctype?: string;
+	fields: any;
+	data: DataImport | null;
+}>();
+
+const uploadProgress = computed(() => {
+	if (total.value === 0) return 0;
+	return Math.floor((uploaded.value / total.value) * 100);
+});
+
+const extractFile = (e: Event): File | null => {
+	const inputFiles = (e.target as HTMLInputElement)?.files;
+	const dt = (e as DragEvent).dataTransfer?.files;
+
+	return inputFiles?.[0] || dt?.[0] || null;
+};
+
+const uploadFile = (e: Event) => {
+	const file = extractFile(e);
+	if (!file) return;
+
+	if (file.type !== "text/csv") {
+		toast.error("Please upload a valid CSV file.");
+		console.error("Please upload a valid CSV file.");
+		return;
+	}
+
+	uploadingdFile.value = file;
+	const uploader = new FileUploadHandler();
+
+	uploader.on("start", () => {
+		uploading.value = true;
+	});
+
+	uploader.on("progress", (data: { uploaded: number; total: number }) => {
+		uploaded.value = data.uploaded;
+		total.value = data.total;
+	});
+
+	uploader.on("error", (error: any) => {
+		uploading.value = false;
+		toast.error(error);
+		console.error("File upload error:", error);
+	});
+
+	uploader.on("finish", () => {
+		uploading.value = false;
+	});
+	uploader
+		.upload(file, {})
+		.then((data) => {
+			importFile.value = data;
+		})
+		.catch((error) => {
+			console.error("File upload error:", error);
+		});
+};
+
+const saveImport = () => {
+	if (props.data?.name) {
+		updateImport();
+	} else {
+		createImport();
+	}
+};
+
+const createImport = () => {
+	props.dataImports.insert.submit(
+		{
+			reference_doctype: props.doctype!,
+			import_type: "Insert New Records",
+			mute_emails: true,
+			status: "Pending",
+			google_sheets_url: googleSheet.value.trim(),
+			import_file: importFile.value?.file_url,
+		},
+		{
+			onSuccess(data: DataImport) {
+				router.replace({
+					name: "DataImport",
+					params: {
+						importName: data.name,
+					},
+					query: {
+						step: "map",
+					},
+				});
+			},
+			onError(error: any) {
+				toast.error(error.messages?.[0] || error);
+				console.error("Error creating data import:", error);
+			},
+		}
+	);
+};
+
+const updateImport = () => {
+	if (!props.data) return;
+	props.dataImports.setValue.submit(
+		{
+			...props.data,
+			google_sheets_url: googleSheet.value.trim(),
+			import_file: importFile.value ? importFile.value.file_url : "",
+		},
+		{
+			onSuccess(data: DataImport) {
+				nextTick(() => {
+					if (importFile.value || googleSheet.value.trim().length) {
+						emit("updateStep", "map", data);
+					} else {
+						emit("updateStep", "upload", data);
+					}
+				});
+			},
+			onError(error: any) {
+				toast.error(error.messages?.[0] || error, { duration: 1000 });
+				console.error("Error updating data import:", error);
+			},
+		}
+	);
+};
+
+const exportTemplate = async (type: "mandatory" | "all") => {
+	let url = getExportURL(type);
+	const response = await fetch(url);
+	const blob = await response.blob();
+	const link = document.createElement("a");
+
+	link.href = URL.createObjectURL(blob);
+	link.download = props.doctype + ".csv";
+	document.body.appendChild(link);
+
+	link.click();
+	document.body.removeChild(link);
+};
+
+const getExportURL = (type: "mandatory" | "all") => {
+	if (!props.doctype && !props.data?.reference_doctype) return "";
+	let exportFields = getExportFields(type);
+
+	return `/api/method/frappe.core.doctype.data_import.data_import.download_template
+        ?doctype=${encodeURIComponent(props.doctype || (props.data?.reference_doctype as string))}
+        &export_fields=${encodeURIComponent(JSON.stringify(exportFields))}
+        &export_records=blank_template
+        &file_type=CSV`.replace(/\s+/g, "");
+};
+
+const getExportFields = (type: "mandatory" | "all") => {
+	/* {'Sales Invoice': ['name', 'customer'], 'Sales Invoice Item': ['item_code']} */
+	if (type == "mandatory") {
+		return getMandatoryFields();
+	}
+	return getAllFields();
+};
+
+const getMandatoryFields = () => {
+	let exportableFields: Record<string, string[]> = {};
+	let docs = props.fields.data?.docs || [];
+	let referenceDoctype = props.doctype || (props.data?.reference_doctype as string);
+	let parentDoctype = docs.find((doc: DocType) => doc.name == referenceDoctype);
+
+	let parentFields = parentDoctype.fields
+		.filter((field: DocField) => {
+			return !fieldsToIgnore.includes(field.fieldtype) && field.reqd;
+		})
+		.map((field: DocField) => field.fieldname);
+	parentFields.unshift("name");
+	exportableFields[referenceDoctype] = parentFields;
+
+	let childDoctypes = parentDoctype.fields.filter((field: DocField) => {
+		return (
+			(field.fieldtype === "Table" || field.fieldtype === "Table MultiSelect") && field.reqd
+		);
+	});
+
+	childDoctypes.forEach((field: DocField) => {
+		let childDoctype = docs.find((doc: DocType) => doc.name == field.options);
+		if (childDoctype) {
+			let childFields = childDoctype.fields
+				.filter((f: DocField) => {
+					return !fieldsToIgnore.includes(f.fieldtype) && f.reqd;
+				})
+				.map((f: DocField) => f.fieldname);
+			childFields.unshift("name");
+			exportableFields[field.fieldname] = childFields;
+		}
+	});
+
+	return exportableFields;
+};
+
+const getAllFields = () => {
+	let doctypeMap: Record<string, string[]> = {};
+	let docs = props.fields.data?.docs || [];
+	docs.forEach((doc: DocType) => {
+		let exportableFields = doc.fields
+			.filter((field: DocField) => {
+				return !fieldsToIgnore.includes(field.fieldtype);
+			})
+			.map((field: DocField) => field.fieldname);
+		exportableFields.unshift("name");
+		let doctypeName =
+			doc.name == props.doctype
+				? doc.name
+				: getChildTableName(
+						doc.name,
+						props.doctype || (props.data?.reference_doctype as string),
+						docs
+				  );
+		doctypeMap[doctypeName] = exportableFields;
+	});
+	return doctypeMap;
+};
+
+const openFileSelector = () => {
+	fileInput.value?.click();
+};
+
+const openSheetSelector = () => {
+	showFileSelector.value = false;
+	showLibrarySelector.value = false;
+	showSheetSelector.value = true;
+};
+
+const backToFileSelector = () => {
+	showFileSelector.value = true;
+	showLibrarySelector.value = false;
+	showSheetSelector.value = false;
+};
+
+const disableContinueButton = computed(() => {
+	return !importFile.value && !googleSheet.value.trim().length;
+});
+
+watch(
+	() => props.data,
+	() => {
+		if (props.data) {
+			if (props.data.import_file) {
+				importFile.value = props.data.import_file;
+			} else if (props.data.google_sheets_url) {
+				openSheetSelector();
+				googleSheet.value = props.data.google_sheets_url;
+			}
+		}
+	},
+	{ immediate: true }
+);
+
+watch([importFile, googleSheet], () => {
+	if (!importFile.value || !googleSheet.value.trim().length) {
+		updateImport();
+	}
+});
+
+const deleteFile = () => {
+	importFile.value = null;
+};
+
+const convertToKB = (bytes: number) => {
+	return (bytes / 1024).toFixed(2) + " KB";
+};
+</script>

--- a/ui/src/components/DataImport/dataImport.ts
+++ b/ui/src/components/DataImport/dataImport.ts
@@ -1,0 +1,62 @@
+import { call, toast } from "frappe-ui";
+import type { DataImportStatus } from "./types";
+
+export const getBadgeColor = (status: DataImportStatus) => {
+  const colorMap = {
+    Pending: "orange",
+    Success: "green",
+    "Partial Success": "orange",
+    Error: "red",
+    "Timed Out": "orange",
+  } as const;
+  return colorMap[status as DataImportStatus] || "gray";
+};
+
+export const fieldsToIgnore = [
+  "Section Break",
+  "Column Break",
+  "Tab Break",
+  "HTML",
+  "Table",
+  "Table MultiSelect",
+  "Button",
+  "Image",
+  "Fold",
+  "Heading",
+];
+
+export const getChildTableName = (
+  doctype: string,
+  parentDocType: string,
+  docs: any[],
+) => {
+  let childTableName = "";
+  let doctypeFields = docs.filter((doc: any) => {
+    return doc.name == parentDocType;
+  })[0].fields;
+
+  doctypeFields.forEach((field: any) => {
+    if (field.options == doctype) {
+      childTableName = field.fieldname;
+    }
+  });
+  return childTableName;
+};
+
+export const getPreviewData = (
+  importName: string,
+  file: string | undefined,
+  sheet: string | undefined,
+) => {
+  return call(
+    "frappe.core.doctype.data_import.data_import.get_preview_from_template",
+    {
+      data_import: importName,
+      import_file: file,
+      google_sheets_url: sheet,
+    },
+  ).catch((error: any) => {
+    toast.error(error.messages?.[0] || error);
+    console.error("Error fetching preview data:", error);
+  });
+};

--- a/ui/src/components/DataImport/index.ts
+++ b/ui/src/components/DataImport/index.ts
@@ -1,0 +1,13 @@
+// Only the composite is public. The step screens (`UploadStep`, `MappingStep`,
+// `PreviewStep`, `TemplateModal`, `ImportSteps`, `DataImportList`) are internal
+// to it, as they were in `frappe-ui/frappe`.
+export { default as DataImport } from "./DataImport.vue";
+export type {
+  DataImport as DataImportRecord,
+  DataImportProps,
+  DataImportSocket,
+  DataImportStatus,
+  DataImports,
+  DocField,
+  DocType,
+} from "./types";

--- a/ui/src/components/DataImport/types.ts
+++ b/ui/src/components/DataImport/types.ts
@@ -1,7 +1,7 @@
 /** Minimal socket.io-compatible listener. Supplied by the host. */
 export interface DataImportSocket {
   on: (event: string, handler: (payload: any) => void) => void;
-  off?: (event: string, handler?: (payload: any) => void) => void;
+  off: (event: string, handler?: (payload: any) => void) => void;
 }
 
 export interface DataImportProps {

--- a/ui/src/components/DataImport/types.ts
+++ b/ui/src/components/DataImport/types.ts
@@ -1,0 +1,89 @@
+/** Minimal socket.io-compatible listener. Supplied by the host. */
+export interface DataImportSocket {
+  on: (event: string, handler: (payload: any) => void) => void;
+  off?: (event: string, handler?: (payload: any) => void) => void;
+}
+
+export interface DataImportProps {
+  label?: string;
+  description?: string;
+  doctype?: string | null;
+  importName?: string | null;
+  doctypeMap?: Record<
+    string,
+    { title: string; listRoute?: string; pageRoute?: string }
+  >;
+  /**
+   * The app's realtime socket. Given one, the preview table refreshes itself
+   * while an import runs. Left out, the user reloads to see progress.
+   */
+  socket?: DataImportSocket;
+}
+
+export interface DataImport {
+  name?: string;
+  reference_doctype: string;
+  import_type: string;
+  status: DataImportStatus;
+  creation?: string;
+  mute_emails: boolean;
+  import_file?: string;
+  google_sheets_url?: string;
+  template_options?: string;
+}
+
+/**
+ * The slice of frappe-ui's `createListResource` return that these screens use.
+ * The paging members are optional so a plain `ListResource` satisfies the type;
+ * `hasNextPage` is a boolean on the resource, not the function it was declared
+ * as before the move.
+ */
+export interface DataImports {
+  data: DataImport[] | null;
+  update: (args: { filters: any[] }) => void;
+  insert: {
+    submit: (
+      params: DataImport,
+      options: {
+        validate?: () => boolean;
+        onSuccess: (data: DataImport) => void;
+        onError: (err: any) => void;
+      },
+    ) => void;
+  };
+  setValue: {
+    submit: (
+      params: DataImport,
+      options: {
+        onSuccess: (data: DataImport) => void;
+        onError: (err: any) => void;
+      },
+    ) => void;
+  };
+  reload: () => void;
+  hasNextPage?: boolean;
+  next?: () => void;
+}
+
+export type DataImportStatus =
+  "Pending" | "Success" | "Partial Success" | "Error" | "Timed Out";
+
+export interface DocField {
+  label: string;
+  fieldname: string;
+  reqd: 0 | 1;
+  fieldtype: string;
+  options?: string;
+}
+
+export interface DocType {
+  name: string;
+  fields: DocField[];
+}
+
+export interface File {
+  name: string;
+  file_url: string;
+  file_name: string;
+  file_size: number;
+}

--- a/ui/src/components/Onboarding/GettingStartedBanner.vue
+++ b/ui/src/components/Onboarding/GettingStartedBanner.vue
@@ -1,0 +1,77 @@
+<template>
+	<div
+		v-if="!isSidebarCollapsed"
+		class="flex flex-col gap-3 shadow-sm rounded-lg py-2.5 px-3 bg-surface-elevation-2 text-base"
+	>
+		<div v-if="stepsCompleted != totalSteps" class="inline-flex text-ink-gray-9 gap-2">
+			<StepsIcon class="h-4 my-0.5 shrink-0" />
+			<div class="flex flex-col text-p-sm gap-0.5">
+				<div class="font-medium">
+					{{ "Getting started" }}
+				</div>
+				<div class="text-ink-gray-7">
+					{{ `${stepsCompleted}/${totalSteps} steps` }}
+				</div>
+			</div>
+		</div>
+		<div v-else class="flex flex-col gap-1">
+			<div class="flex items-center justify-between gap-1">
+				<div class="flex items-center gap-2 shrink-0">
+					<StepsIcon class="h-4 my-0.5" />
+					<div class="text-ink-gray-9 font-medium">
+						{{ "You are all set" }}
+					</div>
+				</div>
+				<FeatherIcon
+					name="x"
+					class="h-4 cursor-pointer"
+					@click="
+						() => {
+							showHelpCenter = true;
+							isOnboardingStepsCompleted = true;
+						}
+					"
+				/>
+			</div>
+			<div class="text-p-sm text-ink-gray-7">
+				{{ "All steps are completed successfully" }}
+			</div>
+		</div>
+		<Button
+			v-if="stepsCompleted != totalSteps"
+			:label="stepsCompleted == 0 ? 'Start now' : 'Continue'"
+			theme="blue"
+			@click="openOnboarding"
+		>
+			<template #prefix>
+				<FeatherIcon name="chevrons-right" class="size-4" />
+			</template>
+		</Button>
+	</div>
+	<Button v-else-if="stepsCompleted != totalSteps" @click="openOnboarding">
+		<StepsIcon class="h-4 my-0.5 shrink-0" />
+	</Button>
+</template>
+<script setup lang="ts">
+import { Button, FeatherIcon } from "frappe-ui";
+import { StepsIcon } from "frappe-ui/icons";
+import { useOnboarding } from "./onboarding";
+import { showHelpCenter } from "./helpCenter";
+import { minimize, showHelpModal } from "./help";
+import type { GettingStartedBannerProps } from "./types";
+
+const props = withDefaults(defineProps<GettingStartedBannerProps>(), {
+	isSidebarCollapsed: false,
+	appName: "frappecrm",
+});
+
+// `useOnboarding` returns undefined for guests, and this banner is only
+// rendered for signed-in users, so the non-null assertion is the call site's
+// existing contract rather than a new one.
+const { stepsCompleted, totalSteps, isOnboardingStepsCompleted } = useOnboarding(props.appName)!;
+
+const openOnboarding = () => {
+	minimize.value = false;
+	showHelpModal.value = true;
+};
+</script>

--- a/ui/src/components/Onboarding/HelpCenter.vue
+++ b/ui/src/components/Onboarding/HelpCenter.vue
@@ -1,0 +1,100 @@
+<template>
+	<div class="flex flex-col gap-2 overflow-hidden">
+		<div class="m-1">
+			<TextInput
+				ref="searchInput"
+				:placeholder="'Search articles...'"
+				v-model="search"
+				:debounce="300"
+			>
+				<template #prefix>
+					<FeatherIcon name="search" class="h-4 text-ink-gray-5" />
+				</template>
+			</TextInput>
+		</div>
+		<div class="flex justify-between items-center text-base text-ink-gray-5 mx-2">
+			<div>All articles</div>
+			<Button variant="ghost" @click="openDocs">
+				<FeatherIcon name="arrow-up-right" class="h-4 text-ink-gray-5" />
+			</Button>
+		</div>
+		<div class="flex flex-col gap-1.5 overflow-y-auto">
+			<div v-for="a in parsedArticles" :key="a.title" class="flex flex-col gap-1.5">
+				<div
+					class="flex items-center justify-between p-1.5 hover:bg-surface-gray-1 rounded cursor-pointer"
+					@click="a.opened = !a.opened"
+				>
+					<div class="flex items-center gap-2">
+						<FeatherIcon
+							:name="a.opened ? 'chevron-down' : 'chevron-right'"
+							class="h-4 text-ink-gray-5"
+						/>
+						<div class="text-base text-ink-gray-8">{{ a.title }}</div>
+					</div>
+				</div>
+				<div v-show="a.opened" class="flex flex-col gap-1.5 ml-5">
+					<div
+						v-for="subArticle in a.subArticles"
+						:key="subArticle.name"
+						class="group flex items-center justify-between gap-2 p-1.5 hover:bg-surface-gray-1 rounded cursor-pointer"
+						@click="() => openDoc(subArticle.name)"
+					>
+						<div class="flex items-center gap-2">
+							<FeatherIcon name="file-text" class="h-4 text-ink-gray-5" />
+							<div class="text-base text-ink-gray-8">
+								{{ subArticle.title }}
+							</div>
+						</div>
+						<FeatherIcon
+							name="arrow-up-right"
+							class="h-4 hidden group-hover:flex text-ink-gray-5"
+						/>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</template>
+<script setup lang="ts">
+import { Button, FeatherIcon, TextInput } from "frappe-ui";
+import { ref, computed, onMounted } from "vue";
+import type { HelpArticle, HelpCenterProps } from "./types";
+
+const props = withDefaults(defineProps<HelpCenterProps>(), {
+	docsLink: "https://docs.frappe.io/crm",
+});
+
+// `el` is frappe-ui's current TextInput template-ref member. It is being
+// renamed to `inputElement` in frappe-ui 1.0.0 (spec/imperative-api.md), so
+// this line follows that rename when the peer range moves to 1.0.0.
+const searchInput = ref<{ el?: HTMLInputElement } | null>(null);
+const search = ref("");
+const articles = defineModel<HelpArticle[]>();
+
+const parsedArticles = computed(() => {
+	if (!search.value) return articles.value;
+
+	return articles.value?.filter((a) => {
+		const filteredSubArticles = a.subArticles.filter((subArticle) => {
+			return subArticle.title.toLowerCase().includes(search.value.toLowerCase());
+		});
+
+		return (
+			a.title.toLowerCase().includes(search.value.toLowerCase()) ||
+			filteredSubArticles.length > 0
+		);
+	});
+});
+
+function openDocs() {
+	window.open(props.docsLink, "_blank");
+}
+
+function openDoc(name: string) {
+	window.open(`${props.docsLink}/${name}`, "_blank");
+}
+
+onMounted(() => {
+	searchInput.value?.el?.focus();
+});
+</script>

--- a/ui/src/components/Onboarding/HelpModal.vue
+++ b/ui/src/components/Onboarding/HelpModal.vue
@@ -1,0 +1,124 @@
+<template>
+	<div
+		v-show="show"
+		class="fixed z-50 right-0 w-80 h-[calc(100%_-_80px)] text-ink-gray-9 m-5 mt-[62px] p-3 flex gap-2 flex-col justify-between rounded-lg bg-surface-elevation-2 shadow-2xl"
+		:class="{ 'top-[calc(100%_-_120px)] border': minimize }"
+		@click.stop
+	>
+		<div class="flex items-center justify-between px-2 py-1.5">
+			<div class="text-base font-medium">
+				{{ headingTitle }}
+			</div>
+			<div class="flex gap-1">
+				<Dropdown v-if="options.length" :options="options">
+					<Button variant="ghost" icon="more-horizontal" />
+				</Dropdown>
+				<Button @click="minimize = !minimize" variant="ghost">
+					<component :is="minimize ? MaximizeIcon : MinimizeIcon" class="h-3.5" />
+				</Button>
+				<Button variant="ghost" @click="show = false">
+					<FeatherIcon name="x" class="h-3.5" />
+				</Button>
+			</div>
+		</div>
+		<div class="h-full overflow-hidden flex flex-col">
+			<OnboardingSteps
+				v-if="!isOnboardingStepsCompleted && !showHelpCenter"
+				:title="title"
+				:logo="logo"
+				:afterSkip="afterSkip"
+				:afterSkipAll="afterSkipAll"
+				:afterReset="afterReset"
+				:afterResetAll="afterResetAll"
+				:appName="appName"
+			/>
+			<HelpCenter v-else-if="showHelpCenter" v-model="articles" :docsLink="docsLink" />
+		</div>
+		<div v-for="item in footerItems" class="flex flex-col gap-1.5">
+			<div
+				class="w-full flex gap-2 items-center hover:bg-surface-gray-1 text-ink-gray-8 rounded px-2 py-1.5 cursor-pointer"
+				@click="item.onClick"
+			>
+				<component :is="item.icon" class="h-4" />
+				<div class="text-base">{{ item.label }}</div>
+			</div>
+		</div>
+	</div>
+</template>
+<script setup lang="ts">
+import { Button, Dropdown, FeatherIcon } from "frappe-ui";
+import { HelpIcon, MaximizeIcon, MinimizeIcon, StepsIcon } from "frappe-ui/icons";
+import OnboardingSteps from "./OnboardingSteps.vue";
+import HelpCenter from "./HelpCenter.vue";
+import { useOnboarding } from "./onboarding";
+import { showHelpCenter } from "./helpCenter";
+import { minimize } from "./help";
+import { onMounted, computed } from "vue";
+import type { HelpArticle, HelpModalProps } from "./types";
+
+const props = withDefaults(defineProps<HelpModalProps>(), {
+	appName: "frappecrm",
+	title: "Frappe CRM",
+	docsLink: "https://docs.frappe.io/crm",
+});
+
+const { syncStatus, resetAll, isOnboardingStepsCompleted } = useOnboarding(props.appName)!;
+
+const show = defineModel<boolean>();
+const articles = defineModel<HelpArticle[]>("articles");
+
+const headingTitle = computed(() => {
+	if (!isOnboardingStepsCompleted.value && !showHelpCenter.value) {
+		return "Getting started";
+	} else if (showHelpCenter.value) {
+		return "Help center";
+	}
+});
+
+const options = computed(() => {
+	let items = [
+		{
+			icon: StepsIcon,
+			label: "Reset onboarding steps",
+			onClick: resetOnboardingSteps,
+			condition: () => showHelpCenter.value && isOnboardingStepsCompleted.value,
+		},
+	];
+
+	return items.filter((item) => item.condition());
+});
+
+const footerItems = computed(() => {
+	let items = [
+		{
+			icon: HelpIcon,
+			label: "Help centre",
+			onClick: () => {
+				syncStatus();
+				showHelpCenter.value = true;
+			},
+			condition: !isOnboardingStepsCompleted.value && !showHelpCenter.value,
+		},
+		{
+			icon: StepsIcon,
+			label: "Getting started",
+			onClick: () => (showHelpCenter.value = false),
+			condition: showHelpCenter.value && !isOnboardingStepsCompleted.value,
+		},
+	];
+
+	return items.filter((item) => item.condition);
+});
+
+function resetOnboardingSteps() {
+	resetAll();
+	isOnboardingStepsCompleted.value = false;
+	showHelpCenter.value = false;
+}
+
+onMounted(() => {
+	if (isOnboardingStepsCompleted.value) {
+		showHelpCenter.value = true;
+	}
+});
+</script>

--- a/ui/src/components/Onboarding/IntermediateStepModal.vue
+++ b/ui/src/components/Onboarding/IntermediateStepModal.vue
@@ -1,6 +1,6 @@
 <template>
 	<Dialog v-model="show" :options="options">
-		<template #boday-header>
+		<template #body-header>
 			<slot name="body-header"></slot>
 		</template>
 		<template #body-content>

--- a/ui/src/components/Onboarding/IntermediateStepModal.vue
+++ b/ui/src/components/Onboarding/IntermediateStepModal.vue
@@ -1,0 +1,65 @@
+<template>
+	<Dialog v-model="show" :options="options">
+		<template #boday-header>
+			<slot name="body-header"></slot>
+		</template>
+		<template #body-content>
+			<slot>
+				<div class="flex flex-col gap-2 text-ink-gray-9 text-base">
+					<div v-if="currentStep.message">{{ currentStep.message }}</div>
+					<video
+						v-if="currentStep.videoURL"
+						class="w-full rounded"
+						controls
+						autoplay
+						muted
+					>
+						<source :src="currentStep.videoURL" type="video/mp4" />
+						Your browser does not support the video tag.
+					</video>
+				</div>
+			</slot>
+		</template>
+		<template #actions>
+			<slot name="actions"></slot>
+		</template>
+	</Dialog>
+</template>
+<script setup lang="ts">
+import { Dialog } from "frappe-ui";
+import { computed } from "vue";
+import type { IntermediateStepModalProps } from "./types";
+
+const props = withDefaults(defineProps<IntermediateStepModalProps>(), {
+	// A factory, unlike the object literal the options API version passed —
+	// that shared one object across every instance.
+	currentStep: () => ({
+		title: "Title",
+		message: "Message",
+		videoURL: "",
+		buttonLabel: "Button Label",
+		onClick: () => {},
+	}),
+	dialogOptions: () => ({}),
+});
+
+const show = defineModel<boolean>();
+
+const options = computed(() => {
+	if (props.dialogOptions && Object.keys(props.dialogOptions).length) {
+		return props.dialogOptions;
+	}
+
+	return {
+		title: props.currentStep.title,
+		size: "2xl",
+		actions: [
+			{
+				label: props.currentStep.buttonLabel,
+				variant: "solid",
+				onClick: props.currentStep.onClick,
+			},
+		],
+	};
+});
+</script>

--- a/ui/src/components/Onboarding/OnboardingSteps.vue
+++ b/ui/src/components/Onboarding/OnboardingSteps.vue
@@ -1,0 +1,108 @@
+<template>
+	<div class="flex flex-col justify-center items-center gap-1 mt-4 mb-7">
+		<component :is="logo" class="size-10 shrink-0 rounded mb-4" />
+		<div class="text-base font-medium">
+			{{ "Welcome to " + title }}
+		</div>
+		<div class="text-p-base font-normal">
+			{{ `${stepsCompleted}/${totalSteps} steps completed` }}
+		</div>
+	</div>
+	<div class="flex flex-col gap-2.5 overflow-hidden">
+		<div class="flex justify-between items-center py-0.5">
+			<Badge
+				:label="`${completedPercentage}% completed`"
+				:theme="completedPercentage == 100 ? 'green' : 'orange'"
+				size="lg"
+			/>
+			<div class="flex">
+				<Button
+					v-if="completedPercentage != 0"
+					variant="ghost"
+					:label="'Reset all'"
+					@click="() => resetAll(afterResetAll)"
+				/>
+				<Button
+					v-if="completedPercentage != 100"
+					variant="ghost"
+					:label="'Skip all'"
+					@click="() => skipAll(afterSkipAll)"
+				/>
+			</div>
+		</div>
+		<div class="flex flex-col gap-1.5 overflow-y-auto">
+			<div
+				v-for="step in steps"
+				:key="step.title"
+				class="group w-full flex gap-2 justify-between items-center hover:bg-surface-gray-1 rounded px-2 py-1.5 cursor-pointer"
+				@click.stop="() => !step.completed && !isDependent(step) && step.onClick?.()"
+			>
+				<component
+					:is="isDependent(step) ? Tooltip : 'div'"
+					:text="dependsOnTooltip(step)"
+				>
+					<div
+						class="flex gap-2 items-center"
+						:class="[
+							step.completed
+								? 'text-ink-gray-5'
+								: isDependent(step)
+								? 'text-ink-gray-4'
+								: 'text-ink-gray-8',
+						]"
+					>
+						<component :is="step.icon" class="h-4" />
+						<div class="text-base" :class="{ 'line-through': step.completed }">
+							{{ step.title }}
+						</div>
+					</div>
+				</component>
+				<Button
+					v-if="!step.completed && !isDependent(step)"
+					:label="'Skip'"
+					class="!h-4 text-xs !text-ink-gray-6 hidden group-hover:flex"
+					@click="() => skip(step.name, afterSkip)"
+				/>
+				<Button
+					v-else-if="!isDependent(step)"
+					:label="'Reset'"
+					class="!h-4 text-xs !text-ink-gray-6 hidden group-hover:flex"
+					@click.stop="() => reset(step.name, afterReset)"
+				/>
+			</div>
+		</div>
+	</div>
+</template>
+<script setup lang="ts">
+import { Badge, Button, Tooltip } from "frappe-ui";
+import { useOnboarding } from "./onboarding";
+import type { OnboardingStep, OnboardingStepsProps } from "./types";
+
+const props = withDefaults(defineProps<OnboardingStepsProps>(), {
+	appName: "frappecrm",
+	title: "Frappe CRM",
+});
+
+function isDependent(step: OnboardingStep) {
+	if (step.dependsOn && !step.completed) {
+		const dependsOnStep = steps?.find((s) => s.name === step.dependsOn);
+		if (dependsOnStep && !dependsOnStep.completed) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function dependsOnTooltip(step: OnboardingStep) {
+	if (step.dependsOn && !step.completed) {
+		const dependsOnStep = steps?.find((s) => s.name === step.dependsOn);
+		if (dependsOnStep && !dependsOnStep.completed) {
+			return `You need to complete "${dependsOnStep.title}" first.`;
+		}
+	}
+	return "";
+}
+
+const { steps, stepsCompleted, totalSteps, completedPercentage, skip, skipAll, reset, resetAll } =
+	useOnboarding(props.appName)!;
+</script>

--- a/ui/src/components/Onboarding/help.ts
+++ b/ui/src/components/Onboarding/help.ts
@@ -1,0 +1,7 @@
+import { ref } from "vue";
+
+/** Whether the getting-started / help modal is on screen. */
+export const showHelpModal = ref(false);
+
+/** Whether that modal is docked to the bottom-right corner instead of full height. */
+export const minimize = ref(false);

--- a/ui/src/components/Onboarding/helpCenter.ts
+++ b/ui/src/components/Onboarding/helpCenter.ts
@@ -1,0 +1,5 @@
+import { ref } from "vue";
+
+// Internal to `<HelpModal>`: which of its two panes is showing. Not exported
+// from the package — `frappe-ui/frappe` exported it, but no app imported it.
+export const showHelpCenter = ref(false);

--- a/ui/src/components/Onboarding/index.ts
+++ b/ui/src/components/Onboarding/index.ts
@@ -1,0 +1,24 @@
+// Onboarding and the help modal are one module: `onboarding.ts` drives the
+// modal's open state, and `HelpModal` renders the step list. They moved out of
+// `frappe-ui/frappe` together for that reason.
+//
+// `OnboardingSteps`, `HelpCenter` and `showHelpCenter` stay internal —
+// `frappe-ui/frappe` exported them, but no app imports them and they are only
+// ever rendered by `HelpModal`.
+export { default as GettingStartedBanner } from "./GettingStartedBanner.vue";
+export { default as HelpModal } from "./HelpModal.vue";
+export { default as IntermediateStepModal } from "./IntermediateStepModal.vue";
+export { useOnboarding } from "./onboarding";
+export { minimize, showHelpModal } from "./help";
+export type {
+  GettingStartedBannerProps,
+  HelpArticle,
+  HelpModalProps,
+  IntermediateStep,
+  IntermediateStepModalProps,
+  IntermediateStepModalSlots,
+  OnboardingBulkCallback,
+  OnboardingStep,
+  OnboardingStepCallback,
+  UseOnboarding,
+} from "./types";

--- a/ui/src/components/Onboarding/onboarding.ts
+++ b/ui/src/components/Onboarding/onboarding.ts
@@ -1,0 +1,190 @@
+import { call, createResource } from "frappe-ui";
+import { useStorage } from "@vueuse/core";
+import { computed, reactive } from "vue";
+import { minimize, showHelpModal } from "./help";
+import { sessionUser } from "../../utils/session";
+import type {
+  OnboardingBulkCallback,
+  OnboardingStep,
+  OnboardingStepCallback,
+  UseOnboarding,
+} from "./types";
+
+type StoredStep = { name: string; completed: boolean };
+type StoredStatus = Record<string, Record<string, StoredStep[]>>;
+
+const onboardings = reactive<Record<string, OnboardingStep[]>>({});
+const onboardingStatus = useStorage<StoredStatus>("onboardingStatus", {});
+
+/**
+ * Read and write the signed-in user's getting-started checklist for one app.
+ *
+ * Returns `undefined` when nobody is signed in, so call sites have to guard —
+ * the banner and the modal are not rendered for guests.
+ */
+export function useOnboarding(appName: string): UseOnboarding | undefined {
+  const user = sessionUser();
+
+  if (!user || user === "Guest") return;
+
+  // `updateOnboardingStep` and `updateAll` are hoisted function declarations, so
+  // TypeScript does not carry the guard above into them. This const does.
+  const userId: string = user;
+
+  const isOnboardingStepsCompleted = useStorage(
+    "isOnboardingStepsCompleted" + appName + userId,
+    false,
+  );
+
+  const onboardingSteps = computed<StoredStep[]>(
+    () =>
+      onboardingStatus.value?.[userId]?.[appName + "_onboarding_status"] || [],
+  );
+
+  if (!onboardingSteps.value.length && !isOnboardingStepsCompleted.value) {
+    createResource({
+      url: "frappe.onboarding.get_onboarding_status",
+      cache: "onboarding_status",
+      auto: true,
+      onSuccess: (data: Record<string, StoredStep[]>) => {
+        onboardingStatus.value[userId] = data;
+        syncStatus();
+      },
+    });
+  }
+
+  const stepsCompleted = computed(
+    () => onboardings[appName]?.filter((step) => step.completed).length || 0,
+  );
+  const totalSteps = computed(() => onboardings[appName]?.length || 0);
+
+  const completedPercentage = computed(() =>
+    Math.floor((stepsCompleted.value / totalSteps.value) * 100),
+  );
+
+  function skip(step: string, callback: OnboardingStepCallback | null = null) {
+    updateOnboardingStep(step, true, true, callback);
+  }
+
+  function skipAll(callback: OnboardingBulkCallback | null = null) {
+    updateAll(true, callback);
+  }
+
+  function reset(step: string, callback: OnboardingStepCallback | null = null) {
+    updateOnboardingStep(step, false, false, callback);
+  }
+
+  function resetAll(callback: OnboardingBulkCallback | null = null) {
+    updateAll(false, callback);
+  }
+
+  function updateOnboardingStep(
+    step: string,
+    value = true,
+    skipped = false,
+    callback: OnboardingStepCallback | null = null,
+  ) {
+    if (isOnboardingStepsCompleted.value) return;
+
+    if (!onboardingSteps.value.length) {
+      if (!onboardingStatus.value[userId]) {
+        onboardingStatus.value[userId] = {};
+      }
+      onboardingStatus.value[userId][appName + "_onboarding_status"] =
+        onboardings[appName].map((s) => {
+          return { name: s.name, completed: false };
+        });
+    }
+
+    let index = onboardingSteps.value.findIndex((s) => s.name === step);
+    if (index !== -1) {
+      onboardingSteps.value[index].completed = value;
+      onboardings[appName][index].completed = value;
+    }
+
+    updateUserOnboardingStatus(onboardingSteps.value);
+
+    callback?.(step, skipped);
+
+    minimize.value = false;
+  }
+
+  function updateAll(
+    value: boolean,
+    callback: OnboardingBulkCallback | null = null,
+  ) {
+    if (isOnboardingStepsCompleted.value && value) return;
+
+    if (!onboardingSteps.value.length) {
+      if (!onboardingStatus.value[userId]) {
+        onboardingStatus.value[userId] = {};
+      }
+
+      onboardingStatus.value[userId][appName + "_onboarding_status"] =
+        onboardings[appName].map((s) => {
+          return { name: s.name, completed: value };
+        });
+    } else {
+      onboardingSteps.value.forEach((step) => {
+        step.completed = value;
+      });
+    }
+
+    onboardings[appName].forEach((step) => {
+      step.completed = value;
+    });
+
+    updateUserOnboardingStatus(onboardingSteps.value);
+
+    callback?.(value);
+  }
+
+  function updateUserOnboardingStatus(steps: StoredStep[]) {
+    call("frappe.onboarding.update_user_onboarding_status", {
+      steps: JSON.stringify(steps),
+      appName,
+    });
+  }
+
+  function syncStatus() {
+    if (isOnboardingStepsCompleted.value) return;
+
+    if (onboardingSteps.value.length) {
+      let _steps = onboardingSteps.value;
+      _steps.forEach((step, index) => {
+        const onboardingExists =
+          onboardings[appName] && onboardings[appName][index];
+        if (onboardingExists) {
+          onboardings[appName][index].completed = step.completed;
+        }
+      });
+      isOnboardingStepsCompleted.value = _steps.every((step) => step.completed);
+    } else {
+      isOnboardingStepsCompleted.value = false;
+    }
+  }
+
+  function setUp(steps: OnboardingStep[]) {
+    showHelpModal.value = !isOnboardingStepsCompleted.value;
+
+    if (onboardings[appName]) return;
+
+    onboardings[appName] = steps;
+    syncStatus();
+  }
+
+  return {
+    steps: onboardings[appName],
+    stepsCompleted,
+    totalSteps,
+    completedPercentage,
+    isOnboardingStepsCompleted,
+    updateOnboardingStep,
+    skip,
+    skipAll,
+    reset,
+    resetAll,
+    setUp,
+    syncStatus,
+  };
+}

--- a/ui/src/components/Onboarding/types.ts
+++ b/ui/src/components/Onboarding/types.ts
@@ -1,0 +1,143 @@
+import type { Component, ComputedRef, Ref } from "vue";
+
+/** One item in an app's getting-started checklist. */
+export interface OnboardingStep {
+  /** Stable id, stored on the server and used by `skip` / `reset`. */
+  name: string;
+  /** Whether the user has finished (or skipped) this step. */
+  completed: boolean;
+  /** Text shown in the list. */
+  title?: string;
+  /** Icon component rendered before the title. */
+  icon?: Component;
+  /** `name` of a step that has to be completed before this one unlocks. */
+  dependsOn?: string;
+  /** Run when the user clicks the row. */
+  onClick?: () => void;
+  [key: string]: any;
+}
+
+/** Called after a step's state changes on the server. */
+export type OnboardingStepCallback = (step: string, skipped: boolean) => void;
+
+/** Called after every step's state changes at once. */
+export type OnboardingBulkCallback = (value: boolean) => void;
+
+/** What `useOnboarding` hands back for one app. */
+export interface UseOnboarding {
+  /** The steps registered by `setUp`, in order. */
+  steps: OnboardingStep[] | undefined;
+  /** How many steps are completed. */
+  stepsCompleted: ComputedRef<number>;
+  /** How many steps there are. */
+  totalSteps: ComputedRef<number>;
+  /** Completed share, rounded down, 0–100. */
+  completedPercentage: ComputedRef<number>;
+  /** True once every step is done. Persisted in localStorage. */
+  isOnboardingStepsCompleted: Ref<boolean>;
+  /** Mark one step completed (or not) and sync it to the server. */
+  updateOnboardingStep: (
+    step: string,
+    value?: boolean,
+    skipped?: boolean,
+    callback?: OnboardingStepCallback | null,
+  ) => void;
+  /** Mark one step completed without the user doing it. */
+  skip: (step: string, callback?: OnboardingStepCallback | null) => void;
+  /** Mark every step completed. */
+  skipAll: (callback?: OnboardingBulkCallback | null) => void;
+  /** Mark one step not completed. */
+  reset: (step: string, callback?: OnboardingStepCallback | null) => void;
+  /** Mark every step not completed. */
+  resetAll: (callback?: OnboardingBulkCallback | null) => void;
+  /** Register this app's steps. Call once, before rendering the banner or modal. */
+  setUp: (steps: OnboardingStep[]) => void;
+  /** Re-read the stored status into the registered steps. */
+  syncStatus: () => void;
+}
+
+/** Props for `<GettingStartedBanner>`. */
+export interface GettingStartedBannerProps {
+  /** Render the collapsed, icon-only form used by a collapsed sidebar. */
+  isSidebarCollapsed?: boolean;
+  /** App the onboarding status belongs to, e.g. `"frappecrm"`. */
+  appName?: string;
+}
+
+/** One slide in an `<IntermediateStepModal>`. */
+export interface IntermediateStep {
+  /** Dialog title. */
+  title?: string;
+  /** Body copy. */
+  message?: string;
+  /** MP4 shown under the message. */
+  videoURL?: string;
+  /** Label of the single action button. */
+  buttonLabel?: string;
+  /** Run when the action button is clicked. */
+  onClick?: () => void;
+}
+
+/** Props for `<IntermediateStepModal>`. */
+export interface IntermediateStepModalProps {
+  /** The step being shown. */
+  currentStep?: IntermediateStep;
+  /** Passed straight to `Dialog`'s `options`; overrides the derived options. */
+  dialogOptions?: Record<string, any>;
+}
+
+/** Slots for `<IntermediateStepModal>`. */
+export interface IntermediateStepModalSlots {
+  /** Replaces the message + video body. */
+  default?: () => any;
+  /** Extra content above the body. */
+  "body-header"?: () => any;
+  /** Replaces the dialog's action row. */
+  actions?: () => any;
+}
+
+/** One article group in the help centre list. */
+export interface HelpArticle {
+  /** Group heading. */
+  title: string;
+  /** Pages inside the group. */
+  subArticles: { name: string; title: string }[];
+  /** Whether the group is expanded. */
+  opened?: boolean;
+}
+
+/** Props for `<HelpModal>`. */
+export interface HelpModalProps {
+  /** App the onboarding status belongs to, e.g. `"frappecrm"`. */
+  appName?: string;
+  /** Product name shown in the "Welcome to …" heading. */
+  title?: string;
+  /** Logo component shown above the heading. */
+  logo: Component;
+  /** Run after a single step is skipped. */
+  afterSkip?: OnboardingStepCallback;
+  /** Run after every step is skipped. */
+  afterSkipAll?: OnboardingBulkCallback;
+  /** Run after a single step is reset. */
+  afterReset?: OnboardingStepCallback;
+  /** Run after every step is reset. */
+  afterResetAll?: OnboardingBulkCallback;
+  /** Base URL articles open against. */
+  docsLink?: string;
+}
+
+/** Props for `<OnboardingSteps>` — internal to `<HelpModal>`. */
+export interface OnboardingStepsProps {
+  appName?: string;
+  title?: string;
+  logo: Component;
+  afterSkip?: OnboardingStepCallback;
+  afterSkipAll?: OnboardingBulkCallback;
+  afterReset?: OnboardingStepCallback;
+  afterResetAll?: OnboardingBulkCallback;
+}
+
+/** Props for `<HelpCenter>` — internal to `<HelpModal>`. */
+export interface HelpCenterProps {
+  docsLink?: string;
+}

--- a/ui/src/components/SignupBanner/SignupBanner.vue
+++ b/ui/src/components/SignupBanner/SignupBanner.vue
@@ -1,0 +1,43 @@
+<template>
+	<div
+		v-if="!isSidebarCollapsed"
+		class="flex flex-col gap-3 shadow-sm rounded-lg py-2.5 px-3 bg-surface-base text-base"
+	>
+		<div class="flex flex-col gap-1">
+			<slot>
+				<div class="inline-flex gap-2 items-center font-medium">
+					<FeatherIcon class="h-4" name="info" />
+					Loved the demo?
+				</div>
+				<div class="text-ink-gray-7 text-p-sm">
+					{{ `Try ${appName} for free with a 14-day trial.` }}
+				</div>
+			</slot>
+		</div>
+		<Button label="Sign up now" theme="blue" @click="signupNow">
+			<template #prefix>
+				<LightningIcon class="size-4" />
+			</template>
+		</Button>
+	</div>
+	<Button v-else @click="signupNow">
+		<LightningIcon class="h-4 my-0.5 shrink-0" />
+	</Button>
+</template>
+<script setup lang="ts">
+import { Button, FeatherIcon } from "frappe-ui";
+import { LightningIcon } from "frappe-ui/icons";
+import type { SignupBannerProps } from "./types";
+
+const props = withDefaults(defineProps<SignupBannerProps>(), {
+	isSidebarCollapsed: false,
+	appName: "Frappe CRM",
+	redirectURL: "https://frappecloud.com/crm/signup",
+	afterSignup: () => {},
+});
+
+function signupNow() {
+	window.open(props.redirectURL, "_blank");
+	props.afterSignup?.();
+}
+</script>

--- a/ui/src/components/SignupBanner/index.ts
+++ b/ui/src/components/SignupBanner/index.ts
@@ -1,0 +1,2 @@
+export { default as SignupBanner } from "./SignupBanner.vue";
+export type { SignupBannerProps } from "./types";

--- a/ui/src/components/SignupBanner/types.ts
+++ b/ui/src/components/SignupBanner/types.ts
@@ -1,0 +1,11 @@
+/** Props for `<SignupBanner>`. */
+export interface SignupBannerProps {
+  /** Render the collapsed, icon-only form used by a collapsed sidebar. */
+  isSidebarCollapsed?: boolean;
+  /** App name used in the default banner copy. */
+  appName?: string;
+  /** Signup page opened in a new tab when the button is clicked. */
+  redirectURL?: string;
+  /** Run after the signup page is opened. */
+  afterSignup?: () => void;
+}

--- a/ui/src/components/TrialBanner/TrialBanner.vue
+++ b/ui/src/components/TrialBanner/TrialBanner.vue
@@ -1,0 +1,75 @@
+<template>
+	<div
+		v-if="!isSidebarCollapsed && showBanner"
+		class="flex flex-col gap-3 shadow-sm rounded-lg py-2.5 px-3 bg-surface-elevation-2 text-base"
+	>
+		<div class="flex flex-col gap-1">
+			<div class="inline-flex text-ink-gray-9 gap-2 items-center font-medium">
+				<FeatherIcon class="h-4" name="info" />
+				{{ trialTitle }}
+			</div>
+			<div class="text-ink-gray-7 text-p-sm">
+				{{ trialMessage }}
+			</div>
+		</div>
+		<Button :label="'Upgrade plan'" theme="blue" @click="upgradePlan">
+			<template #prefix>
+				<LightningIcon class="size-4" />
+			</template>
+		</Button>
+	</div>
+	<Button v-else-if="isSidebarCollapsed && showBanner" @click="upgradePlan">
+		<LightningIcon class="h-4 my-0.5 shrink-0" />
+	</Button>
+</template>
+<script setup lang="ts">
+import { Button, FeatherIcon, createResource } from "frappe-ui";
+import { LightningIcon } from "frappe-ui/icons";
+import { ref, computed } from "vue";
+import type { SiteInfo, TrialBannerProps } from "./types";
+
+const props = withDefaults(defineProps<TrialBannerProps>(), {
+	isSidebarCollapsed: false,
+	afterUpgrade: () => {},
+});
+
+const trialEndDays = ref(0);
+const showBanner = ref(false);
+const baseEndpoint = ref("https://frappecloud.com");
+const siteName = ref("");
+
+const trialTitle = computed(() => {
+	return trialEndDays.value > 1
+		? "Trial ends in " + trialEndDays.value + " days"
+		: "Trial ends tomorrow";
+});
+
+const trialMessage = "Upgrade to a paid plan for uninterrupted services";
+
+createResource({
+	url: "frappe.integrations.frappe_providers.frappecloud_billing.current_site_info",
+	cache: "current_site_info_data",
+	auto: true,
+	onSuccess: (data: SiteInfo) => {
+		trialEndDays.value = calculateTrialEndDays(data.trial_end_date);
+		baseEndpoint.value = data.base_url;
+		siteName.value = data.site_name;
+		showBanner.value = data.plan.is_trial_plan && trialEndDays.value > 0;
+	},
+});
+
+function calculateTrialEndDays(trialEndDate: string | undefined) {
+	if (!trialEndDate) return 0;
+
+	const endDate = new Date(trialEndDate);
+	const today = new Date();
+	const diffTime = endDate.getTime() - today.getTime();
+	const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+	return diffDays;
+}
+
+function upgradePlan() {
+	window.open(`${baseEndpoint.value}/dashboard/sites/${siteName.value}`, "_blank");
+	props.afterUpgrade?.();
+}
+</script>

--- a/ui/src/components/TrialBanner/index.ts
+++ b/ui/src/components/TrialBanner/index.ts
@@ -1,0 +1,2 @@
+export { default as TrialBanner } from "./TrialBanner.vue";
+export type { SiteInfo, TrialBannerProps } from "./types";

--- a/ui/src/components/TrialBanner/types.ts
+++ b/ui/src/components/TrialBanner/types.ts
@@ -1,0 +1,18 @@
+/** Props for `<TrialBanner>`. */
+export interface TrialBannerProps {
+  /** Render the collapsed, icon-only form used by a collapsed sidebar. */
+  isSidebarCollapsed?: boolean;
+  /** Run after the user is sent to Frappe Cloud to upgrade. */
+  afterUpgrade?: () => void;
+}
+
+/** Shape of `frappecloud_billing.current_site_info`. */
+export interface SiteInfo {
+  /** ISO date the trial ends on. */
+  trial_end_date?: string;
+  /** Frappe Cloud dashboard origin, e.g. `https://frappecloud.com`. */
+  base_url: string;
+  /** Site the dashboard link points at. */
+  site_name: string;
+  plan: { is_trial_plan: boolean };
+}

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -22,11 +22,13 @@ export * from "./components/TableMultiSelect";
 export * from "./components/Notifications";
 export * from "./components/ActivityTimeline";
 export * from "./components/InviteUser";
-// Moved out of `frappe-ui/frappe` (frappe/frappe-ui#923). They all read a
-// Frappe backend method, so they sit here rather than in frappe-ui. Everything
-// lands on the root barrel: apps imported the whole set from one path before,
-// and none of these groups has a deep internal API worth its own subpath.
+// Moved out of `frappe-ui/frappe` (frappe/frappe-ui#923). They all know about
+// a Frappe backend or Frappe Cloud, so they sit here rather than in frappe-ui.
+// Everything lands on the root barrel: apps imported the whole set from one
+// path before, and none of these groups has a deep internal API worth its own
+// subpath.
 export * from "./components/DataImport";
 export * from "./components/Onboarding";
+export * from "./components/SignupBanner";
 export * from "./components/TrialBanner";
 export * from "./telemetry";

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -22,3 +22,11 @@ export * from "./components/TableMultiSelect";
 export * from "./components/Notifications";
 export * from "./components/ActivityTimeline";
 export * from "./components/InviteUser";
+// Moved out of `frappe-ui/frappe` (frappe/frappe-ui#923). They all read a
+// Frappe backend method, so they sit here rather than in frappe-ui. Everything
+// lands on the root barrel: apps imported the whole set from one path before,
+// and none of these groups has a deep internal API worth its own subpath.
+export * from "./components/DataImport";
+export * from "./components/Onboarding";
+export * from "./components/TrialBanner";
+export * from "./telemetry";

--- a/ui/src/telemetry/index.ts
+++ b/ui/src/telemetry/index.ts
@@ -1,0 +1,12 @@
+// Product telemetry for Frappe SPAs. Moved here from `frappe-ui/frappe` — the
+// plugin reads its config from a Frappe backend method, so it belongs above
+// frappe-ui rather than inside it.
+//
+// `telemetryPlugin` was frappe-ui's *default* export from `telemetry/index.ts`,
+// but consumers only ever saw the re-exported name, so it is a plain named
+// export here.
+export { telemetryPlugin, useTelemetry } from "./telemetry";
+export type { TelemetryPluginOptions } from "./telemetry";
+// Referenced by `TelemetryPluginOptions.getContext` / `.anonymousMode`, so a
+// consumer cannot write those options without them.
+export type { PulseAnonymousMode, PulseContext } from "./pulse";

--- a/ui/src/telemetry/pulse.ts
+++ b/ui/src/telemetry/pulse.ts
@@ -1,0 +1,99 @@
+// Loads the one canonical pulse client from pulse's own CDN (not the host backend),
+// so it's independent of the backend's framework version. Degrades to null if the
+// asset can't be loaded, leaving telemetry off.
+
+import { call } from "frappe-ui";
+
+export interface PulseContext {
+  user?: string;
+  team?: string;
+}
+
+// "cookieless" (default): host derives the anon id at ingest. "client": mints a
+// persistent localStorage anon id.
+export type PulseAnonymousMode = "cookieless" | "client";
+
+export interface PulseClientOptions {
+  host?: string;
+  apiKey?: string;
+  site?: string;
+  enabled?: boolean;
+  getContext?: () => PulseContext;
+  anonymousMode?: PulseAnonymousMode;
+  flushInterval?: number;
+  maxQueueSize?: number;
+  now?: () => string;
+  clientUrl?: string;
+}
+
+export interface PulseClient {
+  init(): Promise<boolean>;
+  setEnabled(enabled: boolean): void;
+  capture(event_name: string, app: string, props?: Record<string, any>): void;
+  // Distinct id on events (known identity, else anon id); used to alias() pre-signup
+  // activity. Optional: an older CDN build may not expose it.
+  getDistinctId?(): string;
+  flush(): Promise<void> | undefined;
+  stop(): void;
+}
+
+// Shape returned by the framework's whitelisted boot_config method.
+export interface BootConfig {
+  enabled?: boolean;
+  host?: string;
+  key?: string;
+  site?: string;
+  user?: string;
+  team?: string;
+  client_url?: string;
+  site_age?: number;
+}
+
+export const BOOT_CONFIG_METHOD =
+  "frappe.utils.telemetry.pulse.client.boot_config";
+
+// Direct-mode config from the app's own backend (frappe-ui SPAs lack desk's
+// window.frappe.boot). Degrades to {} on any error, including old backends (404).
+export async function fetchBootConfig(): Promise<BootConfig> {
+  try {
+    return (await call(BOOT_CONFIG_METHOD)) || {};
+  } catch (error) {
+    return {};
+  }
+}
+
+export const DEFAULT_PULSE_CLIENT_URL =
+  "https://pulse.m.frappe.cloud/assets/pulse/js/pulse_client.js";
+
+// Only import from a trusted origin: pulse's CDN or the ingest host (self-hosted
+// pulse). Stops a tampered boot_config from redirecting import() to an attacker
+// origin — an untrusted url falls back to the canonical CDN.
+function trustedClientUrl(
+  clientUrl: string | undefined,
+  host?: string,
+): string {
+  if (!clientUrl) return DEFAULT_PULSE_CLIENT_URL;
+  try {
+    const target = new URL(clientUrl);
+    if (target.protocol !== "https:") return DEFAULT_PULSE_CLIENT_URL;
+    const allowed = new Set([new URL(DEFAULT_PULSE_CLIENT_URL).origin]);
+    try {
+      if (host) allowed.add(new URL(host).origin);
+    } catch {}
+    if (allowed.has(target.origin)) return clientUrl;
+  } catch {}
+  return DEFAULT_PULSE_CLIENT_URL;
+}
+
+export async function loadPulseClient(
+  options: PulseClientOptions = {},
+): Promise<PulseClient | null> {
+  const { clientUrl, ...clientOptions } = options;
+  try {
+    const url = trustedClientUrl(clientUrl, clientOptions.host);
+    const mod = await import(/* @vite-ignore */ url);
+    return new mod.PulseClient(clientOptions) as PulseClient;
+  } catch (error) {
+    return null;
+  }
+}

--- a/ui/src/telemetry/telemetry.test.ts
+++ b/ui/src/telemetry/telemetry.test.ts
@@ -1,0 +1,21 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, expect, it } from "vitest";
+import { loadPulseClient, fetchBootConfig } from "./pulse";
+
+// The queue / transport / capture logic lives in the canonical pulse client,
+// loaded at runtime from pulse's CDN (version-independent of the frappe backend).
+// frappe-ui's only job is to load it and its config and degrade gracefully when
+// neither is available — which is exactly the case in the test environment, where
+// the remote asset URL and the backend method can't be resolved.
+describe("telemetry plugin", () => {
+  it("degrades to null when the client asset cannot be loaded", async () => {
+    expect(await loadPulseClient()).toBeNull();
+  });
+
+  it("degrades to {} when the backend config is unreachable (e.g. old framework)", async () => {
+    expect(await fetchBootConfig()).toEqual({});
+  });
+});

--- a/ui/src/telemetry/telemetry.ts
+++ b/ui/src/telemetry/telemetry.ts
@@ -1,0 +1,126 @@
+import { reactive, readonly, ref, type App } from "vue";
+import type { Router, RouteLocationNormalized } from "vue-router";
+
+import {
+  fetchBootConfig,
+  loadPulseClient,
+  type BootConfig,
+  type PulseAnonymousMode,
+  type PulseClient,
+  type PulseContext,
+} from "./pulse";
+
+let client: PulseClient | null = null;
+let removePageviewHook: (() => void) | null = null;
+
+const appName = ref<string>();
+const isEnabled = ref(false);
+
+export function useTelemetry() {
+  return reactive({
+    isEnabled: readonly(isEnabled),
+    disable: () => {
+      isEnabled.value = false;
+      client?.stop();
+    },
+    capture: (event_name: string, data: Record<string, any> = {}) => {
+      if (!isEnabled.value || !appName.value) return;
+      client?.capture(event_name, appName.value, data);
+    },
+    getDistinctId: () => client?.getDistinctId?.() ?? "",
+  });
+}
+
+export interface TelemetryPluginOptions {
+  app_name: string;
+  host?: string;
+  apiKey?: string;
+  site?: string;
+  enabled?: boolean;
+  getContext?: () => PulseContext;
+  anonymousMode?: PulseAnonymousMode;
+  clientUrl?: string;
+  // Pass your vue-router to auto-capture a "pageview" per navigation (new sites only,
+  // site_age <= 15 days, like desk).
+  router?: Router;
+  // Route → PII-safe string. Defaults to the matched path pattern (e.g. "/orders/:id").
+  scrubRoute?: (to: RouteLocationNormalized) => string;
+}
+
+function defaultScrubRoute(to: RouteLocationNormalized): string {
+  const matched = to.matched[to.matched.length - 1];
+  return matched?.path || to.path || "";
+}
+
+export const telemetryPlugin = {
+  async install(app: App, options: TelemetryPluginOptions) {
+    appName.value = options.app_name;
+
+    if (!appName.value) {
+      console.warn(
+        `Telemetry plugin installed without app_name. \n` +
+          `To enable telemetry, please provide the app_name while installing the plugin: \n` +
+          `app.use(telemetryPlugin, { app_name: 'your_app_name' })`,
+      );
+      return;
+    }
+
+    // Explicit options win; fetch the rest from the backend (skip when self-sufficient).
+    const fetched: BootConfig =
+      options.host != null && options.apiKey != null
+        ? {}
+        : await fetchBootConfig();
+
+    const getContext =
+      options.getContext ||
+      (() => ({ user: fetched.user, team: fetched.team }));
+
+    // Reinstalls (tests, HMR, SSR-per-request) reuse the module singletons, so tear
+    // down the previous client's flush timer and router hook before replacing them.
+    client?.stop();
+    removePageviewHook?.();
+    removePageviewHook = null;
+
+    client = await loadPulseClient({
+      host: options.host ?? fetched.host,
+      apiKey: options.apiKey ?? fetched.key,
+      site: options.site ?? fetched.site,
+      enabled: options.enabled ?? fetched.enabled ?? false,
+      getContext,
+      anonymousMode: options.anonymousMode,
+      clientUrl: options.clientUrl ?? fetched.client_url,
+    });
+    if (!client) return;
+
+    isEnabled.value = await client.init();
+    if (isEnabled.value) {
+      removePageviewHook = setupPageviewTracking(options, fetched.site_age);
+    }
+  },
+};
+
+// Older backends omit site_age → track anyway (permissive, matching desk's
+// `site_age && site_age > 15` skip check).
+function setupPageviewTracking(
+  options: TelemetryPluginOptions,
+  site_age: number | undefined,
+): (() => void) | null {
+  if (!options.router || (site_age && site_age > 15)) return null;
+
+  const scrub = options.scrubRoute || defaultScrubRoute;
+  let lastFullPath = "";
+  const capturePageview = (to: RouteLocationNormalized) => {
+    // Dedupe so the initial capture and afterEach can't double-count the same route.
+    if (!isEnabled.value || !appName.value || to.fullPath === lastFullPath)
+      return;
+    lastFullPath = to.fullPath;
+    client?.capture("pageview", appName.value, { route: scrub(to) });
+  };
+
+  // afterEach missed the initial navigation if it resolved during install's awaits,
+  // so capture the landing route once the router is ready.
+  options.router.isReady().then(() => {
+    if (options.router) capturePageview(options.router.currentRoute.value);
+  });
+  return options.router.afterEach((to) => capturePageview(to));
+}

--- a/ui/src/utils/session.ts
+++ b/ui/src/utils/session.ts
@@ -1,0 +1,12 @@
+/**
+ * The signed-in user's id, read from the `user_id` cookie the Frappe backend
+ * sets. `null` for guests.
+ */
+export function sessionUser(): string | null {
+  let cookies = new URLSearchParams(document.cookie.split("; ").join("&"));
+  let _sessionUser = cookies.get("user_id");
+  if (_sessionUser === "Guest") {
+    return null;
+  }
+  return _sessionUser;
+}


### PR DESCRIPTION
Moves four groups of Frappe-aware components out of `frappe-ui` and into this package
(`@framework/ui`).

## Why

`frappe-ui` is meant to be a dumb component library. Nothing in it should know about
doctypes, onboarding flows, billing plans or a Frappe endpoint. These four groups all do,
so they are being deleted from `frappe-ui` before it tags `1.0.0`
(frappe/frappe-ui#867). `@framework/ui` already sits above `frappe-ui` in the stack and is
already used by crm and helpdesk, so it is where they land.

This is step one. The code has to exist here before it can be removed there, otherwise the
migration guide would point at nothing. The `frappe-ui` side is a separate PR
(frappe/frappe-ui#924) that only starts once this merges.

## What moved

| group | members |
| --- | --- |
| Telemetry | `telemetryPlugin`, `useTelemetry`, `TelemetryPluginOptions` |
| Onboarding and help | `useOnboarding`, `OnboardingStep`, `GettingStartedBanner`, `IntermediateStepModal`, `HelpModal`, `showHelpModal`, `minimize` |
| Billing | `TrialBanner`, `SignupBanner` |
| Data import | `DataImport` |

All on the root barrel, so an app changes one import path:

```diff
-import { useTelemetry, TrialBanner } from 'frappe-ui/frappe'
+import { useTelemetry, TrialBanner } from '@framework/ui'
```

No new subpaths. Apps imported the whole set from one path before, and none of these groups
has a deep internal API a subpath would hide.

The step screens inside `DataImport`, plus `OnboardingSteps` and `HelpCenter`, came across
as internal files. They are only ever rendered by the components above them, and no app
imports them.

## What changed on the way

Mostly a straight copy with relative `frappe-ui` imports rewritten as package imports. Four
things could not just move, because they depended on members `frappe-ui` is deleting:

- **The column mapper used `Autocomplete`.** It is a `Combobox` now. The mapping state holds
  the target fieldname instead of its label, because `Combobox` reads the label off options.
- **The import log used `Popover` with `trigger="hover"` and the old `#target` slot.** It is
  a `HoverCard` now.
- **The preview screen called `initSocket`**, which opened a second socket connection per
  page. The host passes its own socket in as a `socket` prop instead, the way
  `useNotifications` already takes one. **crm needs to pass this when it switches over** —
  left out, the screen still works, it just does not refresh while an import runs.
- **The data-import list used `frappe-ui`'s `Link`.** It uses this package's richer `Link`.

The onboarding composable and help state were `.js` and are TypeScript now, so
`useOnboarding` is typed from source rather than a hand-written `.d.ts`.

`@vueuse/core` is declared as a peer dependency — the onboarding composable uses
`useStorage`, and one existing component here relied on it resolving out of the app's tree
by luck. A peer rather than a dependency, so an app does not get two copies of the refs.

## Not moved

`OnboardingSteps`, `HelpCenter`, `showHelpCenter`, `Link`, `Filter` and the
drive components stay behind and get deleted in frappe/frappe-ui#924.

One correction: the plan recorded `SignupBanner` as unused and slated it for outright
deletion, but **crm does import it** (`AppSidebar.vue`). It travels with the Billing group
instead, so crm's migration stays a pure import-path change. `@framework/ui` is free to
refactor or drop it later; the priority right now is minimal impact on app migrations.

## Checks

- `sideEffects: false` still holds — nothing moved has a `<style>` block or a CSS import,
  so nothing gets tree-shaken out of a consumer build.
- The moved files type-check clean with `vue-tsc` against the `frappe-ui` 1.0.0 line. This
  package has no type-check script of its own, so this ran with a config pointed at them.
- The one test that came with telemetry passes in its new home. The rest of the suite is
  unchanged at 328 passing.

## Docs

no-docs. This moves code between two internal packages and changes no user-facing
behaviour, so there is nothing to add to docs.frappe.io. The import-path change apps have
to make is covered by the migration guide in frappe/frappe-ui#924.

Part of frappe/frappe-ui#923.


