### PR TITLE
fix: remove desktop icon when its workspace is deleted

### DIFF
--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -60,11 +60,7 @@ class DesktopIcon(Document):
 
 	def on_update(self):
 		self.export_desktop_icon()
-		if self.standard:
-			frappe.cache.delete_key("desktop_icons")
-			frappe.cache.delete_key("bootinfo")
-		else:
-			clear_desktop_icons_cache(user=self.owner)
+		clear_desktop_icons_cache()
 
 	def after_rename(self, old, new, merge):
 		delete_desktop_icon_file(self.app, old)
@@ -294,8 +290,14 @@ def get_desktop_icons(user=None, bootinfo=None):
 
 
 def clear_desktop_icons_cache(user=None):
-	frappe.cache.hdel("desktop_icons", user or frappe.session.user)
-	frappe.cache.hdel("bootinfo", user or frappe.session.user)
+	"""Drop the cached icon grid for `user`, or for everyone -- an icon is never scoped to one user."""
+	if user:
+		frappe.cache.hdel("desktop_icons", user)
+		frappe.cache.hdel("bootinfo", user)
+		return
+
+	frappe.cache.delete_key("desktop_icons")
+	frappe.cache.delete_key("bootinfo")
 
 
 def create_desktop_icons_from_workspace():
@@ -348,8 +350,8 @@ def create_desktop_icons_from_workspace():
 						"Desktop Icon", [{"label": icon.label, "icon_type": icon.icon_type}]
 					):
 						icon.insert(ignore_if_duplicate=True)
-				except Exception as e:
-					frappe.error_log(title="Creation of Desktop Icon Failed", message=e)
+				except Exception:
+					frappe.log_error(title="Creation of Desktop Icon Failed")
 
 
 def create_desktop_icons_from_installed_apps():

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -50,9 +50,15 @@ class DesktopIcon(Document):
 			self.label = self.module_name
 
 	def on_trash(self):
-		clear_desktop_icons_cache()
+		self.clear_icon_cache()
 		if frappe.conf.developer_mode and self.standard and self.app:
 			delete_desktop_icon_file(self.app, self.label)
+
+	def clear_icon_cache(self):
+		if self.standard or self.owner == "Administrator":
+			clear_desktop_icons_cache()
+		else:
+			clear_desktop_icons_cache(user=self.owner)
 
 	def check_for_restrict_removal(self):
 		if self.restrict_removal:
@@ -60,7 +66,7 @@ class DesktopIcon(Document):
 
 	def on_update(self):
 		self.export_desktop_icon()
-		clear_desktop_icons_cache()
+		self.clear_icon_cache()
 
 	def after_rename(self, old, new, merge):
 		delete_desktop_icon_file(self.app, old)
@@ -99,7 +105,7 @@ class DesktopIcon(Document):
 	# 		return True
 
 	def after_insert(self):
-		clear_desktop_icons_cache()
+		self.clear_icon_cache()
 
 
 def delete_desktop_icon_file(app, label):

--- a/frappe/desk/doctype/desktop_icon/test_desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/test_desktop_icon.py
@@ -36,3 +36,21 @@ class IntegrationTestDesktopIcon(IntegrationTestCase):
 
 		self.assertIsNotNone(frappe.cache.hget("desktop_icons", "someone.else@example.com"))
 		self.assertIsNone(frappe.cache.hget("desktop_icons", frappe.session.user))
+
+	def test_icon_clears_only_the_grids_it_appears_on(self):
+		"""A user's own icon is on no one else's desk, so it must not evict their grids."""
+		other = "someone.else@example.com"
+		icon = frappe.new_doc("Desktop Icon")
+		icon.label = "Cache Scope Test"
+		icon.icon_type = "Link"
+
+		icon.standard = 0
+		icon.owner = "owner@example.com"
+		frappe.cache.hset("desktop_icons", other, [])
+		icon.clear_icon_cache()
+		self.assertIsNotNone(frappe.cache.hget("desktop_icons", other))
+
+		# an Administrator-owned icon is served to every user, so every grid goes
+		icon.owner = "Administrator"
+		icon.clear_icon_cache()
+		self.assertIsNone(frappe.cache.hget("desktop_icons", other))

--- a/frappe/desk/doctype/desktop_icon/test_desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/test_desktop_icon.py
@@ -1,7 +1,8 @@
 # Copyright (c) 2025, Frappe Technologies and Contributors
 # See license.txt
 
-# import frappe
+import frappe
+from frappe.desk.doctype.desktop_icon.desktop_icon import clear_desktop_icons_cache
 from frappe.tests import IntegrationTestCase
 
 # On IntegrationTestCase, the doctype test records and all
@@ -17,4 +18,21 @@ class IntegrationTestDesktopIcon(IntegrationTestCase):
 	Use this class for testing interactions between multiple components.
 	"""
 
-	pass
+	def test_clearing_cache_without_user_clears_every_user(self):
+		"""An icon change invalidates the whole grid cache, not just the session user's."""
+		frappe.cache.hset("desktop_icons", "someone.else@example.com", [])
+		frappe.cache.hset("desktop_icons", frappe.session.user, [])
+
+		clear_desktop_icons_cache()
+
+		self.assertIsNone(frappe.cache.hget("desktop_icons", "someone.else@example.com"))
+		self.assertIsNone(frappe.cache.hget("desktop_icons", frappe.session.user))
+
+	def test_clearing_cache_for_one_user_leaves_others(self):
+		frappe.cache.hset("desktop_icons", "someone.else@example.com", [])
+		frappe.cache.hset("desktop_icons", frappe.session.user, [])
+
+		clear_desktop_icons_cache(user=frappe.session.user)
+
+		self.assertIsNotNone(frappe.cache.hget("desktop_icons", "someone.else@example.com"))
+		self.assertIsNone(frappe.cache.hget("desktop_icons", frappe.session.user))

--- a/frappe/desk/doctype/workspace/test_workspace.py
+++ b/frappe/desk/doctype/workspace/test_workspace.py
@@ -167,6 +167,31 @@ class TestWorkspace(IntegrationTestCase):
 		finally:
 			frappe.db.delete("Workspace", {"name": workspace.name})
 
+	def test_deleting_module_workspace_removes_its_sidebar_and_icon(self):
+		"""A workspace takes its sidebar and desktop icon with it, module or not."""
+		workspace = create_workspace(name="Sidebar Cleanup", label="Sidebar Cleanup", public=1)
+		workspace.insert()
+
+		sidebar = frappe.new_doc("Workspace Sidebar")
+		sidebar.title = workspace.name
+		sidebar.module = workspace.module
+		sidebar.append(
+			"items", {"label": "Home", "type": "Link", "link_type": "Workspace", "link_to": workspace.name}
+		)
+		sidebar.insert()
+
+		icon = frappe.new_doc("Desktop Icon")
+		icon.label = workspace.name
+		icon.icon_type = "Link"
+		icon.link_type = "Workspace Sidebar"
+		icon.link_to = sidebar.name
+		icon.insert()
+
+		frappe.delete_doc("Workspace", workspace.name)
+
+		self.assertFalse(frappe.db.exists("Workspace Sidebar", sidebar.name))
+		self.assertFalse(frappe.db.exists("Desktop Icon", icon.name))
+
 
 def create_module(module_name):
 	module = frappe.get_doc({"doctype": "Module Def", "module_name": module_name, "app_name": "frappe"})

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -238,10 +238,10 @@ class Workspace(Document, DeskViews):
 			frappe.throw(_("You need to be Workspace Manager to delete a public workspace."))
 
 	def delete_desktop_icon(self):
-		frappe.delete_doc_if_exists("Desktop Icon", self.title)
+		frappe.delete_doc_if_exists("Desktop Icon", self.name)
 
 	def delete_sidebar(self):
-		frappe.delete_doc_if_exists("Workspace Sidebar", self.title)
+		frappe.delete_doc_if_exists("Workspace Sidebar", self.name)
 
 	def after_delete(self):
 		if disable_saving_as_public():

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -232,9 +232,8 @@ class Workspace(Document, DeskViews):
 			self.name = doc.name = doc.label = doc.title
 
 	def on_trash(self):
-		if not self.module:
-			self.delete_sidebar()
-			self.delete_desktop_icon()
+		self.delete_sidebar()
+		self.delete_desktop_icon()
 		if self.public and not is_workspace_manager():
 			frappe.throw(_("You need to be Workspace Manager to delete a public workspace."))
 

--- a/frappe/public/js/desktop_icons.bundle.js
+++ b/frappe/public/js/desktop_icons.bundle.js
@@ -46,7 +46,7 @@ function get_route(desktop_icon) {
 	} else {
 		let sidebar = frappe.boot.workspace_sidebar_item[desktop_icon.label.toLowerCase()];
 		if (desktop_icon.link_type == "Workspace Sidebar" && sidebar) {
-			let first_link = sidebar.items.find((i) => i.type == "Link");
+			let first_link = sidebar.items.find((i) => frappe.utils.is_routable_sidebar_item(i));
 			if (first_link) {
 				if (first_link.link_type === "Report") {
 					let args = {

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1405,6 +1405,15 @@ Object.assign(frappe.utils, {
 	// --- Desktop Icon grid -----------------------------------------------------------
 	// Used by the Desktop Icon grid (Desktop Settings -> Desktop Page = Desktop Icons).
 	// They read `frappe.boot.desktop_icons`, which only that mode puts in the boot payload.
+
+	is_routable_sidebar_item(item) {
+		if (item.type != "Link") return false;
+		if (item.link_type === "URL") return !!item.url;
+		if (item.link_type === "Workspace") {
+			return !!frappe.workspaces[frappe.router.slug(item.link_to)];
+		}
+		return !!item.link_to;
+	},
 	get_route_for_icon(desktop_icon) {
 		let route;
 		if (!desktop_icon) return;
@@ -1414,7 +1423,9 @@ Object.assign(frappe.utils, {
 		} else {
 			let sidebar = frappe.boot.workspace_sidebar_item[desktop_icon.label.toLowerCase()];
 			if (desktop_icon.link_type == "Workspace Sidebar" && sidebar) {
-				let first_link = sidebar.items.find((i) => i.type == "Link");
+				let first_link = sidebar.items.find((i) =>
+					frappe.utils.is_routable_sidebar_item(i)
+				);
 				if (first_link) {
 					if (first_link.link_type === "Report") {
 						let args = {


### PR DESCRIPTION
## Problem

Deleting a workspace can leave a desktop icon behind on every user's desk. Clicking it opens a dialog that no user can act on:

> Icon is not correctly configured please check the workspace sidebar to it

`Workspace.on_trash` only cleaned up the workspace's `Workspace Sidebar` and `Desktop Icon` when the workspace had **no module**:

```python
def on_trash(self):
    if not self.module:
        self.delete_sidebar()
        self.delete_desktop_icon()
```

So a module-backed workspace (every standard one) leaves both rows behind. The icon stays "permitted" because `get_desktop_icons` gates a Link icon on the boot sidebar entry for its label, which the orphan sidebar (or the module fallback sidebar) keeps alive, and the icon has no route because the sidebar's first link points at a workspace that no longer exists.

Two things made it stick around even after the icon row was deleted by hand:

- `clear_desktop_icons_cache()` cleared only `frappe.session.user`'s field of the `desktop_icons` hash. A standard icon is site-wide, and a non-standard one owned by Administrator is served to every user, so the admin who deleted the icon got a fresh grid while everyone else kept the stale one until the whole cache was flushed.
- `get_route` picked `items.find((i) => i.type == "Link")` — the first Link, routable or not. A `URL` item authored with an empty `url`, or a `Workspace` item whose workspace was deleted, claimed the icon and left it with no `href`.

## Changes

- `Workspace.on_trash` always deletes the workspace's sidebar and desktop icon. Since `on_trash` runs before `check_if_doc_is_linked`, this also fixes deleting such a workspace failing with "linked with Workspace Sidebar".
- `clear_desktop_icons_cache()` with no user clears the whole `desktop_icons` / `bootinfo` keys instead of one field. `DesktopIcon.on_update` collapses to a single call.
- The desktop grid routes off the first **routable** sidebar item, via a new `frappe.utils.is_routable_sidebar_item`, used by both `desktop_icons.bundle.js` and `frappe.utils.get_route_for_icon`.
- `frappe.error_log(...)` → `frappe.log_error(...)` in the icon seeding loop. `frappe.error_log` is the request's error list, so calling it raised `TypeError: 'list' object is not callable` from inside the exception handler and aborted the whole seeding run while swallowing the original error. `log_error(title=...)` picks up the traceback on its own.

## Tests

- `test_workspace.py::test_deleting_module_workspace_removes_its_sidebar_and_icon`
- `test_desktop_icon.py` — cache clearing is global by default, still scopable to one user

**Support**: [74490](https://support.frappe.io/helpdesk/tickets/74490)
