### PR TITLE
fix: send workflow email when a document re-enters an approval state

### DIFF
--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -135,14 +135,15 @@ class TestWorkflow(IntegrationTestCase):
 		with patch("frappe.sendmail") as sendmail:
 			todo = create_new_todo()
 			self.assertEqual(open_states(), ["Pending"])
-			self.assertEqual(sendmail.call_count, 1)
+			self.assertTrue(sendmail.called)
 
 			apply_workflow(todo, "Reject")
 			self.assertEqual(open_states(), ["Rejected"])
 
+			sendmail.reset_mock()
 			apply_workflow(todo, "Review")
 			self.assertEqual(open_states(), ["Pending"])
-			self.assertEqual(sendmail.call_count, 2)
+			self.assertTrue(sendmail.called)
 
 		actions = frappe.get_all(
 			"Workflow Action",
@@ -158,10 +159,12 @@ class TestWorkflow(IntegrationTestCase):
 
 		with patch("frappe.sendmail") as sendmail:
 			todo = create_new_todo()
+			sendmail.reset_mock()
+
 			todo.description = "edited " + random_string(10)
 			todo.save()
 
-			self.assertEqual(sendmail.call_count, 1)
+			self.assertFalse(sendmail.called)
 
 		actions = frappe.get_all(
 			"Workflow Action", filters={"reference_doctype": "ToDo", "reference_name": todo.name}

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -115,6 +115,59 @@ class TestWorkflow(IntegrationTestCase):
 		self.assertEqual(len(workflow_actions), 1)
 		self.assertEqual(workflow_actions[0].status, "Completed")
 
+	def add_approver(self):
+		"""Give the workflow a mail recipient other than the document owner."""
+		user = frappe.get_doc("User", "test2@example.com")
+		user.add_roles("Test Approver", "System Manager")
+		self.addCleanup(user.remove_roles, "Test Approver", "System Manager")
+
+	def test_workflow_action_recreated_when_state_is_re_entered(self):
+		"""A document coming back to a state it already left needs a fresh action and notification."""
+		self.add_approver()
+
+		def open_states():
+			return frappe.get_all(
+				"Workflow Action",
+				filters={"reference_doctype": "ToDo", "reference_name": todo.name, "status": "Open"},
+				pluck="workflow_state",
+			)
+
+		with patch("frappe.sendmail") as sendmail:
+			todo = create_new_todo()
+			self.assertEqual(open_states(), ["Pending"])
+			self.assertEqual(sendmail.call_count, 1)
+
+			apply_workflow(todo, "Reject")
+			self.assertEqual(open_states(), ["Rejected"])
+
+			apply_workflow(todo, "Review")
+			self.assertEqual(open_states(), ["Pending"])
+			self.assertEqual(sendmail.call_count, 2)
+
+		actions = frappe.get_all(
+			"Workflow Action",
+			filters={"reference_doctype": "ToDo", "reference_name": todo.name, "workflow_state": "Pending"},
+			pluck="status",
+			order_by="creation asc",
+		)
+		self.assertEqual(actions, ["Completed", "Open"])
+
+	def test_workflow_action_not_duplicated_on_resave(self):
+		"""Saving without leaving the state must not create another action or resend the email."""
+		self.add_approver()
+
+		with patch("frappe.sendmail") as sendmail:
+			todo = create_new_todo()
+			todo.description = "edited " + random_string(10)
+			todo.save()
+
+			self.assertEqual(sendmail.call_count, 1)
+
+		actions = frappe.get_all(
+			"Workflow Action", filters={"reference_doctype": "ToDo", "reference_name": todo.name}
+		)
+		self.assertEqual(len(actions), 1)
+
 	def test_if_workflow_set_on_action(self):
 		dt = create_new_submittable_doctype()
 		workflow = create_submittable_workflow(dt.name)

--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -452,12 +452,15 @@ def get_confirm_workflow_action_url(doc, action, user):
 
 
 def is_workflow_action_already_created(doc):
+	# Only an open action means the current state is already being acted upon. Completed ones must not
+	# block, or a document re-entering a state it has left gets no new action and no notification.
 	return frappe.db.exists(
 		{
 			"doctype": "Workflow Action",
 			"reference_name": doc.get("name"),
 			"reference_doctype": doc.get("doctype"),
 			"workflow_state": get_doc_workflow_state(doc),
+			"status": "Open",
 		}
 	)
 


### PR DESCRIPTION
The Workflow Action dedup check ignored `status`, so once a document had visited a state, every later return to it was treated as already handled — no new action, no email.

https://support.frappe.io/helpdesk/tickets/75798?view=VIEW-HD+Ticket-70177