### PR TITLE
fix(deps): bump pypdf to 6.15.0 for CVE fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     # We depend on internal attributes,
     # do NOT add loose requirements on PyMySQL versions.
     "PyMySQL==1.1.2",
-    "pypdf==6.14.2",
+    "pypdf==6.15.0",
     "PyPika @ git+https://github.com/frappe/pypika@2c50e6142b2d61d2d243e466fdd5dc03b3d918f2",
     "mysqlclient==2.2.8",
     "PyQRCode~=1.2.1",


### PR DESCRIPTION
Bumps `pypdf` 6.14.2 → 6.15.0.

pip-audit flags 6.14.2 for [CVE-2026-71852](https://github.com/py-pdf/pypdf/security/advisories) and [CVE-2026-71870] — crafted PDFs with unusually large font width / `/ToUnicode` values cause long runtimes and large memory consumption during text extraction. Both are fixed in 6.15.0, which is a patch-line release on the same 6.x series as the [previous bump for the same reason](https://github.com/frappe/frappe/commit/e999c7c2fe).

The **Vulnerable Dependency Check** job is currently red on every PR because of this (see any recent `linters.yml` run), so this unblocks CI repo-wide.

no-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)