### PR TITLE
fix: blank trailing page in chrome-rendered PDFs

### DIFF
--- a/frappe/public/scss/print_format.bundle.scss
+++ b/frappe/public/scss/print_format.bundle.scss
@@ -3,3 +3,13 @@
 @import "./common/global.scss";
 @import "./common/icons.scss";
 @import "~bootstrap/scss/bootstrap";
+
+// global.scss sets html, body { height: 100% } for the desk; in paged media
+// that makes body a full-page-height box that overflows the page content area
+// (page height minus margins) and emits a trailing blank PDF page.
+@media print {
+	html,
+	body {
+		height: auto;
+	}
+}


### PR DESCRIPTION
- override `html, body { height: 100% }` (from `global.scss`) with `height: auto` under `@media print` in `print_format.bundle.scss`

Why: in paged media the 100% height makes `body` a full-page-height box that overflows the page content area (page height minus margins), so every chrome-rendered PDF ends with a blank page — doubling page counts in bulk multi-PDF downloads.

### Verification

Measured with pypdf on chrome renders of "Request for Quotation Bordered" (Request for Quotation), via `PrintFormatGenerator.render_pdf()`:

```py
reader = PdfReader(io.BytesIO(pdf_bytes))
print(len(reader.pages), [len(p.extract_text().strip()) for p in reader.pages])
```

Before (develop `8221372ac5`):

```
single doc: pages=2 text_lens=[264, 0]
10-doc merge (as _download_multi_pdf): pages=20 text_lens=[264, 0, 264, 0, ...]
61-row doc (genuinely multi-page): pages=3 text_lens=[997, 1191, 450]
```

After this fix:

```
single doc: pages=1 text_lens=[264]
10-doc merge (as _download_multi_pdf): pages=10 text_lens=[264, 264, ...]
61-row doc (genuinely multi-page): pages=3 text_lens=[997, 1191, 450]
```

The 61-row document confirms real multi-page output is unchanged — same page count and per-page text before and after; only the trailing blank page disappears. Also re-ran the single doc with page numbers enabled (footer overlay path): 1 page, page number renders.
