### PR TITLE
fix: use per-currency precision in currency formatter

### DIFF
--- a/cypress/integration/currency_formatter.js
+++ b/cypress/integration/currency_formatter.js
@@ -1,0 +1,51 @@
+context("Currency Formatter", () => {
+	before(() => {
+		cy.login();
+		cy.visit("/app/website");
+	});
+
+	function format_amount(value, currency, defaults = {}) {
+		return cy.window().then((win) => {
+			const frappe = win.frappe;
+			frappe.provide("locals.:Currency");
+			win.locals[":Currency"]["BHD"] = {
+				name: "BHD",
+				number_format: "#,###.###",
+				fraction_units: 1000,
+				symbol: "BD",
+			};
+			win.locals[":Currency"]["AED"] = {
+				name: "AED",
+				number_format: "#,###.##",
+				fraction_units: 100,
+				symbol: "AED",
+			};
+
+			const applied = {
+				currency: "AED",
+				number_format: "#,###.##",
+				currency_precision: "",
+				use_number_format_from_currency: 1,
+				...defaults,
+			};
+			Object.assign(frappe.boot.sysdefaults, applied);
+			Object.assign(frappe.boot.user.defaults, applied);
+
+			return frappe.format(
+				value,
+				{ fieldtype: "Currency", fieldname: "amount", options: "currency" },
+				{ only_value: true },
+				{ currency: currency }
+			);
+		});
+	}
+
+	it("uses the row currency's number format when currency precision is not set", () => {
+		format_amount(97.646, "BHD").should("eq", "BD 97.646");
+		format_amount(97.646, "AED").should("eq", "AED 97.65");
+	});
+
+	it("uses currency precision over the row currency's number format", () => {
+		format_amount(97.646, "BHD", { currency_precision: 2 }).should("eq", "BD 97.65");
+	});
+});

--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -131,12 +131,10 @@ frappe.form.formatters = {
 		var currency = frappe.meta.get_field_currency(docfield, doc);
 
 		let precision;
-		if (typeof docfield.precision == "number") {
-			precision = docfield.precision;
+		if (typeof docfield.precision == "number" || docfield.precision) {
+			precision = cint(docfield.precision);
 		} else {
-			precision = cint(
-				docfield.precision || frappe.boot.sysdefaults.currency_precision || 2
-			);
+			precision = frappe.meta.get_field_precision(docfield, doc);
 		}
 
 		// If you change anything below, it's going to hurt a company in UAE, a bit.


### PR DESCRIPTION
## Description

`frappe.form.formatters.Currency` was falling back to 2 decimal places when no field or system precision was set, even though currency formatting already resolved the correct currency.

This caused values such as `97.646 BHD` to display as `97.65` in reports and list views, while the entry control correctly showed `97.646`.

The formatter now uses `frappe.meta.get_field_precision`, matching the precision resolver used by currency controls and grid rows.

Explicit `Currency Precision` still takes precedence, while unset precision now follows the currency/global number format when applicable. Existing `0` and empty-string precision handling is preserved.