### PR TITLE
fix: page height and PDF password in chrome PDF transformer

### DIFF
--- a/frappe/utils/pdf_generator/pdf_merge.py
+++ b/frappe/utils/pdf_generator/pdf_merge.py
@@ -3,12 +3,12 @@ class PDFTransformer:
 		self.browser = browser
 		self.body_pdf = browser.body_pdf
 		self.is_print_designer = browser.is_print_designer
+		self.encrypt_password = self.browser.options.get("password", None)
 		self._set_header_pdf()
 		self._set_footer_pdf()
 		if not self.header_pdf and not self.footer_pdf:
 			return
 		self.no_of_pages = len(self.body_pdf.pages)
-		self.encrypt_password = self.browser.options.get("password", None)
 		# if not header / footer then return body pdf
 
 	def _set_header_pdf(self):
@@ -31,10 +31,12 @@ class PDFTransformer:
 		footer = self.footer_pdf
 
 		if not header and not footer:
+			if self.encrypt_password:
+				return self._encrypt_raw(body)
 			return body
 
 		body_height = body.pages[0].mediabox.top
-		body_transform = header_height = footer_height = header_body_top = 0
+		body_transform = header_height = footer_height = 0
 
 		if footer:
 			footer_height = footer.pages[0].mediabox.top
@@ -43,24 +45,25 @@ class PDFTransformer:
 		if header:
 			header_height = header.pages[0].mediabox.top
 			header_transform = body_height + footer_height
-			header_body_top = header_height + body_height + footer_height
+
+		# full page height: the body was rendered on a page shortened by the
+		# header/footer heights, so every body page must be raised above the
+		# footer and its mediabox restored to the full paper height
+		page_top = header_height + body_height + footer_height
 
 		# Static headers: pre-transform all pages once.
 		# Dynamic headers: transform each page inline (once per body page).
 		# This matches print_designer's pdf_merge.py exactly.
 		if header and not self.is_header_dynamic:
 			for h in header.pages:
-				self._transform(h, header_body_top, header_transform)
+				self._transform(h, page_top, header_transform)
 
 		for p in body.pages:
-			if header_body_top:
-				self._transform(p, header_body_top, body_transform)
+			self._transform(p, page_top, body_transform)
 
 			if header:
 				if self.is_header_dynamic:
-					p.merge_page(
-						self._transform(header.pages[p.page_number], header_body_top, header_transform)
-					)
+					p.merge_page(self._transform(header.pages[p.page_number], page_top, header_transform))
 				elif self.is_print_designer:
 					if p.page_number == 0:
 						p.merge_page(header.pages[0])
@@ -98,6 +101,16 @@ class PDFTransformer:
 		if self.encrypt_password:
 			writer.encrypt(self.encrypt_password)
 
+		return self.get_file_data_from_writer(writer)
+
+	def _encrypt_raw(self, body):
+		from io import BytesIO
+
+		from pypdf import PdfReader, PdfWriter
+
+		writer = PdfWriter()
+		writer.append_pages_from_reader(PdfReader(BytesIO(body)))
+		writer.encrypt(self.encrypt_password)
 		return self.get_file_data_from_writer(writer)
 
 	def _transform(self, page, page_top, ty):


### PR DESCRIPTION
Two bugs in `PDFTransformer` (chrome PDF pipeline):

- **footer-only formats printed short pages**: body pages were only raised and their mediabox restored to full paper height when a header existed (`if header_body_top:`), so a format with just a footer overlay (e.g. page number at the bottom, no letterhead) produced pages missing the footer+margin height. Now the transform runs whenever a header or footer exists.
- **PDF password silently dropped without overlays**: `encrypt_password` was read after the no-header/no-footer early return, and the raw body path returned unencrypted bytes even when a password was requested (`print_format.py` passes `options["password"]`). The password is now read before the early return and the raw body path encrypts through a writer.

### Verification

Measured on "Request for Quotation Bordered" (chrome render, pypdf):

Before:

```
footer only (page no bottom): mediabox_h=805.0pt  (A4 = 841.9pt)
header only (page no top):    mediabox_h=843.1pt
password + no overlay:        encrypted=False
password + footer overlay:    encrypted=True
```

After:

```
no overlay:                   mediabox_h=841.9pt
footer only (page no bottom): mediabox_h=841.9pt
header only (page no top):    mediabox_h=843.1pt
password + no overlay:        encrypted=True
password + footer overlay:    encrypted=True
```

Pagination regression check (unchanged before/after): 61-row doc renders 3 pages with identical per-page text lengths, with and without page-number overlays.

The multi-PDF `output` path still skips per-doc encryption — same shared-writer design as the wkhtmltopdf path in `pdf.py`.