### PR TITLE
fix(deps): bump pypdf to 6.15.0 for CVE fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     # We depend on internal attributes,
     # do NOT add loose requirements on PyMySQL versions.
     "PyMySQL==1.1.2",
-    "pypdf==6.14.2",
+    "pypdf==6.15.0",
     "PyPika @ git+https://github.com/frappe/pypika@2c50e6142b2d61d2d243e466fdd5dc03b3d918f2",
     "mysqlclient==2.2.8",
     "PyQRCode~=1.2.1",


### PR DESCRIPTION
- bump pypdf 6.14.2 → 6.15.0 for CVE-2026-71852 and CVE-2026-71870 (crafted-PDF resource exhaustion during font parsing), currently failing the Vulnerable Dependency Check on every PR

6.15.0 is parsing hardening + image decode fixes; the only deprecation (`inline_images` setter) is unused in frappe. Verified with 6.15.0 installed: `frappe.tests.test_pdf` (5 passed), `frappe.tests.test_chrome_pdf_interceptor` (4 passed), and a chrome-pipeline smoke run covering `PDFTransformer` merge, multi-PDF concatenation, and writer encryption.