### PR TITLE
fix: resolve currency precision from the currency's number format

### DIFF
--- a/cypress/integration/currency_formatter.js
+++ b/cypress/integration/currency_formatter.js
@@ -1,0 +1,51 @@
+context("Currency Formatter", () => {
+	before(() => {
+		cy.login();
+		cy.visit("/app/website");
+	});
+
+	function format_amount(value, currency, defaults = {}) {
+		return cy.window().then((win) => {
+			const frappe = win.frappe;
+			frappe.provide("locals.:Currency");
+			win.locals[":Currency"]["BHD"] = {
+				name: "BHD",
+				number_format: "#,###.###",
+				fraction_units: 1000,
+				symbol: "BD",
+			};
+			win.locals[":Currency"]["AED"] = {
+				name: "AED",
+				number_format: "#,###.##",
+				fraction_units: 100,
+				symbol: "AED",
+			};
+
+			const applied = {
+				currency: "AED",
+				number_format: "#,###.##",
+				currency_precision: "",
+				use_number_format_from_currency: 1,
+				...defaults,
+			};
+			Object.assign(frappe.boot.sysdefaults, applied);
+			Object.assign(frappe.boot.user.defaults, applied);
+
+			return frappe.format(
+				value,
+				{ fieldtype: "Currency", fieldname: "amount", options: "currency" },
+				{ only_value: true },
+				{ currency: currency }
+			);
+		});
+	}
+
+	it("uses the row currency's number format when currency precision is not set", () => {
+		format_amount(97.646, "BHD").should("eq", "BD 97.646");
+		format_amount(97.646, "AED").should("eq", "AED 97.65");
+	});
+
+	it("uses currency precision over the row currency's number format", () => {
+		format_amount(97.646, "BHD", { currency_precision: 2 }).should("eq", "BD 97.65");
+	});
+});

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -817,20 +817,29 @@ def get_field_currency(df, doc=None):
 
 def get_field_precision(df, doc=None, currency=None):
 	"""get precision based on DocField options and fieldvalue in doc"""
-	from frappe.utils import get_number_format_info
-
 	if df.precision:
 		precision = cint(df.precision)
 
 	elif df.fieldtype == "Currency":
 		precision = cint(frappe.db.get_default("currency_precision"))
 		if not precision:
-			number_format = frappe.db.get_default("number_format") or "#,###.##"
-			_decimal_str, _comma_str, precision = get_number_format_info(number_format)
+			precision = get_precision_from_currency_format(currency or get_field_currency(df, doc))
 	else:
 		precision = cint(frappe.db.get_default("float_precision")) or 3
 
 	return precision
+
+
+def get_precision_from_currency_format(currency: str) -> int:
+	"""Get precision from currency format string if applicable."""
+	from frappe.utils import get_number_format_info
+
+	number_format = None
+	if currency and frappe.get_system_settings("use_number_format_from_currency"):
+		number_format = frappe.db.get_value("Currency", currency, "number_format", cache=True)
+
+	number_format = number_format or frappe.db.get_default("number_format") or "#,###.##"
+	return get_number_format_info(number_format)[2]
 
 
 def get_default_df(fieldname):

--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -128,12 +128,10 @@ frappe.form.formatters = {
 		var currency = frappe.meta.get_field_currency(docfield, doc);
 
 		let precision;
-		if (typeof docfield.precision == "number") {
-			precision = docfield.precision;
+		if (typeof docfield.precision == "number" || docfield.precision) {
+			precision = cint(docfield.precision);
 		} else {
-			precision = cint(
-				docfield.precision || frappe.boot.sysdefaults.currency_precision || 2
-			);
+			precision = frappe.meta.get_field_precision(docfield, doc);
 		}
 
 		// If you change anything below, it's going to hurt a company in UAE, a bit.

--- a/frappe/public/js/frappe/model/meta.js
+++ b/frappe/public/js/frappe/model/meta.js
@@ -327,7 +327,8 @@ $.extend(frappe.meta, {
 		} else if (df && df.fieldtype === "Currency") {
 			precision = cint(frappe.defaults.get_default("currency_precision"));
 			if (!precision) {
-				var number_format = get_number_format();
+				var currency = frappe.meta.get_field_currency(df, doc);
+				var number_format = get_number_format(currency);
 				var number_format_info = get_number_format_info(number_format);
 				precision = number_format_info.precision;
 			}

--- a/frappe/tests/test_meta.py
+++ b/frappe/tests/test_meta.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+
+import frappe
+from frappe.model.meta import get_field_precision
+from frappe.tests.utils import FrappeTestCase, change_settings
+
+
+class TestFieldPrecision(FrappeTestCase):
+	def setUp(self):
+		for currency, number_format in (("BHD", "#,###.###"), ("AED", "#,###.##")):
+			if frappe.db.exists("Currency", currency):
+				frappe.db.set_value("Currency", currency, "number_format", number_format)
+			else:
+				frappe.get_doc(
+					doctype="Currency", currency_name=currency, number_format=number_format
+				).insert()
+
+		self.df = frappe._dict(fieldtype="Currency", fieldname="grand_total", options="currency")
+
+	def invoice(self, currency):
+		return frappe._dict(doctype="Sales Invoice", name=f"ACC-SINV-2024-{currency}", currency=currency)
+
+	@change_settings(
+		"System Settings",
+		{"currency_precision": "", "number_format": "#,###.##", "use_number_format_from_currency": 1},
+	)
+	def test_precision_from_row_currency(self):
+		self.assertEqual(get_field_precision(self.df, self.invoice("BHD")), 3)
+		self.assertEqual(get_field_precision(self.df, self.invoice("AED")), 2)
+		self.assertEqual(get_field_precision(self.df, None, currency="BHD"), 3)
+
+	@change_settings(
+		"System Settings",
+		{"currency_precision": "", "number_format": "#,###.##", "use_number_format_from_currency": 0},
+	)
+	def test_global_number_format_when_currency_format_is_not_used(self):
+		self.assertEqual(get_field_precision(self.df, self.invoice("BHD")), 2)
+
+	@change_settings(
+		"System Settings",
+		{"currency_precision": 2, "number_format": "#,###.##", "use_number_format_from_currency": 1},
+	)
+	def test_currency_precision_takes_precedence(self):
+		self.assertEqual(get_field_precision(self.df, self.invoice("BHD")), 2)


### PR DESCRIPTION
Backport of #41703 and its missing v15 dependencies (#34888, #35017).

Fixes `Currency Precision` for sites using currencies with different decimal places. Previously, `get_field_precision` ignored the row currency and always used the global number format, causing incorrect precision for currencies like BHD, OMR, and AED.

The original backports (#34888, #35017) were closed due to conflicts in `meta.py`. This version adapts the changes for v15, where `NumberFormat` is unavailable, and passes the currency through `frappe.meta.get_field_precision`.

Currency-based precision remains controlled by `Use Number Format from Currency`, while the formatter fallback now uses the global number format instead of a hardcoded 2 decimals.