### PR TITLE
fix: notification read state resets on page reload

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -91,9 +91,6 @@ def get_bootinfo():
 	bootinfo.home_folder = frappe.db.get_value("File", {"is_home_folder": 1})
 	bootinfo.navbar_settings = get_navbar_settings()
 	bootinfo.notification_settings = get_notification_settings()
-	bootinfo.notification_unread_count = frappe.db.count(
-		"Notification Log", {"read": 0, "for_user": frappe.session.user}
-	)
 	bootinfo.onboarding_tours = get_onboarding_ui_tours()
 	set_time_zone(bootinfo)
 

--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -8,7 +8,6 @@ from frappe.desk.doctype.notification_settings.notification_settings import (
 	is_notifications_enabled,
 )
 from frappe.model.document import Document
-from frappe.utils.caching import http_cache
 
 
 class NotificationLog(Document):
@@ -251,7 +250,6 @@ def format_email_header(header_map, language, docname):
 
 
 @frappe.whitelist()
-@http_cache(max_age=60, stale_while_revalidate=60 * 60)
 def get_notification_logs(limit: int = 20):
 	notification_logs = frappe.db.get_list(
 		"Notification Log", fields=["*"], limit=limit, order_by="creation desc"

--- a/frappe/desk/doctype/notification_log/test_notification_log.py
+++ b/frappe/desk/doctype/notification_log/test_notification_log.py
@@ -6,6 +6,7 @@ from frappe.desk.doctype.notification_log.notification_log import (
 	enqueue_create_notification,
 	get_email_header,
 	get_title,
+	mark_as_read,
 )
 from frappe.desk.doctype.notification_type.notification_type import install_notification_types
 from frappe.desk.form.assign_to import add as assign_task
@@ -124,6 +125,29 @@ class TestNotificationLog(IntegrationTestCase):
 		self.assertEqual(
 			frappe.db.get_value("Notification Log", name, "assistance_url"),
 			"https://docs.example.com/fix",
+		)
+
+	def test_mark_as_read_only_affects_the_opened_notification(self):
+		user = get_user()
+		unread_before = frappe.db.count("Notification Log", {"read": 0, "for_user": user})
+		logs = [
+			frappe.get_doc(
+				doctype="Notification Log",
+				for_user=user,
+				from_user="Administrator",
+				subject=subject,
+			).insert(ignore_permissions=True)
+			for subject in ("Leave application pending", "Expense claim rejected")
+		]
+
+		self.addCleanup(frappe.set_user, "Administrator")
+		frappe.set_user(user)
+		mark_as_read(logs[0].name)
+
+		self.assertEqual(frappe.db.get_value("Notification Log", logs[0].name, "read"), 1)
+		self.assertEqual(frappe.db.get_value("Notification Log", logs[1].name, "read"), 0)
+		self.assertEqual(
+			frappe.db.count("Notification Log", {"read": 0, "for_user": user}), unread_before + 1
 		)
 
 	def test_get_title_falls_back_to_docname_when_title_is_empty(self):

--- a/frappe/public/js/frappe/ui/notifications/notifications.js
+++ b/frappe/public/js/frappe/ui/notifications/notifications.js
@@ -315,7 +315,7 @@ class NotificationsView extends BaseNotificationsView {
 		}
 
 		item_html.on("click", () => {
-			!notification_log.read && this.mark_as_read(notification_log.name, item_html);
+			item_html.hasClass("unread") && this.mark_as_read(notification_log.name, item_html);
 			this.notifications_icon.trigger("click");
 		});
 
@@ -357,7 +357,6 @@ class NotificationsView extends BaseNotificationsView {
 			method: "frappe.desk.doctype.notification_log.notification_log.get_notification_logs",
 			args: { limit: limit },
 			type: "GET",
-			cache: true,
 		});
 	}
 

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -163,6 +163,10 @@ def get():
 		bootinfo["metadata_version"] = reset_metadata_version()
 
 	bootinfo.notes = get_unseen_notes()
+	# outside the cached blob above; marking a notification read only writes the row
+	bootinfo.notification_unread_count = frappe.db.count(
+		"Notification Log", {"read": 0, "for_user": frappe.session.user}
+	)
 	bootinfo.assets_json = get_assets_json()
 	bootinfo.read_only = bool(frappe.flags.read_only)
 

--- a/frappe/tests/test_boot.py
+++ b/frappe/tests/test_boot.py
@@ -51,6 +51,42 @@ class TestBootData(IntegrationTestCase):
 		resolve.assert_called_once()
 		self.assertEqual(bootinfo.setup_wizard_url, "/suite/setup")
 
+	def test_notification_unread_count_is_not_served_from_cached_bootinfo(self):
+		from unittest.mock import patch
+
+		import frappe.sessions
+		from frappe.desk.doctype.notification_log.notification_log import mark_as_read
+
+		frappe.set_user("Administrator")
+		user = frappe.session.user
+		self.addCleanup(frappe.cache.hdel, "bootinfo", user)
+
+		unread_before = frappe.db.count("Notification Log", {"read": 0, "for_user": user})
+		notification = frappe.get_doc(
+			doctype="Notification Log",
+			for_user=user,
+			from_user=user,
+			subject="Quarterly payroll run needs approval",
+		).insert(ignore_permissions=True)
+		self.addCleanup(notification.delete, ignore_permissions=True)
+
+		# a cached blob holding a stale count must not reach the client
+		frappe.cache.hset(
+			"bootinfo",
+			user,
+			frappe._dict({"user": {}, "notification_unread_count": 99}),
+		)
+
+		with patch.dict(frappe.conf, {"disable_session_cache": False}):
+			bootinfo = frappe.sessions.get()
+			self.assertEqual(bootinfo.from_cache, 1)
+			self.assertEqual(bootinfo.notification_unread_count, unread_before + 1)
+
+			mark_as_read(notification.name)
+			bootinfo = frappe.sessions.get()
+			self.assertEqual(bootinfo.from_cache, 1)
+			self.assertEqual(bootinfo.notification_unread_count, unread_before)
+
 	def test_empty_allowed_views_are_served_from_cache(self):
 		from unittest.mock import patch
 


### PR DESCRIPTION
## Summary

Marking a notification as read didn't survive a reload. The row was updated, but the cached unread count and notification list kept showing the old state.

### Fix

* Read the unread count fresh in `sessions.get()` instead of using the cached bootinfo value.
* Removed HTTP caching from `get_notification_logs` so the `read` state is always current.
* Fixed the dropdown click handler to check the `unread` class, preventing the badge from being decremented twice.
