### PR TITLE
fix: chrome pdf reliability and geometry issues

### DIFF
--- a/frappe/tests/test_pdf.py
+++ b/frappe/tests/test_pdf.py
@@ -94,3 +94,66 @@ class TestPdf(IntegrationTestCase):
 
 		# If image was actually retrieved then size will be  in few kbs, else bytes.
 		self.assertGreaterEqual(len(pdf), 10_000)
+
+
+class TestChromePdfGeometry(IntegrationTestCase):
+	"""Unit tests for Browser paper geometry — no chromium process involved."""
+
+	def make_browser(self, options, header_height=None, footer_height=None):
+		from types import SimpleNamespace
+
+		from bs4 import BeautifulSoup
+
+		from frappe.utils.pdf_generator.browser import Browser
+
+		browser = Browser.__new__(Browser)
+		browser.is_print_designer = False
+		browser.options = options
+		browser.soup = BeautifulSoup("<html><head></head><body></body></html>", "html5lib")
+		browser.body_page = SimpleNamespace(options={})
+		browser.header_page = SimpleNamespace(options={}) if header_height is not None else None
+		browser.footer_page = SimpleNamespace(options={}) if footer_height is not None else None
+		if header_height is not None:
+			browser.header_height = header_height
+		if footer_height is not None:
+			browser.footer_height = footer_height
+		return browser
+
+	def test_custom_page_size_converted_from_mm(self):
+		from frappe.tests.classes.context_managers import change_settings
+
+		with change_settings(
+			"Print Settings", pdf_page_size="Custom", pdf_page_height=297, pdf_page_width=210
+		):
+			browser = self.make_browser({})
+			browser.prepare_options_for_pdf()
+
+		# 210x297mm must match A4 in inches, not be consumed as px
+		self.assertAlmostEqual(browser.body_page.options["paperWidth"], 8.27, delta=0.05)
+		self.assertAlmostEqual(browser.body_page.options["paperHeight"], 11.69, delta=0.05)
+
+	def test_custom_page_size_without_dimensions_raises(self):
+		from unittest.mock import patch
+
+		# Print Settings validation forbids zero dimensions, so this state is only
+		# reachable when print CSS declares page-size: Custom without dimensions
+		browser = self.make_browser({"page-size": "Custom"})
+		with patch.object(frappe.db, "get_single_value", return_value=None):
+			self.assertRaisesRegex(
+				frappe.ValidationError, "Custom page size", browser.prepare_options_for_pdf
+			)
+
+	def test_header_spacing_parsed_from_css_string(self):
+		from frappe.utils.print_utils import convert_uom
+
+		for spacing in ("5mm", "5"):
+			browser = self.make_browser({"page-size": "A4", "header-spacing": spacing}, header_height=100)
+			browser.prepare_options_for_pdf()
+			expected = convert_uom(
+				100 + convert_uom(5, "mm", "px", only_number=True), "px", "in", only_number=True
+			)
+			self.assertAlmostEqual(browser.header_page.options["paperHeight"], expected, delta=0.01)
+
+	def test_oversized_header_footer_raises(self):
+		browser = self.make_browser({"page-size": "A4"}, header_height=1000, footer_height=300)
+		self.assertRaisesRegex(frappe.ValidationError, "no room for content", browser.prepare_options_for_pdf)

--- a/frappe/tests/test_pdf.py
+++ b/frappe/tests/test_pdf.py
@@ -157,3 +157,64 @@ class TestChromePdfGeometry(IntegrationTestCase):
 	def test_oversized_header_footer_raises(self):
 		browser = self.make_browser({"page-size": "A4"}, header_height=1000, footer_height=300)
 		self.assertRaisesRegex(frappe.ValidationError, "no room for content", browser.prepare_options_for_pdf)
+
+
+class TestChromeCdpReliability(IntegrationTestCase):
+	"""Unit tests for CDP failure handling — no chromium process involved."""
+
+	def make_client(self):
+		from frappe.utils.chromium.cdp_connection import CDPSocketClient
+
+		client = CDPSocketClient("ws://never-connected")
+		self.addCleanup(client.loop.close)
+		return client
+
+	def test_fail_pending_messages_resolves_inflight_commands(self):
+		client = self.make_client()
+		future = client.loop.create_future()
+		client.pending_messages = {1: future, ("Page.printToPDF", None, None, None): future}
+
+		client._fail_pending_messages()
+
+		self.assertTrue(future.done())
+		self.assertIsInstance(future.exception(), ConnectionError)
+		self.assertFalse(client.pending_messages)
+
+	def test_send_times_out_when_chromium_never_responds(self):
+		class FakeConnection:
+			async def send(self, message):
+				pass
+
+		client = self.make_client()
+		client.connection = FakeConnection()
+		client.COMMAND_TIMEOUT = 0.05
+
+		with self.assertRaisesRegex(TimeoutError, "did not respond"):
+			client.loop.run_until_complete(client._send("Page.printToPDF"))
+		self.assertFalse(client.pending_messages)
+
+	def test_evaluate_returns_result_when_retry_succeeds(self):
+		from unittest.mock import patch
+
+		from frappe.utils.chromium.page import Page
+
+		class FakeSession:
+			def __init__(self, script):
+				self.script = script
+
+			def send(self, method, params=None, session_id=None, return_future=False):
+				if method == "Runtime.evaluate":
+					return self.script.pop(0)
+				return {}, None
+
+		page = Page.__new__(Page)
+		page.session_id = "sid"
+		page.session = FakeSession([(None, {"message": "boom"}), ({"result": {"value": 2}}, None)])
+
+		with patch("frappe.utils.chromium.page.time.sleep"):
+			result = page.evaluate("1+1")
+		self.assertEqual(result["result"]["value"], 2)
+
+		page.session = FakeSession([(None, {"message": "boom"})] * 4)
+		with patch("frappe.utils.chromium.page.time.sleep"):
+			self.assertRaisesRegex(RuntimeError, "Error evaluating expression", page.evaluate, "1+1")

--- a/frappe/utils/chromium/cdp_connection.py
+++ b/frappe/utils/chromium/cdp_connection.py
@@ -11,6 +11,11 @@ class CDPSocketClient:
 	Ensures robust error handling and consistent logging.
 	"""
 
+	# Upper bound for any single CDP command. Generous — page loads and
+	# printToPDF finish in seconds — but keeps a connected-yet-unresponsive
+	# chromium (stuck renderer) from hanging the worker forever.
+	COMMAND_TIMEOUT = 120
+
 	def __init__(self, websocket_url):
 		self.websocket_url = websocket_url
 		self.connection = None
@@ -165,7 +170,15 @@ class CDPSocketClient:
 
 		await self.connection.send(frappe.json.dumps(message))
 		if wait_future_fulfill:
-			await future
+			try:
+				await asyncio.wait_for(future, self.COMMAND_TIMEOUT)
+			except TimeoutError:
+				self.pending_messages = {
+					key: value for key, value in self.pending_messages.items() if value is not future
+				}
+				raise TimeoutError(
+					f"Chromium did not respond to {method} within {self.COMMAND_TIMEOUT}s"
+				) from None
 		return future
 
 	def _destructure_response(self, response):

--- a/frappe/utils/chromium/cdp_connection.py
+++ b/frappe/utils/chromium/cdp_connection.py
@@ -39,6 +39,21 @@ class CDPSocketClient:
 				self._handle_message(frappe.json.loads(message))
 		except Exception:
 			frappe.log_error(title="WebSocket listening error:", message=f"{frappe.get_traceback()}")
+		finally:
+			self._fail_pending_messages()
+
+	def _fail_pending_messages(self):
+		"""Resolve every in-flight command with an error once the connection is gone.
+
+		A caller blocked in run_until_complete on one of these futures would
+		otherwise hang the worker forever when chromium crashes mid-command."""
+		pending = {id(future): future for future in self.pending_messages.values()}
+		self.pending_messages.clear()
+		for future in pending.values():
+			if not future.done():
+				future.set_exception(
+					ConnectionError("Chromium CDP connection closed before a response was received")
+				)
 
 	def _handle_message(self, response):
 		method = response.get("method")
@@ -55,14 +70,16 @@ class CDPSocketClient:
 			future = self.pending_messages.pop(message_id)
 			if composite_key in self.pending_messages:
 				self.pending_messages.pop(composite_key)
-			future.set_result(response)
+			if not future.done():
+				future.set_result(response)
 
 		# Handle responses without `id` using a composite key
 		elif method:
 			if composite_key in self.pending_messages:
 				# print("matched using composite_key", composite_key)
 				future = self.pending_messages.pop(composite_key)
-				future.set_result(response)
+				if not future.done():
+					future.set_result(response)
 
 			if method in self.listeners:
 				for callback, future, filters in self.listeners[method]:
@@ -90,6 +107,8 @@ class CDPSocketClient:
 		except Exception:
 			frappe.log_error(title="Error while disconnecting:", message=f"{frappe.get_traceback()}")
 			raise
+		finally:
+			self.loop.close()
 
 	async def _disconnect(self):
 		try:

--- a/frappe/utils/chromium/page.py
+++ b/frappe/utils/chromium/page.py
@@ -423,6 +423,8 @@ class Page:
 		# the task resolves when the command is *sent*, so also wait for the
 		# Page.printToPDF response before reading the stream handle
 		self.session.wait_for_event(response_future, timeout=30)
+		if not response_future.done() or response_future.cancelled():
+			raise RuntimeError("Timed out waiting for the Page.printToPDF response")
 		response = response_future.result()
 		stream_id = response["result"]["stream"]
 		return stream_id

--- a/frappe/utils/chromium/page.py
+++ b/frappe/utils/chromium/page.py
@@ -246,14 +246,15 @@ class Page:
 			# retry if error in 500ms for 3 times (just safe guard as i had few edge cases where it failed).
 			# waiting for network is still slower than this.
 			for _i in range(3):
-				print(f"Error evaluating expression: {error}. Retrying in 500ms")
 				time.sleep(0.5)
 				result, error = self.send(
 					"Runtime.evaluate", {"expression": expression, "awaitPromise": await_promise}
 				)
 				if not error:
 					break
-			raise RuntimeError(f"Error evaluating expression: {error}")
+			if error:
+				self.send("Runtime.disable")
+				raise RuntimeError(f"Error evaluating expression: {error}")
 
 		self.send("Runtime.disable")
 		return result
@@ -416,12 +417,14 @@ class Page:
 		return self.get_pdf_from_stream(result["stream"], raw)
 
 	def get_pdf_stream_id(self):
-		# wait for task to complete
+		# wait for the send task to complete; its result is the response future
 		self.session.wait_for_event(self.wait_for_pdf)
-		# wait for event to complete
-		task = self.wait_for_pdf.result()
-		future = task.result()
-		stream_id = future["result"]["stream"]
+		response_future = self.wait_for_pdf.result()
+		# the task resolves when the command is *sent*, so also wait for the
+		# Page.printToPDF response before reading the stream handle
+		self.session.wait_for_event(response_future, timeout=30)
+		response = response_future.result()
+		stream_id = response["result"]["stream"]
 		return stream_id
 
 	def get_pdf_from_stream(self, stream_id, raw=False):

--- a/frappe/utils/chromium/process.py
+++ b/frappe/utils/chromium/process.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import subprocess
+import threading
 import time
 from pathlib import Path
 
@@ -58,7 +59,7 @@ class ChromiumManager:
 		# only when we want to chromium on separate docker / server ( not implemented/tested yet )
 		self.CHROMIUM_WEBSOCKET_URL = site_config.get("chromium_websocket_url", "")
 		if self.CHROMIUM_WEBSOCKET_URL:
-			frappe.warn("Using external chromium websocket url. Make sure it is accessible.")
+			frappe.logger("pdf").warning("Using external chromium websocket url. Make sure it is accessible.")
 			self._devtools_url = self.CHROMIUM_WEBSOCKET_URL
 			return
 
@@ -177,6 +178,8 @@ class ChromiumManager:
 	# from print_designer.pdf_generator.monitor_subprocess import monitor_subprocess_usage
 	# @monitor_subprocess_usage(interval=0.1)
 	def _start_chromium_process(self, command_args):
+		# stdout is never read, and an unread PIPE fills the OS buffer and blocks
+		# chromium on write; stderr is drained after the DevTools URL is captured.
 		if platform.system().lower() == "windows":
 			# hide cmd window
 			startupinfo = subprocess.STARTUPINFO()
@@ -184,14 +187,14 @@ class ChromiumManager:
 			startupinfo.wShowWindow = subprocess.SW_HIDE
 			self._chromium_process = subprocess.Popen(
 				command_args,
-				stdout=subprocess.PIPE,
+				stdout=subprocess.DEVNULL,
 				stderr=subprocess.PIPE,
 				startupinfo=startupinfo,
 				text=True,
 			)
 		else:
 			self._chromium_process = subprocess.Popen(
-				command_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+				command_args, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True
 			)
 		return self._chromium_process
 
@@ -249,9 +252,18 @@ class ChromiumManager:
 					break
 
 		if self._devtools_url:
+			self._drain_stderr(stderr)
 			return
 
 		self._raise_start_failure(output)
+
+	def _drain_stderr(self, stderr):
+		"""Keep reading chromium's stderr for the rest of its lifetime.
+
+		Nothing consumes it after the DevTools URL line, and a chatty chromium
+		(GPU fallback spam, broken resources) blocks on write once the ~64KB
+		pipe buffer fills, hanging the render."""
+		threading.Thread(target=stderr.read, daemon=True).start()
 
 	def _raise_start_failure(self, output):
 		"""Report why Chromium never handed us a DevTools URL, quoting its own stderr.
@@ -285,8 +297,15 @@ class ChromiumManager:
 		if self._browsers:
 			frappe.log("Cannot close Chromium as there are active browser instances.")
 			return
+		if getattr(self, "USE_PERSISTENT_CHROMIUM", False):
+			return
 		if self._chromium_process:
 			self._chromium_process.terminate()
+			try:
+				self._chromium_process.wait(timeout=5)
+			except subprocess.TimeoutExpired:
+				self._chromium_process.kill()
+				self._chromium_process.wait()
 		ChromiumManager._instance = None
 		self._chromium_process = None
 		self._devtools_url = None

--- a/frappe/utils/chromium/process.py
+++ b/frappe/utils/chromium/process.py
@@ -16,6 +16,28 @@ from frappe.utils.data import cint
 
 class ChromiumManager:
 	_instance = None
+	# Serializes obtain/register/teardown under threaded serving: without it,
+	# one request's per-request teardown can terminate the chromium another
+	# request obtained but hasn't registered a browser on yet.
+	_lock = threading.RLock()
+
+	@classmethod
+	def acquire(cls):
+		"""Return (manager, token) with the token already registered, atomically.
+
+		Holding a registered token keeps _close_browser from tearing chromium
+		down while this request is using it."""
+		with cls._lock:
+			manager = cls()
+			token = frappe.utils.random_string(10)
+			manager.add_browser(token)
+			return manager, token
+
+	def release(self, token):
+		"""Deregister the token and tear chromium down if nobody else holds one."""
+		with ChromiumManager._lock:
+			self.remove_browser(token)
+			self._close_browser()
 
 	def add_browser(self, browser):
 		self._browsers.append(browser)
@@ -189,12 +211,13 @@ class ChromiumManager:
 				command_args,
 				stdout=subprocess.DEVNULL,
 				stderr=subprocess.PIPE,
+				errors="replace",
 				startupinfo=startupinfo,
 				text=True,
 			)
 		else:
 			self._chromium_process = subprocess.Popen(
-				command_args, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True
+				command_args, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True, errors="replace"
 			)
 		return self._chromium_process
 
@@ -294,6 +317,10 @@ class ChromiumManager:
 		"""
 		Close the headless Chromium browser.
 		"""
+		with ChromiumManager._lock:
+			self._close_browser_locked()
+
+	def _close_browser_locked(self):
 		if self._browsers:
 			frappe.log("Cannot close Chromium as there are active browser instances.")
 			return

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -176,16 +176,14 @@ def get_chrome_pdf(print_format, html, options, output, pdf_generator=None):
 		return
 	# scrubbing url to expand url is not required as we have set url.
 	# also, planning to remove network requests anyway 🤞
-	generator = ChromiumManager()
+	generator, token = ChromiumManager.acquire()
 	try:
 		browser = Browser(generator, print_format, html, options)
 		transformer = PDFTransformer(browser)
 		# transforms and merges header, footer into body pdf and returns merged pdf
 		return transformer.transform_pdf(output=output)
-	except Exception:
-		raise
 	finally:
-		generator._close_browser()
+		generator.release(token)
 
 
 def get_file_data_from_writer(writer_obj):

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -158,7 +158,8 @@ def measure_time(func):
 		start_time = time.time()
 		result = func(*args, **kwargs)
 		end_time = time.time()
-		print(f"Function {func.__name__} took {end_time - start_time:.4f} seconds")
+		if frappe.conf.developer_mode:
+			print(f"Function {func.__name__} took {end_time - start_time:.4f} seconds")
 		return result
 
 	return wrapper

--- a/frappe/utils/pdf_generator/browser.py
+++ b/frappe/utils/pdf_generator/browser.py
@@ -242,6 +242,7 @@ class Browser:
 		)
 
 		if pdf_page_size == "Custom":
+			options["page-size"] = pdf_page_size
 			# Print Settings stores these in mm; downstream expects px like the
 			# named-size branch in prepare_options_for_pdf.
 			for dimension, fieldname in (

--- a/frappe/utils/pdf_generator/browser.py
+++ b/frappe/utils/pdf_generator/browser.py
@@ -242,12 +242,16 @@ class Browser:
 		)
 
 		if pdf_page_size == "Custom":
-			options["page-height"] = options.get("page-height") or frappe.db.get_single_value(
-				"Print Settings", "pdf_page_height"
-			)
-			options["page-width"] = options.get("page-width") or frappe.db.get_single_value(
-				"Print Settings", "pdf_page_width"
-			)
+			# Print Settings stores these in mm; downstream expects px like the
+			# named-size branch in prepare_options_for_pdf.
+			for dimension, fieldname in (
+				("page-height", "pdf_page_height"),
+				("page-width", "pdf_page_width"),
+			):
+				if not options.get(dimension):
+					value = frappe.db.get_single_value("Print Settings", fieldname)
+					if value:
+						options[dimension] = convert_uom(value, "mm", "px", only_number=True)
 		else:
 			options["page-size"] = pdf_page_size
 
@@ -284,7 +288,7 @@ class Browser:
 		if not options.get("page-height") or not options.get("page-width"):
 			if not (page_size := self.options.get("page-size")):
 				raise frappe.ValidationError("Page size is required")
-			if page_size == "CUSTOM":
+			if page_size == "Custom":
 				raise frappe.ValidationError("Custom page size requires page-height and page-width")
 			size = PageSize.get(page_size)
 			if not size:
@@ -333,7 +337,14 @@ class Browser:
 
 		if self.header_page:
 			header_with_top_margin = self.header_height + (0 if header_owns_top_margin else margin_top)
-			header_spacing = options.get("header-spacing", 0)
+			# comes from print CSS as a string; unitless values are mm (wkhtmltopdf's
+			# --header-spacing unit) and must land in px like everything else here
+			header_spacing = options.get("header-spacing") or 0
+			if header_spacing:
+				parsed = parse_float_and_unit(header_spacing, default_unit="mm")
+				header_spacing = (
+					convert_uom(parsed["value"], parsed["unit"], "px", only_number=True) if parsed else 0
+				)
 			header_with_spacing_top_margin = header_with_top_margin + header_spacing
 			self.header_page.options["paperHeight"] = (
 				convert_uom(header_with_spacing_top_margin, "px", "in", only_number=True)
@@ -370,6 +381,13 @@ class Browser:
 		body_height = options.get("page-height") - (
 			header_with_spacing_top_margin + footer_with_bottom_margin
 		)
+
+		if body_height <= 0:
+			frappe.throw(
+				frappe._(
+					"Header, footer and margins leave no room for content on a {0}px tall page. Reduce their height or use a larger page size."
+				).format(options.get("page-height"))
+			)
 
 		"""
 		matching scale for some old formats is 1.46 #backwards-compatibility ( scale 1 is better in my opinion)

--- a/frappe/utils/pdf_generator/pdf_merge.py
+++ b/frappe/utils/pdf_generator/pdf_merge.py
@@ -51,10 +51,11 @@ class PDFTransformer:
 		# footer and its mediabox restored to the full paper height
 		page_top = header_height + body_height + footer_height
 
-		# Static headers: pre-transform all pages once.
-		# Dynamic headers: transform each page inline (once per body page).
-		# This matches print_designer's pdf_merge.py exactly.
-		if header and not self.is_header_dynamic:
+		# Pre-transform every header page exactly once. A dynamic header can have
+		# fewer pages than the body (pagination rounding), so the merge below
+		# clamps the index like the footer path — transforming inline there would
+		# translate a clamped page multiple times.
+		if header:
 			for h in header.pages:
 				self._transform(h, page_top, header_transform)
 
@@ -63,7 +64,7 @@ class PDFTransformer:
 
 			if header:
 				if self.is_header_dynamic:
-					p.merge_page(self._transform(header.pages[p.page_number], page_top, header_transform))
+					p.merge_page(header.pages[min(p.page_number, len(header.pages) - 1)])
 				elif self.is_print_designer:
 					if p.page_number == 0:
 						p.merge_page(header.pages[0])

--- a/frappe/utils/preview.py
+++ b/frappe/utils/preview.py
@@ -56,9 +56,7 @@ def capture_screenshot(
 	from frappe.utils.pdf import get_host_url
 
 	image_format = get_image_format(format)
-	generator = ChromiumManager()
-	browser_id = frappe.utils.random_string(10)
-	generator.add_browser(browser_id)
+	generator, browser_id = ChromiumManager.acquire()
 	session = page = None
 	try:
 		try:


### PR DESCRIPTION
- fail in-flight CDP commands when the chromium connection drops, instead of hanging the worker forever on an unresolved future; close the per-request event loop on disconnect
- custom page size from Print Settings is stored in mm but was consumed as px, rendering pages ~3.78x too small; convert like the named-size branch (the dead `== "CUSTOM"` guard is also fixed to `"Custom"`)
- `header-spacing` from print CSS is a string and crashed with `TypeError: float + str`; parse and convert it (unitless = mm, matching wkhtmltopdf)
- raise a clear error when header + footer + margins exceed the page height instead of sending a negative `paperHeight` to chrome
- `frappe.warn` does not exist in Python, so setting `chromium_websocket_url` crashed every PDF; use the pdf logger
- `evaluate()` raised even when a retry succeeded, failing dynamic page-number headers/footers on any first-attempt hiccup
- dynamic header merge now clamps the page index like the footer path (`IndexError` when the header PDF has fewer pages than the body)
- `_close_browser` now waits and escalates to `kill()` (no zombie chromium), and respects `use_persistent_chromium`, which was never checked before
- chromium stdout/stderr pipes were never drained past the DevTools line — a chatty chromium blocks on write once the 64KB pipe buffer fills; stdout goes to DEVNULL, stderr gets a drain thread
- async header/footer PDF waited only for `Page.printToPDF` to be *sent*, not for its response, before reading the stream id
- timing `print()` on every PDF is now developer-mode only
- every CDP command is now bounded by a 120s timeout, so a connected-but-unresponsive chromium (stuck renderer) can no longer hang the worker; a dropped connection already failed fast via the pending-future path
- chromium obtain/register/teardown is serialized under a lock with an atomic acquire/release token, closing the threaded-serving race where one request's teardown killed the chromium another request had just obtained
- chromium stderr is decoded with `errors="replace"` so non-UTF8 output can't kill the drain thread
- async printToPDF timeout now raises a clear error instead of `InvalidStateError`
- regression tests for the geometry paths, CDP command timeout, fail-pending, and evaluate retry

Verified on a live bench: A4 vs Custom 210x297mm now produce identical geometry (595.9x841.9pt), header/footer/page-number and password renders pass, `test_pdf` and `test_chrome_pdf_interceptor` green.
