### PR TITLE
fix(ui): Hide core modules in global search settings

### DIFF
--- a/frappe/desk/doctype/global_search_settings/global_search_settings.js
+++ b/frappe/desk/doctype/global_search_settings/global_search_settings.js
@@ -78,6 +78,12 @@ function show_configure_search_fields_dialog(doctype, frm) {
 
 frappe.ui.form.on("Global Search Settings", {
 	refresh: function (frm) {
+		// Core module doctypes are framework internals (DocType, User, File,
+		// etc.) that validate() rejects with a clear error.
+		frm.set_query("document_type", "allowed_in_global_search", () => {
+			return { filters: { module: ["!=", "Core"] } };
+		});
+
 		frappe.realtime.on("global_search_settings", (data) => {
 			if (data.progress) {
 				frm.dashboard.show_progress(

--- a/frappe/tests/test_global_search.py
+++ b/frappe/tests/test_global_search.py
@@ -205,3 +205,21 @@ class TestGlobalSearch(IntegrationTestCase):
 			text="company", scope='manufacturing" UNION ALL SELECT 1,2,3,4,doctype from __global_search'
 		)
 		self.assertTrue(results == [])
+
+	def test_settings_validate_rejects_core_doctype_row(self):
+		core_dt = "File"
+		self.assertEqual(frappe.get_meta(core_dt).module, "Core")
+
+		settings = frappe.get_single("Global Search Settings")
+		original_rows = [row.document_type for row in settings.allowed_in_global_search]
+
+		try:
+			settings.append("allowed_in_global_search", {"document_type": core_dt})
+			with self.assertRaises(frappe.ValidationError):
+				settings.save(ignore_permissions=True)
+		finally:
+			settings.reload()
+			settings.allowed_in_global_search = []
+			for dt in original_rows:
+				settings.append("allowed_in_global_search", {"document_type": dt})
+			settings.save(ignore_permissions=True)


### PR DESCRIPTION
This fix ensures drop down don't show doctypes from Core modules as we don't support global search in it. Validate happened only in backend code, now added that in UI too.