### PR TITLE
feat: Copy & paste sections in Form Builder

### DIFF
--- a/frappe/public/js/form_builder/components/Section.vue
+++ b/frappe/public/js/form_builder/components/Section.vue
@@ -34,7 +34,16 @@
 						v-html="frappe.utils.icon(collapsed ? 'down' : 'up-line', 'sm')"
 					></div>
 				</div>
-				<Dropdown v-if="!store.read_only" :options="options" @click.stop />
+				<div v-if="!store.read_only" class="section-actions">
+					<button
+						class="btn btn-xs btn-icon section-copy-btn"
+						:title="__('Copy section with all its fields')"
+						@click.stop="copy_section_with_fields"
+					>
+						<div v-html="frappe.utils.icon('duplicate', 'sm')"></div>
+					</button>
+					<Dropdown :options="options" @click.stop />
+				</div>
 			</div>
 			<div v-if="section.df.description" class="section-description">
 				{{ section.df.description }}
@@ -81,6 +90,9 @@ import {
 	move_children_to_parent,
 	confirm_dialog,
 	is_touch_screen_device,
+	copy_section,
+	get_pasted_section,
+	copied_section_available,
 } from "../utils";
 import { useMagicKeys, whenever } from "@vueuse/core";
 
@@ -161,6 +173,24 @@ function delete_section(with_children) {
 	// remove section
 	sections.splice(index, 1);
 	store.form.selected_field = null;
+}
+
+function copy_section_with_fields() {
+	copy_section(props.section);
+}
+
+function paste_section_below() {
+	let section = get_pasted_section();
+	if (!section) return;
+
+	let index = props.tab.sections.indexOf(props.section);
+	props.tab.sections.splice(index + 1, 0, section);
+	store.form.selected_field = section.df;
+}
+
+function duplicate_section() {
+	copy_section(props.section);
+	paste_section_below();
 }
 
 function select_section() {
@@ -263,6 +293,20 @@ const options = computed(() => {
 			group: __("Section"),
 			items: [
 				{ label: __("Add section below"), onClick: add_section_below },
+				{
+					label: __("Duplicate section"),
+					tooltip: __("Duplicate section with all its fields"),
+					onClick: duplicate_section,
+				},
+				...(copied_section_available.value
+					? [
+							{
+								label: __("Paste section below"),
+								tooltip: __("Paste copied section with all its fields"),
+								onClick: paste_section_below,
+							},
+					  ]
+					: []),
 				{ label: __("Remove section"), onClick: remove_section },
 			],
 		},
@@ -325,6 +369,10 @@ const options = computed(() => {
 		&.hovered,
 		&.selected {
 			border-color: var(--border-primary);
+
+			.section-copy-btn {
+				opacity: 1;
+			}
 		}
 
 		.section-header {
@@ -358,6 +406,16 @@ const options = computed(() => {
 				display: flex;
 				gap: 4px;
 				align-items: center;
+
+				.section-copy-btn {
+					opacity: 0;
+					box-shadow: none;
+					padding: 2px;
+
+					&:hover {
+						background-color: var(--bg-light-gray);
+					}
+				}
 			}
 
 			// .btn-section {

--- a/frappe/public/js/form_builder/utils.js
+++ b/frappe/public/js/form_builder/utils.js
@@ -1,4 +1,5 @@
 import { useStore } from "./store";
+import { ref } from "vue";
 
 export function create_layout(fields) {
 	let store = useStore();
@@ -318,6 +319,105 @@ export function clone_field(field) {
 	let cloned_field = JSON.parse(JSON.stringify(field));
 	cloned_field.df.name = frappe.utils.get_random(8);
 	return cloned_field;
+}
+
+const COPIED_SECTION_STORAGE_KEY = "frappe-form-builder-copied-section";
+
+export const copied_section_available = ref(
+	Boolean(localStorage.getItem(COPIED_SECTION_STORAGE_KEY))
+);
+
+// keep availability in sync when a section is copied from another tab/window
+window.addEventListener("storage", (e) => {
+	if (e.key === COPIED_SECTION_STORAGE_KEY) {
+		copied_section_available.value = Boolean(e.newValue);
+	}
+});
+
+export function copy_section(section) {
+	let copied_section = {
+		df: section.df,
+		columns: section.columns.map((column) => ({
+			df: column.df,
+			fields: column.fields.map((field) => ({ df: field.df })),
+		})),
+	};
+
+	localStorage.setItem(COPIED_SECTION_STORAGE_KEY, JSON.stringify(copied_section));
+	copied_section_available.value = true;
+
+	frappe.show_alert({
+		message: __(
+			"Section copied. Use 'Paste section below' from the section menu of any form builder to paste it along with its fields."
+		),
+		indicator: "green",
+	});
+}
+
+export function get_pasted_section() {
+	let copied_section = localStorage.getItem(COPIED_SECTION_STORAGE_KEY);
+	if (!copied_section) return null;
+
+	let store = useStore();
+	let section = JSON.parse(copied_section);
+
+	let taken_fieldnames = new Set();
+	store.form.layout.tabs.forEach((tab) => {
+		tab.df.fieldname && taken_fieldnames.add(tab.df.fieldname);
+		tab.sections.forEach((s) => {
+			s.df.fieldname && taken_fieldnames.add(s.df.fieldname);
+			s.columns.forEach((c) => {
+				c.df.fieldname && taken_fieldnames.add(c.df.fieldname);
+				c.fields.forEach((f) => {
+					f.df.fieldname && taken_fieldnames.add(f.df.fieldname);
+				});
+			});
+		});
+	});
+
+	function prepare_df(df) {
+		df.name = frappe.utils.get_random(8);
+		df.__islocal = 1;
+		df.__unsaved = 1;
+		df.owner = frappe.session.user;
+		df.is_system_generated = 0;
+
+		delete df.creation;
+		delete df.modified;
+		delete df.modified_by;
+
+		if (store.is_customize_form) {
+			df.is_custom_field = 1;
+		} else {
+			delete df.is_custom_field;
+		}
+
+		// fieldname already exists in the target form; make it unique
+		if (df.fieldname && taken_fieldnames.has(df.fieldname)) {
+			if (df.label) {
+				df.label = df.label + " Copy";
+			}
+			let fieldname = df.fieldname + "_copy";
+			while (taken_fieldnames.has(fieldname)) {
+				fieldname = df.fieldname + "_copy_" + frappe.utils.get_random(4).toLowerCase();
+			}
+			df.fieldname = fieldname;
+		}
+		df.fieldname && taken_fieldnames.add(df.fieldname);
+	}
+
+	prepare_df(section.df);
+	section.columns.forEach((column) => {
+		prepare_df(column.df);
+		column.fields.forEach((field) => {
+			prepare_df(field.df);
+			if (field.df.fieldtype === "Table") {
+				field.table_columns = get_table_columns(field.df);
+			}
+		});
+	});
+
+	return section;
 }
 
 export function confirm_dialog(


### PR DESCRIPTION
**## Problem**

In the Form Builder (DocType / Customize Form), individual fields have a **Duplicate** action on hover, but there is no equivalent for sections. Recreating a section means re-adding every column and field one by one — and there is no way at all to reuse an existing section's layout in another DocType.

**## What this PR does**

Adds copy/paste support for entire sections (with all their columns and fields) in the Form Builder:

- **Copy icon on section hover** — same **`duplicate`** icon fields already have. Clicking it copies the whole section to `localStorage`, so it survives navigation and works across DocTypes (and across browser tabs).
- **"Paste section below"** — new option in the section dropdown menu of *any* Form Builder (same or different DocType), shown only when a copied section is available. Inserts the copied section with all its fields below the current section.
- **"Duplicate section"** — new option in the section dropdown for one-click duplication in place.

**Implementation notes:**

- Pasted docfields get fresh internal names and are flagged `__islocal` / `__unsaved`, so the existing save flow treats them as new fields.
- Fieldname collisions (e.g. pasting into the same DocType) are resolved by suffixing the fieldname with `_copy` and the label with " Copy" — consistent with the existing field-level duplicate behavior. Pasting into a different DocType keeps original fieldnames/labels.
- In Customize Form, pasted fields are marked `is_custom_field = 1`, same as the field-level duplicate.
- Table fields rebuild their preview columns on paste; undo/redo (Ctrl+Z) works for paste operations.

No server-side changes — this composes purely with the existing Form Builder save/validation flow.



**VIDEO REFERENCE:**

<img width="340" height="508" alt="image" src="https://github.com/user-attachments/assets/3ebbb993-28ac-4d91-87b8-62344a8cd6e4" />



[form_builder_copy_paste_demo.webm](https://github.com/user-attachments/assets/2879ff6d-cfaa-417c-91fa-23d38a2958a8)
