### PR TITLE
fix(ui): keep a document's realtime room alive while another consumer holds it

### DIFF
--- a/ui/src/socket.ts
+++ b/ui/src/socket.ts
@@ -52,7 +52,8 @@ export function subscribeToDoc(
 ): () => void {
   if (!socket) return () => {};
 
-  const key = `${doctype} ${docname}`;
+  // Doctypes and docnames both allow spaces, so a delimited key is ambiguous.
+  const key = JSON.stringify([doctype, docname]);
   const room = rooms.get(key) ?? { doctype, docname, holders: 0 };
   if (room.holders === 0) socket.emit("doc_subscribe", doctype, docname);
   room.holders += 1;

--- a/ui/src/socket.ts
+++ b/ui/src/socket.ts
@@ -1,6 +1,6 @@
 import { getCurrentInstance, inject } from "vue";
 
-interface RealtimeSocket {
+export interface RealtimeSocket {
   emit(event: string, ...args: unknown[]): void;
   on(event: string, handler: (...args: unknown[]) => void): void;
   off(event: string, handler: (...args: unknown[]) => void): void;
@@ -25,9 +25,53 @@ export function getSocketInstance(): RealtimeSocket | undefined {
   if (!socket && import.meta.env?.DEV) {
     console.warn(
       "getSocketInstance: no socket found. Expose one via " +
-        "provide('socket'|'$socket', …) or a $socket global."
+        "provide('socket'|'$socket', …) or a $socket global.",
     );
   }
 
   return socket;
+}
+
+// The server's `doc_unsubscribe` is a bare `socket.leave` (realtime/handlers.js), so one
+// consumer leaving a room silently deafens every other consumer on the same document.
+interface DocRoom {
+  doctype: string;
+  docname: string;
+  holders: number;
+}
+
+const rooms = new Map<string, DocRoom>();
+
+/**
+ * Joins a document's realtime room, and leaves only when the last holder releases it.
+ */
+export function subscribeToDoc(
+  socket: RealtimeSocket | undefined,
+  doctype: string,
+  docname: string,
+): () => void {
+  if (!socket) return () => {};
+
+  const key = `${doctype} ${docname}`;
+  const room = rooms.get(key) ?? { doctype, docname, holders: 0 };
+  if (room.holders === 0) socket.emit("doc_subscribe", doctype, docname);
+  room.holders += 1;
+  rooms.set(key, room);
+
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    room.holders -= 1;
+    if (room.holders > 0) return;
+    rooms.delete(key);
+    socket.emit("doc_unsubscribe", doctype, docname);
+  };
+}
+
+/** Rejoins every held room, for a reconnect that dropped the server's membership. */
+export function resubscribeHeldDocs(socket: RealtimeSocket | undefined) {
+  if (!socket) return;
+  for (const room of rooms.values())
+    socket.emit("doc_subscribe", room.doctype, room.docname);
 }

--- a/ui/src/tests/socket.test.ts
+++ b/ui/src/tests/socket.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+import type { RealtimeSocket } from "../socket";
+
+// The room table is module state, so a test that reused the import would inherit
+// the previous test's holders. Re-importing after `resetModules()` is what gives
+// each test an empty table.
+async function loadSocket() {
+  vi.resetModules();
+  return import("../socket");
+}
+
+function fakeSocket() {
+  const emitted: unknown[][] = [];
+  const socket: RealtimeSocket = {
+    emit: (event, ...args) => {
+      emitted.push([event, ...args]);
+    },
+    on: () => {},
+    off: () => {},
+  };
+  return { socket, emitted };
+}
+
+describe("subscribeToDoc", () => {
+  it("joins the room for the first holder", async () => {
+    const { subscribeToDoc } = await loadSocket();
+    const { socket, emitted } = fakeSocket();
+
+    subscribeToDoc(socket, "ToDo", "T1");
+
+    expect(emitted).toEqual([["doc_subscribe", "ToDo", "T1"]]);
+  });
+
+  it("does not join again for a second holder of the same document", async () => {
+    const { subscribeToDoc } = await loadSocket();
+    const { socket, emitted } = fakeSocket();
+
+    subscribeToDoc(socket, "ToDo", "T1");
+    subscribeToDoc(socket, "ToDo", "T1");
+
+    expect(emitted).toEqual([["doc_subscribe", "ToDo", "T1"]]);
+  });
+
+  it("leaves only once the last holder has released", async () => {
+    const { subscribeToDoc } = await loadSocket();
+    const { socket, emitted } = fakeSocket();
+
+    const releaseA = subscribeToDoc(socket, "ToDo", "T1");
+    const releaseB = subscribeToDoc(socket, "ToDo", "T1");
+
+    releaseA();
+    expect(emitted).toEqual([["doc_subscribe", "ToDo", "T1"]]); // B still holds it
+
+    releaseB();
+    expect(emitted).toEqual([
+      ["doc_subscribe", "ToDo", "T1"],
+      ["doc_unsubscribe", "ToDo", "T1"],
+    ]);
+  });
+
+  it("ignores a release that already ran, so it cannot drop another holder", async () => {
+    const { subscribeToDoc } = await loadSocket();
+    const { socket, emitted } = fakeSocket();
+
+    const releaseA = subscribeToDoc(socket, "ToDo", "T1");
+    const releaseB = subscribeToDoc(socket, "ToDo", "T1");
+
+    releaseA();
+    releaseA(); // a double unmount must not evict B
+
+    expect(emitted).toEqual([["doc_subscribe", "ToDo", "T1"]]);
+
+    releaseB();
+    expect(emitted).toEqual([
+      ["doc_subscribe", "ToDo", "T1"],
+      ["doc_unsubscribe", "ToDo", "T1"],
+    ]);
+  });
+
+  it("joins afresh after the room was fully released", async () => {
+    const { subscribeToDoc } = await loadSocket();
+    const { socket, emitted } = fakeSocket();
+
+    subscribeToDoc(socket, "ToDo", "T1")();
+    subscribeToDoc(socket, "ToDo", "T1");
+
+    expect(emitted).toEqual([
+      ["doc_subscribe", "ToDo", "T1"],
+      ["doc_unsubscribe", "ToDo", "T1"],
+      ["doc_subscribe", "ToDo", "T1"],
+    ]);
+  });
+
+  it("counts each document separately", async () => {
+    const { subscribeToDoc } = await loadSocket();
+    const { socket, emitted } = fakeSocket();
+
+    const releaseTodo = subscribeToDoc(socket, "ToDo", "T1");
+    subscribeToDoc(socket, "Note", "N1");
+    releaseTodo();
+
+    expect(emitted).toEqual([
+      ["doc_subscribe", "ToDo", "T1"],
+      ["doc_subscribe", "Note", "N1"],
+      ["doc_unsubscribe", "ToDo", "T1"], // Note is untouched
+    ]);
+  });
+
+  it("returns a harmless release when there is no socket", async () => {
+    const { subscribeToDoc, resubscribeHeldDocs } = await loadSocket();
+    const { socket, emitted } = fakeSocket();
+
+    expect(() => subscribeToDoc(undefined, "ToDo", "T1")()).not.toThrow();
+
+    resubscribeHeldDocs(socket);
+    expect(emitted).toEqual([]); // nothing was ever held
+  });
+});
+
+describe("resubscribeHeldDocs", () => {
+  it("re-joins every room still held", async () => {
+    const { subscribeToDoc, resubscribeHeldDocs } = await loadSocket();
+    const { socket, emitted } = fakeSocket();
+
+    subscribeToDoc(socket, "ToDo", "T1");
+    const releaseNote = subscribeToDoc(socket, "Note", "N1");
+    releaseNote();
+    emitted.length = 0;
+
+    resubscribeHeldDocs(socket);
+
+    expect(emitted).toEqual([["doc_subscribe", "ToDo", "T1"]]); // Note was released
+  });
+
+  it("emits nothing when no socket is available", async () => {
+    const { subscribeToDoc, resubscribeHeldDocs } = await loadSocket();
+    const { socket, emitted } = fakeSocket();
+
+    subscribeToDoc(socket, "ToDo", "T1");
+    emitted.length = 0;
+
+    resubscribeHeldDocs(undefined);
+
+    expect(emitted).toEqual([]);
+  });
+});


### PR DESCRIPTION
### The problem

`doc_unsubscribe` on the server is a bare `socket.leave` ([`realtime/handlers.js`](https://github.com/frappe/frappe/blob/develop/realtime/handlers.js)). It carries no notion of who else is in the room, so **the first consumer to release a document evicts every other consumer watching it**.

That is fine while one component per record subscribes, which is the assumption the desk grew up with. It stops being fine the moment two do — a form and a timeline, say, or a sidebar and a detail panel. Whichever unmounts first silently deafens the other, and the survivor simply stops receiving updates with no error anywhere.

### The change

`subscribeToDoc(socket, doctype, docname)` refcounts the room and returns a release function. `doc_subscribe` is emitted for the first holder only, `doc_unsubscribe` when the last one lets go.

```ts
const release = subscribeToDoc(socket, "ToDo", "T1")
// ... later, on unmount
release()
```

Two details that are load-bearing and easy to lose:

- **the holder count** — without it, one consumer's release evicts the others, which is the original bug
- **the `released` flag** — without it, a double unmount decrements a count it no longer owns and evicts a live holder

`resubscribeHeldDocs(socket)` rejoins every room still held, for a reconnect where the server dropped its membership.

### Tests

`ui/src/tests/socket.test.ts`, 9 cases. Room state is module-level, so each test re-imports after `vi.resetModules()` to get a clean table.

I mutation-tested rather than just running them green:

| Mutation | Tests that fail |
|---|---|
| drop `if (room.holders > 0) return` | 2 |
| drop `if (released) return` | 1 |

Both guards are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)