### PR TITLE
feat(activity): show edits, milestones and shares in the activity timeline

### DIFF
--- a/frappe/desk/form/activity.py
+++ b/frappe/desk/form/activity.py
@@ -7,7 +7,13 @@ import re
 import frappe
 import frappe.utils
 from frappe import _
-from frappe.desk.form.load import _get_communications, add_comments, get_versions, get_view_logs
+from frappe.desk.form.load import (
+	_get_communications,
+	add_comments,
+	get_milestones,
+	get_versions,
+	get_view_logs,
+)
 from frappe.model.document import Document
 
 # Non-email sources load in full; emails are paged newest-first.
@@ -22,9 +28,11 @@ def get_activity_timeline(doctype: str, name: str | int) -> dict:
 	emails, has_more_emails = get_email_activities(doc, user_info)
 	activities = [
 		*get_creation_activity(doc, user_info),
+		*get_edit_activity(doc, user_info),
 		*emails,
 		*get_comment_and_log_activities(doc, user_info),
 		*get_view_activities(doc, user_info),
+		*get_milestone_activities(doc, user_info),
 		*get_version_activities(doc, user_info),
 	]
 
@@ -66,6 +74,34 @@ def get_creation_msg(owner: str, fullname: str):
 	if frappe.session.user == owner:
 		return _("You created this document")
 	return _("{0} created this document").format(fullname)
+
+
+def get_edit_activity(doc: "Document", user_info: dict) -> list[dict]:
+	"""The last edit, which is the only sign of one on a doctype that tracks no changes."""
+	if not doc.modified or str(doc.modified) == str(doc.creation):
+		return []
+
+	frappe.utils.add_user_info({doc.modified_by}, user_info)
+	author = get_author_info(doc.modified_by, user_info)
+	return [
+		{
+			"type": "log",
+			"key": "edited",
+			"timestamp": str(doc.modified),
+			"author": author,
+			"data": {
+				"name": "edited",
+				"subtype": "edited",
+				"text": get_edit_msg(doc.modified_by, author["fullname"]),
+			},
+		}
+	]
+
+
+def get_edit_msg(modified_by: str, fullname: str):
+	if frappe.session.user == modified_by:
+		return _("You last edited this document")
+	return _("{0} last edited this document").format(fullname)
 
 
 def get_email_activities(doc: "Document", user_info: dict, start: int = 0) -> tuple[list[dict], bool]:
@@ -139,6 +175,7 @@ def get_comment_and_log_activities(doc: "Document", user_info: dict) -> list[dic
 		+ comment_log_data.info_logs
 		+ comment_log_data.like_logs
 		+ comment_log_data.workflow_logs
+		+ comment_log_data.shared
 	)
 	frappe.utils.add_user_info({c.owner for c in all_rows if c.owner}, user_info)
 
@@ -186,6 +223,11 @@ def get_comment_and_log_activities(doc: "Document", user_info: dict) -> list[dic
 	for c in comment_log_data.info_logs:
 		author = get_author_info(c.owner, user_info)
 		out.append(add_activity_record(c, author, "info", f"{author['fullname']} {activity_text(c.content)}"))
+
+	# docshare.py writes these already naming both the actor and who was shared with.
+	for c in comment_log_data.shared:
+		author = get_author_info(c.owner, user_info)
+		out.append(add_activity_record(c, author, "shared", activity_text(c.content)))
 
 	return out
 
@@ -305,6 +347,42 @@ def get_view_activities(doc: "Document", user_info: dict) -> list[dict]:
 					"name": v.name,
 					"subtype": "view",
 					"text": _("{0} viewed this").format(author["fullname"]),
+				},
+			}
+		)
+	return out
+
+
+def get_milestone_activities(doc: "Document", user_info: dict) -> list[dict]:
+	milestones = get_milestones(doc.doctype, doc.name)
+	if not milestones:
+		return []
+
+	# A milestone names a field and its value, so it needs the same read check as a version.
+	permitted = set(
+		frappe.model.get_permitted_fields(doc.doctype, user=frappe.session.user, permission_type="read")
+	)
+	frappe.utils.add_user_info({m.owner for m in milestones if m.owner}, user_info)
+
+	out = []
+	for m in milestones:
+		df = is_field_visible(doc.meta, permitted, m.track_field)
+		if not df:
+			continue
+
+		author = get_author_info(m.owner, user_info)
+		out.append(
+			{
+				"type": "log",
+				"key": f"milestone:{m.name}",
+				"timestamp": str(m.creation),
+				"author": author,
+				"data": {
+					"name": m.name,
+					"subtype": "milestone",
+					"text": _("{0} changed {1} to {2}").format(
+						author["fullname"], _(df.label or m.track_field), m.value
+					),
 				},
 			}
 		)

--- a/frappe/desk/form/activity.py
+++ b/frappe/desk/form/activity.py
@@ -16,8 +16,9 @@ from frappe.desk.form.load import (
 )
 from frappe.model.document import Document
 
-# Non-email sources load in full; emails are paged newest-first.
+# Emails and milestones are paged newest-first; the remaining sources load in full.
 EMAIL_PAGE_SIZE = 20
+MILESTONE_PAGE_SIZE = 20
 
 
 @frappe.whitelist()
@@ -26,18 +27,24 @@ def get_activity_timeline(doctype: str, name: str | int) -> dict:
 	user_info: dict = {}  # cache user lookups
 
 	emails, has_more_emails = get_email_activities(doc, user_info)
+	milestones, has_more_milestones, next_milestone_start = get_milestone_activities(doc, user_info)
 	activities = [
 		*get_creation_activity(doc, user_info),
 		*get_edit_activity(doc, user_info),
 		*emails,
 		*get_comment_and_log_activities(doc, user_info),
 		*get_view_activities(doc, user_info),
-		*get_milestone_activities(doc, user_info),
+		*milestones,
 		*get_version_activities(doc, user_info),
 	]
 
 	activities.sort(key=lambda a: (a.get("timestamp") or "", a["key"]))
-	return {"activities": activities, "has_more_emails": has_more_emails}
+	return {
+		"activities": activities,
+		"has_more_emails": has_more_emails,
+		"has_more_milestones": has_more_milestones,
+		"next_milestone_start": next_milestone_start,
+	}
 
 
 @frappe.whitelist()
@@ -48,6 +55,22 @@ def get_more_email_activities(doctype: str, name: str | int, start: int) -> dict
 	emails, has_more_emails = get_email_activities(doc, user_info, start=frappe.utils.cint(start))
 	emails.sort(key=lambda a: (a.get("timestamp") or "", a["key"]))
 	return {"activities": emails, "has_more_emails": has_more_emails}
+
+
+@frappe.whitelist()
+def get_more_milestone_activities(doctype: str, name: str | int, start: int) -> dict:
+	doc = frappe.get_lazy_doc(doctype, name, check_permission=True)
+	user_info: dict = {}
+
+	milestones, has_more, next_start = get_milestone_activities(
+		doc, user_info, start=frappe.utils.cint(start)
+	)
+	milestones.sort(key=lambda a: (a.get("timestamp") or "", a["key"]))
+	return {
+		"activities": milestones,
+		"has_more_milestones": has_more,
+		"next_milestone_start": next_start,
+	}
 
 
 def get_creation_activity(doc: "Document", user_info: dict) -> list[dict]:
@@ -353,10 +376,17 @@ def get_view_activities(doc: "Document", user_info: dict) -> list[dict]:
 	return out
 
 
-def get_milestone_activities(doc: "Document", user_info: dict) -> list[dict]:
-	milestones = get_milestones(doc.doctype, doc.name)
+def get_milestone_activities(
+	doc: "Document", user_info: dict, start: int = 0
+) -> tuple[list[dict], bool, int]:
+	# Fetch PAGE_SIZE+1 (DESC); the extra oldest row signals "more exist".
+	milestones = get_milestones(doc.doctype, doc.name, start=start, limit=MILESTONE_PAGE_SIZE + 1)
+	has_more = len(milestones) > MILESTONE_PAGE_SIZE
+	if has_more:
+		milestones = milestones[:MILESTONE_PAGE_SIZE]
+	next_start = start + len(milestones)
 	if not milestones:
-		return []
+		return [], False, next_start
 
 	# A milestone names a field and its value, so it needs the same read check as a version.
 	permitted = set(
@@ -386,7 +416,9 @@ def get_milestone_activities(doc: "Document", user_info: dict) -> list[dict]:
 				},
 			}
 		)
-	return out
+	# next_start counts rows read, not rows returned: a field the user cannot read drops a row here,
+	# so an offset the client derived from what it rendered would skip the rows behind it.
+	return out, has_more, next_start
 
 
 # Fieldtypes shown as "updated {field}" instead of a from → to diff.

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -127,7 +127,7 @@ def get_docinfo(
 			"shared": get_docshares(doc),
 			"views": get_view_logs(doc),
 			"additional_timeline_content": get_additional_timeline_content(doc.doctype, doc.name),
-			"milestones": get_milestones(doc.doctype, doc.name),
+			"milestones": get_milestones(doc.doctype, doc.name, limit=0),
 			"is_document_followed": is_document_followed(doc.doctype, doc.name, frappe.session.user),
 			"tags": get_tags(doc.doctype, doc.name),
 			"document_email": get_document_email(doc.doctype, doc.name),

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -176,13 +176,14 @@ def add_comments(doc, docinfo):
 	return comments
 
 
-def get_milestones(doctype, name, limit=20):
-	# Newest first and capped: a long-lived document accumulates these without end. The cap sits
-	# above the one on versions because a milestone row is four short columns, not a JSON diff.
+def get_milestones(doctype, name, start=0, limit=20):
+	# Newest first and paged: a long-lived document accumulates these without end. The page runs
+	# larger than the one on versions because a milestone row is four short columns, not a JSON diff.
 	return frappe.get_all(
 		"Milestone",
 		fields=["name", "creation", "owner", "track_field", "value"],
 		filters=dict(reference_type=doctype, reference_name=str(name)),
+		limit_start=start,
 		limit=limit,
 		order_by="creation desc",
 	)

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -179,7 +179,7 @@ def add_comments(doc, docinfo):
 def get_milestones(doctype, name):
 	return frappe.get_all(
 		"Milestone",
-		fields=["creation", "owner", "track_field", "value"],
+		fields=["name", "creation", "owner", "track_field", "value"],
 		filters=dict(reference_type=doctype, reference_name=str(name)),
 	)
 

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -176,8 +176,9 @@ def add_comments(doc, docinfo):
 	return comments
 
 
-def get_milestones(doctype, name, limit=10):
-	# Newest first and capped, like versions: a long-lived document accumulates these without end.
+def get_milestones(doctype, name, limit=20):
+	# Newest first and capped: a long-lived document accumulates these without end. The cap sits
+	# above the one on versions because a milestone row is four short columns, not a JSON diff.
 	return frappe.get_all(
 		"Milestone",
 		fields=["name", "creation", "owner", "track_field", "value"],

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -176,11 +176,14 @@ def add_comments(doc, docinfo):
 	return comments
 
 
-def get_milestones(doctype, name):
+def get_milestones(doctype, name, limit=10):
+	# Newest first and capped, like versions: a long-lived document accumulates these without end.
 	return frappe.get_all(
 		"Milestone",
 		fields=["name", "creation", "owner", "track_field", "value"],
 		filters=dict(reference_type=doctype, reference_name=str(name)),
+		limit=limit,
+		order_by="creation desc",
 	)
 
 

--- a/ui/src/components/ActivityTimeline/ActivityTimeline.vue
+++ b/ui/src/components/ActivityTimeline/ActivityTimeline.vue
@@ -134,15 +134,20 @@ const slots = useSlots();
 
 const isFetching = computed(() => !!props.paginate?.isFetchingNextPage);
 
-// "inline" injects a load_more row above the oldest email; top/bottom show a standalone button.
+// "inline" injects a load_more row above the oldest paged row; top/bottom show a standalone button.
 const isInline = computed(() => props.paginate?.loadMore?.position === "inline");
 const showLoadMoreButton = computed(() => !!props.paginate?.hasNextPage && !isInline.value);
 
-// Rows to render: the raw feed, plus an in-feed load_more row above the oldest email when paginating inline.
+// Which rows the next page extends. Emails by default, so a paginate without one behaves as before.
+const isPagedRow = computed(
+	() => props.paginate?.isPagedRow ?? ((a: Activity | CustomActivity) => a.type === "email")
+);
+
+// Rows to render: the raw feed, plus an in-feed load_more row above the oldest paged row.
 const displayActivities = computed<Array<Activity | CustomActivity>>(() => {
 	const list = props.activities;
 	if (!isInline.value || !props.paginate?.hasNextPage) return list;
-	const idx = list.findIndex((a) => a.type === "email");
+	const idx = list.findIndex(isPagedRow.value);
 	if (idx === -1) return list;
 	const loadMore: CustomActivity = {
 		type: "load_more",

--- a/ui/src/components/ActivityTimeline/DOCS.md
+++ b/ui/src/components/ActivityTimeline/DOCS.md
@@ -32,7 +32,7 @@ const { activities, loading } = useActivityTimeline("HD Ticket", route.params.ti
 </template>
 ```
 
-For email pagination, bind `paginate` too — see [Pagination](#pagination).
+For pagination, bind `paginate` too — see [Pagination](#pagination).
 
 > The composable lives in the **consuming app**, not in `@framework/ui` — this keeps the
 > shared renderer decoupled from where activities come from. `useActivityTimeline` binds its
@@ -150,21 +150,23 @@ returns the document's own activities, so you merge yours in yourself — see
 
 ## Pagination
 
-Emails page in oldest-direction on demand. `paginate` is the same object the composable
-returns; pass it through and the component wires the "Load more" control for you.
+Emails and milestones page in oldest-direction on demand; the remaining sources arrive whole
+on the first load. `paginate` is the same object the composable returns; pass it through and
+the component wires the "Load more" control for you. One control advances both paged sources.
 
 | Property             | Details                                                                     |
 | -------------------- | --------------------------------------------------------------------------- |
-| `hasNextPage`        | `boolean` — whether older emails remain                                     |
+| `hasNextPage`        | `boolean` — whether older paged rows remain                                 |
 | `isFetchingNextPage` | `boolean` — a page is in flight                                             |
 | `fetchNextPage()`    | Load and append the next older page                                         |
+| `isPagedRow?`        | `(activity) => boolean` — rows the next page extends; defaults to email rows |
 | `loadMore?`          | Affordance config — `position` (`"top"` \| `"bottom"` \| `"inline"`), `label`, `icon` |
 
-`position: "inline"` injects a `load_more` row directly above the oldest email; `top` /
-`bottom` render a standalone button. Omit `loadMore` for a default top button.
+`position: "inline"` injects a `load_more` row directly above the oldest row `isPagedRow`
+matches; `top` / `bottom` render a standalone button. Omit `loadMore` for a default top button.
 
 The control is configured through the `paginate.loadMore` object you pass. The composable
-bakes in a default (`{ position: "inline", label: "Show previous conversations", icon:
+bakes in a default (`{ position: "inline", label: "Show previous activity", icon:
 "lucide-chevrons-up" }`); override it by spreading the returned `paginate`:
 
 ```vue
@@ -201,7 +203,7 @@ Returns:
 | `activities` | `ComputedRef` — deduped, sorted, and grouped rows ready for the component |
 | `loading`    | `ComputedRef<boolean>`                                                   |
 | `reload()`   | Refetch the feed                                                         |
-| `paginate`   | `Pagination` — email "Load more" controller; bind it to the component only if you want pagination |
+| `paginate`   | `Pagination` — "Load more" controller for emails and milestones; bind it to the component only if you want pagination |
 
 **Realtime.**  While mounted it subscribes to the doc's socket room and
 patches the feed live — new comments/likes/assignments/attachments arrive via

--- a/ui/src/components/ActivityTimeline/GutterIcon.vue
+++ b/ui/src/components/ActivityTimeline/GutterIcon.vue
@@ -53,6 +53,9 @@ import LucideInfo from "~icons/lucide/info";
 import LucideEye from "~icons/lucide/eye";
 import LucidePaperclip from "~icons/lucide/paperclip";
 import LucideTrash2 from "~icons/lucide/trash-2";
+import LucidePencil from "~icons/lucide/pencil";
+import LucideUsers from "~icons/lucide/users";
+import LucideFlag from "~icons/lucide/flag";
 import { CommentIcon, DotIcon, LUCIDE_ICON_CLASS } from "./icons";
 import type { Activity, AttachmentLogActivity, CustomActivity, LogActivity } from "./types";
 
@@ -67,6 +70,9 @@ const LOG_SUBTYPE_ICON: Record<string, Component> = {
 	workflow: LucideGitBranch,
 	info: LucideInfo,
 	view: LucideEye,
+	edited: LucidePencil,
+	shared: LucideUsers,
+	milestone: LucideFlag,
 };
 
 // The gutter icon component for a log / attachment_log row (attachment from its

--- a/ui/src/components/ActivityTimeline/types.ts
+++ b/ui/src/components/ActivityTimeline/types.ts
@@ -13,9 +13,14 @@ export interface Pagination {
   hasNextPage: boolean;
   isFetchingNextPage: boolean;
   fetchNextPage: () => void;
+  /**
+   * Rows the next page extends, which is where an inline `load_more` row sits.
+   * Defaults to email rows.
+   */
+  isPagedRow?: (activity: Activity | CustomActivity) => boolean;
   /** Load More affordance; omit for a default "Load more" button at the top. */
   loadMore?: {
-    /** Placement. "inline" injects a `load_more` row above the oldest email. */
+    /** Placement. "inline" injects a `load_more` row above the oldest paged row. */
     position?: "top" | "bottom" | "inline";
     /** Button copy; default "Load more" / "lucide-refresh-cw". */
     label?: string;
@@ -94,7 +99,10 @@ export type LogActivity = BaseActivity<
       | "workflow"
       | "info"
       | "view"
-      | "created";
+      | "created"
+      | "edited"
+      | "shared"
+      | "milestone";
     text: string;
     /** assignee on assignment logs; bolded alongside the actor (backend-supplied) */
     assignee?: string;

--- a/ui/src/components/ActivityTimeline/useActivityTimeline.ts
+++ b/ui/src/components/ActivityTimeline/useActivityTimeline.ts
@@ -17,17 +17,31 @@ import { getAssignee, stripHtml } from "./utils";
 // One resource per doctype:docname for the session, so reopening a doc is instant.
 const resources = new Map<string, ReturnType<typeof createResource>>();
 
-// "older emails remain" flag, kept outside the resource so it survives cached remounts.
+// Paging state per source, kept outside the resource so it survives cached remounts: "older rows
+// remain" for each, plus the offset the backend reports for the next milestone page.
 const hasMoreEmailsByKey = new Map<string, Ref<boolean>>();
+const hasMoreMilestonesByKey = new Map<string, Ref<boolean>>();
+const milestoneStartByKey = new Map<string, Ref<number>>();
+
+function pagingState<T>(
+  states: Map<string, Ref<T>>,
+  cacheKey: string,
+  initial: T
+): Ref<T> {
+  let state = states.get(cacheKey);
+  if (!state) {
+    state = ref(initial) as Ref<T>;
+    states.set(cacheKey, state);
+  }
+  return state;
+}
 
 export function useActivityTimeline(doctype: string, docname: string) {
   const cacheKey = `${doctype}:${docname}`;
 
-  let hasMoreEmails = hasMoreEmailsByKey.get(cacheKey);
-  if (!hasMoreEmails) {
-    hasMoreEmails = ref(true);
-    hasMoreEmailsByKey.set(cacheKey, hasMoreEmails);
-  }
+  const hasMoreEmails = pagingState(hasMoreEmailsByKey, cacheKey, true);
+  const hasMoreMilestones = pagingState(hasMoreMilestonesByKey, cacheKey, false);
+  const milestoneStart = pagingState(milestoneStartByKey, cacheKey, 0);
 
   let resource = resources.get(cacheKey);
   if (!resource) {
@@ -36,22 +50,32 @@ export function useActivityTimeline(doctype: string, docname: string) {
       params: { doctype, name: docname },
       cache: `activities:${cacheKey}`,
       auto: true,
-      // transform sets resource.data; onSuccess still sees the raw response, so
-      // has_more_emails is read there (not from transform's output). On reload
-      // (e.g. a doc_update), re-append the older email pages the user has already loaded.
+      // transform sets resource.data; onSuccess still sees the raw response, so the
+      // has_more_* flags are read there (not from transform's output). On reload
+      // (e.g. a doc_update), re-append the older pages the user has already loaded.
       transform: (res: { activities: Activity[] }) => {
         const oldActivities = (resource.data as Activity[] | undefined) ?? [];
 
         const newActivities = res.activities;
         const newActivityKeys = new Set(newActivities.map((a) => a.key));
 
-        const paginatedOlderEmails = oldActivities.filter(
-          (a) => a.type === "email" && !newActivityKeys.has(a.key)
+        const paginatedOlderRows = oldActivities.filter(
+          (a) => isPagedRow(a) && !newActivityKeys.has(a.key)
         );
-        return [...newActivities, ...paginatedOlderEmails];
+        return [...newActivities, ...paginatedOlderRows];
       },
-      onSuccess: (res: { has_more_emails?: boolean }) => {
-        hasMoreEmails!.value = !!res.has_more_emails;
+      onSuccess: (res: {
+        has_more_emails?: boolean;
+        has_more_milestones?: boolean;
+        next_milestone_start?: number;
+      }) => {
+        hasMoreEmails.value = !!res.has_more_emails;
+        // This response only carries the first milestone page. Once the user has paged past it
+        // the transform above keeps those older rows, so page one's flag and offset are stale.
+        if (milestoneStart.value === 0) {
+          hasMoreMilestones.value = !!res.has_more_milestones;
+          milestoneStart.value = res.next_milestone_start ?? 0;
+        }
       },
     });
     resources.set(cacheKey, resource);
@@ -70,44 +94,95 @@ export function useActivityTimeline(doctype: string, docname: string) {
     activities,
     loading: computed<boolean>(() => resource.loading),
     reload: () => resource.reload(),
-    paginate: createEmailPagination(doctype, docname, resource, hasMoreEmails),
+    paginate: createHistoryPagination(doctype, docname, resource, {
+      hasMoreEmails,
+      hasMoreMilestones,
+      milestoneStart,
+    }),
   };
 }
 
-// Email paging: fetch the next older page and append; the activities computed re-sorts.
-function createEmailPagination(
+// The two paged sources; everything else in the feed arrives whole on the first load.
+function isPagedRow(activity: Activity | CustomActivity): boolean {
+  if (activity.type === "email") return true;
+  if (activity.type !== "log") return false;
+  return (activity.data as { subtype?: string } | null)?.subtype === "milestone";
+}
+
+// History paging: fetch the next older page of each paged source and append; activities re-sorts.
+function createHistoryPagination(
   doctype: string,
   docname: string,
   resource: ReturnType<typeof createResource>,
-  hasMoreEmails: Ref<boolean>
+  state: {
+    hasMoreEmails: Ref<boolean>;
+    hasMoreMilestones: Ref<boolean>;
+    milestoneStart: Ref<number>;
+  }
 ): Pagination {
+  const append = (activities: Activity[]) => {
+    const loaded = (resource.data as Activity[] | undefined) ?? [];
+    resource.data = [...loaded, ...activities];
+  };
+
   const olderEmails = createResource({
     url: "frappe.desk.form.activity.get_more_email_activities",
     auto: false,
     onSuccess: (res: { activities: Activity[]; has_more_emails?: boolean }) => {
-      const loaded = (resource.data as Activity[] | undefined) ?? [];
-      resource.data = [...loaded, ...res.activities];
-      hasMoreEmails.value = !!res.has_more_emails;
+      append(res.activities);
+      state.hasMoreEmails.value = !!res.has_more_emails;
     },
   });
 
+  const olderMilestones = createResource({
+    url: "frappe.desk.form.activity.get_more_milestone_activities",
+    auto: false,
+    onSuccess: (res: {
+      activities: Activity[];
+      has_more_milestones?: boolean;
+      next_milestone_start?: number;
+    }) => {
+      append(res.activities);
+      state.hasMoreMilestones.value = !!res.has_more_milestones;
+      // backend-supplied: a milestone on a field the user cannot read is counted but not
+      // returned, so an offset counted from the rendered rows would skip the rows behind it
+      state.milestoneStart.value =
+        res.next_milestone_start ?? state.milestoneStart.value;
+    },
+  });
+
+  const isFetching = () => olderEmails.loading || olderMilestones.loading;
+
+  // One control, both sources: a row is older history whichever source it came from.
   const fetchNextPage = () => {
-    if (olderEmails.loading || !hasMoreEmails.value) return;
-    const loaded = (resource.data as Activity[] | undefined) ?? [];
-    // count-based offset: emails are only appended, so the loaded count is the next start
-    const emailsLoaded = loaded.filter((a) => a.type === "email").length;
-    olderEmails.submit({ doctype, name: docname, start: emailsLoaded });
+    if (isFetching()) return;
+    if (state.hasMoreEmails.value) {
+      const loaded = (resource.data as Activity[] | undefined) ?? [];
+      // count-based offset: emails are only appended, so the loaded count is the next start
+      const emailsLoaded = loaded.filter((a) => a.type === "email").length;
+      olderEmails.submit({ doctype, name: docname, start: emailsLoaded });
+    }
+    if (state.hasMoreMilestones.value) {
+      olderMilestones.submit({
+        doctype,
+        name: docname,
+        start: state.milestoneStart.value,
+      });
+    }
   };
 
   // reactive() so the refs unwrap when read through the `paginate` prop.
   return reactive({
-    hasNextPage: computed(() => hasMoreEmails.value),
-    isFetchingNextPage: computed(() => olderEmails.loading),
+    hasNextPage: computed(
+      () => state.hasMoreEmails.value || state.hasMoreMilestones.value
+    ),
+    isFetchingNextPage: computed(() => isFetching()),
     fetchNextPage,
-    // in-feed row above the oldest email; email-specific copy lives here, not in the component
+    isPagedRow,
+    // in-feed row above the oldest paged row; the copy lives here, not in the component
     loadMore: {
       position: "inline" as const,
-      label: "Show previous conversations",
+      label: "Show previous activity",
       icon: "lucide-chevrons-up",
     },
   });


### PR DESCRIPTION
### The problem

`get_activity_timeline` assembles creations, emails, comments, logs, views and versions, and stops there. Three kinds of history never reach the client, even though two of them are already sitting in memory when the function runs:

- **An edit.** On a doctype that tracks no changes there is no version row at all, so the last edit is the document's only unrecorded event — the timeline claims nothing has happened since creation.
- **A milestone.** `Milestone` rows record a tracked field changing value, and nothing surfaced them.
- **A share.** `docshare.py` already writes these, naming both the actor and the recipient, and `comment_log_data.shared` already carried the list. Nothing read it.

### The change

Three new assemblers, wired into the existing list:

```python
activities = [
    *get_creation_activity(doc, user_info),
    *get_edit_activity(doc, user_info),        # new
    *emails,
    *get_comment_and_log_activities(doc, user_info),
    *get_view_activities(doc, user_info),
    *get_milestone_activities(doc, user_info), # new
    *get_version_activities(doc, user_info),
]
```

**Permissions.** A milestone names a field and its value, so it gets the same `get_permitted_fields` check a version already gets — a user who cannot read the field does not learn its value through the timeline. Shares are emitted with the text `docshare.py` already composed, so no new information is derived there.

**Edits** are skipped when `modified == creation`, so a freshly created document does not report an edit it never had.

### Also

`get_milestones` now selects `name`, so a milestone row can carry a stable key (`milestone:{name}`) for the client to diff against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

>no-docs