### PR TITLE
feat(core): let apps supply their own inline SVG icons

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -10,6 +10,7 @@ import frappe
 import frappe.defaults
 import frappe.desk.desk_page
 from frappe.app_state import filter_out_disabled_doctypes, get_disabled_modules
+from frappe.core.doctype.custom_icon.custom_icon import get_symbols
 from frappe.core.doctype.installed_applications.installed_applications import (
 	get_setup_wizard_completed_apps,
 )
@@ -143,6 +144,7 @@ def get_bootinfo():
 	bootinfo.desktop_icon_urls = get_desktop_icon_urls()
 	bootinfo.desktop_icon_style = get_icon_style() or "Subtle"
 	bootinfo.desktop_page = get_desktop_page()
+	bootinfo.custom_icons = get_symbols()
 	if bootinfo.is_fc_site:
 		bootinfo.site_info = current_site_info()
 	return bootinfo

--- a/frappe/core/doctype/custom_icon/custom_icon.js
+++ b/frappe/core/doctype/custom_icon/custom_icon.js
@@ -1,0 +1,34 @@
+// Copyright (c) 2026, Frappe Technologies and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Custom Icon", {
+	refresh(frm) {
+		frm.trigger("warn_if_shadowed");
+	},
+
+	icon_name(frm) {
+		frm.trigger("warn_if_shadowed");
+	},
+
+	warn_if_shadowed(frm) {
+		// Two symbols with one id resolve to whichever the sprite loaded first, so the
+		// icon would silently keep rendering as the bundled one.
+		frm.dashboard.clear_headline();
+		let icon_name = frm.doc.icon_name;
+		if (!icon_name) return;
+
+		let registered = (frappe.boot.custom_icons || []).some((icon) => icon.name === icon_name);
+		let matches = document.querySelectorAll(
+			`#all-symbols symbol[id="icon-${CSS.escape(icon_name)}"]`
+		).length;
+
+		if (matches > (registered ? 1 : 0)) {
+			frm.dashboard.set_headline_alert(
+				__("An icon named {0} already ships with the desk, and it takes precedence.", [
+					icon_name.bold(),
+				]),
+				"orange"
+			);
+		}
+	},
+});

--- a/frappe/core/doctype/custom_icon/custom_icon.json
+++ b/frappe/core/doctype/custom_icon/custom_icon.json
@@ -42,10 +42,6 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
-  },
-  {
-   "read": 1,
-   "role": "All"
   }
  ],
  "sort_field": "modified",

--- a/frappe/core/doctype/custom_icon/custom_icon.json
+++ b/frappe/core/doctype/custom_icon/custom_icon.json
@@ -1,0 +1,54 @@
+{
+ "actions": [],
+ "autoname": "field:icon_name",
+ "creation": "2026-07-23 12:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "icon_name",
+  "svg"
+ ],
+ "fields": [
+  {
+   "fieldname": "icon_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Icon Name",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "svg",
+   "fieldtype": "Code",
+   "label": "SVG",
+   "options": "HTML"
+  }
+ ],
+ "links": [],
+ "modified": "2026-07-23 12:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Core",
+ "name": "Custom Icon",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "read": 1,
+   "role": "All"
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/frappe/core/doctype/custom_icon/custom_icon.py
+++ b/frappe/core/doctype/custom_icon/custom_icon.py
@@ -8,6 +8,9 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils.html_utils import sanitize_svg
 
+SYMBOL_CACHE_KEY = "custom_icon_symbols"
+DROPPED_ATTRIBUTES = ("id", "width", "height")
+
 
 class CustomIcon(Document):
 	# begin: auto-generated types
@@ -27,6 +30,12 @@ class CustomIcon(Document):
 		if not is_single_svg(self.svg):
 			frappe.throw(_("Content must be a single <svg> element"))
 
+	def on_update(self):
+		clear_symbol_cache()
+
+	def on_trash(self):
+		clear_symbol_cache()
+
 
 def is_single_svg(svg: str) -> bool:
 	"""True only when `svg` parses as a lone root element and that element is <svg>."""
@@ -35,3 +44,51 @@ def is_single_svg(svg: str) -> bool:
 	except ElementTree.ParseError:
 		return False
 	return root.tag.rsplit("}", 1)[-1] == "svg"
+
+
+def get_symbols() -> list[dict]:
+	"""Every Custom Icon as `<symbol>` markup the desk sprite can resolve through `<use>`."""
+	return frappe.cache.get_value(
+		SYMBOL_CACHE_KEY,
+		lambda: [
+			{"name": icon.icon_name, "symbol": to_symbol(icon.icon_name, icon.svg)}
+			for icon in frappe.get_all("Custom Icon", fields=["icon_name", "svg"], order_by="icon_name")
+		],
+	)
+
+
+def clear_symbol_cache() -> None:
+	frappe.cache.delete_value(SYMBOL_CACHE_KEY)
+	# boot is cached per user and now carries a stale icon set
+	frappe.clear_cache()
+
+
+def to_symbol(icon_name: str, svg: str) -> str:
+	"""Rewrite a standalone `<svg>` as a `<symbol id="icon-{icon_name}">`.
+
+	Presentation attributes stay on the symbol: lucide-style icons carry `stroke`
+	and `fill` on the root element and render blank without them. Width and height
+	are dropped so the sizing classes on `<use>` win.
+	"""
+	root = ElementTree.fromstring(svg)
+	symbol = ElementTree.Element("symbol")
+	symbol.attrib = {key: value for key, value in root.attrib.items() if key not in DROPPED_ATTRIBUTES}
+	symbol.set("id", f"icon-{icon_name}")
+	if "stroke" not in symbol.attrib:
+		# an SVG that names no stroke has none, but the desk icon styles would inherit one in
+		symbol.set("stroke", "none")
+	symbol.text = root.text
+	symbol.extend(list(root))
+	strip_namespaces(symbol)
+
+	return ElementTree.tostring(symbol, encoding="unicode")
+
+
+def strip_namespaces(element: ElementTree.Element) -> None:
+	"""Drop `{http://www.w3.org/2000/svg}` tag prefixes, which serialize back as `ns0:` noise.
+
+	The sprite wrapper the desk injects these into already declares the SVG namespace.
+	"""
+	for node in element.iter():
+		if isinstance(node.tag, str):
+			node.tag = node.tag.rsplit("}", 1)[-1]

--- a/frappe/core/doctype/custom_icon/custom_icon.py
+++ b/frappe/core/doctype/custom_icon/custom_icon.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026, Frappe Technologies and contributors
 # License: MIT. See LICENSE
 
+import re
 from xml.etree import ElementTree
 
 import frappe
@@ -10,6 +11,7 @@ from frappe.utils.html_utils import sanitize_svg
 
 SYMBOL_CACHE_KEY = "custom_icon_symbols"
 DROPPED_ATTRIBUTES = ("id", "width", "height")
+ICON_NAME = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
 class CustomIcon(Document):
@@ -26,6 +28,10 @@ class CustomIcon(Document):
 	# end: auto-generated types
 
 	def validate(self):
+		# the name becomes a DOM id and reaches markup templates unescaped, so keep it inert
+		if not ICON_NAME.match(self.icon_name or ""):
+			frappe.throw(_("Icon Name can only contain letters, numbers, hyphens and underscores"))
+
 		self.svg = sanitize_svg(self.svg or "").strip()
 		if not is_single_svg(self.svg):
 			frappe.throw(_("Content must be a single <svg> element"))

--- a/frappe/core/doctype/custom_icon/custom_icon.py
+++ b/frappe/core/doctype/custom_icon/custom_icon.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2026, Frappe Technologies and contributors
+# License: MIT. See LICENSE
+
+from xml.etree import ElementTree
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+from frappe.utils.html_utils import sanitize_svg
+
+
+class CustomIcon(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		icon_name: DF.Data
+		svg: DF.Code
+	# end: auto-generated types
+
+	def validate(self):
+		self.svg = sanitize_svg(self.svg or "").strip()
+		if not is_single_svg(self.svg):
+			frappe.throw(_("Content must be a single <svg> element"))
+
+
+def is_single_svg(svg: str) -> bool:
+	"""True only when `svg` parses as a lone root element and that element is <svg>."""
+	try:
+		root = ElementTree.fromstring(svg)
+	except ElementTree.ParseError:
+		return False
+	return root.tag.rsplit("}", 1)[-1] == "svg"

--- a/frappe/core/doctype/custom_icon/test_custom_icon.py
+++ b/frappe/core/doctype/custom_icon/test_custom_icon.py
@@ -2,19 +2,21 @@
 # License: MIT. See LICENSE
 
 import frappe
+from frappe.core.doctype.custom_icon.custom_icon import clear_symbol_cache, get_symbols, to_symbol
 from frappe.tests import IntegrationTestCase
 
 SAFE_SVG = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><circle cx="8" cy="8" r="6" fill="currentColor"></circle></svg>'
+LUCIDE_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 3h18"></path></svg>'
 
 
 class TestCustomIcon(IntegrationTestCase):
 	def tearDown(self):
 		frappe.db.rollback()
+		# the cache outlives the rolled back transaction
+		clear_symbol_cache()
 
 	def test_safe_svg_is_kept(self):
-		icon = frappe.get_doc(
-			{"doctype": "Custom Icon", "icon_name": "test-dot", "svg": SAFE_SVG}
-		).insert()
+		icon = frappe.get_doc({"doctype": "Custom Icon", "icon_name": "test-dot", "svg": SAFE_SVG}).insert()
 		self.assertIn("<circle", icon.svg)
 		self.assertIn('fill="currentColor"', icon.svg)
 
@@ -44,6 +46,35 @@ class TestCustomIcon(IntegrationTestCase):
 
 	def test_empty_svg_is_rejected(self):
 		with self.assertRaises(frappe.ValidationError):
-			frappe.get_doc(
-				{"doctype": "Custom Icon", "icon_name": "test-empty", "svg": ""}
-			).insert()
+			frappe.get_doc({"doctype": "Custom Icon", "icon_name": "test-empty", "svg": ""}).insert()
+
+	def test_symbol_carries_the_id_and_drawing(self):
+		symbol = to_symbol("test-dot", SAFE_SVG)
+		self.assertIn('id="icon-test-dot"', symbol)
+		self.assertIn('viewBox="0 0 16 16"', symbol)
+		self.assertIn("<circle", symbol)
+		self.assertTrue(symbol.startswith("<symbol"))
+		self.assertNotIn("ns0:", symbol)
+
+	def test_symbol_keeps_presentation_attributes_but_drops_sizing(self):
+		symbol = to_symbol("test-line", LUCIDE_SVG)
+		self.assertIn('stroke="currentColor"', symbol)
+		self.assertIn('stroke-width="2"', symbol)
+		self.assertIn('fill="none"', symbol)
+		self.assertNotIn('width="24"', symbol)
+		self.assertNotIn('height="24"', symbol)
+		self.assertNotIn('stroke="none"', symbol)
+
+	def test_symbol_without_a_stroke_opts_out_of_the_desk_stroke(self):
+		self.assertIn('stroke="none"', to_symbol("test-dot", SAFE_SVG))
+
+	def test_saved_icons_reach_the_sprite(self):
+		frappe.get_doc({"doctype": "Custom Icon", "icon_name": "test-dot", "svg": SAFE_SVG}).insert()
+		symbols = get_symbols()
+		self.assertIn("test-dot", [symbol["name"] for symbol in symbols])
+
+	def test_deleting_an_icon_drops_it_from_the_sprite(self):
+		icon = frappe.get_doc({"doctype": "Custom Icon", "icon_name": "test-dot", "svg": SAFE_SVG}).insert()
+		get_symbols()
+		icon.delete()
+		self.assertNotIn("test-dot", [symbol["name"] for symbol in get_symbols()])

--- a/frappe/core/doctype/custom_icon/test_custom_icon.py
+++ b/frappe/core/doctype/custom_icon/test_custom_icon.py
@@ -65,6 +65,12 @@ class TestCustomIcon(IntegrationTestCase):
 		self.assertNotIn('height="24"', symbol)
 		self.assertNotIn('stroke="none"', symbol)
 
+	def test_names_that_carry_markup_are_rejected(self):
+		# `<` and `>` never reach validate, since document naming rejects them first
+		for icon_name in ('evil" onload="alert(1)', "<img src=x>", "spaced name", "quote'name"):
+			with self.assertRaises((frappe.ValidationError, frappe.NameError)):
+				frappe.get_doc({"doctype": "Custom Icon", "icon_name": icon_name, "svg": SAFE_SVG}).insert()
+
 	def test_symbol_without_a_stroke_opts_out_of_the_desk_stroke(self):
 		self.assertIn('stroke="none"', to_symbol("test-dot", SAFE_SVG))
 

--- a/frappe/core/doctype/custom_icon/test_custom_icon.py
+++ b/frappe/core/doctype/custom_icon/test_custom_icon.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2026, Frappe Technologies and contributors
+# License: MIT. See LICENSE
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+SAFE_SVG = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><circle cx="8" cy="8" r="6" fill="currentColor"></circle></svg>'
+
+
+class TestCustomIcon(IntegrationTestCase):
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_safe_svg_is_kept(self):
+		icon = frappe.get_doc(
+			{"doctype": "Custom Icon", "icon_name": "test-dot", "svg": SAFE_SVG}
+		).insert()
+		self.assertIn("<circle", icon.svg)
+		self.assertIn('fill="currentColor"', icon.svg)
+
+	def test_scripts_and_handlers_are_stripped(self):
+		icon = frappe.get_doc(
+			{
+				"doctype": "Custom Icon",
+				"icon_name": "test-evil",
+				"svg": '<svg viewBox="0 0 16 16" onload="alert(1)"><script>alert(1)</script><path d="M0 0h16v16H0z"/></svg>',
+			}
+		).insert()
+		self.assertNotIn("script", icon.svg)
+		self.assertNotIn("onload", icon.svg)
+		self.assertIn("<path", icon.svg)
+
+	def test_plain_html_is_rejected(self):
+		with self.assertRaises(frappe.ValidationError):
+			frappe.get_doc(
+				{"doctype": "Custom Icon", "icon_name": "test-html", "svg": "<div>not an icon</div>"}
+			).insert()
+
+	def test_trailing_content_after_svg_is_rejected(self):
+		with self.assertRaises(frappe.ValidationError):
+			frappe.get_doc(
+				{"doctype": "Custom Icon", "icon_name": "test-trailing", "svg": SAFE_SVG + "<svg></svg>"}
+			).insert()
+
+	def test_empty_svg_is_rejected(self):
+		with self.assertRaises(frappe.ValidationError):
+			frappe.get_doc(
+				{"doctype": "Custom Icon", "icon_name": "test-empty", "svg": ""}
+			).insert()

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -285,6 +285,7 @@ frappe.Application = class Application {
 	load_bootinfo() {
 		if (frappe.boot) {
 			this.setup_workspaces();
+			this.load_custom_icons();
 			frappe.model.sync(frappe.boot.docs);
 			this.check_metadata_cache_status();
 			this.set_globals();
@@ -301,6 +302,21 @@ frappe.Application = class Application {
 			this.set_as_guest();
 		}
 		frappe.ui.toolbar.fetch_session_defaults();
+	}
+
+	load_custom_icons() {
+		// Custom Icons join the sprite the bundled icon files are fetched into, so
+		// `frappe.utils.icon()` and the Icon field resolve them like any other icon.
+		let icons = frappe.boot.custom_icons || [];
+		if (!icons.length) return;
+
+		let symbols = icons.map((icon) => icon.symbol).join("");
+		document
+			.getElementById("all-symbols")
+			?.insertAdjacentHTML(
+				"beforeend",
+				`<svg xmlns="http://www.w3.org/2000/svg" style="display: none">${symbols}</svg>`
+			);
 	}
 
 	setup_workspaces() {

--- a/frappe/public/js/frappe/form/controls/icon.js
+++ b/frappe/public/js/frappe/form/controls/icon.js
@@ -15,12 +15,30 @@ frappe.ui.form.ControlIcon = class ControlIcon extends frappe.ui.form.ControlDat
 		});
 	}
 
+	get_icon_sections() {
+		// Custom Icons live in the same sprite, so split them back out by name
+		let custom_names = new Set((frappe.boot.custom_icons || []).map((icon) => icon.name));
+		let custom = frappe.symbols.filter((icon) => custom_names.has(icon));
+		if (!custom.length) {
+			return [{ icons: frappe.symbols }];
+		}
+
+		return [
+			{ label: __("Custom"), icons: custom },
+			{
+				// the bundled set is named, not called "Icons", since every section holds icons
+				label: "Lucide",
+				icons: frappe.symbols.filter((icon) => !custom_names.has(icon)),
+			},
+		];
+	}
+
 	make_icon_input() {
 		let picker_wrapper = $("<div>");
 		this.picker = new Picker({
 			parent: picker_wrapper,
 			icon: this.get_icon(),
-			icons: frappe.symbols,
+			sections: this.get_icon_sections(),
 			include_emoji: this.df.options == "Emojis",
 		});
 

--- a/frappe/public/js/frappe/icon_picker/icon_picker.js
+++ b/frappe/public/js/frappe/icon_picker/icon_picker.js
@@ -108,9 +108,10 @@ class Picker {
 
 		let $icons = $group.find(".icons");
 		icons.forEach((icon) => {
-			let $icon = $(
-				`<div id="${icon}" class="icon-wrapper">${frappe.utils.icon(icon, "md")}</div>`
-			);
+			// the name is set as an attribute, not parsed as markup, since custom icons name themselves
+			let $icon = $('<div class="icon-wrapper"></div>')
+				.attr("id", icon)
+				.html(frappe.utils.icon(icon, "md"));
 			$icons.append($icon);
 			const set_values = () => {
 				this.set_icon(icon);

--- a/frappe/public/js/frappe/icon_picker/icon_picker.js
+++ b/frappe/public/js/frappe/icon_picker/icon_picker.js
@@ -4,7 +4,8 @@ class Picker {
 		this.width = opts.width;
 		this.height = opts.height;
 		this.set_icon(opts.icon);
-		this.icons = opts.icons;
+		// [{ label, icons }] -- a section renders a heading only when it is labelled
+		this.sections = opts.sections;
 		this.include_emoji = opts.include_emoji;
 		this.setup_picker();
 	}
@@ -20,13 +21,11 @@ class Picker {
 					<input type="search" placeholder="${__("Search for icons...")}" class="form-control">
 					<span class="search-icon">${frappe.utils.icon("search", "sm")}</span>
 				</div>
-				<div class="icon-section" id='icon-section'>
-					<div class="icons"></div>
-				</div>
+				<div class="icon-section" id='icon-section'></div>
 			</div>
 		`);
 		this.parent.append(this.icon_picker_wrapper);
-		this.icon_wrapper = this.icon_picker_wrapper.find(".icons");
+		this.icon_section = this.icon_picker_wrapper.find(".icon-section");
 		this.search_input = this.icon_picker_wrapper.find(".search-icons > input");
 		this.refresh();
 		this.setup_icons();
@@ -87,11 +86,32 @@ class Picker {
 		});
 	}
 	setup_icons() {
-		this.icons.forEach((icon) => {
+		this.sections.forEach((section) => {
+			this.setup_section(section);
+		});
+		this.search_input.keyup((e) => {
+			e.preventDefault();
+			this.filter_icons();
+		});
+
+		this.search_input.on("search", () => {
+			this.filter_icons();
+		});
+	}
+
+	setup_section({ label, icons }) {
+		let $group = $(`<div class="icon-group">
+				${label ? `<div class="icon-group-label">${label}</div>` : ""}
+				<div class="icons"></div>
+			</div>`);
+		this.icon_section.append($group);
+
+		let $icons = $group.find(".icons");
+		icons.forEach((icon) => {
 			let $icon = $(
 				`<div id="${icon}" class="icon-wrapper">${frappe.utils.icon(icon, "md")}</div>`
 			);
-			this.icon_wrapper.append($icon);
+			$icons.append($icon);
 			const set_values = () => {
 				this.set_icon(icon);
 				this.update_icon_selected();
@@ -107,24 +127,21 @@ class Picker {
 				}
 			});
 		});
-		this.search_input.keyup((e) => {
-			e.preventDefault();
-			this.filter_icons();
-		});
-
-		this.search_input.on("search", () => {
-			this.filter_icons();
-		});
 	}
 
 	filter_icons() {
 		let value = this.search_input.val();
+		let $icons = this.icon_section.find(".icon-wrapper");
 		if (!value) {
-			this.icon_wrapper.find(".icon-wrapper").removeClass("hidden");
+			$icons.removeClass("hidden");
 		} else {
-			this.icon_wrapper.find(".icon-wrapper").addClass("hidden");
-			this.icon_wrapper.find(`.icon-wrapper[id*='${value}']`).removeClass("hidden");
+			$icons.addClass("hidden");
+			this.icon_section.find(`.icon-wrapper[id*='${value}']`).removeClass("hidden");
 		}
+		// a labelled section with nothing left to show would sit above an empty grid
+		this.icon_section.find(".icon-group").each(function () {
+			$(this).toggleClass("hidden", !$(this).find(".icon-wrapper:not(.hidden)").length);
+		});
 	}
 
 	update_icon_selected(silent) {

--- a/frappe/public/scss/common/icon_picker.scss
+++ b/frappe/public/scss/common/icon_picker.scss
@@ -3,13 +3,37 @@
 	color: var(--text-muted);
 	--icon-picker-width: 240px;
 	width: var(--icon-picker-width);
+	.icon-section {
+		// grouped sections scroll together, not one grid at a time
+		overflow-y: auto;
+		max-height: 210px;
+		scrollbar-width: none;
+
+		&::-webkit-scrollbar {
+			display: none;
+		}
+	}
+
+	.icon-group-label {
+		margin-top: 10px;
+		font-size: var(--text-xs);
+		color: var(--text-light);
+
+		+ .icons {
+			margin-top: 4px;
+		}
+	}
+
+	.emojis {
+		overflow-y: scroll;
+		max-height: 210px;
+	}
+
 	.icons,
 	.emojis {
 		margin-top: 10px;
 		display: flex;
 		flex-wrap: wrap;
-		overflow-y: scroll;
-		max-height: 210px;
 		cursor: pointer;
 
 		/* Hide scrollbar for IE, Edge and Firefox */

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -581,6 +581,16 @@ class TestHTMLUtils(IntegrationTestCase):
 		self.assertIn("ordered", clean)
 		self.assertNotIn("xyz", clean)
 
+	def test_sanitize_svg(self):
+		from frappe.utils.html_utils import sanitize_svg
+
+		clean = sanitize_svg('<svg onload="alert(1)"><script>alert(1)</script><circle r="4"/></svg>')
+		self.assertIn("<circle", clean)
+		self.assertNotIn("script", clean)
+		self.assertNotIn("onload", clean)
+
+		self.assertIsNone(sanitize_svg(None))
+
 
 class TestValidationUtils(IntegrationTestCase):
 	def test_valid_url(self):

--- a/frappe/utils/html_utils.py
+++ b/frappe/utils/html_utils.py
@@ -191,6 +191,23 @@ def sanitize_html(html, linkify=False, always_sanitize=False, disallowed_tags=No
 	return escaped_html
 
 
+def sanitize_svg(svg: str) -> str:
+	"""Sanitize standalone SVG markup for safe inline rendering (e.g. custom icons).
+
+	Stricter than sanitize_html: only SVG elements and attributes survive, so
+	scripts, event handlers, foreignObject and plain HTML are all stripped.
+	"""
+	if not isinstance(svg, str):
+		return svg
+
+	return nh3.clean(
+		svg,
+		tags=svg_elements,
+		attributes={"*": svg_attributes},
+		strip_comments=True,
+	)
+
+
 def is_json(text):
 	try:
 		json.loads(text)


### PR DESCRIPTION
### The problem

An app that wants an icon outside the bundled set has nowhere to put it. Icons end up inlined into templates, committed as one-off assets, or worked around with a Data field holding raw markup that nothing validates.

### The change

`Custom Icon` is a small registry: an `icon_name` and one inline `<svg>`, resolvable by name wherever an icon is named.

### Security

The `svg` field is user-supplied markup rendered inline, which is a script-injection surface. `sanitize_html` is the wrong gate for it — it permits the HTML and the event handlers an inline SVG must never carry.

This adds `sanitize_svg` to `frappe/utils/html_utils.py`:

```python
nh3.clean(svg, tags=svg_elements, attributes={"*": svg_attributes}, strip_comments=True)
```

It reuses the `svg_elements` / `svg_attributes` sets `html_utils` already defines, so there is no second allowlist to keep in sync. Scripts, event handlers, `foreignObject` and plain HTML are all stripped.

`validate` then rejects anything that is not a lone `<svg>` root, so a stored icon cannot smuggle a sibling element past the parser:

```python
self.svg = sanitize_svg(self.svg or "").strip()
if not is_single_svg(self.svg):
    frappe.throw(_("Content must be a single <svg> element"))
```

### Resolving a stored icon

Desk icons resolve as `<use href="#icon-{name}">` against the sprite that the bundled icon files are fetched into at `#all-symbols`. A row in a table never enters that sprite, so storage alone leaves a registered icon rendering as missing.

`to_symbol` rewrites each stored `<svg>` as a `<symbol id="icon-{name}">`, boot carries the set, and the desk appends it to `#all-symbols` on startup. Everything downstream picks the icons up unchanged — the Icon field, sidebars, workspaces, `frappe.utils.icon()`.

Two details the rewrite has to get right:

- Presentation attributes stay on the symbol, since lucide-style icons carry `stroke` and `fill` on the root element and render blank without them. `width` and `height` are dropped so the sizing classes on `<use>` win.
- An icon that names no stroke gets `stroke="none"`, which is SVG's own initial value. Without it, `.icon` in `icons.scss` inherits a stroke into the symbol and paints a grey outline around what should be a flat filled shape.

The set is cached and cleared whenever an icon is saved or deleted.

### Picker

The icon picker groups the sprite into **Custom** and **Lucide**. The custom section renders only when custom icons exist, and a section hides itself once a search leaves it empty.

Two symbols sharing an id resolve to whichever the sprite loaded first, so a custom icon named after a bundled one would silently keep rendering as the bundled one. The form warns when a name collides.

### Tests

`test_custom_icon.py`, 10 cases. Sanitization: safe SVG survives intact, scripts and `onload` are stripped, plain HTML is rejected, trailing content after the root is rejected, empty is rejected. Rendering: the symbol carries the id, `viewBox` and drawing, presentation attributes survive while sizing is dropped, a strokeless icon opts out of the desk stroke, saved icons reach the sprite and deleted ones leave it.

Plus `test_sanitize_svg` in `frappe/tests/test_utils.py` for the utility on its own.

All pass locally against a site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
>no-docs
