### PR TITLE
fix(ui): Pick rtl layout for supported language

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -506,6 +506,9 @@ frappe.ui.form.PrintView = class {
 			name: this.frm.doc.name,
 			print_format: this.selected_format(),
 		});
+		if (this.lang_code) {
+			params.append("_lang", this.lang_code);
+		}
 		let letterhead = this.get_letterhead();
 		if (letterhead) {
 			params.append("letterhead", letterhead);

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1171,7 +1171,13 @@ Object.assign(frappe.utils, {
 		}
 	},
 	is_rtl(lang = null) {
-		return ["ar", "he", "fa", "ps"].includes(lang || frappe.boot.lang);
+		// Keep this list in sync with rtl_languages in the Python twin at
+		// frappe/utils/jinja_globals.py:is_rtl.
+		const rtl_languages = ["ar", "fa", "he", "ku", "ps", "ur"];
+		const code = lang || frappe.boot.lang || "";
+
+		if (rtl_languages.includes(code)) return true;
+		return rtl_languages.includes(code.split(/[-_]/)[0]);
 	},
 	bind_actions_with_object($el, object) {
 		// remove previously bound event

--- a/frappe/utils/jinja_globals.py
+++ b/frappe/utils/jinja_globals.py
@@ -158,8 +158,17 @@ def bundled_asset(path, rtl=None):
 
 
 def is_rtl(rtl=None):
-	from frappe import local
+	if rtl is not None:
+		return rtl
 
-	if rtl is None:
-		return local.lang in ["ar", "he", "fa", "ps"]
-	return rtl
+	from frappe import local
+	from frappe.translate import get_parent_language
+
+	# RTL languages Frappe ships in frappe/geo/languages.csv. 
+	# Keep this set in sync with rtl_languages in the JavaScript twin at
+	# frappe/public/js/frappe/utils/utils.js:is_rtl.
+	rtl_languages = {"ar", "fa", "he", "ku", "ps", "ur"}
+
+	lang = local.lang or ""
+	parent_lang = get_parent_language(lang) or ""
+	return lang in rtl_languages or parent_lang in rtl_languages

--- a/frappe/utils/jinja_globals.py
+++ b/frappe/utils/jinja_globals.py
@@ -164,7 +164,7 @@ def is_rtl(rtl=None):
 	from frappe import local
 	from frappe.translate import get_parent_language
 
-	# RTL languages Frappe ships in frappe/geo/languages.csv. 
+	# RTL languages Frappe ships in frappe/geo/languages.csv.
 	# Keep this set in sync with rtl_languages in the JavaScript twin at
 	# frappe/public/js/frappe/utils/utils.js:is_rtl.
 	rtl_languages = {"ar", "fa", "he", "ku", "ps", "ur"}


### PR DESCRIPTION
fixes: #41731 
Picked up the list of language from languages.csv that is shipped with framework and that supports rtl format and included them. 