### PR TITLE
fix(API v2): return plain dicts and echo the doc after execute_doc_method

### DIFF
--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -65,7 +65,7 @@ def read_doc(doctype: str, name: str):
 	doc = frappe.get_doc(doctype, name)
 	doc.check_permission("read")
 	doc.apply_fieldlevel_read_permissions()
-	return doc
+	return doc.as_dict()
 
 
 def document_list(doctype: str):
@@ -95,7 +95,7 @@ def create_doc(doctype: str):
 	if (name := data.get("name")) and isinstance(name, str | int):
 		doc.flags.name_set = True
 
-	return doc.insert()
+	return doc.insert().as_dict()
 
 
 def copy_doc(doctype: str, name: str, ignore_no_copy: bool = True):
@@ -122,7 +122,7 @@ def update_doc(doctype: str, name: str):
 	if doc.get("parenttype"):
 		frappe.get_doc(doc.parenttype, doc.parent).save()
 
-	return doc
+	return doc.as_dict()
 
 
 def delete_doc(doctype: str, name: str):
@@ -148,7 +148,10 @@ def execute_doc_method(doctype: str, name: str, method: str | None = None):
 	doc.is_whitelisted(method)
 
 	doc.check_permission(PERMISSION_MAP[frappe.request.method])
-	return doc.run_method(method, **frappe.form_dict)
+	result = doc.run_method(method, **frappe.form_dict)
+	doc.apply_fieldlevel_read_permissions()
+	frappe.response.docs.append(doc.as_dict())
+	return result
 
 
 def run_doc_method(method: str, document: dict[str, Any] | str, kwargs=None):

--- a/frappe/tests/test_api_v2.py
+++ b/frappe/tests/test_api_v2.py
@@ -127,22 +127,19 @@ class TestResourceAPIV2(FrappeAPITestCase):
 		self.assertEqual(response.json["docs"][0]["name"], "Standard")
 
 	def test_document_apis_retain_null_fields(self):
-		# unset fields must be present as null instead of being dropped from the payload
+		# unset fields must be present as null instead of being dropped from the payload.
+		# only fields backed by a column, so layout fieldtypes never enter the expectation
+		expected = [
+			df.fieldname for df in frappe.get_meta(self.DOCTYPE).fields if df.fieldtype not in no_value_fields
+		]
+		self.assertTrue(expected, f"{self.DOCTYPE} is expected to have column-backed fields")
+
 		create = self.post(
 			self.resource(self.DOCTYPE), {"description": frappe.mock("paragraph"), "sid": self.sid}
 		)
 		self.assertEqual(create.status_code, 200)
 		docname = create.json["data"]["name"]
-		self.addCleanup(frappe.delete_doc_if_exists, self.DOCTYPE, docname)
-
-		# only fields backed by a column, so layout fieldtypes never enter the expectation
-		doc = frappe.get_doc(self.DOCTYPE, docname)
-		null_fields = [
-			df.fieldname
-			for df in frappe.get_meta(self.DOCTYPE).fields
-			if df.fieldtype not in no_value_fields and doc.get(df.fieldname) is None
-		]
-		self.assertTrue(null_fields, "expected the fixture to have at least one unset field")
+		self.GENERATED_DOCUMENTS.append(docname)
 
 		read = self.get(self.resource(self.DOCTYPE, docname), {"sid": self.sid})
 		update = self.patch(
@@ -152,7 +149,7 @@ class TestResourceAPIV2(FrappeAPITestCase):
 
 		for label, response in (("create", create), ("read", read), ("update", update)):
 			self.assertEqual(response.status_code, 200, label)
-			for fieldname in null_fields:
+			for fieldname in expected:
 				self.assertIn(fieldname, response.json["data"], f"{fieldname} dropped from {label} response")
 
 	def test_update_document(self):

--- a/frappe/tests/test_api_v2.py
+++ b/frappe/tests/test_api_v2.py
@@ -118,6 +118,30 @@ class TestResourceAPIV2(FrappeAPITestCase):
 		response = self.get(self.resource("Website Theme", "Standard", "method", "get_apps"))
 		self.assertEqual(response.json["data"][0]["name"], "frappe")
 
+	def test_execute_doc_method_returns_doc(self):
+		# the method may mutate the doc, so clients need the updated copy alongside the result
+		response = self.post(
+			self.resource("User", "Administrator", "method", "add_comment"),
+			{"text": frappe.generate_hash()},
+		)
+		self.assertEqual(response.status_code, 200)
+		self.assertGreaterEqual(len(response.json["docs"]), 1)
+		self.assertEqual(response.json["docs"][0]["name"], "Administrator")
+
+	def test_read_doc_retains_null_fields(self):
+		# unset fields must be present as null instead of being dropped from the payload
+		doc = frappe.get_doc({"doctype": self.DOCTYPE, "description": frappe.mock("paragraph")}).insert()
+		self.addCleanup(frappe.delete_doc_if_exists, self.DOCTYPE, doc.name)
+		frappe.db.commit()
+
+		null_fields = [field for field, value in doc.as_dict().items() if value is None]
+		self.assertTrue(null_fields, "expected the fixture to have at least one unset field")
+
+		response = self.get(self.resource(self.DOCTYPE, doc.name), {"sid": self.sid})
+		self.assertEqual(response.status_code, 200)
+		for fieldname in null_fields:
+			self.assertIn(fieldname, response.json["data"])
+
 	def test_update_document(self):
 		generated_desc = frappe.mock("paragraph")
 		data = {"description": generated_desc, "sid": self.sid}

--- a/frappe/tests/test_api_v2.py
+++ b/frappe/tests/test_api_v2.py
@@ -5,6 +5,7 @@ import requests
 
 import frappe
 from frappe.installer import update_site_config
+from frappe.model import no_value_fields
 from frappe.tests.test_api import FrappeAPITestCase, suppress_stdout
 
 authorization_token = None
@@ -120,27 +121,39 @@ class TestResourceAPIV2(FrappeAPITestCase):
 
 	def test_execute_doc_method_returns_doc(self):
 		# the method may mutate the doc, so clients need the updated copy alongside the result
-		response = self.post(
-			self.resource("User", "Administrator", "method", "add_comment"),
-			{"text": frappe.generate_hash()},
-		)
+		response = self.get(self.resource("Website Theme", "Standard", "method", "get_apps"))
 		self.assertEqual(response.status_code, 200)
 		self.assertGreaterEqual(len(response.json["docs"]), 1)
-		self.assertEqual(response.json["docs"][0]["name"], "Administrator")
+		self.assertEqual(response.json["docs"][0]["name"], "Standard")
 
-	def test_read_doc_retains_null_fields(self):
+	def test_document_apis_retain_null_fields(self):
 		# unset fields must be present as null instead of being dropped from the payload
-		doc = frappe.get_doc({"doctype": self.DOCTYPE, "description": frappe.mock("paragraph")}).insert()
-		self.addCleanup(frappe.delete_doc_if_exists, self.DOCTYPE, doc.name)
-		frappe.db.commit()
+		create = self.post(
+			self.resource(self.DOCTYPE), {"description": frappe.mock("paragraph"), "sid": self.sid}
+		)
+		self.assertEqual(create.status_code, 200)
+		docname = create.json["data"]["name"]
+		self.addCleanup(frappe.delete_doc_if_exists, self.DOCTYPE, docname)
 
-		null_fields = [field for field, value in doc.as_dict().items() if value is None]
+		# only fields backed by a column, so layout fieldtypes never enter the expectation
+		doc = frappe.get_doc(self.DOCTYPE, docname)
+		null_fields = [
+			df.fieldname
+			for df in frappe.get_meta(self.DOCTYPE).fields
+			if df.fieldtype not in no_value_fields and doc.get(df.fieldname) is None
+		]
 		self.assertTrue(null_fields, "expected the fixture to have at least one unset field")
 
-		response = self.get(self.resource(self.DOCTYPE, doc.name), {"sid": self.sid})
-		self.assertEqual(response.status_code, 200)
-		for fieldname in null_fields:
-			self.assertIn(fieldname, response.json["data"])
+		read = self.get(self.resource(self.DOCTYPE, docname), {"sid": self.sid})
+		update = self.patch(
+			self.resource(self.DOCTYPE, docname),
+			data={"description": frappe.mock("paragraph"), "sid": self.sid},
+		)
+
+		for label, response in (("create", create), ("read", read), ("update", update)):
+			self.assertEqual(response.status_code, 200, label)
+			for fieldname in null_fields:
+				self.assertIn(fieldname, response.json["data"], f"{fieldname} dropped from {label} response")
 
 	def test_update_document(self):
 		generated_desc = frappe.mock("paragraph")


### PR DESCRIPTION
Re-raised on the hotfix branch. Supersedes #41747, which Mergify closed for targeting the stable `version-15` branch.

Backports two API v2 response-shape behaviours from `develop`. Both are cases where a v2 client on v15 receives a payload that is missing information the same client gets on v16, with no way to detect it.

### 1. Null fields are silently dropped from document payloads

`read_doc`, `create_doc` and `update_doc` return `Document` objects. Those are serialised by `json_handler`, which calls `as_dict(no_nulls=True)` — so every unset field is omitted from the response entirely.

A client cannot distinguish "field is empty" from "field was not returned". Concretely, clearing a field and PUTing the doc returns a payload with that field absent, so a client merging the response back into its local cache keeps the stale value.

On `develop` these endpoints already return `doc.as_dict()`, which preserves nulls. This does the same.

`copy_doc` deliberately keeps its explicit `no_nulls=True` and is left untouched.

### 2. `execute_doc_method` does not return the mutated doc

`/api/v2/document/<dt>/<name>/method/<method>` returns only the method's return value. Doc methods routinely mutate the document (submit, cancel, status transitions), and the client has no way to observe that without a full refetch.

`run_doc_method` already appends to `frappe.response.docs` for exactly this reason, and `develop`'s `execute_doc_method` does too. This aligns the v15 route with both.

### Notes

- `frappe.local.response` is already initialised as `_dict({"docs": []})`, and `build_response` already drops the key when the list is empty, so no response-plumbing change is needed and responses for non-mutating methods are unchanged.
- `apply_fieldlevel_read_permissions()` is applied to the echoed doc, matching `develop`.
- Both changes are additive from a client's perspective: previously-present keys keep their values, and previously-absent keys appear.

### Tests

Added two cases to `frappe/tests/test_api_v2.py`:

- `test_document_apis_retain_null_fields` — creates a doc over the API, then asserts that every column-backed field which is `None` on the server survives in the create, read *and* update payloads. Scoped via `no_value_fields` so layout fieldtypes never enter the expectation.
- `test_execute_doc_method_returns_doc` — the response carries the doc under `docs`. Uses a read-only method so the suite leaves no durable state behind.

I do not have a v15 bench available to run the suite locally, so these are unverified against a live site and I would appreciate CI confirming them.