### PR TITLE
fix: disable JS source maps in production builds

### DIFF
--- a/esbuild/esbuild.js
+++ b/esbuild/esbuild.js
@@ -348,7 +348,7 @@ function get_build_options(files, outdir, plugins) {
 		entryNames: "[dir]/[name].[hash]",
 		target: [ESBUILD_TARGET],
 		outdir,
-		sourcemap: true,
+		sourcemap: !PRODUCTION,
 		bundle: true,
 		metafile: true,
 		minify: PRODUCTION,


### PR DESCRIPTION
The application publicly exposes a JavaScript source map containing sourcesContent, which allows users to retrieve the original JavaScript source code associated with the bundled client-side application. The source map also discloses internal project/dependency paths such as apps/frappe/....

CWE-200
