### PR TITLE
fix(postgres): index parent column on child tables

### DIFF
--- a/frappe/database/postgres/schema.py
+++ b/frappe/database/postgres/schema.py
@@ -118,6 +118,11 @@ class PostgresTable(DBTable):
 
 	def create_indexes(self):
 		create_index_query = ""
+		if self.meta.get("istable", default=0):
+			index_name = get_single_column_index_name(self.table_name, "parent")
+			create_index_query += (
+				f'CREATE INDEX IF NOT EXISTS "{index_name}" ON `{self.table_name}`(`parent`);'
+			)
 		for col in self.columns.values():
 			if (
 				col.set_index


### PR DESCRIPTION
MariaDB and SQLite index `parent` when creating a child table, and `framework_postgres.sql` does the same for the bootstrap tables, but `PostgresTable.create` never did. On postgres, loading a document's child rows and any correlated subquery on `parent` runs as a sequential scan.

Creates the index in `PostgresTable.create_indexes`, named via `get_single_column_index_name` so it stays schema-unique. No backfill patch since postgres is not a supported production target yet.