### PR TITLE
fix(postgres): index creation and modified columns like MariaDB

### DIFF
--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -538,6 +538,9 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 				AND a.attname = %(fieldname)s
 				AND i.indisunique = {"true" if unique else "false"}
 				AND i.indnkeyatts = 1
+				AND i.indisvalid
+				AND i.indisready
+				AND i.indislive
 				AND am.amname = 'btree'
 				AND i.indpred IS NULL
 			LIMIT 1

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -520,7 +520,9 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 
 		Cross-db counterpart of the MariaDB implementation (which uses ``SHOW INDEX`` with
 		``Seq_in_index = 1`` and a single-column constraint). Uses the PostgreSQL system
-		catalogs so callers stay db-agnostic.
+		catalogs so callers stay db-agnostic. Only full (non-partial) btree indexes count,
+		like the indexes SHOW INDEX reports on InnoDB -- a hash or partial index cannot
+		serve the ordering and unrestricted lookups callers are checking for.
 		"""
 		result = self.sql(
 			f"""
@@ -528,6 +530,7 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 			FROM pg_index i
 			JOIN pg_class tc ON tc.oid = i.indrelid
 			JOIN pg_class ic ON ic.oid = i.indexrelid
+			JOIN pg_am am ON am.oid = ic.relam
 			JOIN pg_namespace n ON n.oid = tc.relnamespace
 			JOIN pg_attribute a ON a.attrelid = tc.oid AND a.attnum = i.indkey[0]
 			WHERE tc.relname = %(table_name)s
@@ -535,6 +538,8 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 				AND a.attname = %(fieldname)s
 				AND i.indisunique = {"true" if unique else "false"}
 				AND i.indnkeyatts = 1
+				AND am.amname = 'btree'
+				AND i.indpred IS NULL
 			LIMIT 1
 			""",
 			{"table_name": table_name, "schema": self.db_schema, "fieldname": fieldname},

--- a/frappe/database/postgres/schema.py
+++ b/frappe/database/postgres/schema.py
@@ -118,6 +118,11 @@ class PostgresTable(DBTable):
 
 	def create_indexes(self):
 		create_index_query = ""
+		if self.meta.get("istable", default=0):
+			index_name = get_single_column_index_name(self.table_name, "parent")
+			create_index_query += (
+				f'CREATE INDEX IF NOT EXISTS "{index_name}" ON `{self.table_name}`(`parent`);'
+			)
 		for col in self.columns.values():
 			if (
 				col.set_index

--- a/frappe/database/postgres/schema.py
+++ b/frappe/database/postgres/schema.py
@@ -117,25 +117,31 @@ class PostgresTable(DBTable):
 		frappe.db.commit()
 
 	def create_indexes(self):
-		create_index_query = ""
 		if self.meta.get("istable", default=0):
-			index_name = get_single_column_index_name(self.table_name, "parent")
-			create_index_query += (
-				f'CREATE INDEX IF NOT EXISTS "{index_name}" ON `{self.table_name}`(`parent`);'
-			)
-		for col in self.columns.values():
+			index_fields = ["parent"]
+		else:
+			index_fields = ["creation"]
+			if self.meta.sort_field == "modified":
+				index_fields.append("modified")
+
+		index_fields += [
+			col.fieldname
+			for col in self.columns.values()
 			if (
 				col.set_index
 				and col.fieldtype in frappe.db.type_map
 				and frappe.db.type_map.get(col.fieldtype)[0] not in ("text", "longtext")
-			):
-				index_name = get_single_column_index_name(self.table_name, col.fieldname)
-				create_index_query += (
-					f'CREATE INDEX IF NOT EXISTS "{index_name}" ON `{self.table_name}`(`{col.fieldname}`);'
-				)
-		if create_index_query:
-			# nosemgrep
-			frappe.db.sql(create_index_query)
+			)
+		]
+
+		create_index_query = ""
+		for fieldname in index_fields:
+			index_name = get_single_column_index_name(self.table_name, fieldname)
+			create_index_query += (
+				f'CREATE INDEX IF NOT EXISTS "{index_name}" ON `{self.table_name}`(`{fieldname}`);'
+			)
+		# nosemgrep
+		frappe.db.sql(create_index_query)
 
 	def alter(self):
 		for col in self.columns.values():
@@ -222,6 +228,14 @@ class PostgresTable(DBTable):
 			index_name = get_single_column_index_name(self.table_name, col.fieldname)
 			create_contraint_query += (
 				f'CREATE INDEX IF NOT EXISTS "{index_name}" ON `{self.table_name}`(`{col.fieldname}`);'
+			)
+
+		if self.meta.sort_field == "modified" and not frappe.db.get_column_index(
+			self.table_name, "modified", unique=False
+		):
+			index_name = get_single_column_index_name(self.table_name, "modified")
+			create_contraint_query += (
+				f'CREATE INDEX IF NOT EXISTS "{index_name}" ON `{self.table_name}`(`modified`);'
 			)
 
 		for col in self.add_unique:


### PR DESCRIPTION
MariaDB and SQLite index `creation` on every non-child table at creation, plus `modified` when the doctype sorts by it, and their alter paths add the `modified` index when `sort_field` changes later. `PostgresTable` did none of this, so list views (`order by creation desc`) sort every row on postgres.

Mirrors the behavior in `PostgresTable.create_indexes` and `alter`. The postgres `get_column_index` now counts only full btree indexes — like `SHOW INDEX` on InnoDB — so a partial or hash index on `modified` cannot suppress the alter catch-up. No backfill patch since postgres is not a supported production target yet.

Stacked on #41756 — its commit appears here until it merges.