### PR TITLE
fix: support translated_doctypes in search_widget custom queries

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -17,6 +17,8 @@ from frappe.permissions import has_permission
 from frappe.utils import cint, cstr, unique
 from frappe.utils.data import make_filter_tuple
 
+PAGE_LENGTH_FOR_LINK_VALIDATION = 25_000
+
 
 def sanitize_searchfield(searchfield: str):
 	if not searchfield:
@@ -89,15 +91,20 @@ def search_widget(
 		query = standard_queries[doctype][-1]
 
 	if query:  # Query = custom search query i.e. python function
+		meta = frappe.get_meta(doctype)
+		# translated doctypes are matched against translated values below, so the query must
+		# not filter or truncate on the untranslated ones
+		query_txt = "" if meta.translated_doctype else txt
+		query_page_length = PAGE_LENGTH_FOR_LINK_VALIDATION if meta.translated_doctype else page_length
 		try:
 			is_whitelisted(frappe.get_attr(query))
-			return frappe.call(
+			values = frappe.call(
 				query,
 				doctype,
-				txt,
+				query_txt,
 				searchfield,
 				start,
-				page_length,
+				query_page_length,
 				filters,
 				as_dict=as_dict,
 				reference_doctype=reference_doctype,
@@ -114,6 +121,13 @@ def search_widget(
 					http_status_code=404,
 				)
 				return []
+
+		if meta.translated_doctype:
+			values = filter_translated(values, txt, as_dict)
+			values = sorted(values, key=lambda x: relevance_sorter(x, txt, as_dict))
+			values = values[:page_length]
+
+		return values
 
 	meta = frappe.get_meta(doctype)
 
@@ -206,15 +220,7 @@ def search_widget(
 	)
 
 	if meta.translated_doctype:
-		# Filtering the values array so that query is included in very element
-		values = (
-			result
-			for result in values
-			if any(
-				re.search(f"{re.escape(txt)}.*", _(cstr(value)) or "", re.IGNORECASE)
-				for value in (result.values() if as_dict else result)
-			)
-		)
+		values = filter_translated(values, txt, as_dict)
 
 	# Sorting the values array so that relevant results always come first
 	# This will first bring elements on top in which query is a prefix of element
@@ -286,6 +292,18 @@ def scrub_custom_query(query, key, txt):
 def relevance_sorter(key, query, as_dict):
 	value = _(key.name if as_dict else key[0])
 	return (cstr(value).casefold().startswith(query.casefold()) is not True, value)
+
+
+def filter_translated(values, txt: str, as_dict: bool) -> list:
+	"""Return only those results where txt matches any translated field value."""
+	return [
+		result
+		for result in values
+		if any(
+			re.search(f"{re.escape(txt)}.*", _(cstr(value)) or "", re.IGNORECASE)
+			for value in (result.values() if as_dict else result)
+		)
+	]
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Summary
- Backports translated-doctype support in `search_widget` custom queries from `develop` (PR #39366) to `version-15-hotfix`
- Drops the `if not for_link_validation:` guard from the original; that parameter does not exist on v15's `search_widget`

---

Ref: https://support.frappe.io/helpdesk/tickets/75903?view=VIEW-HD+Ticket-1252
