### PR TITLE
fix(ui): migrate remaining v1 colour tokens to the v2 token set

### DIFF
--- a/ui/src/components/ActivityTimeline/ActivityTimeline.vue
+++ b/ui/src/components/ActivityTimeline/ActivityTimeline.vue
@@ -28,7 +28,7 @@
 				<div class="grid w-full grid-cols-[30px_minmax(auto,_1fr)] gap-2 px-6 md:px-0">
 					<!-- gutter column: vertical connector line + icon/avatar -->
 					<div
-						class="relative flex justify-center after:absolute after:start-[50%] after:z-0 after:border-s after:border-outline-gray-modals"
+						class="relative flex justify-center after:absolute after:start-[50%] after:z-0 after:border-s after:border-outline-elevation-2"
 						:class="
 							activity.type === 'load_more'
 								? 'after:-top-2 after:h-[calc(100%+1rem)]'
@@ -43,7 +43,7 @@
 						<!-- load_more has no gutter icon — the connector line passes straight through -->
 						<div
 							v-if="activity.type !== 'load_more'"
-							class="relative z-10 flex items-center justify-center self-start bg-surface-white"
+							class="relative z-10 flex items-center justify-center self-start bg-surface-base"
 							:class="[isAvatarActivity(activity) ? 'h-10' : 'h-6 w-6 rounded-full']"
 						>
 							<!-- gutter ladder: #icon-{type} slot > GutterIcon (activity.icon > per-type default) -->

--- a/ui/src/components/ActivityTimeline/GutterIcon.vue
+++ b/ui/src/components/ActivityTimeline/GutterIcon.vue
@@ -14,7 +14,7 @@
 		<div v-if="activity.type === 'email' || activity.type === 'comment'" class="relative">
 			<Avatar size="lg" :label="activity.author.fullname" :image="activity.author.image" />
 			<span
-				class="absolute -bottom-0.5 -end-1.5 flex size-4.5 items-center justify-center rounded-full bg-surface-white text-ink-gray-5"
+				class="absolute -bottom-0.5 -end-1.5 flex size-4.5 items-center justify-center rounded-full bg-surface-base text-ink-gray-5"
 			>
 				<MailIcon v-if="activity.type === 'email'" class="size-3" />
 				<CommentIcon v-else class="size-3" />

--- a/ui/src/components/ActivityTimeline/TimelineCard.vue
+++ b/ui/src/components/ActivityTimeline/TimelineCard.vue
@@ -1,10 +1,10 @@
 <template>
 	<!-- shared card frame for email/comment rows; the header (incl. its padding) is fully slotted -->
 	<div
-		class="grow cursor-pointer overflow-hidden rounded-md border border-outline-gray-2 bg-surface-white text-base leading-6 transition-all duration-300 ease-in-out"
+		class="grow cursor-pointer overflow-hidden rounded-md border border-outline-gray-2 bg-surface-base text-base leading-6 transition-all duration-300 ease-in-out"
 	>
 		<slot name="header" />
-		<hr class="border-t border-outline-gray-modals" />
+		<hr class="border-t border-outline-elevation-2" />
 		<!-- content region; padding/background varies per row type -->
 		<div :class="contentClass">
 			<slot />

--- a/ui/src/components/ActivityTimeline/VersionItem.vue
+++ b/ui/src/components/ActivityTimeline/VersionItem.vue
@@ -86,7 +86,7 @@
 					class="relative ms-2 flex flex-col gap-2 ps-4"
 				>
 					<!-- inset half a row (leading-6 ÷ 2) so the line spans first→last entry centers -->
-					<div class="absolute inset-y-3 start-0 w-px bg-[var(--outline-gray-modals)]" />
+					<div class="absolute inset-y-3 start-0 w-px bg-[var(--outline-elevation-2)]" />
 					<div
 						v-for="(historyEntry, idx) in historyOf(change)"
 						:key="idx"

--- a/ui/src/components/Composer/ComposerEditor.vue
+++ b/ui/src/components/Composer/ComposerEditor.vue
@@ -115,7 +115,7 @@
 									style="
 										background: linear-gradient(
 											to left,
-											var(--surface-white, white),
+											var(--surface-base, white),
 											transparent
 										);
 									"

--- a/ui/src/components/DataImport/PreviewStep.vue
+++ b/ui/src/components/DataImport/PreviewStep.vue
@@ -72,7 +72,7 @@
 						</th>
 					</tr>
 				</thead>
-				<tbody class="bg-surface-base divide-y divide-surface-gray-2">
+				<tbody class="bg-surface-base divide-y divide-outline-gray-1">
 					<tr v-for="(row, rowIndex) in previewData" :key="rowIndex">
 						<td
 							v-for="column in previewColumns"
@@ -116,7 +116,7 @@
 							<th class="p-2 text-left text-sm text-ink-gray-5 w-[80%]">Message</th>
 						</tr>
 					</thead>
-					<tbody class="bg-surface-base divide-y divide-surface-gray-2">
+					<tbody class="bg-surface-base divide-y divide-outline-gray-1">
 						<tr v-for="(row, rowIndex) in filteredLogs" :key="rowIndex" class="group">
 							<td class="px-3 py-2 text-sm text-ink-gray-7 border-r">
 								<div class="flex items-center justify-center space-x-2">

--- a/ui/src/components/Fields/CodeEditorField.vue
+++ b/ui/src/components/Fields/CodeEditorField.vue
@@ -83,7 +83,7 @@
 					v-show="previewOpen"
 					:modelValue="value"
 					:language="language"
-					class="mt-1 min-h-[4.5rem] rounded-md border border-surface-gray-2 p-3"
+					class="mt-1 min-h-[4.5rem] rounded-md border border-outline-gray-1 p-3"
 				/>
 			</div>
 		</div>
@@ -103,7 +103,7 @@
 			<CodePreview
 				:modelValue="value"
 				:language="language"
-				class="min-h-[4.5rem] rounded-md border border-surface-gray-2 p-3"
+				class="min-h-[4.5rem] rounded-md border border-outline-gray-1 p-3"
 			/>
 		</div>
 	</div>

--- a/ui/src/components/ListView/ListViewShell.vue
+++ b/ui/src/components/ListView/ListViewShell.vue
@@ -18,7 +18,7 @@
 -->
 <template>
 	<div
-		class="flex min-h-0 flex-col overflow-hidden rounded-lg border border-outline-gray-1 bg-surface-white"
+		class="flex min-h-0 flex-col overflow-hidden rounded-lg border border-outline-gray-1 bg-surface-base"
 	>
 		<!-- Toolbar region: the home of the list-view controls. The slotted content
 		     owns its own alignment (quick filters left, Filter/Sort right). -->


### PR DESCRIPTION
### Problem

A handful of Tailwind colour utilities in `ui/src` silently render nothing.

`surface-white` and `outline-gray-modals` were retired when the v2 token set landed — they are not in `tailwind/generated/colors.json`, so Tailwind emits no rule for `bg-surface-white` / `border-outline-gray-modals` and the utility is a no-op. The two CSS-variable uses (`var(--surface-white)`, `var(--outline-gray-modals)`) resolve to nothing for the same reason.

Separately, four utilities name a token that exists but is not registered for that utility. `tailwind/plugin.js` extends `borderColor`, `ringColor` and `divideColor` with `outline*` only — `surface*` goes to `backgroundColor`/`fill`/gradients. So `border-surface-gray-2` and `divide-surface-gray-2` were never generated either.

### Fix

Renames follow frappe-ui's own migration map in `tailwind/migrate-tokens-v2.js`:

| from | to |
| --- | --- |
| `surface-white` | `surface-base` |
| `outline-gray-modals` | `outline-elevation-2` |

For the wrong-utility cases, the elements were already falling back to `borderColor.DEFAULT` (`--outline-gray-1`), so naming `outline-gray-1` explicitly keeps the rendering byte-identical rather than changing any colour:

- `border-surface-gray-2` → `border-outline-gray-1` (`CodeEditorField.vue`)
- `divide-surface-gray-2` → `divide-outline-gray-1` (`PreviewStep.vue`)

### Notes

- Found by resolving the valid token set from `tailwind/generated/colors.json` plus the per-utility matrix in `tailwind/plugin.js`, then scanning every `.vue`/`.ts`/`.js`/`.css` in `ui/src` for both class names and `var(--token)` references. `ui/src` is clean afterwards.
- Every substitution is the same character length, so no line reflows. I deliberately did not run `prettier --write`: several of these files already fail `prettier --check` on `develop`, and running it would have mixed ~30 lines of unrelated reformatting into the diff. Worth a separate formatting-only pass.
- The intent behind `border-surface-gray-2` was likely gray-100; the closest outline token is gray-200. I preserved current rendering instead of guessing — happy to change if the lighter border was intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)