### PR TITLE
fix: restore Global Search shortcut (⌘G / Ctrl+G)

### DIFF
--- a/frappe/public/js/desktop_icons.bundle.js
+++ b/frappe/public/js/desktop_icons.bundle.js
@@ -509,15 +509,8 @@ class DesktopPage {
 			let awesome_bar = new frappe.search.AwesomeBar();
 			awesome_bar.setup(".desktop-search-wrapper #desktop-navbar-modal-search");
 		}
-		frappe.ui.keys.add_shortcut({
-			shortcut: "ctrl+g",
-			action: function (e) {
-				$(".desktop-search-wrapper #desktop-navbar-modal-search").click();
-				e.preventDefault();
-				return false;
-			},
-			description: __("Open Awesomebar"),
-		});
+		// Only rebind Ctrl/Cmd+K to trigger the desktop-page Awesome Bar wrapper.
+		// Ctrl/Cmd+G is intentionally left alone so the global handler in
 		frappe.ui.keys.add_shortcut({
 			shortcut: "ctrl+k",
 			action: function (e) {

--- a/frappe/public/js/desktop_icons.bundle.js
+++ b/frappe/public/js/desktop_icons.bundle.js
@@ -510,7 +510,6 @@ class DesktopPage {
 			awesome_bar.setup(".desktop-search-wrapper #desktop-navbar-modal-search");
 		}
 		// Only rebind Ctrl/Cmd+K to trigger the desktop-page Awesome Bar wrapper.
-		// Ctrl/Cmd+G is intentionally left alone so the global handler in
 		frappe.ui.keys.add_shortcut({
 			shortcut: "ctrl+k",
 			action: function (e) {

--- a/frappe/public/js/frappe/ui/toolbar/toolbar.js
+++ b/frappe/public/js/frappe/ui/toolbar/toolbar.js
@@ -39,6 +39,12 @@ frappe.ui.toolbar.Toolbar = class {
 	}
 
 	setup_help() {
+		// Global Search (⌘G / Ctrl+G) is independent of the help/notifications UI,
+		// so its dialog is initialised before the early-return that skips help setup.
+		this.search = new frappe.search.SearchDialog();
+		frappe.provide("frappe.searchdialog");
+		frappe.searchdialog.search = this.search;
+
 		if (!frappe.boot.desk_settings.notifications) {
 			// hide the help section
 			$(".navbar .vertical-bar").removeClass("d-sm-block");
@@ -47,10 +53,6 @@ frappe.ui.toolbar.Toolbar = class {
 		}
 		frappe.provide("frappe.help");
 		frappe.help.show_results = show_results;
-
-		this.search = new frappe.search.SearchDialog();
-		frappe.provide("frappe.searchdialog");
-		frappe.searchdialog.search = this.search;
 
 		$(".dropdown-help .dropdown-toggle").on("click", function () {
 			$(".dropdown-help input").focus();


### PR DESCRIPTION
Bug: On `/app/desktop` (Desktop Icons mode), ⌘G opens the Awesomebar instead of Global Search. The override leaks — once the page is visited, ⌘G stays broken on every other route until a full reload.

On the Desktop Icons page, `setup_awesomebar()` registers `ctrl+g` without a page scope. Because `add_shortcut` removes every existing handler for that key before adding the new one, the app-wide `Open Global Search` binding from `keyboard.js` gets wiped.

Introduced by: PR #41218 (sokumon/navigation-flag, commit dcae5965b47) — leftover from before Global Search existed, when ⌘G meant "open Awesomebar" on the desktop page.

Fix: Drop the `ctrl+g` override on the desktop page so the global handler stays active. ⌘K untouched.

Screenshots:
before:
on app/desktop - presses `CMD + G` open awesome bar 
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/1f0619b9-ce8d-4ec4-952e-4b31382b89ae" />
but on other screen and reloaded then work fine (but needed reload if not reloaded opens awesome bar)
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/bbaf390d-2073-4b04-8788-f0dd1107fac2" />

after:
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/760619eb-df61-4bc9-8f63-1168c1ddc499" />


`no-docs`