### PR TITLE
 feat(ui): add ConditionBuilder, a nested and/or condition editor 

### DIFF
--- a/ui/docs/adr/0008-conditionbuilder-composes-filter-rules.md
+++ b/ui/docs/adr/0008-conditionbuilder-composes-filter-rules.md
@@ -1,0 +1,164 @@
+# ConditionBuilder composes `Filter`'s rules and holds one conjunction per group
+
+`ConditionBuilder` is the nested and/or condition editor behind rules that are
+persisted as Frappe's interleaved condition array — an Assignment Rule's
+`assign_condition_json`, an SLA's `condition_json`. Two decisions shape it.
+
+## It composes `Filter`'s rules rather than carrying its own
+
+A fieldtype → operator table, a default-value table and a fieldtype →
+value-input dispatch already exist in this package as `Filter/operators.ts` and
+`Filter/valueControl.ts`. The leaf is built over those instead of a second copy,
+so the two editors cannot drift:
+
+| Own | Reused |
+| --- | --- |
+| `tree.ts`, `context.ts`, `adapters.ts`, the group / row / conjunction / actions components, `ConditionLeaf.vue` | `Filter/operators.ts`, `Filter/valueControl.ts`, the shared `Fields` registry (ADR-0004) |
+
+Reusing the value dispatch is also what lets a Link condition search its target
+doctype, which a self-contained value-input table cannot do.
+
+The row's grid markup — about forty lines — stays duplicated. `Filter.vue` has
+no component test, so extracting its template would refactor code people already
+use with nothing to catch a regression. The markup is cheap and visible; the
+rules that drift are not, and those are shared.
+
+### The operator vocabulary is narrower on write than on read
+
+`Filter` queries Frappe's list API. This component writes an array that the host
+application compiles into a Python expression for `safe_eval`, and the two
+vocabularies differ at two points, so `conditionOperators` adjusts the shared
+table rather than forking it: `is not` is offered because the compiler
+implements it, and `timespan` is withheld because the compiler has no rule for
+it and would emit an expression that raises every time the rule runs.
+
+Reading is deliberately wider than writing. `fromFrappeConditions` accepts every
+operator the stored format can hold, and the leaf keeps a stored operator in its
+own dropdown even when the field would not offer it today, so a saved rule is
+always legible and is only ever rewritten deliberately.
+
+An entry that cannot be modelled as a fieldname/operator/value leaf at all — a
+doctype-qualified filter, an unlisted operator, a stray token — is **dropped on
+read**, together with the conjunction beside it so the level never re-joins on an
+operator nobody wrote. An earlier design kept such an entry verbatim and
+round-tripped it untouched; that is no longer true. Preserving it meant a row the
+editor could not render, could not validate and could not compile, so a record
+holding one was editable everywhere except in the one place it was wrong, and the
+array and the expression disagreed about what the rule was. Dropping it costs
+that entry and makes the two halves agree — a record is now edited without it and
+saved without it, which is visible rather than silent.
+
+### What it does not inherit
+
+`parseFilters` drops a condition whose field is absent from Meta. Here a rule
+naming a since-deleted field is kept, shown, and repairable by re-pointing its
+field picker — dropping it would silently delete part of a saved rule.
+
+The multi-value controls take `string[]` while `in` / `not in` are persisted as
+a comma-separated string, and they drop a string value on the first edit. The
+leaf splits it on read, option-aware, so a value whose own label contains a
+comma is not split into members that match nothing. A Link's values are not
+enumerable client-side, so a docname containing a comma is still split; that
+residual is noted at the call site.
+
+## A group holds one conjunction per group
+
+`ConditionGroup` stores `conjunction: Conjunction`, one operator for the whole
+level: every child is joined to the next by the same `and` or `or`. A group of
+four children reads `A and B and C and D`, and `A and B or C` is not a shape it
+can hold. A rule that mixes them is spelled by nesting, `A and (B or C)`.
+
+**This reverses the original decision, which was one operator per gap**
+(`conjunctions: Conjunction[]`, `conjunctions[i]` joining `conditions[i]` to
+`conditions[i + 1]`). That shape matched the persisted format exactly and
+round-tripped losslessly. What it did not match was any host: CRM, Helpdesk and
+LMS each drove a whole group from one operator and each wrote that policy by
+hand through the `#conjunction` slot, so the shape the component offered was one
+nobody used and three copies of the same workaround existed to hide it.
+
+Three things the per-gap model cost, which per-group does not:
+
+- **A per-gap invariant**, `conjunctions.length === conditions.length - 1`, that
+  every add, remove, splice and move had to maintain at every depth. Getting it
+  wrong re-joined the survivors on an operator nobody picked, silently. Removing
+  a row had to decide which gap died with it; a move had to carry the operator
+  the row displayed to its new position. None of that code exists now.
+- **A move that changes what a rule matches.** In a mixed level, which rows sit
+  either side of an `or` is the rule, so dragging a row could alter it. With one
+  operator per group a reorder cannot change the result at all.
+- **A third accessible name.** A mixed level is neither "match all" nor "match
+  any", so the labels needed a `matchMixed` that no longer has a case to state.
+
+### The cost: reading a mixed record is lossy
+
+The stored array still carries a token per gap, and the wire format is
+unchanged — `toFrappeConditions` repeats the group's one token between every
+pair, so anything written here reads everywhere it read before. But a *stored*
+array can be mixed, and the tree cannot hold one.
+
+`fromFrappeConditions` takes the **first** separator token on a level and
+discards the rest. A record stored as `A and B or C` loads, and re-saves, as
+`A and B and C` — silently a different rule. The alternatives were reshaping a
+mixed level into nested groups nobody authored, which returns a record shaped
+differently from how it was written, or keeping a second editing model alive for
+a shape the component no longer offers any way to create. Frappe's own editors
+write uniform levels, so what reaches this is a hand-edited record, another
+tool, or an earlier version of this component. The loss is documented in the
+reader's doc comment, in `ConditionBuilder.md`, and pinned by tests.
+
+Ungrouping is lossy for the same reason at the other end: a nested `or` group
+spliced into an `and` parent is re-joined by the parent's operator, because that
+is the only one its new level has.
+
+### One live cell, in the component
+
+`setGroupConjunction` is now the only way to change an operator, and the
+component applies the one-live-cell policy itself: the cell on row 1 is the
+and/or button, and every cell below it repeats the word as **plain text**. Not a
+disabled button — a disabled control is skipped in a screen reader's forms mode
+and is exempt from the contrast minimum, which is the same rule `readonly`
+follows.
+
+The `#conjunction` slot stays, for restyling that cell. It is no longer what a
+host reaches for to get uniform behaviour, which is what it had become.
+
+## A drag may leave the group it started in
+
+Each group's list was its own Sortable group, so a row physically could not be
+dragged out of the group it was in. Grouping was an explicit menu action and a
+drag could only reorder. That is reversed: every list in one builder shares a
+Sortable group name, scoped to the builder id so two builders on a page cannot
+exchange rows.
+
+The tree edit is one primitive, `moveNodeToGroup`, and it is one edit — the tree
+is never briefly missing the row it is carrying. Everything after the clone is
+done through object references rather than paths, because the two splices
+invalidate paths as they go: taking a row out of a group re-points every later
+sibling, and putting it into another re-points that group's. A group emptied by
+the move is pruned by identity for the same reason, and takes the same cascade
+`removeNode` takes.
+
+### Applying it once
+
+vuedraggable is used controlled — `:model-value`, not `v-model`, committing from
+the event — and a cross-group drop raises `change` **twice**: `removed` on the
+source list and `added` on the target, on two different components. Each of them
+holds the tree as it was before the drag, so applying both commits the second
+edit on top of a tree that never had the first, and the row is duplicated or
+lost depending on which lands last. Neither component can see the other half of
+the move, so neither can merge them.
+
+Sortable's `end` is the single-application path: it fires **once**, on the list
+the drag started in, and carries `from`, `to`, `oldIndex` and `newIndex` in one
+event — the whole move, in one component. It also fires last, after vuedraggable
+has restored the DOM, so the commit is what actually moves the row. Each `<ul>`
+carries a `data-group-path` for it to read the two groups off, matching the
+`data-condition-path` the rows already carried.
+
+### Refusing a drop while it is still a drop
+
+`maxDepth` is enforced through Sortable's `put` callback, which is asked of the
+group being dropped into, rather than only in the commit. A drop that would nest
+too deep shows no drop indicator, instead of landing and being snapped back by a
+commit that declines it. `put` and the commit call the same `canMoveInto`, so
+there is one rule rather than a guard and a re-guard that can disagree.

--- a/ui/package.json
+++ b/ui/package.json
@@ -33,6 +33,10 @@
       "import": "./src/components/Filter/index.ts",
       "types": "./src/components/Filter/index.ts"
     },
+    "./ConditionBuilder": {
+      "import": "./src/components/ConditionBuilder/index.ts",
+      "types": "./src/components/ConditionBuilder/index.ts"
+    },
     "./QuickFilter": {
       "import": "./src/components/QuickFilter/index.ts",
       "types": "./src/components/QuickFilter/index.ts"

--- a/ui/src/components/ConditionBuilder/AddConditionButton.vue
+++ b/ui/src/components/ConditionBuilder/AddConditionButton.vue
@@ -1,0 +1,63 @@
+<!--
+  A group's add affordance, extracted so both conjunction placements draw the
+  same control. Two things to add, so it is a menu, until `maxDepth` leaves only
+  one and the control is the button itself. Adding a group is dropped rather than
+  disabled: nothing the user can do from here would re-enable it.
+-->
+<template>
+	<Dropdown v-if="canAddGroup" v-slot="{ open }" :options="options">
+		<Button
+			data-slot="add-condition"
+			:label="labels.addCondition"
+			icon-left="lucide-plus"
+			:icon-right="open ? 'lucide-chevron-up' : 'lucide-chevron-down'"
+		/>
+	</Dropdown>
+	<Button
+		v-else
+		data-slot="add-condition"
+		:label="labels.addCondition"
+		icon-left="lucide-plus"
+		@click="addCondition"
+	/>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { Button, Dropdown } from "frappe-ui";
+import { useConditionBuilderContext } from "./internal/context";
+import type { ConditionPath } from "./types";
+
+const props = defineProps<{
+	/** The group to add into. */
+	path: ConditionPath;
+
+	/** False when a new group here would exceed `maxDepth`. */
+	canAddGroup?: boolean;
+}>();
+
+const context = useConditionBuilderContext();
+const labels = context.labels;
+
+function addCondition() {
+	context.addCondition(props.path);
+}
+
+interface AddItem {
+	label: string;
+	onClick: () => void;
+}
+
+const options = computed<AddItem[]>(() => {
+	return [
+		{
+			label: labels.value.addCondition,
+			onClick: () => context.addCondition(props.path),
+		},
+		{
+			label: labels.value.addGroup,
+			onClick: () => context.addGroup(props.path),
+		},
+	];
+});
+</script>

--- a/ui/src/components/ConditionBuilder/ConditionActions.vue
+++ b/ui/src/components/ConditionBuilder/ConditionActions.vue
@@ -1,0 +1,100 @@
+<!--
+  The per-row overflow menu: Turn into a Group / Ungroup / Remove. `Button`
+  overwrites `aria-label` from its `label`, so the icon-only trigger is named
+  through `aria-labelledby`, including the row's field.
+
+  Past the depth limit a leaf has only Remove left, and the single action is
+  drawn as itself rather than as a menu of one.
+
+  Reordering is not in here: the handle is the way a row moves, which leaves it
+  pointer-only. A host that needs a keyboard path puts one in `#condition-actions`.
+-->
+<template>
+	<div v-if="!readonly" data-slot="condition-actions" class="w-max">
+		<Dropdown v-if="!only" placement="right" :options="options">
+			<Button variant="ghost" icon="lucide-more-horizontal" :aria-labelledby="nameIds" />
+		</Dropdown>
+		<Button
+			v-else
+			variant="ghost"
+			:icon="only.icon"
+			:theme="only.theme"
+			:aria-labelledby="nameIds"
+			@click="only.onClick"
+		/>
+		<span :id="nameId" class="sr-only">{{ name }}</span>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed, useId } from "vue";
+import { Button, Dropdown } from "frappe-ui";
+import { useConditionBuilderContext } from "./internal/context";
+import { canNest } from "./tree";
+import type { ConditionPath } from "./types";
+
+const props = defineProps<{
+	path: ConditionPath;
+	isGroup: boolean;
+
+	/** Id of the element holding this row's field label, rendered by the row. */
+	fieldLabelId?: string;
+}>();
+
+const context = useConditionBuilderContext();
+const labels = context.labels;
+const readonly = computed(() => context.readonly.value);
+const nameId = useId();
+
+const nameIds = computed(() => (props.fieldLabelId ? `${props.fieldLabelId} ${nameId}` : nameId));
+
+interface ActionItem {
+	label: string;
+	icon?: string;
+	theme?: "red";
+	onClick: () => void;
+}
+
+const options = computed<ActionItem[]>(() => {
+	const items: ActionItem[] = [];
+
+	// Wrapping a leaf has the same reach as adding a group to its parent.
+	const parentPath = props.path.slice(0, -1);
+
+	if (!props.isGroup && canNest(parentPath, context.maxDepth.value)) {
+		items.push({
+			label: labels.value.turnIntoGroup,
+			icon: "lucide-group",
+			onClick: () => context.turnIntoGroup(props.path),
+		});
+	}
+
+	if (props.isGroup) {
+		items.push({
+			label: labels.value.ungroup,
+			icon: "lucide-ungroup",
+			onClick: () => context.ungroup(props.path),
+		});
+	}
+
+	items.push({
+		label: props.isGroup ? labels.value.removeGroup : labels.value.remove,
+		icon: "lucide-trash-2",
+		theme: "red",
+		onClick: () => context.remove(props.path),
+	});
+
+	return items;
+});
+
+/** The one action, when there is only one. Null draws the menu. */
+const only = computed<ActionItem | null>(() =>
+	options.value.length === 1 ? options.value[0] : null
+);
+
+// Named by the action once it is the control, by the menu while it is a menu.
+const name = computed(() => {
+	if (only.value) return only.value.label;
+	return props.isGroup ? labels.value.groupActions : labels.value.rowActions;
+});
+</script>

--- a/ui/src/components/ConditionBuilder/ConditionBuilder.md
+++ b/ui/src/components/ConditionBuilder/ConditionBuilder.md
@@ -1,0 +1,543 @@
+# ConditionBuilder
+
+A nested tree of conditions joined by AND / OR. The control behind an
+Assignment Rule's conditions, an SLA's, or any rule that needs `A and (B or C)`.
+Grouping, the group's conjunction and add/remove belong to the component; the row is
+a slot, so it fits doctype field conditions and domain-specific rules alike.
+
+`Filter` is the flat, AND-only version of the same idea. Both read their
+operator tables and value controls from the same modules, so they cannot drift.
+`ConditionOperator` is `Filter`'s operator union minus `timespan`, and `ConditionField`
+is `FilterField`, both derived rather than copied, so there is nothing to keep in step.
+See [ADR-0008](../../../docs/adr/0008-conditionbuilder-composes-filter-rules.md).
+
+```ts
+import { ConditionBuilder } from "@framework/ui/ConditionBuilder";
+import type { ConditionField, ConditionGroup } from "@framework/ui/ConditionBuilder";
+```
+
+An app that aliases the package to its source directory rather than resolving
+`exports` imports `@framework/ui/components/ConditionBuilder`.
+
+## Fields
+
+Either give it a `doctype` and let it derive fields from Meta, as `Filter` does:
+
+```vue
+<ConditionBuilder v-model="conditions" doctype="ToDo" />
+```
+
+…or supply them yourself, in the `ConditionField` shape (`options` is Frappe's
+newline-joined string):
+
+```vue
+<ConditionBuilder v-model="conditions" :fields="fields" />
+```
+
+`doctype` is read once at setup, so a host that switches doctype should remount
+with `:key`. When the Meta request fails the component says so and offers a
+retry, rather than presenting every row as though its field had been deleted.
+
+## The model
+
+```ts
+{
+  // one operator for the whole group: every child joins the next by this
+  conjunction: "and",
+  conditions: [
+    { fieldname: "status", operator: "equals", value: "Open" },
+    { fieldname: "subject", operator: "like", value: "refund" },
+    {
+      conjunction: "or",
+      conditions: [
+        { fieldname: "priority", operator: "equals", value: "High" },
+        { fieldname: "priority", operator: "equals", value: "Urgent" },
+      ],
+    },
+  ],
+}
+```
+
+A group is anything with a `conditions` array; everything else is a leaf. The
+distinction is structural on purpose, so the tree survives a JSON round-trip
+with no discriminator to keep in sync. A group written without a `conjunction`
+is still a group, and reads as `and`.
+
+`modelValue` is required and the component holds nothing of its own: an edit is
+an emit, and a host that drops it renders a tree that does not move. `null` is
+an empty tree, which is what a nullable backend field bound straight to
+`v-model` arrives as, so the only thing left for a missing prop to mean is a wiring
+mistake, which is worth failing on.
+
+### One operator per group
+
+A group holds one `and` or `or` and joins every one of its children by it, so a
+level reads `A and B and C` and never `A and B or C`. A rule that mixes them is
+spelled by nesting, as `A and (B or C)`, which is the only spelling of it a
+reader has to learn, and the one the brackets on screen already show.
+
+The operator sits on a rule drawn down the start edge of the group, so what it
+joins is visible rather than inferred from the row it happens to sit on. Every
+row after the first shows it, including the row a nested group's card sits in.
+A card with nothing in that cell reads as unattached.
+
+**Only the first gap is a control.** The cell on row 1 is the and/or button;
+every cell below it repeats the same word as plain text, because there is only
+one value and a second button for it would read as per-gap editing to anyone who
+found the lower one first. Text rather than a disabled button, for the reason
+`readonly` gives: a disabled control is skipped in a screen reader's forms mode
+and is exempt from the contrast minimum, so a group of eight would be read as
+one operator and seven blanks.
+
+This is what CRM, Helpdesk and LMS each write by hand today through
+`#condition-conjunction`. The slot stays, for restyling the cell, but a host no longer needs
+it to get uniform behaviour, and `setGroupConjunction` is exported for a host
+that wants to write the operator from somewhere else entirely, a group header of
+its own, say:
+
+```vue
+<template #conjunction="{ conjunction, groupPath, canToggle, toggle }">
+  <Button v-if="canToggle" :label="conjunction" @click="toggle" />
+  <span v-else>{{ conjunction }}</span>
+</template>
+```
+
+Ungrouping is where the one-operator rule costs something. A nested `or` group
+spliced into an `and` parent is re-joined by the parent's operator, because that
+is the only one its new level has. That is what taking the brackets off would
+mean if the rule were written out, and the same thing the menu item says it
+does.
+
+### Rows taller than one line
+
+A row is as tall as its condition, and a condition is free to grow: a hint under
+a control, a wrapped value, a second row of inputs. The operator, the drag handle
+and the actions menu are anchored to the row's **first line** rather than centred
+in it, so a condition that grows downward does not carry its operator halfway
+down beside nothing.
+
+The first line is assumed to be one control tall, which is what the built-in leaf
+renders. A `#condition` slot that leads with something taller, say visible field
+labels above its controls, will show the operator beside that instead. Use
+`#condition-where` / `#condition-conjunction` to place it yourself in that case; they exist for it.
+
+A row holding a nested group is the one row whose first line is not at its top
+edge, and the component accounts for it: the card draws its own border and
+padding, so the first line of that row is the first rule _inside_ the card, and
+the operator, handle and menu drop to meet it. A card's operator belongs beside
+the rule it introduces, not beside the card's empty top corner. Under
+`bordered="root"` or `"none"` there is no card and so no drop.
+
+### Nesting is always inline
+
+Every group renders in place, at every depth. There is no dialog and no
+`modalDepth`: a group deep enough to be cramped is still a group on the page,
+drawn where it sits.
+
+**The cost is width, and at `maxDepth` 4 it is severe.** A nested group sits in a
+row of its parent, so each level spends that row's leading tracks before the
+group's own contents start: the conjunction cell (`minmax(66px, max-content)`),
+the drag handle (`w-4`), the two `gap-x-2`s between them, and, under
+`bordered="all"`, the card's own `border` and `p-3`. That is **111px of start
+edge per level**, and the innermost leaf row then spends another 98px on its own
+conjunction cell and handle before its field control begins.
+
+At the default `maxDepth` of 4 that is roughly **540px gone before the deepest
+row's first cell**, with the card paddings taking another ~50px off the end. In
+a form column around 600px wide there is nothing left: the three content-sized
+cells collapse to their `minmax(0, …)` floor and the row wraps rather than
+overflowing. This is exactly the problem `modalDepth` existed to solve, and
+removing it is a deliberate trade. The component stops carrying a second
+rendering mode, and a host that needs the width back has three ways to get it:
+lower `maxDepth`, set `bordered="root"` or `"none"` (which returns the 26px per
+level the cards cost), or wrap the whole builder in a dialog of its own. The
+last is a host's answer to "this form is too narrow", not a mode here with its
+own answers for focus, teleporting, and what a drag may cross.
+
+**Opening a deep group in a dialog is a host recipe now, rather than a prop.**
+`#group` hands the host the default rendering as a component, so the host writes
+the dialog it wants and puts the real group in its body: the same tree, the same
+context, the same announcements, and not a second builder.
+
+Render the tree in **tiers** and the width cost stops compounding. At a tier of
+3, depths 0-2 are on the page, a group at depth 3 opens a dialog holding 3-5,
+and one at depth 6 opens another holding 6-8. Each dialog starts back at the
+left edge, so no row is indented more than one tier, which is what makes
+`maxDepth: 8` usable.
+
+```vue
+<script setup lang="ts">
+/** How many levels share one surface. Host state, not a prop. */
+const tier = 3
+
+/** True only where a tier starts: one dialog per tier, not one per level. */
+const startsTier = (depth: number) => depth % tier === 0
+
+/**
+ * The open tiers, outermost first. A STACK, not a single path: a tier past the
+ * second is opened from INSIDE the dialog of the tier above it, so writing one
+ * path would close that dialog, and with it the button just clicked. The inner
+ * dialog appears to shut the instant it opens.
+ */
+const openTiers = ref<string[]>([])
+const key = (path: number[]) => path.join(".")
+
+const isTierOpen = (path: number[]) => openTiers.value.includes(key(path))
+
+function openTier(path: number[]) {
+  if (!isTierOpen(path)) openTiers.value = [...openTiers.value, key(path)]
+}
+
+/** Closing a tier closes every tier opened from inside it. */
+function setTierOpen(path: number[], open: boolean) {
+  if (open) return openTier(path)
+  const at = openTiers.value.indexOf(key(path))
+  if (at !== -1) openTiers.value = openTiers.value.slice(0, at)
+}
+</script>
+
+<template>
+  <ConditionBuilder v-model="tree" :fields="fields" :max-depth="8" bordered="root">
+    <template #group="{ path, depth, Group }">
+      <component :is="Group" v-if="!startsTier(depth)" />
+
+      <template v-else>
+        <Button label="Open nested conditions" @click="openTier(path)" />
+        <!-- The Dialog goes INSIDE the slot. It teleports its DOM to <body>, but
+             Vue resolves provide/inject up the component tree rather than the
+             DOM, so the group inside it is still inside this builder. Stashing
+             `Group` in a ref and rendering it outside the builder throws. -->
+        <Dialog
+          :open="isTierOpen(path)"
+          :title="`Depths ${depth}-${depth + tier - 1}`"
+          size="3xl"
+          @update:open="setTierOpen(path, $event)"
+        >
+          <component :is="Group" />
+        </Dialog>
+      </template>
+    </template>
+  </ConditionBuilder>
+</template>
+```
+
+Three things the recipe does not get for free, and they are exactly what a prop
+here would have had to answer the same way for every host:
+
+- The operator beside a collapsed group drops 13px under `bordered="all"`, which
+  is the card's border and padding. The component cannot know the slot stopped
+  drawing a card. `bordered="root"` or `"none"` removes the drop.
+- A collapsed group's list is not in the DOM, so nothing can be dragged into it
+  until it is open. Tiering makes this cheaper than a dialog per level: there is
+  one boundary every `tier` levels rather than one at every level past a
+  threshold.
+- The builder's `role="status"` region is outside the dialog, and `aria-modal`
+  hides it while the dialog is open. A host that needs edits made inside the
+  dialog announced puts its own live region in it.
+- Tiers nest, so the open ones are a stack. reka-ui's `DialogRoot` handles the
+  nesting and each layer keeps its own focus trap, but the host owns the state:
+  hold one path and opening an inner tier unmounts the outer dialog rendering
+  it, which reads as the inner dialog closing the moment it opens.
+
+## Reordering
+
+`reorderable: true` puts a drag handle beside the operator, and a drag announces
+where the row came from and where it landed. It is off by default, so a flat
+filter does not have to opt out.
+
+Dragging is the only built-in path, so it is pointer-only. `#condition-actions` is handed
+`moveUp` / `moveDown` and their guards, so a host that needs a keyboard path puts
+its own items in that menu; they run the same edit and announce the same
+sentence.
+
+A move within a group cannot change what a rule matches. The group's one
+operator joins every pair alike, so every arrangement of `A or B or C` is still
+`A or B or C`. There is no gap for a reorder to re-point.
+
+### Rows move between groups
+
+A row can also be dragged **out** of its group: into a sibling group, into a
+nested one, or back out to an ancestor. Every list in one builder shares a
+Sortable group named after the builder, so two builders on a page cannot
+exchange rows.
+
+Reparenting does change what a rule matches, since the row is joined by its new
+group's operator rather than its old one. That is the edit, not a side effect.
+It is what dropping a rule inside a bracket means.
+
+Three things refuse a drop, and they refuse it **during** the drag, so there is
+no drop indicator and nothing lands and snaps back:
+
+- a drop whose subtree would sit deeper than `maxDepth`. The whole subtree
+  travels, so a group two levels deep needs two levels of room, not one; a leaf
+  adds no level and is never refused on depth.
+- a group dropped into itself or into anything it contains, which would detach
+  that subtree from the tree entirely.
+- anything, while `reorderable` is false. It turns off dragging between groups
+  as well as within them, since both are this one edit.
+
+A group left empty by a row leaving goes, cascading up, exactly as it does when
+its last row is removed. The root never goes: an empty root is the empty state.
+
+Grouping is still an explicit `Turn into a Group` / `Add Condition Group`.
+Dropping a row **on** a nested group's card does not put it inside; you drop it
+into the card's list.
+
+A drop is announced like a menu move, except that a reparent says it landed in
+another group rather than naming two positions: the position it left is in a
+group the row is no longer in, and reading it out beside the new one would
+describe a reorder that did not happen.
+
+## Operators
+
+Reading is wider than writing: the reader accepts every operator the stored
+format can hold, and a leaf keeps a stored operator in its own dropdown even
+when the field's own operator list would not offer it today, so a saved rule is
+always legible, and is only rewritten deliberately.
+
+Writing is narrower than `Filter`'s list. `is not` is offered because the host's
+compiler implements it; `timespan` is withheld because the host's compiler has
+no rule for it and would emit an expression that raises whenever the rule runs.
+
+## Persisting
+
+Frappe's Assignment Rule and SLA condition fields store an array that interleaves
+conjunctions between conditions. Convert at the persistence boundary:
+
+```ts
+import {
+  fromFrappeConditions,
+  toFrappeConditions,
+} from "@framework/ui/ConditionBuilder";
+
+const tree = fromFrappeConditions(JSON.parse(doc.assign_condition_json || "[]"));
+doc.assign_condition_json = JSON.stringify(toFrappeConditions(tree));
+```
+
+Separator tokens are matched case-insensitively, since a record hand-edited or
+written by another tool can carry `"OR"`, and reading that as an operand would
+invert the rule.
+
+### Reading a mixed record changes what it means
+
+The stored array carries a token per gap, so it **can** hold `A and B or C`. A
+group holds one token and cannot. **On read, the first separator token on a
+level wins and every other one is discarded**, so a record stored as
+`A and B or C` loads, and the next save writes back, as `A and B and C`. It now
+means something different, and nothing on screen says so: the rule looks like
+the one the record holds.
+
+That is accepted, not an oversight. The alternative is either reshaping a mixed
+level into nested groups nobody authored, or a second editing model for a shape
+the component no longer offers a way to create. Frappe's own editors write
+uniform levels, so what reaches this is a record hand-edited, written by another
+tool, or written by an earlier version of this component. A host with such
+records to protect should compare `toFrappeConditions(fromFrappeConditions(x))`
+against `x` before saving, and prompt rather than write.
+
+The expression is compiled from the array the tree writes, so the two halves of
+a record still agree with each other after a save. They just no longer agree
+with what was stored.
+
+An entry that cannot be parsed as a condition is **dropped**, along with the
+conjunction beside it: an unknown operator, a doctype-qualified filter, a stray
+`null`, a number or a token between two filters. The tree is what the editor
+shows and what the next save writes, so such an entry is gone from the record
+rather than carried through it. Nothing it could do instead is honest: it has no
+row to render, no Python to compile to, and leaving it in the array while the
+expression omits it makes the two halves of a record disagree.
+
+Two things are dropped rather than written: an empty group, and a row the user
+added but never gave a field to. Neither holds a condition, so both are
+lossless, and both would otherwise be written as an entry the host's compiler cannot
+destructure into a field, an operator and a value.
+
+A stored `==`, `=` or `!=` is read as an alias and re-saved in this component's
+vocabulary. No migration is needed: `equals`, `=` and `==` all compile to the
+same `==`, so the compiled expression does not change.
+
+### The expression
+
+The array is what a record stores; the Python expression is what `safe_eval`
+runs. A host writes both, and does not have to compile anything: bind the second
+v-model and the component keeps it, compiled with the fields it already derived
+from `doctype`.
+
+Both apps name a `doctype` and let Meta supply the fields. Neither hand-builds a
+`fields` array, and neither writes a compiler. What differs between them is one
+prop:
+
+```vue
+<!-- CRM, an Assignment Rule over deals -->
+<ConditionBuilder
+  v-model="tree"
+  v-model:expression="doc.assign_condition"
+  doctype="CRM Deal"
+/>
+```
+
+```vue
+<!-- Helpdesk, an SLA over tickets -->
+<ConditionBuilder
+  v-model="tree"
+  v-model:expression="doc.condition"
+  doctype="HD Ticket"
+  field-prefix="doc"
+/>
+```
+
+`fieldPrefix` is not cosmetic, and it is not a preference: it is decided by what
+the Python caller puts in scope, so read the caller before choosing it.
+
+| Host | How it evaluates | What the expression must say |
+| --- | --- | --- |
+| Assignment Rule | `safe_eval(cond, None, doc)`, where the document **is** the locals | `status == "Open"`, no prefix |
+| Notification | `safe_eval(cond, None, get_context(doc))`, a dict holding `{"doc": …}` | `doc.status == "Open"` |
+| Helpdesk SLA | the same `get_context(ticket)` shape | `doc.status == "Open"` |
+
+Get it wrong and nothing catches it: the rule saves, renders and reads back, and
+raises `NameError` only when it is finally evaluated against a real document,
+inside a `try`.
+
+The same compiler is exported for a host that needs an expression away from the
+control, say to compare what a stored array evaluates to:
+
+```ts
+import { toConditionExpression } from "@framework/ui/ConditionBuilder";
+
+// doc.status == "Open" and (doc.subject and "refund" in doc.subject)
+//   and (doc.priority == "High" or doc.priority == "Urgent")
+toConditionExpression(tree, { fieldPrefix: "doc", fields });
+```
+
+Two rules need the fields, which is why the control passes them and a bare call
+should too: a **Check** field compiles to its own truthiness (`is_open`, not
+`is_open == "Yes"`, which never matches a 0/1), and a **numeric** field compiles
+to a number (`total > 100`, not `total > "100"`, which raises rather than
+compares). Without fields both fall back to reading the value, which is what
+CRM's and Helpdesk's compilers do, and what makes a Data field holding the word
+"Yes" compile as a Check.
+
+The rules are not a `join(" and ")`. `like` compiles to a membership test
+guarded on the field, `is set` to the bare field, a Check field's `== "Yes"` to
+the bare field too, `between` to two comparisons, and `in` to a guarded list.
+A nested group is parenthesised rather than left to Python's precedence, and an
+operator with no rule, such as a legacy `timespan`, compiles to nothing rather than to
+something that changes what the rule matches without saying so. `timespan` is dropped on
+read as well, so it does not survive a round-trip through this component.
+
+The expression is compiled from the array, so the two always agree about what the
+record means: an entry dropped on read is absent from both, and a row with no
+field is written to neither.
+
+## Slots
+
+| Slot | Replaces |
+| --- | --- |
+| `#condition` | the whole row, for a leaf of your own shape |
+| `#group` | how a **nested** group renders: wrap it, or put it elsewhere |
+| `#condition-value` | only the value control inside the built-in row |
+| `#condition-where` / `#condition-conjunction` | the leading cell of a row |
+| `#condition-actions` | the row's actions: a menu, or the single action when only one applies |
+| `#add-condition` | a group's add affordance |
+| `#empty` | the empty state's content |
+
+**An empty template does not remove that furniture.** Vue renders a slot's
+fallback whenever the slot produced no vnode, so `<template #where />` puts the
+built-in cell straight back. Removing a piece takes a node that draws nothing;
+`<template #where><span /></template>` is the smallest one. And what goes is the
+content: the row still spends that cell's grid track, and the group's bracket is
+still drawn through it, since both belong to the row rather than to the cell.
+
+### `#group`
+
+The odd one out: it does not hand over a cell, it hands over a subtree. A group
+renders itself again, all the way down, and nothing a host writes can stand in
+for that, so the slot is handed the default rendering **as a component**, and
+what a host chooses is where to put it.
+
+```vue
+<template #group="{ group, path, depth, Group }">
+  <component :is="Group" v-if="depth < 2" />
+  <Button v-else :label="`${group.conditions.length} rules`" @click="open(path)" />
+</template>
+```
+
+- **The root is not passed through it.** The root group is the builder itself:
+  there is no row around it to keep and no ancestor to render it into, so a host
+  wrapping the root is wrapping the whole control, which it does where it mounts
+  it.
+- **`Group` has to be rendered inside the slot.** Vue resolves `inject` and slots
+  up the component tree rather than the DOM, so a dialog declared in the slot can
+  teleport its markup to `<body>` and the group inside it is still inside this
+  builder. Stashing `Group` in a ref and rendering it beside the builder instead
+  throws, because it is a group with no builder around it.
+- **It takes no props, and its identity is stable for as long as the row is**, so
+  an edit anywhere in the tree does not remount the subtree, and a dialog opening
+  and closing over it keeps what is inside it.
+- **An empty template renders the default group**, as it does in every other
+  slot here, since Vue falls back when a slot produces no vnode. A node that draws
+  nothing (`<span />`) renders no group at all, which leaves the group in the
+  tree, still saved, with its rows unreachable.
+- **The row around the group is not the slot's.** The and/or cell, the drag
+  handle and the `···` menu are the group's place in its parent, and stay the
+  component's; `#condition-where`, `#condition-conjunction` and `#condition-actions` are how those are
+  replaced.
+
+## Props worth knowing
+
+| Prop | Does |
+| --- | --- |
+| `expression` | write-only; `v-model:expression` gets the compiled Python |
+| `fieldPrefix` | prefixes fieldnames in that expression (`doc`), nothing on screen |
+| `columns` | the three cells' grid track sizes |
+| `maxDepth` | how deep nesting is offered (default 4) |
+| `bordered` | `all` / `root` / `none`: which groups draw a card |
+| `newCondition` | factory for a new leaf, when `#condition` is used |
+| `labels` | every string it renders, for `__()` |
+| `readonly` | nothing is editable; the tree renders as text |
+| `reorderable` | whether rows can be dragged or moved (default false) |
+| `label` / `description` / `error` / `required` | the shared labeling contract every input control in this package exposes |
+
+`readonly` shows a rule you are not editing, and is the only not-editable mode.
+There is no state between it and a live builder: a form that wants its rows
+fixable but not extendable, say one failing validation, puts its own control
+in `#add-condition` and disables that. The reach is the same, and what "cannot be
+extended" means stays the host's sentence rather than a second half-editable mode
+here with its own answer for every menu item.
+
+One add affordance is outside that slot: the empty state's button, which is what
+shows when there is no group to hang `#add-condition` on. A host blocking adds on
+an empty tree has nothing to replace, so it renders no builder until it does.
+
+## Accessibility
+
+- A group is a `<fieldset>` at the root and `role="group"` nested, named from its
+  own conjunction. Nested `<legend>`s are read before every control, and a
+  fixed name would state the opposite the moment the conjunction is changed. One
+  operator per group is what makes that name honest for every row under it, and
+  what reduces the vocabulary to "match all" and "match any".
+- Only the first gap's cell is a control; the rest of the group repeats the word
+  as text rather than as disabled buttons, for the same reason `readonly` does.
+  That text is `ink-gray-6`, not the cell's `ink-gray-5`: gray-5 is 4.18:1 on
+  white at 14px, and dropping the disabled exemption is the whole point of
+  rendering it as text, so the 4.5:1 minimum has to be met once it is gone.
+- Rows are a real list, so position is announced without a name to keep in sync.
+- Every control is named by `aria-labelledby` against the row's field, so eight
+  operator selects are told apart ("Status, operator"). Attribute fallthrough is
+  not used: `Button` overwrites `aria-label` from `label`, and `Combobox` never
+  passes attrs to its trigger.
+- Removing a row moves focus to the row that took its place, and announces the
+  count, plus the cascade when the group went with it.
+- The drag handle is `aria-hidden`: it duplicates no control and names nothing.
+  **Reordering has no built-in keyboard path.** A known gap, and the reason
+  `#condition-actions` is handed `moveUp` / `moveDown`. Where a host adds them, the move
+  announces both positions (a position alone means nothing to someone who did not
+  watch it move) and returns focus to the menu it was run from.
+- `readonly` renders text rather than disabled controls: a disabled control is
+  skipped in a screen reader's forms mode and is exempt from the contrast
+  minimum, which would make a read-only tree unreadable.
+
+Known gap: the date and rating value controls drop attributes, so their cell
+carries the name instead of the control. Fixing that needs an `aria-labelledby`
+passthrough on the shared `Fields` components and frappe-ui's `DateRangePicker`.

--- a/ui/src/components/ConditionBuilder/ConditionBuilder.vue
+++ b/ui/src/components/ConditionBuilder/ConditionBuilder.vue
@@ -1,0 +1,360 @@
+<!--
+  ConditionBuilder, a controlled editor for a nested and/or condition tree. Its
+  `v-model` is the tree; it owns no data resource and never calls an app endpoint
+  (FP2). The built-in leaf's fields come from the doctype's Meta (FP3) or from an
+  explicit `fields` array. It owns the two singular things: the live region and
+  focus.
+-->
+<template>
+	<div ref="rootRef" data-slot="condition-builder" class="w-full">
+		<div
+			v-if="label"
+			:id="labelId"
+			data-slot="condition-label"
+			class="mb-1.5 text-p-sm text-ink-gray-5"
+		>
+			{{ label }}
+			<span v-if="required" aria-hidden="true" class="text-ink-red-6">*</span>
+			<span v-if="required" class="sr-only">(required)</span>
+		</div>
+
+		<div
+			v-if="description"
+			:id="descriptionId"
+			data-slot="condition-description"
+			class="mb-2 text-p-sm text-ink-gray-5"
+		>
+			{{ description }}
+		</div>
+
+		<div role="status" aria-live="polite" aria-atomic="true" class="sr-only">
+			{{ announcement }}
+		</div>
+
+		<div
+			v-if="fieldsError"
+			data-slot="condition-fields-error"
+			class="mb-4 flex items-center gap-2 rounded-md bg-surface-red-2 p-2 text-p-sm text-ink-red-6"
+		>
+			<span :id="fieldsErrorId" class="min-w-0 flex-1">{{ labels.fieldsError }}</span>
+			<Button
+				:label="labels.retryFields"
+				:aria-labelledby="`${retryId} ${fieldsErrorId}`"
+				@click="reloadFields"
+			/>
+			<span :id="retryId" class="sr-only">{{ labels.retryFields }}</span>
+		</div>
+
+		<!-- One element, not a button and a div: only the tag and the click differ,
+		and the fallback content was written twice. A read-only empty state still
+		takes focus, through tabindex, without claiming to be a button. -->
+		<component
+			:is="readonly ? 'div' : 'button'"
+			v-if="isEmpty"
+			data-slot="condition-empty"
+			:type="readonly ? undefined : 'button'"
+			:tabindex="readonly ? -1 : undefined"
+			class="flex w-full items-center justify-center gap-2 rounded-md border border-outline-gray-2 p-4 text-p-sm text-ink-gray-5"
+			:class="!readonly && 'cursor-pointer'"
+			@click="onEmptyClick"
+		>
+			<slot name="empty">
+				<span class="lucide-plus size-4" aria-hidden="true" />
+				{{ labels.empty }}
+			</slot>
+		</component>
+
+		<div
+			v-else
+			class="flex w-full flex-col gap-4"
+			:class="bordered !== 'none' && 'rounded-lg border border-outline-gray-2 p-3'"
+		>
+			<ConditionGroup :group="tree" :path="[]">
+				<template v-if="$slots.condition" #condition="slotProps">
+					<slot name="condition" v-bind="asConditionSlotProps(slotProps)" />
+				</template>
+				<template v-if="$slots.group" #group="groupSlot">
+					<slot name="group" v-bind="asGroupSlotProps(groupSlot)" />
+				</template>
+				<template v-if="$slots['condition-value']" #condition-value="valueProps">
+					<slot name="condition-value" v-bind="valueProps" />
+				</template>
+				<template v-if="$slots['condition-where']" #condition-where="whereSlot">
+					<slot name="condition-where" v-bind="whereSlot" />
+				</template>
+				<template v-if="$slots['condition-conjunction']" #condition-conjunction="conjSlot">
+					<slot name="condition-conjunction" v-bind="conjSlot" />
+				</template>
+				<template v-if="$slots['condition-actions']" #condition-actions="actionsSlot">
+					<slot name="condition-actions" v-bind="actionsSlot" />
+				</template>
+				<template v-if="$slots['add-condition']" #add-condition="addSlot">
+					<slot name="add-condition" v-bind="addSlot" />
+				</template>
+			</ConditionGroup>
+		</div>
+
+		<div
+			v-if="errorText"
+			:id="errorId"
+			data-slot="condition-error"
+			class="mt-2 text-p-sm text-ink-red-6"
+		>
+			{{ errorText }}
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts" generic="TLeaf = FieldConditionValue">
+import { computed, nextTick, provide, ref, useId, watch } from "vue";
+import { Button } from "frappe-ui";
+import ConditionGroup from "./ConditionGroup.vue";
+import { useConditionFields } from "./internal/fields";
+import {
+	focusAfterAdd,
+	focusAfterAddGroup,
+	focusAfterRemove,
+	useConditionFocus,
+} from "./internal/focus";
+import {
+	conditionBuilderKey,
+	DEFAULT_BORDERS,
+	DEFAULT_MAX_DEPTH,
+	DEFAULT_REORDERABLE,
+	mergeColumns,
+	mergeLabels,
+	uncachedLabels,
+} from "./internal/context";
+import {
+	addCondition as addConditionAt,
+	addGroup as addGroupAt,
+	canMoveInto,
+	countConditions,
+	countGroups,
+	emptyTree,
+	getNode,
+	isGroup,
+	moveNode,
+	removeNode,
+	samePath,
+	setGroupConjunction,
+	turnIntoGroup as turnIntoGroupAt,
+	ungroup as ungroupAt,
+	updateLeaf,
+} from "./tree";
+import type {
+	ConditionBuilderProps,
+	ConditionBuilderSlots,
+	ConditionField,
+	ConditionGroup as ConditionGroupType,
+	ConditionPath,
+	ConditionSlotProps,
+	Conjunction,
+	FieldConditionValue,
+	GroupSlotProps,
+} from "./types";
+
+// Declared explicitly: the slots are forwarded down the tree, not rendered
+// here, so vue-component-meta cannot infer them.
+defineSlots<ConditionBuilderSlots<TLeaf>>();
+
+// ConditionGroup types its slots as `unknown` to break a recursive inference
+// cycle, so re-forwarding needs a cast back.
+function asConditionSlotProps(slotProps: ConditionSlotProps<unknown>): ConditionSlotProps<TLeaf> {
+	return slotProps as ConditionSlotProps<TLeaf>;
+}
+
+function asGroupSlotProps(slotProps: GroupSlotProps<unknown>): GroupSlotProps<TLeaf> {
+	return slotProps as GroupSlotProps<TLeaf>;
+}
+
+const props = withDefaults(defineProps<ConditionBuilderProps<TLeaf>>(), {
+	maxDepth: DEFAULT_MAX_DEPTH,
+	bordered: DEFAULT_BORDERS,
+	readonly: false,
+	reorderable: DEFAULT_REORDERABLE,
+});
+
+const emit = defineEmits<{
+	"update:modelValue": [value: ConditionGroupType<TLeaf>];
+	"update:expression": [value: string];
+}>();
+
+const rootRef = ref<HTMLElement | null>(null);
+const id = useId();
+const fieldsErrorId = useId();
+const labelId = useId();
+const descriptionId = useId();
+const errorId = useId();
+
+// `error` takes a string or an Error, per the shared contract.
+const errorText = computed(() =>
+	props.error instanceof Error ? props.error.message : props.error
+);
+const retryId = useId();
+
+// The row a drag is carrying, for as long as it is carrying it. Lives here so
+// every group sees the same one; see `dragFrom` on the context.
+const dragFrom = ref<ConditionPath | null>(null);
+
+const { moveFocus, focusAfterMenuCloses } = useConditionFocus(id, rootRef);
+
+// Controlled outright. A host that drops the event renders a tree that does not
+// move.
+const tree = computed<ConditionGroupType<TLeaf>>(() => props.modelValue ?? emptyTree<TLeaf>());
+
+// See `uncachedLabels`: a `computed` would freeze the labels in whatever
+// language was current at first render.
+const labels = uncachedLabels(() => mergeLabels(props.labels));
+const columns = computed(() => mergeColumns(props.columns));
+const isEmpty = computed(() => tree.value.conditions.length === 0);
+
+const { fields, fieldsLoading, fieldsError, reloadFields } = useConditionFields(
+	props,
+	tree,
+	(value) => emit("update:expression", value)
+);
+
+const announcement = ref("");
+let pending: string[] = [];
+
+// Cleared first so the same message twice is still a change; messages in one
+// tick are joined.
+function announce(message: string) {
+	pending.push(message);
+	announcement.value = "";
+	nextTick(() => {
+		if (pending.length === 0) return;
+		announcement.value = pending.join(" ");
+		pending = [];
+	});
+}
+
+// Announced so a second failure after a retry is announced too.
+watch(fieldsError, (error) => {
+	if (error) announce(labels.value.fieldsError);
+});
+
+function newLeaf(): TLeaf {
+	if (props.newCondition) return props.newCondition();
+	return { fieldname: "", operator: "equals", value: "" } as TLeaf;
+}
+
+function commit(next: ConditionGroupType<TLeaf>) {
+	emit("update:modelValue", next);
+}
+
+function onEmptyClick() {
+	if (!props.readonly) addCondition([]);
+}
+
+/** Append a condition to the group at `path` and put focus in it. */
+function addCondition(path: ConditionPath) {
+	const next = addConditionAt(tree.value, path, newLeaf());
+	commit(next);
+	moveFocus(focusAfterAdd(next, path), "add");
+}
+
+provide(conditionBuilderKey, {
+	builderId: computed(() => id),
+	labelId: computed(() => (props.label ? labelId : "")),
+	// Both, in reading order, so a screen reader gets the description before the
+	// error rather than in id order.
+	describedBy: computed(() =>
+		[props.description ? descriptionId : "", errorText.value ? errorId : ""]
+			.filter(Boolean)
+			.join(" ")
+	),
+	invalid: computed(() => Boolean(errorText.value)),
+	fields,
+	fieldsLoading,
+	fieldsError,
+	reloadFields,
+	columns,
+	labels,
+	bordered: computed(() => props.bordered),
+	maxDepth: computed(() => props.maxDepth),
+	readonly: computed(() => props.readonly),
+	reorderable: computed(() => props.reorderable),
+
+	addCondition,
+	addGroup: (path: ConditionPath) => {
+		const next = addGroupAt(tree.value, path, newLeaf());
+		commit(next);
+		moveFocus(focusAfterAddGroup(next, path), "add");
+	},
+	remove: (path: ConditionPath) => {
+		const removed = getNode(tree.value, path);
+		const groupsBefore = countGroups(tree.value);
+		const next = removeNode(tree.value, path);
+		commit(next);
+		// Only a removed condition counts: removing a group is meant to take
+		// one.
+		const cascaded =
+			removed !== undefined && !isGroup(removed) && countGroups(next) < groupsBefore;
+		announce(labels.value.removed(countConditions(next), cascaded));
+		moveFocus(focusAfterRemove(next, path), "remove");
+	},
+	update: (path: ConditionPath, leaf: unknown) =>
+		commit(updateLeaf(tree.value, path, leaf as TLeaf)),
+	turnIntoGroup: (path: ConditionPath) => commit(turnIntoGroupAt(tree.value, path)),
+	// The group's row goes with the menu, so focus lands as a removal places
+	// it.
+	ungroup: (path: ConditionPath) => {
+		const next = ungroupAt(tree.value, path);
+		commit(next);
+		moveFocus(focusAfterRemove(next, path), "remove");
+	},
+	setConjunction: (path: ConditionPath, value: Conjunction) =>
+		commit(setGroupConjunction(tree.value, path, value)),
+	// A reorder keeps every path valid: only the two swapped rows change.
+	move: (
+		path: ConditionPath,
+		from: number,
+		to: number,
+		options?: { name?: string; focus?: boolean }
+	) => {
+		const group = getNode(tree.value, path);
+		if (group === undefined || !isGroup(group)) return;
+		const total = group.conditions.length;
+		if (from === to || from < 0 || to < 0 || from >= total || to >= total) return;
+
+		commit(moveNode(tree.value, [...path, from], path, to, props.maxDepth));
+		announce(labels.value.moved(options?.name ?? "", from + 1, to + 1, total));
+		// Onto the row's menu at its new position, outlasting the menu it ran
+		// from, which restores focus to the row this one displaced.
+		if (options?.focus !== false) focusAfterMenuCloses([...path, to]);
+	},
+	canDrop: (from: ConditionPath, toGroupPath: ConditionPath) =>
+		canMoveInto(tree.value, from, toGroupPath, props.maxDepth),
+	dragFrom,
+	// Counts are read before the edit, which re-points the paths.
+	moveInto: (
+		from: ConditionPath,
+		toGroupPath: ConditionPath,
+		toIndex: number,
+		options?: { name?: string }
+	) => {
+		if (!canMoveInto(tree.value, from, toGroupPath, props.maxDepth)) return;
+
+		const target = getNode(tree.value, toGroupPath);
+		if (target === undefined || !isGroup(target)) return;
+
+		const sameGroup = samePath(from.slice(0, -1), toGroupPath);
+		const total = target.conditions.length + (sameGroup ? 0 : 1);
+		const name = options?.name ?? "";
+
+		commit(moveNode(tree.value, from, toGroupPath, toIndex, props.maxDepth));
+
+		// A reparent cannot name where it came from: that position is in a
+		// group the row has left.
+		announce(
+			sameGroup
+				? labels.value.moved(name, from[from.length - 1] + 1, toIndex + 1, total)
+				: labels.value.movedToGroup(name, toIndex + 1, total)
+		);
+		// No focus is placed: the pointer took none.
+	},
+	announce,
+});
+</script>

--- a/ui/src/components/ConditionBuilder/ConditionGroup.vue
+++ b/ui/src/components/ConditionBuilder/ConditionGroup.vue
@@ -1,0 +1,422 @@
+<!--
+  One group of conditions, rendering its children and itself again for a nested
+  group. The root is a `<fieldset>` with a hidden `<legend>`; nested groups use
+  `role="group"`. `role="list"` stays explicit: WebKit drops list semantics under
+  `list-style: none`, taking the item count with it.
+-->
+<template>
+	<component
+		:is="rootTag"
+		data-slot="condition-group"
+		:data-depth="path.length"
+		:role="rootTag === 'fieldset' ? undefined : 'group'"
+		:aria-label="rootTag === 'fieldset' ? undefined : groupName"
+		:aria-labelledby="labelledBy"
+		:aria-describedby="describedBy || undefined"
+		:aria-invalid="invalid || undefined"
+		class="flex w-full min-w-0 flex-col gap-4"
+		:class="hasCard && 'rounded-lg border border-outline-gray-2 bg-surface-white p-3'"
+	>
+		<legend v-if="rootTag === 'fieldset'" :id="legendId" class="sr-only">
+			{{ groupName }}
+		</legend>
+
+		<!-- Each row carries its own grid rather than sharing one with its
+		siblings: a shared grid sizes every track from the widest cell in the
+		group. What the rows do share is their end edge, so the actions line up.
+
+		`ghost-class` marks the slot the row would land in; the fill marks every
+		list that would take it, and a list left unfilled is one that refuses.
+
+		Nothing may sit between this tag and its `#item` template: vuedraggable's
+		`computeNodes` requires that slot to render exactly one node, and a comment
+		counts as a second one. -->
+		<Draggable
+			v-if="group.conditions.length"
+			:model-value="group.conditions"
+			:item-key="keyOf"
+			:disabled="!canReorder"
+			:group="sortableGroup"
+			handle=".condition-drag-handle"
+			tag="ul"
+			role="list"
+			:data-group-path="path.join('.')"
+			:data-condition-builder="builderId"
+			class="flex w-full min-w-0 list-none flex-col gap-4 rounded-md"
+			:class="canTakeDrag && 'bg-surface-gray-2'"
+			ghost-class="opacity-40"
+			chosen-class="cursor-grabbing"
+			@start="onDragStart"
+			@end="onDragEnd"
+		>
+			<template #item="{ element: condition, index }">
+				<li
+					class="group/row grid min-w-0 items-start gap-x-2"
+					:style="{ gridTemplateColumns: trackListFor(condition) }"
+					:data-condition-path="[...path, index].join('.')"
+					:data-condition-builder="builderId"
+				>
+					<!-- The row owns the leading cell, not what goes in it. The band
+					is one control tall and centres its content, so a bare word lines
+					up with the controls beside it instead of sitting above them, and
+					it grows if the host's cell is taller. The bracket is drawn here
+					for the same reason: it spans the row, and replacing the cell
+					should not erase it. -->
+					<ConditionRule
+						:index="index"
+						:count="group.conditions.length"
+						:offset="firstLineOffset(condition)"
+					>
+						<div
+							class="flex min-h-7 items-center justify-center"
+							:style="firstLineStyle(condition)"
+						>
+							<slot v-if="index === 0" name="condition-where" v-bind="whereProps()">
+								<ConjunctionCell v-bind="cellProps(index)" />
+							</slot>
+							<slot
+								v-else
+								name="condition-conjunction"
+								v-bind="conjunctionProps(index)"
+							>
+								<ConjunctionCell v-bind="cellProps(index)" />
+							</slot>
+						</div>
+					</ConditionRule>
+
+					<!-- Pointer-only, and hidden from assistive tech: it duplicates no
+					control, so there is nothing for it to name. A keyboard path to
+					the same edit goes in `#condition-actions`. -->
+					<div
+						v-if="canReorder"
+						class="condition-drag-handle flex h-7 w-5 cursor-grab items-center justify-center active:cursor-grabbing"
+						:style="firstLineStyle(condition)"
+						aria-hidden="true"
+					>
+						<span
+							class="lucide-grip-vertical size-4 text-ink-gray-4 transition-colors motion-reduce:transition-none group-hover/row:text-ink-gray-6"
+						/>
+					</div>
+
+					<!-- A card gets a row of its own shape: one stretching track, so
+					it runs to the end of the row rather than to wherever three
+					content-sized cells stop.
+
+					`#group` wraps what goes in that cell and is handed the default
+					rendering as a component, so a host can put the real group
+					elsewhere, a dialog body most of all. The fallback renders that
+					same component. The row around it is not the slot's: `#condition-where`,
+					`#condition-conjunction` and `#condition-actions` replace those. -->
+					<template v-if="isGroup(condition)">
+						<div class="min-w-0">
+							<slot name="group" v-bind="groupSlotProps(condition, index)">
+								<component :is="groupRenderer(index)" />
+							</slot>
+						</div>
+					</template>
+
+					<ConditionRow
+						v-else
+						:condition="condition"
+						:path="[...path, index]"
+						:field-label-id="rowFieldId(index)"
+					>
+						<template v-if="$slots.condition" #condition="slotProps">
+							<slot name="condition" v-bind="slotProps" />
+						</template>
+						<template v-if="$slots['condition-value']" #condition-value="valueProps">
+							<slot name="condition-value" v-bind="valueProps" />
+						</template>
+					</ConditionRow>
+
+					<!-- The same first-line band as the leading cell, so `#condition-actions` is
+					level with the controls rather than with the top of a grown row. -->
+					<div
+						class="flex min-h-7 items-center justify-end justify-self-end"
+						:style="firstLineStyle(condition)"
+					>
+						<slot
+							name="condition-actions"
+							v-bind="actionsProps(index, isGroup(condition))"
+						>
+							<ConditionActions
+								:path="[...path, index]"
+								:is-group="isGroup(condition)"
+								:field-label-id="rowFieldId(index)"
+							/>
+						</slot>
+					</div>
+
+					<span :id="rowFieldId(index)" class="sr-only">
+						{{ leafFieldLabel(condition) }}
+					</span>
+				</li>
+			</template>
+		</Draggable>
+
+		<div
+			v-if="!readonly"
+			class="flex"
+			:data-add-group="path.join('.')"
+			:data-condition-builder="builderId"
+		>
+			<slot name="add-condition" v-bind="addConditionProps()">
+				<AddConditionButton :path="path" :can-add-group="canAddGroup" />
+			</slot>
+		</div>
+	</component>
+</template>
+
+<script setup lang="ts">
+import { computed, defineComponent, getCurrentInstance, h, useId, useSlots } from "vue";
+import type { Component, Slot } from "vue";
+// @ts-ignore, vuedraggable ships no bundled types
+import Draggable from "vuedraggable";
+import AddConditionButton from "./AddConditionButton.vue";
+import ConditionActions from "./ConditionActions.vue";
+import ConditionRow from "./ConditionRow.vue";
+import ConditionRule from "./ConditionRule.vue";
+import ConjunctionCell from "./ConjunctionCell.vue";
+import { useConditionBuilderContext } from "./internal/context";
+import { useDragBridge } from "./internal/dragBridge";
+import { useConditionLayout } from "./internal/layout";
+import { canNest, isGroup, samePath } from "./tree";
+import type {
+	ActionsSlotProps,
+	AddConditionSlotProps,
+	ConditionBuilderSlots,
+	ConditionGroup as ConditionGroupType,
+	ConditionPath,
+	ConjunctionSlotProps,
+	Conjunction,
+	FieldConditionValue,
+	GroupSlotProps,
+	WhereSlotProps,
+} from "./types";
+
+defineOptions({ name: "ConditionGroup" });
+
+const props = defineProps<{
+	group: ConditionGroupType<unknown>;
+	path: ConditionPath;
+}>();
+
+// Explicit slot types break the inference cycle self-recursion creates.
+type GroupSlots = Omit<ConditionBuilderSlots<unknown>, "empty">;
+
+defineSlots<GroupSlots>();
+
+const context = useConditionBuilderContext();
+const slots = useSlots();
+const rowIdPrefix = useId();
+
+const builderId = computed(() => context.builderId.value);
+const readonly = computed(() => context.readonly.value);
+
+const canAddGroup = computed(() => canNest(props.path, context.maxDepth.value));
+
+/** Whether this group's rows can be dragged. A read-only tree cannot be edited at all. */
+const canReorder = computed(() => context.reorderable.value && !readonly.value);
+
+const { trackListFor, firstLineOffset, firstLineStyle } = useConditionLayout(
+	context.columns,
+	context.bordered,
+	canReorder
+);
+
+const { sortableGroup, canTakeDrag, onDragStart, onDragEnd } = useDragBridge(
+	context,
+	computed(() => props.path),
+	computed(() => props.group),
+	leafFieldLabel
+);
+
+/**
+ * Keyed by index, so a row's DOM and the focus inside it survive an edit.
+ * Keying by identity would remount every row on every keystroke.
+ */
+function keyOf(node: unknown): number {
+	return props.group.conditions.indexOf(node);
+}
+
+// Only nested groups draw a card; the root's border is the builder's.
+const isNested = computed(() => props.path.length > 0);
+const hasCard = computed(() => isNested.value && context.bordered.value === "all");
+
+// A `<fieldset>` groups form controls, and a read-only tree has none.
+const rootTag = computed(() => (!isNested.value && !readonly.value ? "fieldset" : "div"));
+
+const legendId = useId();
+
+// The host's label names the whole control, and the legend still says how this
+// level joins. Both, in that order, so the name reads "Conditions, match all".
+// Only the root carries them: a nested group is named by its own conjunction.
+const labelledBy = computed(() => {
+	if (isNested.value || !context.labelId.value) return undefined;
+	return `${context.labelId.value} ${legendId}`;
+});
+const describedBy = computed(() => (isNested.value ? "" : context.describedBy.value));
+const invalid = computed(() => !isNested.value && context.invalid.value);
+
+/** The group's operator, which every row after the first shows. */
+const conjunction = computed<Conjunction>(() => props.group.conjunction ?? "and");
+
+// A group's conjunction is otherwise conveyed only by a button between rows.
+const groupName = computed(() =>
+	conjunction.value === "or" ? context.labels.value.matchAny : context.labels.value.matchAll
+);
+
+/**
+ * Exactly one cell per group is live: row 1. The rest render as text, not
+ * disabled buttons, which a screen reader skips in forms mode and which is
+ * exempt from the contrast minimum.
+ */
+function canToggleAt(index: number): boolean {
+	return index === 1 && !readonly.value;
+}
+
+/** Id of the span holding a row's field label, which names its controls. */
+function rowFieldId(index: number): string {
+	return `${rowIdPrefix}-${index}`;
+}
+
+/**
+ * Every control in a row is named after it, so eight operator selects are told
+ * apart. Duck-typed on `fieldname`, so a custom leaf is labelled too.
+ */
+function leafFieldLabel(node: unknown): string {
+	const fields = context.fields.value;
+	if (node === null || typeof node !== "object") return "";
+	const fieldname = (node as Partial<FieldConditionValue>).fieldname;
+	if (typeof fieldname !== "string" || fieldname === "") return "";
+	return fields.find((f) => f.fieldname === fieldname)?.label ?? fieldname;
+}
+
+/** What the built-in cell needs, whichever of the two slots falls back to it. */
+function cellProps(index: number): Omit<ConjunctionSlotProps, "toggle"> {
+	return {
+		index,
+		conjunction: conjunction.value,
+		canToggle: canToggleAt(index),
+		groupPath: props.path,
+	};
+}
+
+function whereProps(): WhereSlotProps {
+	return { groupPath: props.path, conjunction: conjunction.value };
+}
+
+function conjunctionProps(index: number): ConjunctionSlotProps {
+	return { ...cellProps(index), toggle: toggleConjunction };
+}
+
+function toggleConjunction() {
+	context.setConjunction(props.path, conjunction.value === "and" ? "or" : "and");
+}
+
+function actionsProps(index: number, group: boolean): ActionsSlotProps {
+	const path = [...props.path, index];
+	const last = props.group.conditions.length - 1;
+	return {
+		path,
+		isGroup: group,
+		readonly: readonly.value,
+		canGroup: !group && canNest(props.path, context.maxDepth.value),
+		canMoveUp: canReorder.value && index > 0,
+		canMoveDown: canReorder.value && index < last,
+		moveUp: () => moveRow(index, index - 1),
+		moveDown: () => moveRow(index, index + 1),
+		turnIntoGroup: () => context.turnIntoGroup(path),
+		ungroup: () => context.ungroup(path),
+		remove: () => context.remove(path),
+	};
+}
+
+/** A move run from a row's menu, which keeps its focus on the way. */
+function moveRow(from: number, to: number) {
+	context.move(props.path, from, to, {
+		name: leafFieldLabel(props.group.conditions[from]),
+	});
+}
+
+function addConditionProps(): AddConditionSlotProps {
+	return {
+		groupPath: props.path,
+		addCondition: () => context.addCondition(props.path),
+		addGroup: () => context.addGroup(props.path),
+		canAddGroup: canAddGroup.value,
+	};
+}
+
+// `v-if="isGroup(...)"` does not narrow the union for vue-tsc, hence the cast.
+function asGroup(node: unknown) {
+	return node as ConditionGroupType<unknown>;
+}
+
+/**
+ * `group` is among them: a host wrapping one level expects the same at every
+ * level below.
+ */
+const FORWARDED_SLOTS = [
+	"condition",
+	"condition-value",
+	"condition-where",
+	"condition-conjunction",
+	"condition-actions",
+	"add-condition",
+	"group",
+] as const;
+
+/**
+ * `getCurrentInstance().type`, not an import: the template's self-reference is
+ * not in scope, and importing the SFC into itself is a cycle.
+ */
+const self = getCurrentInstance()?.type as Component;
+
+/**
+ * A component, not a vnode, so `<component :is>` instantiates it fresh wherever
+ * the host renders it. Cached per row index: a renderer built during render
+ * would remount the subtree on every keystroke.
+ */
+const renderers = new Map<number, Component>();
+
+function groupRenderer(index: number): Component {
+	const cached = renderers.get(index);
+	if (cached) return cached;
+
+	const renderer = defineComponent({
+		name: "ConditionGroupDefault",
+		// Read at render time, so the component survives an edit replacing the
+		// node.
+		setup: () => () => renderNestedGroup(index),
+	});
+
+	renderers.set(index, renderer);
+	return renderer;
+}
+
+/** The nested group in row `index`, with this group's slots passed down it. */
+function renderNestedGroup(index: number) {
+	const node = props.group.conditions[index];
+	if (!isGroup(node)) return null;
+
+	const forwarded: Record<string, Slot> = {};
+	for (const name of FORWARDED_SLOTS) {
+		const slot = slots[name];
+		if (slot) forwarded[name] = slot;
+	}
+
+	return h(self, { group: asGroup(node), path: [...props.path, index] }, forwarded);
+}
+
+function groupSlotProps(node: unknown, index: number): GroupSlotProps<unknown> {
+	return {
+		group: asGroup(node),
+		path: [...props.path, index],
+		// The root never reaches this slot, so depth here is 1 or more.
+		depth: props.path.length + 1,
+		readonly: readonly.value,
+		Group: groupRenderer(index),
+	};
+}
+</script>

--- a/ui/src/components/ConditionBuilder/ConditionLeaf.vue
+++ b/ui/src/components/ConditionBuilder/ConditionLeaf.vue
@@ -1,0 +1,339 @@
+<!--
+  The built-in leaf editor: field picker, operator select, value control. Every
+  rule it applies comes from the `Filter` modules rather than a second copy here
+  (FP1).
+
+  Controls are named by reference with `aria-labelledby`, the one attribute that
+  survives every atom: the field's own text plus a hidden word for the cell. The
+  controls that drop attrs get a named `role="group"` wrapper instead.
+
+  Read-only rows render as text, not disabled controls: a disabled control is
+  exempt from the contrast minimum and cannot be selected or copied.
+-->
+<template>
+	<div
+		data-slot="condition-leaf"
+		class="grid items-center gap-2"
+		style="grid-template-columns: subgrid; grid-column: span 3"
+	>
+		<div data-slot="condition-field" class="min-w-0">
+			<span v-if="readonly" class="truncate text-p-base text-ink-gray-8">
+				{{ fieldText }}
+			</span>
+			<TextInput
+				v-else-if="isFieldsUnavailable"
+				class="w-full"
+				readonly
+				:modelValue="fieldText"
+				:aria-labelledby="`${fieldTextId} ${fieldWordId}`"
+			/>
+			<Combobox
+				v-else
+				class="w-full"
+				trigger="button"
+				variant="subtle"
+				:options="fieldOptions"
+				:modelValue="condition.fieldname"
+				:placeholder="labels.field"
+				@update:selectedOption="onFieldChange"
+			>
+				<template #trigger="{ open }">
+					<Button
+						class="w-max max-w-full"
+						variant="subtle"
+						:label="fieldText || labels.field"
+						:iconRight="open ? 'lucide-chevron-up' : 'lucide-chevron-down'"
+						:aria-labelledby="`${fieldTextId} ${fieldWordId}`"
+						:aria-expanded="open"
+						aria-haspopup="listbox"
+					/>
+				</template>
+			</Combobox>
+		</div>
+
+		<div data-slot="condition-operator" class="min-w-0">
+			<span v-if="readonly" class="truncate text-p-base text-ink-gray-8">
+				{{ operatorText }}
+			</span>
+			<TextInput
+				v-else-if="!isEditable"
+				class="w-full"
+				readonly
+				:modelValue="operatorText"
+				:aria-labelledby="operatorNameIds"
+			/>
+			<Select
+				v-else
+				class="w-full"
+				:options="operators"
+				:modelValue="condition.operator"
+				:placeholder="labels.operator"
+				:aria-labelledby="operatorNameIds"
+				@update:modelValue="onOperatorChange"
+			/>
+		</div>
+
+		<div
+			data-slot="condition-value"
+			class="min-w-0"
+			:role="valueNeedsGroup ? 'group' : undefined"
+			:aria-labelledby="valueNeedsGroup ? valueNameIds : undefined"
+		>
+			<!-- The slot wraps all three states, not just the editable one: a host
+			that replaces the cell owns how its value reads when it cannot be
+			edited, and `readonly` tells it which state it is in. -->
+			<slot
+				name="condition-value"
+				:field="field"
+				:operator="condition.operator"
+				:modelValue="condition.value"
+				:readonly="!isEditable"
+				:update="onValueChange"
+			>
+				<span v-if="readonly" class="truncate text-p-base text-ink-gray-8">
+					{{ valueText }}
+				</span>
+				<TextInput
+					v-else-if="!isEditable"
+					class="w-full"
+					readonly
+					:modelValue="valueText"
+					:aria-labelledby="valueNameIds"
+				/>
+				<component
+					v-else
+					:is="VALUE_CONTROLS[control.control]"
+					v-bind="control.props"
+					class="w-full"
+					:modelValue="controlValue"
+					:aria-labelledby="valueNameIds"
+					@update:modelValue="onValueChange"
+				/>
+			</slot>
+		</div>
+
+		<span :id="fieldWordId" class="sr-only">{{ labels.field }}</span>
+		<span :id="operatorWordId" class="sr-only">{{ labels.operator }}</span>
+		<span :id="valueWordId" class="sr-only">{{ labels.value }}</span>
+		<span v-if="!fieldLabelId" :id="fieldTextId" class="sr-only">
+			{{ fieldText }}
+		</span>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed, useId } from "vue";
+import { Button, Combobox, Select, TextInput } from "frappe-ui";
+// Composed, not re-exported: none of `Filter`'s names reach this component's
+// exports. See ADR-0008.
+import { carryOver, defaultValueFor } from "../Filter/operators";
+import type { Filter } from "../Filter/types";
+import { valueControl } from "../Filter/valueControl";
+import { VALUE_CONTROLS } from "../Filter/valueControlComponents";
+import { conditionOperators } from "./adapters";
+import { useConditionBuilderContext } from "./internal/context";
+import type {
+	ConditionField,
+	ConditionOperator,
+	ConditionValue,
+	FieldConditionValue,
+} from "./types";
+
+const props = defineProps<{
+	condition: FieldConditionValue;
+
+	/** Id of the span holding this row's field label. Omitted for a standalone
+	 *  leaf. */
+	fieldLabelId?: string;
+}>();
+
+const emit = defineEmits<{ update: [value: FieldConditionValue] }>();
+
+const context = useConditionBuilderContext();
+const labels = context.labels;
+
+const fieldWordId = useId();
+const operatorWordId = useId();
+const valueWordId = useId();
+const localFieldTextId = useId();
+const fieldTextId = computed(() => props.fieldLabelId ?? localFieldTextId);
+
+const operatorNameIds = computed(() => `${fieldTextId.value} ${operatorWordId}`);
+const valueNameIds = computed(() => `${fieldTextId.value} ${valueWordId}`);
+
+const fields = computed(() => context.fields.value);
+const field = computed(() => fields.value.find((f) => f.fieldname === props.condition.fieldname));
+
+const readonly = computed(() => context.readonly.value);
+// An unmatched fieldname is unknowable while the list is in flight or failed,
+// and a deleted field once it has loaded. Neither drops the condition.
+const isFieldsUnavailable = computed(
+	() => (context.fieldsLoading.value || Boolean(context.fieldsError.value)) && !field.value
+);
+const isUnknownField = computed(
+	() => !isFieldsUnavailable.value && Boolean(props.condition.fieldname) && !field.value
+);
+
+const fieldOptions = computed(() =>
+	fields.value.map((f) => ({ label: f.label, value: f.fieldname }))
+);
+
+const offeredOperators = computed(() =>
+	conditionOperators(field.value?.fieldtype ?? "", field.value?.fieldname)
+);
+
+const operators = computed(() => {
+	const offered = offeredOperators.value;
+	const stored = props.condition.operator;
+	// A stored operator the field's list doesn't offer is appended, so the rule
+	// reads instead of rendering as a blank Select.
+	if (!stored || offered.some((option) => option.value === stored)) return offered;
+	return [...offered, { label: stored, value: stored }];
+});
+
+// A fieldtype with no operator rules reads like a deleted-field row: text, with
+// the field picker live so it can be pointed somewhere editable.
+const isUnsupportedField = computed(
+	() => Boolean(field.value) && offeredOperators.value.length === 0
+);
+
+// The operator and value cells need a field to have any rules behind them.
+const isEditable = computed(
+	() =>
+		!readonly.value &&
+		!isFieldsUnavailable.value &&
+		!isUnknownField.value &&
+		!isUnsupportedField.value &&
+		Boolean(field.value)
+);
+
+// The condition as `Filter` sees it: the same three values plus the Meta, which
+// is all its rules need.
+const filterCondition = computed<Filter>(() => ({
+	fieldname: props.condition.fieldname,
+	operator: props.condition.operator,
+	value: props.condition.value as Filter["value"],
+	field: field.value,
+}));
+
+const control = computed(() => valueControl(filterCondition.value));
+
+// The date pickers render inside a Popover, `MultiSelect` reads only class and
+// style, and the rating widget has no single element to name.
+const UNNAMEABLE_CONTROLS = [
+	"date",
+	"datetime",
+	"dateRange",
+	"rating",
+	"multiSelect",
+	"multiLink",
+];
+const valueNeedsGroup = computed(
+	() => isEditable.value && UNNAMEABLE_CONTROLS.includes(control.value.control)
+);
+
+// Controls that take and emit `string[]`: both coerce a non-array to `[]`, so a
+// stored comma string is dropped the moment the row is touched.
+const ARRAY_CONTROLS = ["multiSelect", "multiLink"];
+
+/** The field's own option list, where the fieldtype has a fixed one. Empty for
+ *  a Link, whose values are not enumerable here. */
+const knownOptions = computed<Set<string>>(() => {
+	const options = field.value?.options;
+	if (control.value.control !== "multiSelect" || typeof options !== "string") {
+		return new Set();
+	}
+	return new Set(
+		options
+			.split("\n")
+			.map((option) => option.trim())
+			.filter(Boolean)
+	);
+});
+
+/**
+ * Persisted as a comma string while the multi-value controls take arrays. A
+ * whole string that is itself a known option wins over splitting, since a value
+ * may contain a comma.
+ */
+const controlValue = computed<ConditionValue>(() => {
+	const value = props.condition.value;
+	if (!ARRAY_CONTROLS.includes(control.value.control)) return value;
+	if (Array.isArray(value)) return value;
+	if (typeof value !== "string" || value === "") return [];
+
+	const known = knownOptions.value;
+	if (known.has(value.trim())) return [value.trim()];
+
+	const parts = value
+		.split(",")
+		.map((part) => part.trim())
+		.filter(Boolean);
+
+	// One unrecognised part means the comma was inside a value, not between two.
+	if (known.size > 0 && parts.some((part) => !known.has(part))) {
+		return [value.trim()];
+	}
+	return parts;
+});
+
+const fieldText = computed(() => {
+	if (field.value) return field.value.label;
+	return props.condition.fieldname;
+});
+
+const operatorText = computed(() => {
+	if (!props.condition.fieldname) return "";
+	const known = operators.value.find((o) => o.value === props.condition.operator);
+	return known?.label ?? props.condition.operator;
+});
+
+const valueText = computed(() => {
+	const value = props.condition.value;
+	if (value == null || value === "") return "";
+	return Array.isArray(value) ? value.join(", ") : String(value);
+});
+
+// Combobox hands back the chosen option; its `value` is the fieldname.
+function fieldFromOption(option: unknown): ConditionField | undefined {
+	if (!option) return undefined;
+	const fieldname =
+		typeof option === "string" ? option : (option as { value?: string }).value ?? "";
+	return fields.value.find((f) => f.fieldname === fieldname);
+}
+
+function onFieldChange(option: unknown) {
+	const next = fieldFromOption(option);
+	if (!next) return;
+	// Told what this component offers, not what `Filter` does, or `is not`
+	// would read as unavailable on every field and reset the row.
+	const carried = carryOver(
+		filterCondition.value,
+		next,
+		conditionOperators(next.fieldtype, next.fieldname)
+	);
+	emit("update", {
+		fieldname: carried.fieldname,
+		// `carryOver` was handed this component's own list, so what it kept came
+		// from there, narrower than its `FilterOperator` return type.
+		operator: carried.operator as ConditionOperator,
+		value: carried.value as ConditionValue,
+	});
+}
+
+// `Select` emits its own option value type, so the operator is matched against
+// what this row actually offers rather than asserted to be one.
+function onOperatorChange(value: unknown) {
+	const operator = operators.value.find((o) => o.value === value)?.value;
+	if (!operator || !field.value) return;
+	emit("update", {
+		...props.condition,
+		operator,
+		value: defaultValueFor(field.value, operator) as ConditionValue,
+	});
+}
+
+function onValueChange(value: ConditionValue) {
+	emit("update", { ...props.condition, value });
+}
+</script>

--- a/ui/src/components/ConditionBuilder/ConditionRow.vue
+++ b/ui/src/components/ConditionBuilder/ConditionRow.vue
@@ -1,0 +1,67 @@
+<!--
+  One leaf's slot boundary: the consumer's `#condition`, or the built-in editor.
+  `ConditionLeaf` is a subgrid, so its three cells sit in the row's three middle
+  tracks. A custom `#condition` gets one box spanning the same three.
+-->
+<template>
+	<div
+		v-if="$slots.condition"
+		data-slot="condition-row"
+		class="min-w-0"
+		style="grid-column: span 3"
+	>
+		<slot
+			name="condition"
+			:condition="condition"
+			:path="path"
+			:depth="depth"
+			:readonly="readonly"
+			:update="update"
+		/>
+	</div>
+
+	<ConditionLeaf
+		v-else
+		:condition="condition as FieldConditionValue"
+		:field-label-id="fieldLabelId"
+		@update="update"
+	>
+		<template v-if="$slots['condition-value']" #condition-value="valueProps">
+			<slot name="condition-value" v-bind="valueProps" />
+		</template>
+	</ConditionLeaf>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import ConditionLeaf from "./ConditionLeaf.vue";
+import { useConditionBuilderContext } from "./internal/context";
+import type {
+	ConditionPath,
+	ConditionSlotProps,
+	FieldConditionValue,
+	ValueSlotProps,
+} from "./types";
+
+const props = defineProps<{
+	condition: unknown;
+	path: ConditionPath;
+
+	/** Id of the element holding this row's field label, rendered by the row. */
+	fieldLabelId?: string;
+}>();
+
+defineSlots<{
+	condition?(props: ConditionSlotProps<unknown>): unknown;
+	"condition-value"?(props: ValueSlotProps): unknown;
+}>();
+
+const context = useConditionBuilderContext();
+
+const depth = computed(() => props.path.length);
+const readonly = computed(() => context.readonly.value);
+
+function update(value: unknown) {
+	context.update(props.path, value);
+}
+</script>

--- a/ui/src/components/ConditionBuilder/ConditionRule.vue
+++ b/ui/src/components/ConditionBuilder/ConditionRule.vue
@@ -1,0 +1,58 @@
+<!--
+  The group's bracket as it passes one row, with the operator sitting on it. The
+  cell is the default slot, so the bracket and the word it parts around are laid
+  out together.
+
+  Drawn as two lengths so it stops short of the word instead of running behind
+  it. The lower one is a flex item after the cell rather than a span positioned a
+  control's height down, so it starts wherever the cell actually ends and a
+  two-line `#condition-conjunction` still works.
+-->
+<template>
+	<div class="relative flex min-w-[66px] flex-col self-stretch">
+		<span
+			v-if="count > 1 && index > 0"
+			aria-hidden="true"
+			class="absolute start-1/2 border-s border-outline-gray-2"
+			:style="above"
+		/>
+		<slot />
+		<span
+			v-if="count > 1 && index < count - 1"
+			aria-hidden="true"
+			class="w-0 flex-1 self-center border-s border-outline-gray-2"
+			:style="below"
+		/>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+
+const props = withDefaults(
+	defineProps<{
+		/** This row's index within its group. */
+		index: number;
+
+		/** How many rows the group holds. A group of one joins nothing. */
+		count: number;
+
+		/** How far below the row's top edge its first line starts. The row decides
+		 *  it, because a card's first line sits inside the card's own chrome. */
+		offset?: number;
+	}>(),
+	{ offset: 0 }
+);
+
+/** Half of the group's `gap-y-4`, which each end reaches into to meet the next. */
+const HALF_GAP = 8;
+
+// Bridges the row gap, then runs down to the word wherever the offset put it.
+const above = computed(() => ({
+	top: `-${HALF_GAP}px`,
+	height: `${HALF_GAP + props.offset}px`,
+}));
+
+// Takes the rest of the column and reaches into the gap below.
+const below = { marginBottom: `-${HALF_GAP}px` };
+</script>

--- a/ui/src/components/ConditionBuilder/ConjunctionCell.vue
+++ b/ui/src/components/ConditionBuilder/ConjunctionCell.vue
@@ -1,0 +1,56 @@
+<!--
+  A row's leading word: "Where" on the first row, the group's operator on every
+  row after it. The cell around it belongs to the row; this renders the word.
+
+  A group holds one operator, so exactly one cell is a control. The repeats are
+  text, not disabled buttons: a disabled control is skipped in a screen reader's
+  forms mode and exempt from the contrast minimum. Which is why they are
+  ink-gray-6, not the cell's ink-gray-5, which is 4.18:1 on white and misses
+  1.4.3 at 14px.
+-->
+<template>
+	<div class="text-p-base text-ink-gray-5">
+		<div v-if="index === 0">{{ labels.where }}</div>
+		<template v-else>
+			<Button
+				v-if="canToggle"
+				variant="subtle"
+				class="w-max"
+				iconRight="lucide-refresh-cw"
+				:label="word"
+				:aria-describedby="hintId"
+				@click="toggle"
+			/>
+			<div v-else class="text-ink-gray-6">{{ word }}</div>
+			<span v-if="canToggle" :id="hintId" class="sr-only">
+				{{ labels.conjunctionHint }}
+			</span>
+		</template>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed, useId } from "vue";
+import { Button } from "frappe-ui";
+import { useConditionBuilderContext } from "./internal/context";
+import type { ConditionPath, Conjunction } from "./types";
+
+const props = defineProps<{
+	index: number;
+	conjunction: Conjunction;
+	groupPath: ConditionPath;
+
+	/** Whether this cell's control is live. Decided by the group, not here. */
+	canToggle?: boolean;
+}>();
+
+const context = useConditionBuilderContext();
+const labels = context.labels;
+const hintId = useId();
+
+function toggle() {
+	context.setConjunction(props.groupPath, props.conjunction === "and" ? "or" : "and");
+}
+
+const word = computed(() => (props.conjunction === "and" ? labels.value.and : labels.value.or));
+</script>

--- a/ui/src/components/ConditionBuilder/adapters.ts
+++ b/ui/src/components/ConditionBuilder/adapters.ts
@@ -1,0 +1,113 @@
+// Reading and writing Frappe's interleaved condition array. The operator table
+// lives in `internal/operators`, the Python compiler in `internal/compile`;
+// this module is what a host imports, so both are re-exported through it.
+import { emptyTree, isGroup } from "./tree";
+import { READ_OPERATOR } from "./internal/operators";
+import { compileEntries, foldEntries } from "./internal/compile";
+import type {
+  ConditionExpressionOptions,
+  ConditionGroup,
+  ConditionNode,
+  ConditionValue,
+  FieldConditionValue,
+} from "./types";
+
+type Leaf = FieldConditionValue;
+type Node = ConditionNode<Leaf>;
+
+export { emptyTree, isGroup, setGroupConjunction } from "./tree";
+export { conditionOperators } from "./internal/operators";
+export type { ConditionExpressionOptions } from "./types";
+
+/**
+ * Convert a tree to the interleaved array Assignment Rule and SLA persist. The
+ * format carries a token per gap, so the group's one token is repeated between
+ * every surviving pair.
+ */
+export function toFrappeConditions(tree: ConditionGroup<Leaf>): unknown[] {
+  const out: unknown[] = [];
+  let written = 0;
+
+  tree.conditions.forEach((node) => {
+    // A row with no field holds no condition, so dropping it is lossless.
+    if (!isGroup(node) && !node.fieldname) return;
+
+    const encoded = nodeToFrappe(node);
+
+    // A group encoding to nothing is dropped rather than written as `[]`, which
+    // the host's compiler would destructure.
+    if (isGroup(node) && Array.isArray(encoded) && encoded.length === 0) return;
+
+    // `written`, not the index, so a skipped entry cannot leave the array
+    // starting on a conjunction.
+    if (written > 0) out.push(tree.conjunction ?? "and");
+    out.push(encoded);
+    written += 1;
+  });
+
+  return out;
+}
+
+/**
+ * Compile a tree into the Python expression `safe_eval` runs. Goes through
+ * `toFrappeConditions`, so a row with no field is dropped exactly as it is on
+ * save.
+ */
+export function toConditionExpression(
+  tree: ConditionGroup<Leaf>,
+  options: ConditionExpressionOptions = {}
+): string {
+  return compileEntries(toFrappeConditions(tree), options);
+}
+
+/**
+ * Parse the array back into a tree, dropping any entry it cannot model. **Lossy
+ * on a mixed record:** the array carries a token per gap, a group one per
+ * level, so `A and B or C` loads and re-saves as `A and B and C`.
+ */
+export function fromFrappeConditions(
+  conditions: unknown
+): ConditionGroup<Leaf> {
+  if (!Array.isArray(conditions) || conditions.length === 0) {
+    return emptyTree<Leaf>();
+  }
+
+  const { items, separators } = foldEntries(conditions, frappeToNode);
+  return { conjunction: separators[0] ?? "and", conditions: items };
+}
+
+// Helpers
+
+function nodeToFrappe(node: Node): unknown {
+  if (isGroup(node)) return toFrappeConditions(node);
+  return [node.fieldname, node.operator, node.value];
+}
+
+/** A node, or null for an entry this parser cannot model. */
+function frappeToNode(item: unknown): Node | null {
+  if (Array.isArray(item)) {
+    // A new, still-empty group is persisted as `[]`.
+    if (item.length === 0) return emptyTree<Leaf>();
+
+    // A group's first element is itself an array; a leaf's is a fieldname.
+    if (Array.isArray(item[0])) return fromFrappeConditions(item);
+  }
+
+  if (Array.isArray(item) && item.length === 3 && typeof item[0] === "string") {
+    const token = String(item[1]).toLowerCase();
+    // `hasOwn`, not a bare index: a stored operator named `constructor` would
+    // otherwise resolve through `Object.prototype`.
+    const operator = Object.hasOwn(READ_OPERATOR, token)
+      ? READ_OPERATOR[token]
+      : undefined;
+    if (operator) {
+      return {
+        fieldname: item[0],
+        operator,
+        value: item[2] as ConditionValue,
+      };
+    }
+  }
+
+  return null;
+}

--- a/ui/src/components/ConditionBuilder/index.ts
+++ b/ui/src/components/ConditionBuilder/index.ts
@@ -1,0 +1,30 @@
+// ConditionBuilder, a controlled editor for a nested and/or condition tree.
+// `adapters` holds everything that is not the component: reading and writing
+// Frappe's interleaved condition array, and compiling the expression `safe_eval`
+// runs. The operator and value-control rules are composed from `Filter`
+// (ADR-0008), but every name a host imports is this component's own.
+export { default as ConditionBuilder } from "./ConditionBuilder.vue";
+export {
+  emptyTree,
+  fromFrappeConditions,
+  isGroup,
+  setGroupConjunction,
+  toConditionExpression,
+  toFrappeConditions,
+} from "./adapters";
+export type { ConditionExpressionOptions } from "./adapters";
+export type {
+  ConditionBorders,
+  ConditionBuilderLabels,
+  ConditionBuilderProps,
+  ConditionColumns,
+  ConditionField,
+  ConditionGroup,
+  ConditionNode,
+  ConditionOperator,
+  ConditionOperatorOption,
+  ConditionPath,
+  ConditionValue,
+  Conjunction,
+  FieldConditionValue,
+} from "./types";

--- a/ui/src/components/ConditionBuilder/internal/compile.ts
+++ b/ui/src/components/ConditionBuilder/internal/compile.ts
@@ -1,0 +1,274 @@
+// Compiling the interleaved array into the Python expression `safe_eval` runs.
+//
+// `foldEntries` sits here rather than beside the parser because both readers of
+// the array need it and this is the lower of the two: `adapters.ts` imports it,
+// nothing here imports `adapters.ts`.
+import type {
+  ConditionExpressionOptions,
+  ConditionOperator,
+  Conjunction,
+} from "../types";
+import {
+  NUMERIC_FIELDTYPES,
+  OPERATORS,
+  ORDERING,
+  SCALAR_COMPARISONS,
+  pythonToken,
+} from "./operators";
+
+/**
+ * Split one level into operands and separators. An entry `read` makes nothing
+ * of takes its pending separator with it. Every separator is returned: only
+ * `fromFrappeConditions` collapses them.
+ */
+export function foldEntries<T>(
+  entries: unknown[],
+  read: (entry: unknown) => T | null
+): { items: T[]; separators: Conjunction[] } {
+  const items: T[] = [];
+  const separators: Conjunction[] = [];
+  let pending: Conjunction | null = null;
+
+  for (const entry of entries) {
+    const token = asConjunction(entry);
+    if (token !== null) {
+      pending = token;
+      continue;
+    }
+
+    const item = read(entry);
+    if (item === null) {
+      pending = null;
+      continue;
+    }
+
+    if (items.length > 0) separators.push(pending ?? "and");
+    items.push(item);
+    pending = null;
+  }
+
+  return { items, separators };
+}
+
+/** The separator tokens, case-insensitively: a hand-edited record can carry
+ *  `"OR"`, and sending it down the operand path would invert the rule. */
+function asConjunction(item: unknown): Conjunction | null {
+  if (typeof item !== "string") return null;
+  const token = item.trim().toLowerCase();
+  return token === "and" || token === "or" ? token : null;
+}
+
+/** One level of the array, as the expression it evaluates to. */
+export function compileEntries(
+  entries: unknown[],
+  options: ConditionExpressionOptions
+): string {
+  const { items, separators } = foldEntries(entries, (entry) => {
+    const compiled = compileEntry(entry, options);
+    return compiled === "" ? null : compiled;
+  });
+
+  return items.reduce(
+    (expression, operand, index) =>
+      index === 0
+        ? operand
+        : `${expression} ${separators[index - 1]} ${operand}`,
+    ""
+  );
+}
+
+/** A nested group is parenthesised, so the tree's shape decides the reading
+ *  rather than Python's precedence. */
+function compileEntry(
+  entry: unknown,
+  options: ConditionExpressionOptions
+): string {
+  if (Array.isArray(entry) && Array.isArray(entry[0])) {
+    const nested = compileEntries(entry, options);
+    return nested === "" ? "" : `(${nested})`;
+  }
+  return compileLeaf(entry, options);
+}
+
+function compileLeaf(
+  entry: unknown,
+  options: ConditionExpressionOptions
+): string {
+  if (
+    !Array.isArray(entry) ||
+    entry.length !== 3 ||
+    typeof entry[0] !== "string"
+  ) {
+    return "";
+  }
+
+  const [fieldname, rawOperator, value] = entry;
+  const { fieldPrefix, fields } = options;
+  const field = fieldPrefix ? `${fieldPrefix}.${fieldname}` : fieldname;
+  const token = String(rawOperator).toLowerCase();
+  const rule = Object.hasOwn(OPERATORS, token)
+    ? OPERATORS[token as ConditionOperator]
+    : undefined;
+  const operator = rule ? pythonToken(token, rule) : token;
+  const fieldtype = fields?.find((f) => f.fieldname === fieldname)?.fieldtype;
+
+  // A Check holds "Yes"/"No" but the document holds 0/1, which `== "Yes"` never
+  // matches. Without `fields` the value is all there is to go on.
+  const check = String(value).trim().toLowerCase();
+  const isCheck =
+    fields !== undefined
+      ? fieldtype === "Check"
+      : check === "yes" || check === "no";
+  if (
+    (operator === "==" || operator === "!=") &&
+    isCheck &&
+    (check === "yes" || check === "no")
+  ) {
+    return (check === "yes") === (operator === "==") ? field : `not ${field}`;
+  }
+
+  // All four pairings of is/is not against Set/Not Set are the field's own
+  // truthiness.
+  if (operator === "is" || operator === "is not") {
+    if (check === "set" || check === "not set") {
+      return (check === "set") === (operator === "is") ? field : `not ${field}`;
+    }
+  }
+
+  const isNumeric =
+    fieldtype !== undefined && NUMERIC_FIELDTYPES.includes(fieldtype);
+
+  // `field and` keeps a null out of the membership test, where it would raise.
+  // A number cannot be its subject at all and `safe_eval` has no `str` to
+  // coerce with.
+  if (operator === "like" || operator === "not like") {
+    if (isNumeric) return "";
+    // `"" in doc.subject` is True of every document that has one, so `like ""`
+    // would read as "is set". This is where a fresh text row starts.
+    if (!isNamed(value)) return "";
+    const membership = operator === "like" ? "in" : "not in";
+    return `(${field} and ${quote(value)} ${membership} ${field})`;
+  }
+
+  // A numeric member goes in unquoted or it matches nothing: `100 in ["100"]`
+  // is False.
+  if (operator === "in" || operator === "not in") {
+    // `in []` matches nothing and `not in []` matches everything, so an
+    // unfinished row would fire on all of them.
+    const members = asList(value).filter(isNamed);
+    if (members.length === 0) return "";
+    const items = members.map((item) => literal(item, isNumeric)).join(", ");
+    return `(${field} and ${field} ${operator} [${items}])`;
+  }
+
+  // `between` answers for itself rather than falling through to the unset-value
+  // rule below, which would turn a cleared range into "is set".
+  if (operator === "between") {
+    const range = asRange(value);
+    if (!range) return "";
+    const from = rangeEnd(range[0], isNumeric);
+    const to = rangeEnd(range[1], isNumeric);
+    return from !== null && to !== null
+      ? `(${field} >= ${from} and ${field} <= ${to})`
+      : "";
+  }
+
+  // An unset value is the field's own falsiness. `field == None` is not what an
+  // empty condition means.
+  if (value === null || value === undefined) {
+    return operator === "==" || operator === "is" ? `not ${field}` : field;
+  }
+
+  if (!SCALAR_COMPARISONS.includes(operator)) return "";
+
+  // `doc.grand_total > "100"` is a TypeError, not False. An unreadable value
+  // drops the row where the comparison is an ordering; `==`/`!=` compile quoted.
+  if (isNumeric) {
+    const number = numeric(value);
+    if (number !== null) return `${field} ${operator} ${number}`;
+    if (ORDERING.includes(operator)) return "";
+  }
+
+  if (typeof value === "number") return `${field} ${operator} ${value}`;
+  // Python's booleans: `true` is a NameError under `safe_eval`.
+  if (typeof value === "boolean")
+    return `${field} ${operator} ${value ? "True" : "False"}`;
+
+  return `${field} ${operator} ${quote(value)}`;
+}
+
+const CONTROL = /[\u0000-\u001f\u007f]/g;
+const NAMED_ESCAPE: Record<string, string> = {
+  "\n": "\\n",
+  "\r": "\\r",
+  "\t": "\\t",
+};
+
+/**
+ * A Python string literal. The backslash goes first, or it escapes the escapes.
+ * A raw newline would end the literal, and an unparseable rule matches nothing.
+ */
+function quote(value: unknown): string {
+  const escaped = String(value)
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(
+      CONTROL,
+      (character) =>
+        NAMED_ESCAPE[character] ??
+        `\\x${character.charCodeAt(0).toString(16).padStart(2, "0")}`
+    );
+  return `"${escaped}"`;
+}
+
+/** A value as a Python number, or null where it cannot be read as one. */
+function numeric(value: unknown): number | null {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  const text = String(value).trim();
+  if (text === "") return null;
+  const number = Number(text);
+  return Number.isFinite(number) ? number : null;
+}
+
+/** A list member, as the literal it compiles to. */
+function literal(value: unknown, isNumeric: boolean): string {
+  if (isNumeric) {
+    const number = numeric(value);
+    if (number !== null) return String(number);
+  }
+  return quote(value);
+}
+
+/** One end of a range, or null where an ordering comparison could not use it. */
+function rangeEnd(value: unknown, isNumeric: boolean): string | null {
+  if (!isNumeric) return quote(value);
+  const number = numeric(value);
+  return number === null ? null : String(number);
+}
+
+/** `in`'s operand: a list as it stands, a comma string as its parts. */
+function asList(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value.map((item) => String(item).trim());
+  if (typeof value === "string")
+    return value.split(",").map((item) => item.trim());
+  return [value];
+}
+
+/** `between`'s two ends, or null unless both are named: a cleared picker leaves
+ *  `[null, null]`, and `>= ""` is true of every date there is. */
+function asRange(value: unknown): [unknown, unknown] | null {
+  const pair = asPair(value);
+  return pair !== null && pair.every(isNamed) ? pair : null;
+}
+
+function asPair(value: unknown): [unknown, unknown] | null {
+  if (Array.isArray(value))
+    return value.length === 2 ? [value[0], value[1]] : null;
+  if (typeof value !== "string" || !value.includes(",")) return null;
+  const [from, to] = value.split(",").map((part) => part.trim());
+  return [from, to];
+}
+
+function isNamed(end: unknown): boolean {
+  return end !== null && end !== undefined && String(end).trim() !== "";
+}

--- a/ui/src/components/ConditionBuilder/internal/context.ts
+++ b/ui/src/components/ConditionBuilder/internal/context.ts
@@ -1,0 +1,238 @@
+import { customRef, inject } from "vue";
+import type { ComputedRef, InjectionKey, Ref } from "vue";
+import type {
+  ConditionBorders,
+  ConditionBuilderLabels,
+  ConditionColumns,
+  ConditionField,
+  ConditionPath,
+  Conjunction,
+} from "../types";
+
+/**
+ * Shared by every node. Mutations are reported by path, so no group relays
+ * events up through its own recursion.
+ */
+export interface ConditionBuilderContext {
+  /** Scopes the focus queries: a path is only unique inside one builder. */
+  builderId: ComputedRef<string>;
+
+  /** Ids of the host-facing label, description and error, for the root group to
+   *  name and describe itself with. Empty string where there is none. */
+  labelId: ComputedRef<string>;
+  describedBy: ComputedRef<string>;
+  invalid: ComputedRef<boolean>;
+
+  fields: ComputedRef<ConditionField[]>;
+
+  /** While Meta is in flight a missing fieldname means "not loaded" rather than
+   *  "not a field any more", and the two get opposite treatments in the leaf. */
+  fieldsLoading: ComputedRef<boolean>;
+  fieldsError: ComputedRef<unknown>;
+  reloadFields: () => void;
+
+  columns: ComputedRef<Required<ConditionColumns>>;
+  labels: Ref<ConditionBuilderLabels>;
+  bordered: ComputedRef<ConditionBorders>;
+  maxDepth: ComputedRef<number>;
+  readonly: ComputedRef<boolean>;
+  reorderable: ComputedRef<boolean>;
+
+  addCondition: (groupPath: ConditionPath) => void;
+  addGroup: (groupPath: ConditionPath) => void;
+  remove: (path: ConditionPath) => void;
+  update: (path: ConditionPath, leaf: unknown) => void;
+  turnIntoGroup: (path: ConditionPath) => void;
+  ungroup: (path: ConditionPath) => void;
+  setConjunction: (groupPath: ConditionPath, value: Conjunction) => void;
+
+  /** Reorder one child within its group. Only a menu move places focus; a
+   *  pointer drop has not taken any. */
+  move: (
+    groupPath: ConditionPath,
+    from: number,
+    to: number,
+    options?: { name?: string; focus?: boolean }
+  ) => void;
+
+  /** Asked while a drag is in flight, so a drop past `maxDepth` shows no
+   *  indicator rather than landing and snapping back. */
+  canDrop: (from: ConditionPath, toGroupPath: ConditionPath) => boolean;
+
+  /** The row being dragged. Shared, because a row can land in any group and each
+   *  one answers for itself whether it would take it. */
+  dragFrom: Ref<ConditionPath | null>;
+
+  /** The pointer's edit: a drop into any group, run once, from the list the drag
+   *  started in. It takes no focus and places none. */
+  moveInto: (
+    from: ConditionPath,
+    toGroupPath: ConditionPath,
+    toIndex: number,
+    options?: { name?: string }
+  ) => void;
+
+  /** Put a message in the builder's live region. */
+  announce: (message: string) => void;
+}
+
+export const conditionBuilderKey: InjectionKey<ConditionBuilderContext> =
+  Symbol("conditionBuilder");
+
+/**
+ * Resolved per row, so only a row naming a long field pays for it. No `fr`: it
+ * is a share of the leftover and would stretch a cell past its content.
+ * `minmax(0, ...)` because a bare `max-content` floors at min-content and
+ * overflows a narrow container.
+ */
+export const DEFAULT_COLUMNS: Required<ConditionColumns> = {
+  field: "minmax(0, max-content)",
+  operator: "minmax(0, max-content)",
+  value: "minmax(0, max-content)",
+};
+
+/** Deepest nesting level offered. The root group is depth 0. */
+export const DEFAULT_MAX_DEPTH = 4;
+
+export const DEFAULT_BORDERS: ConditionBorders = "all";
+
+/** Off, so a flat filter does not have to opt out. */
+export const DEFAULT_REORDERABLE = false;
+
+/**
+ * Read off the global at call time: this package has no i18n of its own. Values
+ * go through `{0}`, since a sentence glued from translated halves only reads in
+ * English.
+ */
+function t(message: string, replace?: unknown[]): string {
+  const translate = (
+    globalThis as { __?: (m: string, r?: unknown[]) => string }
+  ).__;
+  if (typeof translate === "function") return translate(message, replace);
+  if (!replace) return message;
+  // The fallback substitutes too, or a literal `{0}` is read out on a host with
+  // no plugin.
+  return message.replace(/\{(\d+)\}/g, (match, index) => {
+    const value = replace[Number(index)];
+    return value === undefined ? match : String(value);
+  });
+}
+
+/**
+ * A function, not a const: a module-level object is built before the host
+ * installs its translations, freezing every label as English.
+ */
+export function defaultLabels(): ConditionBuilderLabels {
+  return {
+    where: t("Where"),
+    and: t("and"),
+    or: t("or"),
+    matchAll: t("Match all of the following"),
+    matchAny: t("Match any of the following"),
+    conjunctionHint: t("Changes how every condition in this group is joined"),
+    addCondition: t("Add Condition"),
+    addGroup: t("Add Condition Group"),
+    turnIntoGroup: t("Turn into a Group"),
+    ungroup: t("Ungroup Conditions"),
+    remove: t("Remove"),
+    removeGroup: t("Remove Group"),
+    empty: t("Add a Condition"),
+    rowActions: t("Condition actions"),
+    groupActions: t("Group actions"),
+    field: t("Field"),
+    operator: t("Operator"),
+    value: t("Value"),
+    fieldsError: t("Could not load this doctype's fields."),
+    retryFields: t("Retry"),
+    removed: (remaining, groupRemoved) =>
+      [
+        t("Condition removed."),
+        groupRemoved ? t("Its group was left empty and was removed too.") : "",
+        t("{0} remaining.", [remaining]),
+      ]
+        .filter(Boolean)
+        .join(" "),
+    movedToGroup: (name, to, total) =>
+      name
+        ? t("{0} moved into another group, at position {1} of {2}.", [
+            name,
+            to,
+            total,
+          ])
+        : t("Condition moved into another group, at position {0} of {1}.", [
+            to,
+            total,
+          ]),
+    moved: (name, from, to, total) =>
+      name
+        ? t("{0} moved from position {1} to position {2} of {3}.", [
+            name,
+            from,
+            to,
+            total,
+          ])
+        : t("Condition moved from position {0} to position {1} of {2}.", [
+            from,
+            to,
+            total,
+          ]),
+  };
+}
+
+/**
+ * Re-read on every access, so the host's messages land. A `computed` caches the
+ * first read; a bare getter object is not a ref.
+ */
+export function uncachedLabels(
+  read: () => ConditionBuilderLabels
+): Ref<ConditionBuilderLabels> {
+  let probe = t("Where");
+  return customRef((track, trigger) => ({
+    get() {
+      track();
+      const current = t("Where");
+      if (current !== probe) {
+        probe = current;
+        queueMicrotask(trigger);
+      }
+      return read();
+    },
+    set() {},
+  }));
+}
+
+/**
+ * Not a spread: an object built from optional values carries explicit
+ * `undefined` keys, which a spread copies over the defaults.
+ */
+function overlay<T extends object>(defaults: T, overrides?: Partial<T>): T {
+  const merged = { ...defaults };
+  if (!overrides) return merged;
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined || !(key in defaults)) continue;
+    (merged as Record<string, unknown>)[key] = value;
+  }
+  return merged;
+}
+
+export function mergeLabels(
+  overrides?: Partial<ConditionBuilderLabels>
+): ConditionBuilderLabels {
+  return overlay(defaultLabels(), overrides);
+}
+
+export function mergeColumns(
+  overrides?: ConditionColumns
+): Required<ConditionColumns> {
+  return overlay(DEFAULT_COLUMNS, overrides);
+}
+
+export function useConditionBuilderContext(): ConditionBuilderContext {
+  const context = inject(conditionBuilderKey, null);
+  if (!context) {
+    throw new Error(
+      "ConditionBuilder: this component must be used inside one."
+    );
+  }
+  return context;
+}

--- a/ui/src/components/ConditionBuilder/internal/dragBridge.ts
+++ b/ui/src/components/ConditionBuilder/internal/dragBridge.ts
@@ -1,0 +1,87 @@
+import { computed } from "vue";
+import type { ComputedRef } from "vue";
+import { samePath } from "../tree";
+import type { ConditionGroup, ConditionPath } from "../types";
+import type { ConditionBuilderContext } from "./context";
+
+interface DragEndEvent {
+  from: HTMLElement;
+  to: HTMLElement;
+  oldIndex?: number;
+  newIndex?: number;
+}
+
+/** A path as it is written on a row or a list. `""` is the root group. */
+export function parsePath(value: string | null): ConditionPath | null {
+  if (value === null) return null;
+  if (value === "") return [];
+  const path = value.split(".").map(Number);
+  return path.every(Number.isInteger) ? path : null;
+}
+
+/**
+ * Sortable's events, as tree edits. One group's half of a drag: whether it would
+ * take the travelling row, and what to commit when the drop lands in it.
+ */
+export function useDragBridge(
+  context: ConditionBuilderContext,
+  path: ComputedRef<ConditionPath>,
+  group: ComputedRef<ConditionGroup<unknown>>,
+  nameOf: (node: unknown) => string
+) {
+  /**
+   * One Sortable group per builder, so a row can be dragged anywhere in this
+   * tree and nowhere in another.
+   */
+  const sortableGroup = computed(() => ({
+    name: `condition-builder-${context.builderId.value}`,
+
+    // Asked of the destination. Refusing during the drag means no indicator,
+    // rather than landing and snapping back.
+    put: (_to: unknown, _from: unknown, dragged: HTMLElement) => {
+      const from = parsePath(dragged.getAttribute("data-condition-path"));
+      return from !== null && context.canDrop(from, path.value);
+    },
+  }));
+
+  /** Every group asks this of itself, so the fill marks every place the row
+   *  can go. */
+  const canTakeDrag = computed(() => {
+    const from = context.dragFrom.value;
+    return from !== null && context.canDrop(from, path.value);
+  });
+
+  /** Sortable tells only the list a drag starts in, which is where the row is. */
+  function onDragStart(event: { oldIndex?: number }) {
+    if (event.oldIndex === undefined) return;
+    context.dragFrom.value = [...path.value, event.oldIndex];
+  }
+
+  /**
+   * `end`, not `change`: a cross-group drop raises `change` twice, on two
+   * components each holding the pre-drag tree. `end` fires once, on the source
+   * list, with both lists and both indices.
+   */
+  function onDragEnd(event: DragEndEvent) {
+    context.dragFrom.value = null;
+
+    const from = parsePath(event.from.getAttribute("data-group-path"));
+    const to = parsePath(event.to.getAttribute("data-group-path"));
+    const { oldIndex, newIndex } = event;
+
+    if (from === null || to === null) return;
+    if (oldIndex === undefined || newIndex === undefined) return;
+    if (samePath(from, to) && oldIndex === newIndex) return;
+
+    // `end` fires on the source list, so this group holds the row that moved.
+    const moved = samePath(from, path.value)
+      ? group.value.conditions[oldIndex]
+      : undefined;
+
+    context.moveInto([...from, oldIndex], to, newIndex, {
+      name: nameOf(moved),
+    });
+  }
+
+  return { sortableGroup, canTakeDrag, onDragStart, onDragEnd };
+}

--- a/ui/src/components/ConditionBuilder/internal/fields.ts
+++ b/ui/src/components/ConditionBuilder/internal/fields.ts
@@ -1,0 +1,74 @@
+import { computed, watch } from "vue";
+import type { ComputedRef } from "vue";
+import { useDoctypeMeta } from "../../../composables/useDoctypeMeta";
+import { getFilterableFields } from "../../Filter/getFilterableFields";
+import { toConditionExpression } from "../adapters";
+import type {
+  ConditionField,
+  ConditionGroup,
+  FieldConditionValue,
+} from "../types";
+
+/**
+ * The doctype's fields, and the expression the tree compiles to with them.
+ *
+ * `doctype` is read once, at setup: `useDoctypeMeta` starts a request, so a host
+ * switching doctype remounts with `:key` rather than fetching each one.
+ */
+export function useConditionFields<T>(
+  props: { doctype?: string; fields?: ConditionField[]; fieldPrefix?: string },
+  tree: ComputedRef<ConditionGroup<T>>,
+  emitExpression: (value: string) => void
+) {
+  const doctype = props.fields ? "" : props.doctype ?? "";
+  const meta = doctype ? useDoctypeMeta(doctype) : null;
+
+  const fields = computed<ConditionField[]>(() => {
+    if (props.fields) return props.fields;
+    const loaded = meta?.meta.value;
+    if (!loaded) return [];
+    return getFilterableFields(loaded.fields ?? [], doctype);
+  });
+
+  const fieldsLoading = computed(() =>
+    Boolean(meta && meta.loading.value && !meta.meta.value)
+  );
+
+  // A failed request looks like every field being deleted. The alert says
+  // otherwise.
+  const fieldsError = computed<unknown>(() => (meta ? meta.error.value : null));
+
+  function reloadFields() {
+    meta?.reload();
+  }
+
+  /**
+   * Re-emitted when the fields arrive, since Check and numeric fields compile
+   * from their fieldtype rather than their value.
+   */
+  const expression = computed(() =>
+    toConditionExpression(
+      tree.value as unknown as ConditionGroup<FieldConditionValue>,
+      {
+        // An empty list is Meta in flight or failed, not a doctype with no
+        // fields. Withheld so the compiler's value-reading fallback runs.
+        fields: fields.value.length ? fields.value : undefined,
+        fieldPrefix: props.fieldPrefix,
+      }
+    )
+  );
+
+  // Withheld while fields are loading or failed: the guessing fallback would
+  // overwrite a correct stored expression. In the watch source, not a bare
+  // guard, so it still fires when that flips.
+  watch(
+    [expression, fieldsLoading, fieldsError],
+    ([value, loading, error]) => {
+      if (loading || error) return;
+      emitExpression(value);
+    },
+    { immediate: true }
+  );
+
+  return { fields, fieldsLoading, fieldsError, reloadFields };
+}

--- a/ui/src/components/ConditionBuilder/internal/focus.ts
+++ b/ui/src/components/ConditionBuilder/internal/focus.ts
@@ -1,0 +1,194 @@
+import { nextTick, onBeforeUnmount } from "vue";
+import type { Ref } from "vue";
+import { getNode, isGroup } from "../tree";
+import type { ConditionGroup, ConditionPath } from "../types";
+
+/** Where focus goes after an edit. */
+export type FocusTarget =
+  | { kind: "row"; path: ConditionPath }
+  | { kind: "add"; groupPath: ConditionPath };
+
+/**
+ * The row that slid into the deleted one's place, or the one before it for the
+ * last row. A group pruned with it asks again one level up.
+ */
+export function focusAfterRemove<T>(
+  root: ConditionGroup<T>,
+  removed: ConditionPath
+): FocusTarget {
+  let path = removed;
+
+  while (path.length > 0) {
+    const groupPath = path.slice(0, -1);
+    const node = getNode(root, groupPath);
+
+    if (node !== undefined && isGroup(node)) {
+      const count = node.conditions.length;
+      if (count === 0) return { kind: "add", groupPath };
+      const index = Math.min(path[path.length - 1], count - 1);
+      return { kind: "row", path: [...groupPath, index] };
+    }
+
+    // That group was pruned too, so ask the same question about its own row.
+    path = groupPath;
+  }
+
+  return { kind: "add", groupPath: [] };
+}
+
+/** The row just appended to `groupPath`. */
+export function focusAfterAdd<T>(
+  root: ConditionGroup<T>,
+  groupPath: ConditionPath
+): FocusTarget {
+  const node = getNode(root, groupPath);
+  if (node === undefined || !isGroup(node) || node.conditions.length === 0) {
+    return { kind: "add", groupPath };
+  }
+  return { kind: "row", path: [...groupPath, node.conditions.length - 1] };
+}
+
+/**
+ * The condition inside a new group, not the group's row, whose first focusable
+ * is the and/or toggle.
+ */
+export function focusAfterAddGroup<T>(
+  root: ConditionGroup<T>,
+  groupPath: ConditionPath
+): FocusTarget {
+  const target = focusAfterAdd(root, groupPath);
+  if (target.kind !== "row") return target;
+  const added = getNode(root, target.path);
+  if (added === undefined || !isGroup(added) || added.conditions.length === 0) {
+    return target;
+  }
+  return { kind: "row", path: [...target.path, 0] };
+}
+
+const FOCUSABLE =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+/** Where the user was standing when a row was removed. */
+const ROW_ACTIONS = '[data-slot="condition-actions"] button';
+
+/** Where the user is going when a row is added. */
+const ROW_ENTRY =
+  '[data-slot="condition-field"] button, [data-slot="condition-field"] input';
+
+/** Fallback if a closing menu never returns focus to its trigger. */
+const MENU_RESTORE_TIMEOUT = 300;
+
+/**
+ * Placing focus for one builder. Scoped by `builderId`, because two builders on
+ * a page hold the same paths.
+ */
+export function useConditionFocus(
+  builderId: string,
+  rootRef: Ref<HTMLElement | null>
+) {
+  let cancelMenuFocus: (() => void) | null = null;
+  const scope = `[data-condition-builder="${builderId}"]`;
+
+  /**
+   * By path, not a held ref: after a cascade the target is a row this group
+   * never rendered.
+   */
+  function moveFocus(target: FocusTarget, after: "add" | "remove") {
+    nextTick(() => {
+      if (target.kind === "row") {
+        const preferred = after === "remove" ? ROW_ACTIONS : ROW_ENTRY;
+        const row = document.querySelector<HTMLElement>(
+          `${scope}[data-condition-path="${target.path.join(".")}"]`
+        );
+        const element =
+          ownElement(row, preferred) ?? ownElement(row, FOCUSABLE);
+        element?.focus();
+        return;
+      }
+
+      // Not path-scoped: the add cell sits outside any row.
+      const add = firstEnabled(
+        document.querySelector<HTMLElement>(
+          `${scope}[data-add-group="${target.groupPath.join(".")}"]`
+        ),
+        "button"
+      );
+      // Nothing left to add into. The empty state carries tabindex="-1" to take
+      // focus without being a button.
+      const empty = rootRef.value?.querySelector<HTMLElement>(
+        '[data-slot="condition-empty"]'
+      );
+      (add ?? empty)?.focus();
+    });
+  }
+
+  /**
+   * Focus the row at `path` after the closing menu has restored focus, which
+   * lands a frame or more later.
+   */
+  function focusAfterMenuCloses(path: ConditionPath) {
+    // Only ever one in flight: a second menu action supersedes the first.
+    cancelMenuFocus?.();
+
+    let timer: ReturnType<typeof setTimeout>;
+
+    function stop() {
+      document.removeEventListener("focusin", onFocusIn);
+      clearTimeout(timer);
+      cancelMenuFocus = null;
+    }
+
+    function place() {
+      stop();
+      moveFocus({ kind: "row", path }, "remove");
+    }
+
+    // A focusin outside this builder is the user moving deliberately, and
+    // taking focus back would be worse than not placing it.
+    function onFocusIn(event: FocusEvent) {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      if (target.closest(scope)) place();
+      else stop();
+    }
+
+    timer = setTimeout(place, MENU_RESTORE_TIMEOUT);
+    document.addEventListener("focusin", onFocusIn);
+    cancelMenuFocus = stop;
+  }
+
+  // An unmount inside the wait would leave a listener focusing a builder that
+  // is gone.
+  onBeforeUnmount(() => cancelMenuFocus?.());
+
+  return { moveFocus, focusAfterMenuCloses };
+}
+
+/**
+ * The first match belonging to `row` itself, since a row holding a nested group
+ * contains that whole subtree. Disabled elements are skipped.
+ */
+function ownElement(
+  row: HTMLElement | null,
+  selector: string
+): HTMLElement | null {
+  if (!row) return null;
+  for (const element of row.querySelectorAll<HTMLElement>(selector)) {
+    if (element.closest("[data-condition-path]") !== row) continue;
+    if (element.hasAttribute("disabled")) continue;
+    return element;
+  }
+  return null;
+}
+
+/** The first match that can actually take focus. */
+function firstEnabled(
+  root: HTMLElement | null,
+  selector: string
+): HTMLElement | null {
+  if (!root) return null;
+  for (const element of root.querySelectorAll<HTMLElement>(selector)) {
+    if (!element.hasAttribute("disabled")) return element;
+  }
+  return null;
+}

--- a/ui/src/components/ConditionBuilder/internal/layout.ts
+++ b/ui/src/components/ConditionBuilder/internal/layout.ts
@@ -1,0 +1,76 @@
+import { computed } from "vue";
+import type { ComputedRef } from "vue";
+import { isGroup } from "../tree";
+import type { ConditionBorders, ConditionColumns } from "../types";
+
+/** The leading conjunction cell, wide enough for `Where` at any of its lengths. */
+const CONJUNCTION_TRACK = "minmax(66px, max-content)";
+
+/**
+ * Takes the row's leftover width, so the actions land on the end edge in every
+ * row. `max-content` floors it so the buttons are never squeezed.
+ */
+const ACTIONS_TRACK = "minmax(max-content, 1fr)";
+
+/**
+ * The card's border and `p-3`, both set on the group element so they move
+ * together.
+ */
+const CARD_FIRST_LINE = 13;
+
+/**
+ * A group's grid arithmetic: which tracks a row has, and how far into it the
+ * first line starts. No markup, so it is here rather than in the component.
+ */
+export function useConditionLayout(
+  columns: ComputedRef<Required<ConditionColumns>>,
+  bordered: ComputedRef<ConditionBorders>,
+  canReorder: ComputedRef<boolean>
+) {
+  // Only where there is a handle: an empty track would indent every row of a
+  // fixed tree.
+  const handleTrack = computed(() => (canReorder.value ? ["max-content"] : []));
+
+  const trackList = computed(() =>
+    [
+      CONJUNCTION_TRACK,
+      ...handleTrack.value,
+      columns.value.field,
+      columns.value.operator,
+      columns.value.value,
+      ACTIONS_TRACK,
+    ].join(" ")
+  );
+
+  // A card's row is one stretching track: a group has no field, operator or
+  // value of its own.
+  const groupTrackList = computed(() =>
+    [
+      CONJUNCTION_TRACK,
+      ...handleTrack.value,
+      "minmax(0, 1fr)",
+      "max-content",
+    ].join(" ")
+  );
+
+  function trackListFor(node: unknown): string {
+    return isGroup(node) ? groupTrackList.value : trackList.value;
+  }
+
+  /**
+   * Zero for a leaf. A card's first rule begins inside its border and padding,
+   * and the operator joining it belongs beside that rule.
+   */
+  function firstLineOffset(node: unknown): number {
+    const drawsCard = isGroup(node) && bordered.value === "all";
+    return drawsCard ? CARD_FIRST_LINE : 0;
+  }
+
+  /** The offset as the row's cells take it; the bracket takes the number. */
+  function firstLineStyle(node: unknown): { marginTop: string } | undefined {
+    const offset = firstLineOffset(node);
+    return offset ? { marginTop: `${offset}px` } : undefined;
+  }
+
+  return { trackListFor, firstLineOffset, firstLineStyle };
+}

--- a/ui/src/components/ConditionBuilder/internal/operators.ts
+++ b/ui/src/components/ConditionBuilder/internal/operators.ts
@@ -1,0 +1,94 @@
+// The operator table is composed rather than copied, per ADR-0008.
+import { getOperators } from "../../Filter/operators";
+import type { OperatorOption } from "../../Filter/operators";
+import type { ConditionOperator, ConditionOperatorOption } from "../types";
+
+// Everything this component knows about an operator is here.
+export interface OperatorRule {
+  /** Stored tokens that also read as this operator, besides its own name. */
+  reads?: string[];
+  /** The Python token, where Python spells it differently. */
+  python?: string;
+  /**
+   * May be emitted as `field <op> value`. An operator reaching the end of
+   * `compileLeaf` without one compiles to nothing: an unparseable expression
+   * matches nothing at all, losing every other condition with it.
+   */
+  scalar?: boolean;
+  /**
+   * Python refuses these across types: `1 > "1"` raises where `1 == "1"` is
+   * merely False.
+   */
+  ordering?: boolean;
+}
+
+/** A full `Record`, so an operator added to `Filter` fails the build here
+ *  until it is given a rule, rather than compiling to nothing. */
+export const OPERATORS: Record<ConditionOperator, OperatorRule> = {
+  equals: { reads: ["==", "="], python: "==", scalar: true },
+  "not equals": { reads: ["!="], python: "!=", scalar: true },
+  like: {},
+  "not like": {},
+  in: {},
+  "not in": {},
+  is: {},
+  "is not": {},
+  "<": { scalar: true, ordering: true },
+  ">": { scalar: true, ordering: true },
+  "<=": { scalar: true, ordering: true },
+  ">=": { scalar: true, ordering: true },
+  between: {},
+};
+
+/** Every stored token this parser accepts, and the operator it reads as. */
+export const READ_OPERATOR: Record<string, ConditionOperator> =
+  Object.fromEntries(
+    Object.entries(OPERATORS).flatMap(([name, rule]) =>
+      [name, ...(rule.reads ?? [])].map((token) => [
+        token,
+        name as ConditionOperator,
+      ])
+    )
+  );
+
+/** A rule's Python token, which is its own name unless it says otherwise. */
+export function pythonToken(name: string, rule: OperatorRule): string {
+  return rule.python ?? name;
+}
+
+function pythonTokensWhere(
+  wanted: (rule: OperatorRule) => boolean | undefined
+): string[] {
+  return Object.entries(OPERATORS)
+    .filter(([, rule]) => wanted(rule))
+    .map(([name, rule]) => pythonToken(name, rule));
+}
+
+export const SCALAR_COMPARISONS = pythonTokensWhere((rule) => rule.scalar);
+export const ORDERING = pythonTokensWhere((rule) => rule.ordering);
+
+/** Fieldtypes whose value is a number in the document, not a string. */
+export const NUMERIC_FIELDTYPES = [
+  "Int",
+  "Float",
+  "Currency",
+  "Percent",
+  "Rating",
+];
+
+const IS_NOT: ConditionOperatorOption = { label: "Is not", value: "is not" };
+
+/** The operators this component can write, for a field of this type. */
+export function conditionOperators(
+  fieldtype: string,
+  fieldname?: string
+): ConditionOperatorOption[] {
+  const offered = getOperators(fieldtype, fieldname).filter(isWritable);
+  const is = offered.findIndex((option) => option.value === "is");
+  if (is !== -1) offered.splice(is + 1, 0, IS_NOT);
+  return offered;
+}
+
+function isWritable(option: OperatorOption): option is ConditionOperatorOption {
+  return option.value !== "timespan";
+}

--- a/ui/src/components/ConditionBuilder/stories/ConditionBuilder.story.vue
+++ b/ui/src/components/ConditionBuilder/stories/ConditionBuilder.story.vue
@@ -1,0 +1,61 @@
+<!--
+  Every ConditionBuilder demo on one page, where the interactive behaviour is
+  exercised by hand.
+-->
+<template>
+	<div class="flex flex-col gap-10 p-6">
+		<section v-for="demo in demos" :key="demo.title" class="flex flex-col gap-3">
+			<h3 class="text-lg font-semibold text-ink-gray-8">{{ demo.title }}</h3>
+			<p class="text-p-sm text-ink-gray-6">{{ demo.description }}</p>
+			<component :is="demo.component" />
+		</section>
+	</div>
+</template>
+
+<script setup lang="ts">
+import CustomLeaf from "./CustomLeaf.vue";
+import Doctype from "./Doctype.vue";
+import FrappeFormat from "./FrappeFormat.vue";
+import Minimal from "./Minimal.vue";
+import Nested from "./Nested.vue";
+import Simple from "./Simple.vue";
+import States from "./States.vue";
+
+const demos = [
+	{
+		title: "Simple",
+		description: "One condition, fields supplied by the host.",
+		component: Simple,
+	},
+	{
+		title: "From a doctype",
+		description: "No fields prop: they come from the doctype's Meta.",
+		component: Doctype,
+	},
+	{
+		title: "Nested",
+		description: "A group inside a group, each with its own conjunction.",
+		component: Nested,
+	},
+	{
+		title: "Frappe format",
+		description: "The array a host persists, and a legacy record read back.",
+		component: FrappeFormat,
+	},
+	{
+		title: "States",
+		description: "Empty, null, read-only, a host-blocked add, every control, raw entries.",
+		component: States,
+	},
+	{
+		title: "Minimal",
+		description: "Every optional part switched off.",
+		component: Minimal,
+	},
+	{
+		title: "Custom leaf",
+		description: "A consumer's own leaf shape through #condition.",
+		component: CustomLeaf,
+	},
+];
+</script>

--- a/ui/src/components/ConditionBuilder/stories/CustomLeaf.vue
+++ b/ui/src/components/ConditionBuilder/stories/CustomLeaf.vue
@@ -1,0 +1,62 @@
+<!--
+  A leaf of the consumer's own shape through `#condition`: the tree, the
+  conjunction, the nesting and the actions are unchanged, and only what a row
+  edits is replaced.
+-->
+<template>
+	<div class="w-full max-w-3xl">
+		<ConditionBuilder v-model="conditions" :new-condition="newRule">
+			<template #condition="{ condition, update }">
+				<div class="flex w-full items-center gap-2">
+					<Select
+						class="shrink-0"
+						:options="ruleTypes"
+						:modelValue="condition.ruleType"
+						aria-label="Rule"
+						@update:modelValue="
+							update({
+								...condition,
+								ruleType: String($event ?? condition.ruleType),
+							})
+						"
+					/>
+					<Select
+						class="shrink-0"
+						:options="courses"
+						:modelValue="condition.course"
+						aria-label="Course"
+						@update:modelValue="update({ ...condition, course: String($event ?? '') })"
+					/>
+				</div>
+			</template>
+		</ConditionBuilder>
+		<pre class="mt-4 overflow-x-auto text-xs text-ink-gray-6">{{ conditions }}</pre>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { Select } from "frappe-ui";
+import { ConditionBuilder } from "../index";
+import type { ConditionGroup } from "../index";
+
+interface EnrollmentRule {
+	ruleType: string;
+	course: string;
+}
+
+const ruleTypes = ["Enrolled in Course", "Completed Course"];
+const courses = [
+	{ label: "Introduction to Python", value: "intro-python" },
+	{ label: "Advanced TypeScript", value: "advanced-typescript" },
+];
+
+const conditions = ref<ConditionGroup<EnrollmentRule>>({
+	conjunction: "and",
+	conditions: [{ ruleType: "Enrolled in Course", course: "intro-python" }],
+});
+
+function newRule(): EnrollmentRule {
+	return { ruleType: "Enrolled in Course", course: "" };
+}
+</script>

--- a/ui/src/components/ConditionBuilder/stories/Doctype.vue
+++ b/ui/src/components/ConditionBuilder/stories/Doctype.vue
@@ -1,0 +1,33 @@
+<!--
+  No `fields` at all: the leaf derives them from the doctype's Meta as `Filter`
+  does (FP3), so a Link condition searches its target doctype.
+-->
+<template>
+	<div class="flex w-full max-w-3xl flex-col gap-4">
+		<div class="flex items-center gap-2">
+			<span class="text-p-sm text-ink-gray-6">Doctype</span>
+			<Select v-model="doctype" :options="doctypeOptions" class="w-56" />
+		</div>
+
+		<ConditionBuilder :key="doctype" v-model="conditions" :doctype="doctype" />
+
+		<pre class="overflow-x-auto text-xs text-ink-gray-6">{{ conditions }}</pre>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { Select } from "frappe-ui";
+import { ConditionBuilder } from "../index";
+import type { ConditionGroup } from "../index";
+
+// `useDoctypeMeta` reads once at setup, so `:key` remounts the builder on a
+// switch rather than leaving it on the previous doctype's fields.
+const doctypeOptions = ["ToDo", "User", "Contact"];
+const doctype = ref("ToDo");
+
+const conditions = ref<ConditionGroup>({
+	conjunction: "and",
+	conditions: [{ fieldname: "status", operator: "equals", value: "Open" }],
+});
+</script>

--- a/ui/src/components/ConditionBuilder/stories/FrappeFormat.vue
+++ b/ui/src/components/ConditionBuilder/stories/FrappeFormat.vue
@@ -1,0 +1,39 @@
+<!--
+  The round trip a host persists: the tree in, Frappe's interleaved array out,
+  the array a host compiles into the expression `safe_eval` runs.
+-->
+<template>
+	<div class="w-full max-w-3xl">
+		<ConditionBuilder v-model="conditions" :fields="sampleFields" />
+		<p class="mt-4 text-xs text-ink-gray-5">Saved to the backend as:</p>
+		<pre class="overflow-x-auto text-xs text-ink-gray-6">{{ persisted }}</pre>
+		<p class="mt-3 text-xs text-ink-gray-5">Read back from a legacy record:</p>
+		<pre class="overflow-x-auto text-xs text-ink-gray-6">{{ legacy }}</pre>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { ConditionBuilder, fromFrappeConditions, toFrappeConditions } from "../index";
+import type { ConditionGroup } from "../index";
+import { sampleFields } from "./fields";
+
+const conditions = ref<ConditionGroup>({
+	conjunction: "and",
+	conditions: [
+		{ fieldname: "status", operator: "equals", value: "Open" },
+		{
+			conjunction: "and",
+			conditions: [{ fieldname: "subject", operator: "like", value: "bug" }],
+		},
+	],
+});
+
+const persisted = computed(() => toFrappeConditions(conditions.value));
+
+// A record stored with Python's own operator tokens, which read back as the
+// Filter ids this component stores.
+const legacy = computed(() =>
+	fromFrappeConditions([["status", "==", "Open"], "and", ["priority", "!=", "Low"]])
+);
+</script>

--- a/ui/src/components/ConditionBuilder/stories/Minimal.vue
+++ b/ui/src/components/ConditionBuilder/stories/Minimal.vue
@@ -1,0 +1,36 @@
+<!--
+  Everything optional switched off for a panel that supplies its own frame and
+  controls: no card, no "Where", no overflow menu, no add affordance.
+-->
+<template>
+	<div class="w-full max-w-3xl">
+		<ConditionBuilder
+			v-model="conditions"
+			:fields="sampleFields"
+			bordered="none"
+			:columns="{ operator: 'minmax(0, 9rem)' }"
+		>
+			<!-- A node that draws nothing, not an empty template: an empty one
+			     produces no vnode, and Vue then renders the slot's fallback. -->
+			<template #condition-where><span /></template>
+			<template #condition-conjunction><span /></template>
+			<template #condition-actions><span /></template>
+			<template #add-condition><span /></template>
+		</ConditionBuilder>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { ConditionBuilder } from "../index";
+import type { ConditionGroup } from "../index";
+import { sampleFields } from "./fields";
+
+const conditions = ref<ConditionGroup>({
+	conjunction: "and",
+	conditions: [
+		{ fieldname: "status", operator: "equals", value: "Open" },
+		{ fieldname: "subject", operator: "like", value: "refund" },
+	],
+});
+</script>

--- a/ui/src/components/ConditionBuilder/stories/Nested.vue
+++ b/ui/src/components/ConditionBuilder/stories/Nested.vue
@@ -1,0 +1,27 @@
+<template>
+	<div class="w-full max-w-3xl">
+		<ConditionBuilder v-model="conditions" :fields="sampleFields" :max-depth="3" />
+		<pre class="mt-4 overflow-x-auto text-xs text-ink-gray-6">{{ conditions }}</pre>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { ConditionBuilder } from "../index";
+import type { ConditionGroup } from "../index";
+import { sampleFields } from "./fields";
+
+const conditions = ref<ConditionGroup>({
+	conjunction: "and",
+	conditions: [
+		{ fieldname: "status", operator: "equals", value: "Open" },
+		{
+			conjunction: "or",
+			conditions: [
+				{ fieldname: "priority", operator: "equals", value: "High" },
+				{ fieldname: "subject", operator: "like", value: "urgent" },
+			],
+		},
+	],
+});
+</script>

--- a/ui/src/components/ConditionBuilder/stories/Simple.vue
+++ b/ui/src/components/ConditionBuilder/stories/Simple.vue
@@ -1,0 +1,17 @@
+<template>
+	<div class="w-full max-w-3xl">
+		<ConditionBuilder v-model="conditions" :fields="sampleFields" />
+	</div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { ConditionBuilder } from "../index";
+import type { ConditionGroup } from "../index";
+import { sampleFields } from "./fields";
+
+const conditions = ref<ConditionGroup>({
+	conjunction: "and",
+	conditions: [{ fieldname: "status", operator: "equals", value: "Open" }],
+});
+</script>

--- a/ui/src/components/ConditionBuilder/stories/States.vue
+++ b/ui/src/components/ConditionBuilder/stories/States.vue
@@ -1,0 +1,91 @@
+<!--
+  Every state the builder survives: empty and `null` models, read-only, an add
+  control the host has blocked, every value control, and a condition on a field
+  the doctype no longer has.
+-->
+<template>
+	<div class="grid w-full max-w-3xl gap-8">
+		<section v-for="c in cases" :key="c.title" class="grid gap-2">
+			<h4 class="font-mono text-xs uppercase tracking-wide text-ink-gray-5">
+				{{ c.title }}
+			</h4>
+			<ConditionBuilder v-model="c.model.value" :fields="sampleFields" v-bind="c.props" />
+		</section>
+
+		<section class="grid gap-2">
+			<h4 class="font-mono text-xs uppercase tracking-wide text-ink-gray-5">
+				Adding blocked by the host
+			</h4>
+			<ConditionBuilder v-model="hostBlockedAdd" :fields="sampleFields">
+				<template #add-condition>
+					<Button label="Add Condition" icon-left="lucide-plus" disabled />
+				</template>
+			</ConditionBuilder>
+		</section>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { Button } from "frappe-ui";
+import { ConditionBuilder, fromFrappeConditions } from "../index";
+import type { ConditionGroup } from "../index";
+import { sampleFields } from "./fields";
+
+const filled: ConditionGroup = {
+	conjunction: "and",
+	conditions: [{ fieldname: "status", operator: "equals", value: "Open" }],
+};
+
+const empty = ref<ConditionGroup>({ conjunction: "and", conditions: [] });
+const nullish = ref<ConditionGroup | null>(null);
+const readonlyTree = ref<ConditionGroup>(structuredClone(filled));
+
+// There is no prop for "editable but not extendable" any more: the host renders
+// the add control it wants through `#addCondition` and disables that.
+const hostBlockedAdd = ref<ConditionGroup>(structuredClone(filled));
+
+// Handles and move items are opt-in: `reorderable` is off by default.
+const fixedOrder = ref<ConditionGroup>({
+	conjunction: "and",
+	conditions: [
+		{ fieldname: "status", operator: "equals", value: "Open" },
+		{ fieldname: "subject", operator: "like", value: "urgent" },
+	],
+});
+
+// Every value control the dispatch can pick, so each one renders.
+const allTypes = ref<ConditionGroup>({
+	conjunction: "and",
+	conditions: [
+		{ fieldname: "subject", operator: "like", value: "urgent" },
+		{ fieldname: "creation", operator: "between", value: "" },
+		{ fieldname: "rating", operator: ">=", value: 3 },
+		{ fieldname: "resolved", operator: "equals", value: "Yes" },
+		{ fieldname: "status", operator: "is", value: "set" },
+		{ fieldname: "owner", operator: "in", value: [] },
+		{ fieldname: "_assign", operator: "like", value: "john" },
+	],
+});
+
+// A stored condition naming a field that is not in `fields` at all: a field the
+// rule has outlived. The row stays readable and its picker stays live; an entry
+// the parser cannot model as a leaf at all is dropped on read, so there is none
+// to show here.
+const deletedField = ref<ConditionGroup>(
+	fromFrappeConditions([["deleted_field", "equals", "Open"]])
+);
+
+const cases = [
+	{ title: "Empty", model: empty, props: {} },
+	{ title: "modelValue = null", model: nullish, props: {} },
+	{ title: "Read-only", model: readonlyTree, props: { readonly: true } },
+	{
+		title: "Reorderable",
+		model: fixedOrder,
+		props: { reorderable: true },
+	},
+	{ title: "Every value control", model: allTypes, props: {} },
+	{ title: "Condition on a deleted field", model: deletedField, props: {} },
+];
+</script>

--- a/ui/src/components/ConditionBuilder/stories/fields.ts
+++ b/ui/src/components/ConditionBuilder/stories/fields.ts
@@ -1,0 +1,56 @@
+import type { ConditionField } from "../types";
+
+/**
+ * A sample field list shared by the stories, in the shape the built-in leaf
+ * takes, the shape `getFilterableFields` derives from doctype Meta,
+ * so `options` is Frappe's newline-joined string rather than an array.
+ */
+export const sampleFields: ConditionField[] = [
+  {
+    label: "Subject",
+    value: "subject",
+    fieldname: "subject",
+    fieldtype: "Data",
+  },
+  {
+    label: "Status",
+    value: "status",
+    fieldname: "status",
+    fieldtype: "Select",
+    options: "Open\nReplied\nClosed",
+  },
+  {
+    label: "Priority",
+    value: "priority",
+    fieldname: "priority",
+    fieldtype: "Select",
+    options: "Low\nMedium\nHigh",
+  },
+  // Here for the fieldname that overrides its operators.
+  {
+    label: "Assigned To",
+    value: "_assign",
+    fieldname: "_assign",
+    fieldtype: "Text",
+  },
+  {
+    label: "Created By",
+    value: "owner",
+    fieldname: "owner",
+    fieldtype: "Link",
+    options: "User",
+  },
+  { label: "Rating", value: "rating", fieldname: "rating", fieldtype: "Rating" },
+  {
+    label: "Resolved",
+    value: "resolved",
+    fieldname: "resolved",
+    fieldtype: "Check",
+  },
+  {
+    label: "Created On",
+    value: "creation",
+    fieldname: "creation",
+    fieldtype: "Datetime",
+  },
+];

--- a/ui/src/components/ConditionBuilder/tests/adapters.test.ts
+++ b/ui/src/components/ConditionBuilder/tests/adapters.test.ts
@@ -1,0 +1,592 @@
+import { describe, expect, it } from "vitest";
+import {
+  fromFrappeConditions,
+  toConditionExpression,
+  toFrappeConditions,
+} from "../adapters";
+import type { ConditionGroup, FieldConditionValue } from "../types";
+import type { ConditionField } from "../types";
+
+type Tree = ConditionGroup<FieldConditionValue>;
+
+function leaf(
+  fieldname: string,
+  operator: FieldConditionValue["operator"],
+  value: FieldConditionValue["value"]
+): FieldConditionValue {
+  return { fieldname, operator, value };
+}
+
+/** A group over the nodes given, joined by one operator. Defaults to `and`. */
+function group(
+  conditions: Tree["conditions"],
+  conjunction: Tree["conjunction"] = "and"
+): Tree {
+  return { conjunction, conditions };
+}
+
+describe("toConditionExpression", () => {
+  it("is empty for a tree with nothing in it", () => {
+    expect(toConditionExpression(group([]))).toBe("");
+  });
+
+  it("joins a level with the group's one operator, repeated", () => {
+    const tree = group(
+      [
+        leaf("status", "equals", "Open"),
+        leaf("priority", "equals", "High"),
+        leaf("agent", "equals", "sam"),
+      ],
+      "or"
+    );
+
+    expect(toConditionExpression(tree)).toBe(
+      'status == "Open" or priority == "High" or agent == "sam"'
+    );
+  });
+
+  it("parenthesises a nested group rather than relying on precedence", () => {
+    const tree = group(
+      [
+        group(
+          [
+            leaf("status", "equals", "Open"),
+            leaf("status", "equals", "Replied"),
+          ],
+          "or"
+        ),
+        leaf("priority", "equals", "High"),
+      ],
+      "and"
+    );
+
+    expect(toConditionExpression(tree)).toBe(
+      '(status == "Open" or status == "Replied") and priority == "High"'
+    );
+  });
+
+  it("prefixes fieldnames when the host evaluates against a document", () => {
+    const tree = group([leaf("status", "equals", "Open")]);
+
+    expect(toConditionExpression(tree, { fieldPrefix: "doc" })).toBe(
+      'doc.status == "Open"'
+    );
+  });
+
+  describe("operators", () => {
+    const compile = (
+      operator: FieldConditionValue["operator"],
+      value: FieldConditionValue["value"]
+    ) => toConditionExpression(group([leaf("subject", operator, value)]));
+
+    it("compiles equality and its aliases", () => {
+      expect(compile("equals", "refund")).toBe('subject == "refund"');
+      expect(compile("not equals", "refund")).toBe('subject != "refund"');
+    });
+
+    it("compiles like to a membership test guarded on the field", () => {
+      expect(compile("like", "refund")).toBe(
+        '(subject and "refund" in subject)'
+      );
+      expect(compile("not like", "refund")).toBe(
+        '(subject and "refund" not in subject)'
+      );
+    });
+
+    it("compiles in from a list and from a comma string alike", () => {
+      expect(compile("in", ["Open", "Replied"])).toBe(
+        '(subject and subject in ["Open", "Replied"])'
+      );
+      expect(compile("in", "Open, Replied")).toBe(
+        '(subject and subject in ["Open", "Replied"])'
+      );
+      expect(compile("not in", ["Open"])).toBe(
+        '(subject and subject not in ["Open"])'
+      );
+    });
+
+    it("compiles between to two comparisons, from a pair or a comma string", () => {
+      expect(compile("between", ["2026-01-01", "2026-01-31"])).toBe(
+        '(subject >= "2026-01-01" and subject <= "2026-01-31")'
+      );
+      expect(compile("between", "2026-01-01,2026-01-31")).toBe(
+        '(subject >= "2026-01-01" and subject <= "2026-01-31")'
+      );
+    });
+
+    it("compiles every set/not set pairing to the field's truthiness", () => {
+      expect(compile("is", "set")).toBe("subject");
+      expect(compile("is", "not set")).toBe("not subject");
+      expect(compile("is not", "set")).toBe("not subject");
+      // CRM's compiler leaves this one to fall through to `subject is not "not
+      // set"`, which is true of every document.
+      expect(compile("is not", "not set")).toBe("subject");
+    });
+
+    it("compiles a Check field's Yes/No to the field itself", () => {
+      expect(compile("equals", "Yes")).toBe("subject");
+      expect(compile("equals", "No")).toBe("not subject");
+      expect(compile("not equals", "Yes")).toBe("not subject");
+      expect(compile("not equals", "No")).toBe("subject");
+    });
+
+    it("compiles an unset value to the field's own falsiness", () => {
+      expect(compile("equals", null)).toBe("not subject");
+      expect(compile(">", null)).toBe("subject");
+    });
+
+    it("emits numbers bare and booleans as Python's", () => {
+      expect(compile(">", 5)).toBe("subject > 5");
+      expect(compile("equals", true)).toBe("subject == True");
+      expect(compile("equals", false)).toBe("subject == False");
+    });
+
+    it("escapes a value that would otherwise end the literal early", () => {
+      expect(compile("equals", 'a "quoted" word')).toBe(
+        'subject == "a \\"quoted\\" word"'
+      );
+      expect(compile("equals", "back\\slash")).toBe(
+        'subject == "back\\\\slash"'
+      );
+    });
+  });
+
+  describe("with the doctype's fields", () => {
+    const fields: ConditionField[] = [
+      {
+        label: "Is Open",
+        value: "is_open",
+        fieldname: "is_open",
+        fieldtype: "Check",
+      },
+      {
+        label: "Subject",
+        value: "subject",
+        fieldname: "subject",
+        fieldtype: "Data",
+      },
+      {
+        label: "Grand Total",
+        value: "grand_total",
+        fieldname: "grand_total",
+        fieldtype: "Currency",
+      },
+    ];
+
+    const compile = (
+      fieldname: string,
+      operator: FieldConditionValue["operator"],
+      value: FieldConditionValue["value"]
+    ) =>
+      toConditionExpression(group([leaf(fieldname, operator, value)]), {
+        fields,
+      });
+
+    it("compiles a Check field to its truthiness and a Data field to a comparison", () => {
+      expect(compile("is_open", "equals", "Yes")).toBe("is_open");
+      expect(compile("is_open", "equals", "No")).toBe("not is_open");
+      // Without fields this would read as a Check, since the value is the word.
+      expect(compile("subject", "equals", "Yes")).toBe('subject == "Yes"');
+    });
+
+    it("compiles a numeric field's value to a number, not a quoted string", () => {
+      // `doc.grand_total > "100"` raises under safe_eval rather than comparing.
+      expect(compile("grand_total", ">", "100")).toBe("grand_total > 100");
+      expect(compile("grand_total", "equals", "0")).toBe("grand_total == 0");
+      // Not a number: quoted, so the expression still parses.
+      expect(compile("grand_total", "equals", "lots")).toBe(
+        'grand_total == "lots"'
+      );
+    });
+
+    it("leaves an unknown fieldname to the value-only rules", () => {
+      expect(compile("nonexistent", "equals", "Yes")).toBe(
+        'nonexistent == "Yes"'
+      );
+    });
+
+    it("compiles nothing for a membership test on a number", () => {
+      // `"1" in doc.grand_total` raises, and safe_eval has no `str` to coerce
+      // with: its whitelist is int/float/long/round.
+      expect(compile("grand_total", "like", "100")).toBe("");
+      expect(compile("grand_total", "not like", "100")).toBe("");
+      // Still a membership test on anything that holds a string.
+      expect(compile("subject", "like", "refund")).toBe(
+        '(subject and "refund" in subject)'
+      );
+    });
+
+    it("compiles a numeric field's list members as numbers", () => {
+      // The document holds 100, and `100 in ["100"]` is False, so quoting the
+      // members makes the row match nothing at all rather than raise, which is
+      // the harder kind to notice.
+      expect(compile("grand_total", "in", "100, 200")).toBe(
+        "(grand_total and grand_total in [100, 200])"
+      );
+      // A member that is not a number stays quoted: `in` compares by equality
+      // and answers False across types, so it costs that member, not the rule.
+      expect(compile("grand_total", "in", "100, lots")).toBe(
+        '(grand_total and grand_total in [100, "lots"])'
+      );
+      expect(compile("subject", "in", "a, b")).toBe(
+        '(subject and subject in ["a", "b"])'
+      );
+    });
+
+    it("compiles a numeric field's range ends as numbers", () => {
+      expect(compile("grand_total", "between", ["100", "200"])).toBe(
+        "(grand_total >= 100 and grand_total <= 200)"
+      );
+      // Both ends are ordering comparisons, and `100 >= "abc"` raises, so an
+      // end that cannot be read as a number takes the row rather than the rule.
+      expect(compile("grand_total", "between", ["abc", "200"])).toBe("");
+    });
+
+    it("compiles nothing for an ordering comparison it cannot make", () => {
+      // `doc.grand_total > "lots"` is a TypeError, which loses every other
+      // condition in the rule. `==` is left alone: Python compares across types
+      // and answers False, so it is merely a row that never matches.
+      expect(compile("grand_total", ">", "lots")).toBe("");
+      expect(compile("grand_total", "<=", "")).toBe("");
+      expect(compile("grand_total", "equals", "lots")).toBe(
+        'grand_total == "lots"'
+      );
+    });
+  });
+
+  describe("values that would not survive being written into Python", () => {
+    const fields: ConditionField[] = [
+      {
+        label: "Subject",
+        value: "subject",
+        fieldname: "subject",
+        fieldtype: "Small Text",
+      },
+    ];
+
+    const compile = (value: FieldConditionValue["value"]) =>
+      toConditionExpression(group([leaf("subject", "equals", value)]), {
+        fields,
+      });
+
+    it("escapes the characters that would end the literal early", () => {
+      // A newline written through ends the string it is inside, so the whole
+      // expression is a SyntaxError, and an unparseable rule matches nothing,
+      // losing every other condition in the record along with this row. Reachable
+      // from any Long Text, Small Text or Text Editor value.
+      expect(compile(`a${String.fromCharCode(10)}b`)).toBe(
+        'subject == "a\\nb"'
+      );
+      expect(compile(`a${String.fromCharCode(13)}b`)).toBe(
+        'subject == "a\\rb"'
+      );
+      expect(compile(`a${String.fromCharCode(9)}b`)).toBe('subject == "a\\tb"');
+      // Anything else in the control range escapes numerically.
+      expect(compile(`a${String.fromCharCode(0)}b`)).toBe(
+        'subject == "a\\x00b"'
+      );
+      expect(compile(`a${String.fromCharCode(7)}b`)).toBe(
+        'subject == "a\\x07b"'
+      );
+    });
+
+    it("still escapes the backslash before the quote", () => {
+      expect(compile('a\\b"c')).toBe('subject == "a\\\\b\\"c"');
+    });
+  });
+
+  describe("an operator with no rule", () => {
+    it("compiles nothing for a between whose value names one end or none", () => {
+      // What frappe-ui's DateRangePicker.clearSelection() leaves behind. Emitted
+      // as `due_date between ""` it is a SyntaxError, which takes down the whole
+      // rule rather than this one row.
+      const one = (value: FieldConditionValue["value"]) =>
+        toConditionExpression(group([leaf("due_date", "between", value)]));
+
+      expect(one("")).toBe("");
+      expect(one("2026-01-01")).toBe("");
+      expect(one(["2026-01-01"])).toBe("");
+      expect(one(["2026-01-01", "2026-01-31"])).toBe(
+        '(due_date >= "2026-01-01" and due_date <= "2026-01-31")'
+      );
+    });
+
+    it("compiles nothing for a between holding a pair of empty ends", () => {
+      // The state every Date row starts in: `getDefaultOperator` is `between`
+      // and `getDefaultValue` is null, so this is what a freshly picked Date
+      // field compiles to before the range is filled. Falling through to the
+      // unset-value rule made it `due_date`, which reads as "is set" and matches
+      // every document that has a date at all, the opposite of matching none.
+      const one = (value: FieldConditionValue["value"]) =>
+        toConditionExpression(group([leaf("due_date", "between", value)]));
+
+      expect(one(null)).toBe("");
+      // `DateRangePicker.clearSelection()` emits this, which the value type
+      // does not admit and the compiler still has to survive.
+      expect(one([null, null] as unknown as FieldConditionValue["value"])).toBe(
+        ""
+      );
+      expect(one(["", ""])).toBe("");
+      expect(one(["2026-01-01", ""])).toBe("");
+      expect(one(["", "2026-01-31"])).toBe("");
+    });
+
+    it("compiles nothing for an in whose list names no member", () => {
+      // Where `defaultValueFor` starts an option field the moment `in` or
+      // `not in` is picked. `not in []` is True of every document that has the
+      // field, so the rule fired on all of them before a value was chosen, and
+      // `in []` is False for every one.
+      const one = (
+        operator: FieldConditionValue["operator"],
+        value: FieldConditionValue["value"]
+      ) => toConditionExpression(group([leaf("status", operator, value)]));
+
+      expect(one("in", [])).toBe("");
+      expect(one("not in", [])).toBe("");
+      expect(one("in", "")).toBe("");
+      expect(one("not in", "")).toBe("");
+      expect(one("in", ["", ""])).toBe("");
+      expect(one("in", ["Open"])).toBe('(status and status in ["Open"])');
+      // A blank member beside a real one goes, and takes nothing with it: the
+      // `status and` guard already excludes the documents it could have matched.
+      expect(one("in", ["Open", ""])).toBe('(status and status in ["Open"])');
+    });
+
+    it("compiles nothing for a like with no pattern", () => {
+      // Where a fresh text row starts: `like` is `getDefaultOperator`'s answer
+      // for a Data field and the value beside it is the empty string. `"" in
+      // doc.subject` is True of every document that has one, so this read as
+      // "is set"; `not like ""` is False for every document and lost the rule.
+      const one = (
+        operator: FieldConditionValue["operator"],
+        value: FieldConditionValue["value"]
+      ) => toConditionExpression(group([leaf("subject", operator, value)]));
+
+      expect(one("like", "")).toBe("");
+      expect(one("not like", "")).toBe("");
+      expect(one("like", null)).toBe("");
+      expect(one("like", "refund")).toBe('(subject and "refund" in subject)');
+    });
+
+    it("compiles nothing for is against something other than set/not set", () => {
+      expect(toConditionExpression(group([leaf("status", "is", "Open")]))).toBe(
+        ""
+      );
+    });
+
+    it("drops a stored timespan on read, so none reaches the compiler", () => {
+      // `timespan` has no safe_eval expression at all, so it is not in
+      // READ_OPERATOR: the entry is unparseable and goes the way of any other.
+      const tree = fromFrappeConditions([
+        ["status", "==", "Open"],
+        "and",
+        ["due_date", "timespan", "last week"],
+      ]);
+
+      expect(tree).toEqual(group([leaf("status", "equals", "Open")]));
+      expect(toConditionExpression(tree)).toBe('status == "Open"');
+    });
+
+    it("keeps the level readable when a row compiles to nothing", () => {
+      const tree = group(
+        [
+          leaf("status", "equals", "Open"),
+          leaf("due_date", "between", ""),
+          leaf("priority", "equals", "High"),
+        ],
+        "or"
+      );
+
+      expect(toConditionExpression(tree)).toBe(
+        'status == "Open" or priority == "High"'
+      );
+    });
+  });
+
+  it("drops what the array drops, and the conjunction beside it", () => {
+    const tree = group(
+      [
+        leaf("status", "equals", "Open"),
+        // Added but never given a field: dropped on save, so dropped here.
+        leaf("", "equals", ""),
+        leaf("priority", "equals", "High"),
+      ],
+      "or"
+    );
+
+    expect(toConditionExpression(tree)).toBe(
+      'status == "Open" or priority == "High"'
+    );
+  });
+
+  it("drops an empty group without leaving its operator dangling", () => {
+    const tree = group([group([]), leaf("status", "equals", "Open")], "and");
+
+    expect(toConditionExpression(tree)).toBe('status == "Open"');
+  });
+
+  it("drops an entry it cannot parse, and the conjunction beside it", () => {
+    // A doctype-qualified filter has no row to render and no Python to compile
+    // to, so the reader drops it rather than carrying a leaf nothing can edit.
+    const tree = fromFrappeConditions([
+      ["status", "==", "Open"],
+      "and",
+      ["HD Ticket", "priority", "==", "High"],
+    ]);
+
+    expect(toConditionExpression(tree)).toBe('status == "Open"');
+  });
+});
+
+describe("toFrappeConditions / fromFrappeConditions", () => {
+  it("round-trips a nested tree through the stored array", () => {
+    const tree = group(
+      [
+        leaf("status", "equals", "Open"),
+        group(
+          [leaf("priority", "equals", "High"), leaf("agent", "is", "not set")],
+          "or"
+        ),
+      ],
+      "and"
+    );
+
+    const stored = toFrappeConditions(tree);
+
+    expect(stored).toEqual([
+      ["status", "equals", "Open"],
+      "and",
+      [["priority", "equals", "High"], "or", ["agent", "is", "not set"]],
+    ]);
+    expect(fromFrappeConditions(stored)).toEqual(tree);
+  });
+
+  it("drops a leading entry it cannot parse without stranding its operator", () => {
+    // The dropped entry takes the token that followed it: kept, it would join
+    // the level's first survivor to nothing and re-save as a leading `or`.
+    expect(
+      fromFrappeConditions([
+        ["HD Ticket", "status", "==", "Open"],
+        "or",
+        ["priority", "==", "High"],
+      ])
+    ).toEqual(group([leaf("priority", "equals", "High")]));
+  });
+
+  it("keeps one gap per pair when a record repeats a token", () => {
+    expect(
+      fromFrappeConditions([
+        ["status", "==", "Open"],
+        "and",
+        "or",
+        ["priority", "==", "High"],
+      ])
+    ).toEqual(
+      group(
+        [leaf("status", "equals", "Open"), leaf("priority", "equals", "High")],
+        "or"
+      )
+    );
+  });
+
+  it("writes the group's one token between every surviving pair", () => {
+    const tree = group(
+      [
+        leaf("status", "equals", "Open"),
+        leaf("priority", "equals", "High"),
+        leaf("agent", "equals", "sam"),
+      ],
+      "or"
+    );
+
+    expect(toFrappeConditions(tree)).toEqual([
+      ["status", "equals", "Open"],
+      "or",
+      ["priority", "equals", "High"],
+      "or",
+      ["agent", "equals", "sam"],
+    ]);
+  });
+
+  describe("a stored level that mixes and with or", () => {
+    // The array can hold a token per gap; a group holds one. The first
+    // separator wins and the rest are discarded, so what loads is not what was
+    // stored. This is the lossy half of the model, pinned here so it cannot
+    // change silently.
+    const mixed = [
+      ["status", "==", "Open"],
+      "and",
+      ["priority", "==", "High"],
+      "or",
+      ["agent", "==", "sam"],
+    ];
+
+    it("takes the first token and discards the rest", () => {
+      expect(fromFrappeConditions(mixed)).toEqual(
+        group(
+          [
+            leaf("status", "equals", "Open"),
+            leaf("priority", "equals", "High"),
+            leaf("agent", "equals", "sam"),
+          ],
+          "and"
+        )
+      );
+    });
+
+    it("re-saves as a different rule than it loaded", () => {
+      // `A and B or C` was stored; `A and B and C` is what a save writes back.
+      // Accepted, and stated in the reader's doc comment and in the README.
+      expect(toFrappeConditions(fromFrappeConditions(mixed))).toEqual([
+        ["status", "equals", "Open"],
+        "and",
+        ["priority", "equals", "High"],
+        "and",
+        ["agent", "equals", "sam"],
+      ]);
+    });
+
+    it("normalises each level by its own first token", () => {
+      expect(
+        fromFrappeConditions([
+          ["status", "==", "Open"],
+          "or",
+          [
+            ["priority", "==", "High"],
+            "and",
+            ["agent", "==", "sam"],
+            "or",
+            ["team", "==", "billing"],
+          ],
+          "and",
+          ["subject", "like", "refund"],
+        ])
+      ).toEqual(
+        group(
+          [
+            leaf("status", "equals", "Open"),
+            group(
+              [
+                leaf("priority", "equals", "High"),
+                leaf("agent", "equals", "sam"),
+                leaf("team", "equals", "billing"),
+              ],
+              "and"
+            ),
+            leaf("subject", "like", "refund"),
+          ],
+          "or"
+        )
+      );
+    });
+
+    it("compiles the flattened rule, agreeing with what a save writes", () => {
+      // The expression is compiled from the array the tree writes, not from the
+      // one that was read, so the two halves of the record still agree with
+      // each other. They just no longer agree with what was stored.
+      expect(toConditionExpression(fromFrappeConditions(mixed))).toBe(
+        'status == "Open" and priority == "High" and agent == "sam"'
+      );
+    });
+  });
+});

--- a/ui/src/components/ConditionBuilder/tests/moveNode.test.ts
+++ b/ui/src/components/ConditionBuilder/tests/moveNode.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "vitest";
+import { canMoveInto, moveNode } from "../tree";
+import type { ConditionGroup, ConditionNode } from "../types";
+
+type Node = ConditionNode<string>;
+type Group = ConditionGroup<string>;
+
+function group(conditions: Node[], conjunction: "and" | "or" = "and"): Group {
+  return { conjunction, conditions };
+}
+
+/**
+ * ```
+ * root         A, B, [G: C, D], [H: E, [I: F]]
+ * ```
+ * Deep enough to drop into a sibling, into a nested group, and back out.
+ */
+function tree(): Group {
+  return group(["A", "B", group(["C", "D"], "or"), group(["E", group(["F"])])]);
+}
+
+const DEEP = 9;
+
+/** The group at `path`, for asserting on what a move left behind. */
+function at(root: Group, ...path: number[]): Group {
+  let node: Node = root;
+  for (const index of path) node = (node as Group).conditions[index];
+  return node as Group;
+}
+
+describe("moveNode", () => {
+  it("moves a row into a sibling group", () => {
+    // A (root index 0) into G, between C and D.
+    const next = moveNode(tree(), [0], [2], 1, DEEP);
+
+    expect(next.conditions[0]).toBe("B");
+    expect(at(next, 1).conditions).toEqual(["C", "A", "D"]);
+  });
+
+  it("moves a row into a group nested inside a sibling", () => {
+    // B into I, which is root -> H(3) -> I(1).
+    const next = moveNode(tree(), [1], [3, 1], 0, DEEP);
+
+    expect(next.conditions).toHaveLength(3);
+    expect(at(next, 2, 1).conditions).toEqual(["B", "F"]);
+  });
+
+  it("moves a row out to an ancestor", () => {
+    // F, the only child of I, out to the root's front.
+    const next = moveNode(tree(), [3, 1, 0], [], 0, DEEP);
+
+    expect(next.conditions[0]).toBe("F");
+    // I is emptied by the move and goes, the way removeNode takes one.
+    expect(at(next, 4).conditions).toEqual(["E"]);
+  });
+
+  it("leaves the source tree untouched", () => {
+    const before = tree();
+    moveNode(before, [0], [2], 0, DEEP);
+    expect(before).toEqual(tree());
+  });
+
+  it("keeps the destination's operator, not the traveller's", () => {
+    // A comes from an `and` root into G, which is `or`. G stays `or`.
+    const next = moveNode(tree(), [0], [2], 0, DEEP);
+    expect(at(next, 1).conjunction).toBe("or");
+    expect(next.conjunction).toBe("and");
+  });
+
+  describe("a group emptied by the move", () => {
+    it("goes, the same way removeNode takes an emptied group", () => {
+      const start = group(["A", group(["B"])]);
+      const next = moveNode(start, [1, 0], [], 0, DEEP);
+
+      expect(next.conditions).toEqual(["B", "A"]);
+    });
+
+    it("cascades, so an emptied parent goes with it", () => {
+      const start = group(["A", group([group(["B"])])]);
+      const next = moveNode(start, [1, 0, 0], [], 0, DEEP);
+
+      expect(next.conditions).toEqual(["B", "A"]);
+    });
+
+    it("never takes the root, which is the empty state", () => {
+      const next = moveNode(group(["A"]), [0], [], 0, DEEP);
+      expect(next).toEqual(group(["A"]));
+    });
+
+    it("is pruned by identity, not by the path it used to have", () => {
+      // The row lands in an ancestor, in front of the very group it came from,
+      // so the insertion re-points that group before the prune runs. Pruning by
+      // the source's original path removes whatever slid into it. Here, the
+      // row that was just dropped.
+      const start = group([group(["A"]), "B"]);
+      const next = moveNode(start, [0, 0], [], 0, DEEP);
+
+      expect(next.conditions).toEqual(["A", "B"]);
+    });
+  });
+
+  describe("indices", () => {
+    it("appends for a drop past the end", () => {
+      const next = moveNode(tree(), [0], [2], 99, DEEP);
+      expect(at(next, 1).conditions).toEqual(["C", "D", "A"]);
+    });
+
+    it("reorders within one group, which is the same edit", () => {
+      const next = moveNode(tree(), [0], [], 1, DEEP);
+      expect(next.conditions.slice(0, 2)).toEqual(["B", "A"]);
+      expect(next.conditions).toHaveLength(4);
+    });
+  });
+
+  describe("a reorder, which is a move into the group it is already in", () => {
+    /** `A or B or C`, flat. */
+    function flat(): Group {
+      return group(["A", "B", "C"], "or");
+    }
+
+    it("reorders a row within its group", () => {
+      expect(moveNode(flat(), [2], [], 0, DEEP).conditions).toEqual([
+        "C",
+        "A",
+        "B",
+      ]);
+    });
+
+    it("cannot change what the level matches", () => {
+      // One operator for the group, so there is no gap for a move to re-point:
+      // every arrangement of `A or B or C` is still `A or B or C`.
+      for (const [from, to] of [
+        [0, 1],
+        [0, 2],
+        [1, 0],
+        [1, 2],
+        [2, 0],
+        [2, 1],
+      ]) {
+        const next = moveNode(flat(), [from], [], to, DEEP);
+        expect(next.conjunction).toBe("or");
+        expect(next.conditions).toHaveLength(3);
+      }
+    });
+
+    it("moves inside a nested group without touching its parent", () => {
+      const next = moveNode(tree(), [2, 1], [2], 0, DEEP);
+      expect(at(next, 2).conditions).toEqual(["D", "C"]);
+      expect(at(next, 2).conjunction).toBe("or");
+      expect(next.conditions[0]).toBe("A");
+      expect(next.conditions).toHaveLength(4);
+    });
+
+    it("is a no-op when the row does not move", () => {
+      expect(moveNode(flat(), [1], [], 1, DEEP)).toEqual(flat());
+    });
+
+    it("appends for an index past the end, rather than refusing it", () => {
+      // The reparent rule, applied here too: one function, one answer. The row
+      // menu never asks for one, since it guards the last row itself.
+      expect(moveNode(flat(), [0], [], 3, DEEP).conditions).toEqual([
+        "B",
+        "C",
+        "A",
+      ]);
+    });
+
+    it("is a no-op for a row that is not there", () => {
+      expect(moveNode(flat(), [-1], [], 0, DEEP)).toEqual(flat());
+      expect(moveNode(flat(), [9], [], 0, DEEP)).toEqual(flat());
+    });
+
+    it("is not refused on depth, since it changes no node's depth", () => {
+      // maxDepth 0 forbids every group, and the tree already breaks it. The
+      // rows inside stay rearrangeable rather than freezing where they sit.
+      expect(moveNode(tree(), [2, 1], [2], 0, 0).conditions).toHaveLength(4);
+      expect(at(moveNode(tree(), [2, 1], [2], 0, 0), 2).conditions).toEqual([
+        "D",
+        "C",
+      ]);
+    });
+  });
+
+  describe("refusals", () => {
+    it("refuses a drop that would nest past maxDepth", () => {
+      // G is a group at depth 1; dropping it into H (depth 1) would put it at
+      // depth 2, and its own contents no deeper. maxDepth 1 refuses it.
+      expect(moveNode(tree(), [2], [3], 0, 1)).toEqual(tree());
+      // The same move fits under maxDepth 2.
+      expect(moveNode(tree(), [2], [3], 0, 2)).not.toEqual(tree());
+    });
+
+    it("counts the whole subtree, not just the node that was grabbed", () => {
+      // H is a group holding a group, so it is two levels deep. Landing it in G
+      // (depth 1) puts its own nested group at depth 3.
+      expect(moveNode(tree(), [3], [2], 0, 2)).toEqual(tree());
+      expect(moveNode(tree(), [3], [2], 0, 3)).not.toEqual(tree());
+    });
+
+    it("never refuses a leaf on depth, since a leaf adds no level", () => {
+      expect(canMoveInto(tree(), [0], [3, 1], 2)).toBe(true);
+    });
+
+    it("refuses a group dropped into itself or into its own contents", () => {
+      expect(moveNode(tree(), [3], [3], 0, DEEP)).toEqual(tree());
+      expect(moveNode(tree(), [3], [3, 1], 0, DEEP)).toEqual(tree());
+    });
+
+    it("refuses to move the root", () => {
+      expect(moveNode(tree(), [], [2], 0, DEEP)).toEqual(tree());
+    });
+
+    it("refuses a path that names nothing, or a destination that is a leaf", () => {
+      expect(moveNode(tree(), [9], [2], 0, DEEP)).toEqual(tree());
+      expect(moveNode(tree(), [0], [9], 0, DEEP)).toEqual(tree());
+      expect(moveNode(tree(), [0], [1], 0, DEEP)).toEqual(tree());
+    });
+  });
+});
+
+describe("canMoveInto", () => {
+  it("agrees with what the move actually does", () => {
+    const cases: Array<[number[], number[], number]> = [
+      [[0], [2], DEEP],
+      [[3], [2], 2],
+      [[3], [3, 1], DEEP],
+      [[], [2], DEEP],
+      [[9], [2], DEEP],
+      [[0], [1], DEEP],
+    ];
+
+    for (const [from, to, maxDepth] of cases) {
+      const refused = moveNode(tree(), from, to, 0, maxDepth);
+      expect(canMoveInto(tree(), from, to, maxDepth)).toBe(
+        JSON.stringify(refused) !== JSON.stringify(tree())
+      );
+    }
+  });
+});

--- a/ui/src/components/ConditionBuilder/tests/operators.test.ts
+++ b/ui/src/components/ConditionBuilder/tests/operators.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { carryOver } from "../../Filter/operators";
+import type { Filter } from "../../Filter/types";
+import type { ConditionField } from "../types";
+import { conditionOperators } from "../adapters";
+
+const status: ConditionField = {
+  label: "Status",
+  value: "status",
+  fieldname: "status",
+  fieldtype: "Select",
+  options: "Open\nReplied",
+};
+
+const priority: ConditionField = {
+  label: "Priority",
+  value: "priority",
+  fieldname: "priority",
+  fieldtype: "Select",
+  options: "Low\nHigh",
+};
+
+describe("carryOver", () => {
+  it("keeps an operator the caller offers but Filter does not", () => {
+    // `is not` exists only in `conditionOperators`. Checked against
+    // `getOperators` it reads as unavailable on every field, so changing the
+    // field silently reset the row and lost both operator and value.
+    const prev: Filter = {
+      field: status,
+      fieldname: "status",
+      operator: "is not",
+      value: "set",
+    };
+
+    const carried = carryOver(
+      prev,
+      priority,
+      conditionOperators(priority.fieldtype, priority.fieldname)
+    );
+
+    expect(carried.operator).toBe("is not");
+    expect(carried.value).toBe("set");
+    expect(carried.fieldname).toBe("priority");
+  });
+
+  it("still resets an operator the new field is not offered", () => {
+    const prev: Filter = {
+      field: status,
+      fieldname: "status",
+      operator: "between",
+      value: ["a", "b"],
+    };
+
+    const carried = carryOver(
+      prev,
+      priority,
+      conditionOperators(priority.fieldtype, priority.fieldname)
+    );
+
+    expect(carried.operator).not.toBe("between");
+  });
+
+  it("drops a deleted field's value where the new field cannot hold it", () => {
+    // A row whose own field was removed from the doctype: `prev.field` is
+    // undefined, so there is no domain to compare and the value is whatever
+    // text the record stored. Carried into a Date it made `creation == "Open"`
+    // offered, because `equals` is a Date operator, and handed the value
+    // straight to a DateField.
+    const gone: Filter = {
+      field: undefined,
+      fieldname: "deleted_field",
+      operator: "equals",
+      value: "Open",
+    };
+
+    const created: ConditionField = {
+      label: "Created On",
+      value: "creation",
+      fieldname: "creation",
+      fieldtype: "Datetime",
+    };
+
+    const subject: ConditionField = {
+      label: "Subject",
+      value: "subject",
+      fieldname: "subject",
+      fieldtype: "Data",
+    };
+
+    expect(
+      carryOver(
+        gone,
+        created,
+        conditionOperators(created.fieldtype, created.fieldname)
+      ).value
+    ).not.toBe("Open");
+
+    // Text is what it was, so a text field still takes it.
+    expect(
+      carryOver(
+        gone,
+        subject,
+        conditionOperators(subject.fieldtype, subject.fieldname)
+      ).value
+    ).toBe("Open");
+
+    // A Select proves for itself whether the word is one of its options.
+    expect(
+      carryOver(
+        gone,
+        status,
+        conditionOperators(status.fieldtype, status.fieldname)
+      ).value
+    ).toBe("Open");
+    expect(
+      carryOver(
+        gone,
+        priority,
+        conditionOperators(priority.fieldtype, priority.fieldname)
+      ).value
+    ).not.toBe("Open");
+  });
+
+  it("falls back to Filter's own list when the caller names none", () => {
+    const prev: Filter = {
+      field: status,
+      fieldname: "status",
+      operator: "is not",
+      value: "set",
+    };
+
+    expect(carryOver(prev, priority).operator).not.toBe("is not");
+  });
+});

--- a/ui/src/components/ConditionBuilder/tests/removeNode.test.ts
+++ b/ui/src/components/ConditionBuilder/tests/removeNode.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { removeNode } from "../tree";
+import type { ConditionGroup } from "../types";
+
+/** `A and (B and (C))`, deep enough for a cascade to have somewhere to go. */
+function nested(): ConditionGroup<string> {
+  return {
+    conjunction: "and",
+    conditions: [
+      "A",
+      {
+        conjunction: "and",
+        conditions: ["B", { conjunction: "or", conditions: ["C"] }],
+      },
+    ],
+  };
+}
+
+describe("removeNode", () => {
+  it("takes a row and leaves its siblings", () => {
+    const next = removeNode(
+      { conjunction: "and", conditions: ["A", "B", "C"] },
+      [1]
+    );
+    expect(next.conditions).toEqual(["A", "C"]);
+  });
+
+  it("takes the group a row leaves empty", () => {
+    // C is the only child of the innermost group, so that group goes too.
+    const next = removeNode(nested(), [1, 1, 0]);
+    expect(next).toEqual({
+      conjunction: "and",
+      conditions: ["A", { conjunction: "and", conditions: ["B"] }],
+    });
+  });
+
+  it("cascades past more than one level", () => {
+    const tree: ConditionGroup<string> = {
+      conjunction: "and",
+      conditions: [
+        "A",
+        {
+          conjunction: "and",
+          conditions: [{ conjunction: "or", conditions: ["B"] }],
+        },
+      ],
+    };
+    // Removing B empties its group, which empties the group holding that.
+    const next = removeNode(tree, [1, 0, 0]);
+    expect(next).toEqual({ conjunction: "and", conditions: ["A"] });
+  });
+
+  it("never takes the root, however empty it gets", () => {
+    const next = removeNode({ conjunction: "and", conditions: ["A"] }, [0]);
+    expect(next).toEqual({ conjunction: "and", conditions: [] });
+  });
+
+  it("leaves a group that still holds something", () => {
+    const next = removeNode(nested(), [1, 0]);
+    expect(next.conditions[1]).toEqual({
+      conjunction: "and",
+      conditions: [{ conjunction: "or", conditions: ["C"] }],
+    });
+  });
+
+  it("empties the tree when the root itself is named", () => {
+    const next = removeNode(nested(), []);
+    expect(next.conditions).toEqual([]);
+  });
+
+  it("does not touch the tree it was handed", () => {
+    const before = nested();
+    removeNode(before, [1, 1, 0]);
+    expect(before).toEqual(nested());
+  });
+
+  it("is a no-op on a path that resolves to nothing", () => {
+    const next = removeNode(nested(), [9, 9]);
+    expect(next).toEqual(nested());
+  });
+});

--- a/ui/src/components/ConditionBuilder/tree.ts
+++ b/ui/src/components/ConditionBuilder/tree.ts
@@ -1,0 +1,296 @@
+import type {
+  ConditionGroup,
+  ConditionNode,
+  ConditionPath,
+  Conjunction,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// Reading a tree
+// ---------------------------------------------------------------------------
+
+export function isGroup<T>(node: ConditionNode<T>): node is ConditionGroup<T> {
+  return (
+    node !== null &&
+    typeof node === "object" &&
+    Array.isArray((node as ConditionGroup<T>).conditions)
+  );
+}
+
+export function emptyTree<T>(): ConditionGroup<T> {
+  return { conjunction: "and", conditions: [] };
+}
+
+export function getNode<T>(
+  tree: ConditionGroup<T>,
+  path: ConditionPath
+): ConditionNode<T> | undefined {
+  let node: ConditionNode<T> = tree;
+  for (const index of path) {
+    if (!isGroup(node)) return undefined;
+    node = node.conditions[index];
+    if (node === undefined) return undefined;
+  }
+  return node;
+}
+
+/** How many conditions the tree holds, at any depth. Groups are not counted. */
+export function countConditions<T>(group: ConditionGroup<T>): number {
+  return group.conditions.reduce<number>(
+    (total, node) => total + (isGroup(node) ? countConditions(node) : 1),
+    0
+  );
+}
+
+/**
+ * How many groups the tree holds below the root. Comparing the count before and
+ * after is the only way to know a removal cascaded: a sibling shifts into the
+ * pruned index.
+ */
+export function countGroups<T>(group: ConditionGroup<T>): number {
+  return group.conditions.reduce<number>(
+    (total, node) => total + (isGroup(node) ? 1 + countGroups(node) : 0),
+    0
+  );
+}
+
+/** Whether two paths address the same node. */
+export function samePath(a: ConditionPath, b: ConditionPath): boolean {
+  return a.length === b.length && a.every((index, depth) => index === b[depth]);
+}
+
+export function canNest(groupPath: ConditionPath, maxDepth: number): boolean {
+  return groupPath.length < maxDepth;
+}
+
+export function canMoveInto<T>(
+  tree: ConditionGroup<T>,
+  from: ConditionPath,
+  toGroupPath: ConditionPath,
+  maxDepth: number
+): boolean {
+  if (from.length === 0) return false;
+
+  const node = getNode(tree, from);
+  if (node === undefined) return false;
+
+  const target = getNode(tree, toGroupPath);
+  if (target === undefined || !isGroup(target)) return false;
+
+  if (isAtOrBelow(toGroupPath, from)) return false;
+
+  return toGroupPath.length + groupLevels(node) <= maxDepth;
+}
+
+// ---------------------------------------------------------------------------
+// Editing a tree. Every one returns a new tree and leaves the old one alone.
+// ---------------------------------------------------------------------------
+
+export function addCondition<T>(
+  tree: ConditionGroup<T>,
+  groupPath: ConditionPath,
+  leaf: T
+): ConditionGroup<T> {
+  return editGroup(tree, groupPath, (group) => {
+    group.conditions.push(leaf);
+  });
+}
+
+export function addGroup<T>(
+  tree: ConditionGroup<T>,
+  groupPath: ConditionPath,
+  leaf: T
+): ConditionGroup<T> {
+  return editGroup(tree, groupPath, (group) => {
+    group.conditions.push({ conjunction: "and", conditions: [leaf] });
+  });
+}
+
+export function updateLeaf<T>(
+  tree: ConditionGroup<T>,
+  path: ConditionPath,
+  leaf: T
+): ConditionGroup<T> {
+  return editParent(tree, path, (parent, index) => {
+    parent.conditions[index] = leaf;
+  });
+}
+
+export function setGroupConjunction<T>(
+  tree: ConditionGroup<T>,
+  groupPath: ConditionPath,
+  value: Conjunction
+): ConditionGroup<T> {
+  return editGroup(tree, groupPath, (group) => {
+    group.conjunction = value;
+  });
+}
+
+export function turnIntoGroup<T>(
+  tree: ConditionGroup<T>,
+  path: ConditionPath
+): ConditionGroup<T> {
+  return editParent(tree, path, (parent, index) => {
+    const node = parent.conditions[index];
+    if (node === undefined || isGroup(node)) return;
+    parent.conditions[index] = { conjunction: "and", conditions: [node] };
+  });
+}
+
+export function ungroup<T>(
+  tree: ConditionGroup<T>,
+  path: ConditionPath
+): ConditionGroup<T> {
+  if (path.length === 0) return clone(tree);
+
+  return editParent(tree, path, (parent, index) => {
+    const group = parent.conditions[index];
+    if (group === undefined || !isGroup(group)) return;
+    parent.conditions.splice(index, 1, ...group.conditions);
+  });
+}
+
+export function removeNode<T>(
+  tree: ConditionGroup<T>,
+  path: ConditionPath
+): ConditionGroup<T> {
+  if (path.length === 0) return emptyTree<T>();
+
+  const next = clone(tree);
+  const parent = parentOf(next, path);
+  if (!parent) return next;
+
+  parent.conditions.splice(path[path.length - 1], 1);
+  pruneEmpty(next, parent);
+  return next;
+}
+
+/**
+ * Move the node at `from` to `toIndex` of the group at `toGroupPath`, its own
+ * group included. A reorder and a reparent are the same edit. `toIndex` is
+ * clamped, since a drop past the end means append.
+ */
+export function moveNode<T>(
+  tree: ConditionGroup<T>,
+  from: ConditionPath,
+  toGroupPath: ConditionPath,
+  toIndex: number,
+  maxDepth: number
+): ConditionGroup<T> {
+  const next = clone(tree);
+
+  // The root has no group to leave, and the reorder below skips `canMoveInto`.
+  if (from.length === 0 || getNode(next, from) === undefined) return next;
+
+  // A reorder changes no depth, so a tree already past `maxDepth` stays
+  // rearrangeable.
+  const reorder = samePath(from.slice(0, -1), toGroupPath);
+  if (!reorder && !canMoveInto(next, from, toGroupPath, maxDepth)) return next;
+
+  const source = parentOf(next, from);
+  const target = getNode(next, toGroupPath);
+  if (!source || target === undefined || !isGroup(target)) return next;
+
+  const [node] = source.conditions.splice(from[from.length - 1], 1);
+  if (node === undefined) return next;
+
+  target.conditions.splice(
+    Math.max(0, Math.min(toIndex, target.conditions.length)),
+    0,
+    node
+  );
+
+  if (source !== target) pruneEmpty(next, source);
+  return next;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function clone<T>(tree: ConditionGroup<T>): ConditionGroup<T> {
+  try {
+    return structuredClone(tree);
+  } catch {
+    return JSON.parse(JSON.stringify(tree));
+  }
+}
+
+function parentOf<T>(
+  tree: ConditionGroup<T>,
+  path: ConditionPath
+): ConditionGroup<T> | undefined {
+  const node = getNode(tree, path.slice(0, -1));
+  return node !== undefined && isGroup(node) ? node : undefined;
+}
+
+/** Clone, resolve, bail if the path names nothing, then apply `edit`. */
+function editGroup<T>(
+  tree: ConditionGroup<T>,
+  groupPath: ConditionPath,
+  edit: (group: ConditionGroup<T>) => void
+): ConditionGroup<T> {
+  const next = clone(tree);
+  const group = getNode(next, groupPath);
+  if (group !== undefined && isGroup(group)) edit(group);
+  return next;
+}
+
+/** `editGroup`, addressed by the node instead of the group holding it. */
+function editParent<T>(
+  tree: ConditionGroup<T>,
+  path: ConditionPath,
+  edit: (parent: ConditionGroup<T>, index: number) => void
+): ConditionGroup<T> {
+  return editGroup(tree, path.slice(0, -1), (parent) =>
+    edit(parent, path[path.length - 1])
+  );
+}
+
+/** Whether `path` addresses `other` or something inside it. */
+function isAtOrBelow(path: ConditionPath, other: ConditionPath): boolean {
+  return path.length >= other.length && other.every((i, d) => i === path[d]);
+}
+
+/** How many levels of group a node is: 0 for a leaf, 1 for a group of leaves. */
+function groupLevels<T>(node: ConditionNode<T>): number {
+  if (!isGroup(node)) return 0;
+  return (
+    1 +
+    node.conditions.reduce(
+      (deepest, child) => Math.max(deepest, groupLevels(child)),
+      0
+    )
+  );
+}
+
+function parentGroupOf<T>(
+  root: ConditionGroup<T>,
+  child: ConditionNode<T>
+): ConditionGroup<T> | null {
+  if (root.conditions.includes(child)) return root;
+  for (const node of root.conditions) {
+    if (!isGroup(node)) continue;
+    const found = parentGroupOf(node, child);
+    if (found) return found;
+  }
+  return null;
+}
+
+/**
+ * An emptied group goes, cascading up. By reference, not path: a splice
+ * invalidates every path after it. `parentGroupOf` answers null for the root,
+ * so the root is never pruned.
+ */
+function pruneEmpty<T>(
+  root: ConditionGroup<T>,
+  group: ConditionGroup<T>
+): void {
+  if (group.conditions.length > 0) return;
+
+  const parent = parentGroupOf(root, group);
+  if (!parent) return;
+
+  parent.conditions.splice(parent.conditions.indexOf(group), 1);
+  pruneEmpty(root, parent);
+}

--- a/ui/src/components/ConditionBuilder/types.ts
+++ b/ui/src/components/ConditionBuilder/types.ts
@@ -1,0 +1,242 @@
+import type { Component } from "vue";
+import type { InputLabelingProps } from "../types";
+import type { FilterField, FilterOperator, FilterValue } from "../Filter/types";
+
+export type Conjunction = "and" | "or";
+
+/**
+ * Derived from the rules it composes (ADR-0008), so the two cannot drift.
+ * `timespan` is excluded: no expression compiles from one.
+ */
+export type ConditionOperator = Exclude<FilterOperator, "timespan">;
+export type ConditionField = FilterField;
+
+/** Widened by the two shapes the shared controls emit: a Rating number, and the
+ *  null a date holds before anything is picked. */
+export type ConditionValue = FilterValue | number | null;
+
+export interface ConditionExpressionOptions {
+  fieldPrefix?: string;
+  fields?: ConditionField[];
+}
+
+export interface ConditionOperatorOption {
+  label: string;
+  value: ConditionOperator;
+}
+
+/** Child indices from the root group. `[]` addresses the root itself. */
+export type ConditionPath = number[];
+
+/** The built-in leaf. No resolved Meta on it, so a tree stays JSON. */
+export interface FieldConditionValue {
+  fieldname: string;
+  operator: ConditionOperator;
+  value: ConditionValue;
+}
+
+/**
+ * One operator for the whole group, so a level reads `A and B and C`. Mixing is
+ * expressed by nesting. The `conditions` array is what tells a group from a
+ * leaf.
+ */
+export interface ConditionGroup<TLeaf = FieldConditionValue> {
+  conjunction: Conjunction;
+  conditions: ConditionNode<TLeaf>[];
+}
+
+export type ConditionNode<TLeaf = FieldConditionValue> =
+  | TLeaf
+  | ConditionGroup<TLeaf>;
+
+/** Grid track sizes for the leaf's three cells. An `fr` stretches a cell past
+ *  its content to use up the row's leftover width. */
+export interface ConditionColumns {
+  field?: string;
+  operator?: string;
+  value?: string;
+}
+
+/** `'all'` borders every group, `'root'` only the outer card, `'none'` neither. */
+export type ConditionBorders = "all" | "root" | "none";
+
+export interface ConditionBuilderLabels {
+  where: string;
+  and: string;
+  or: string;
+
+  /** Names the root `<fieldset>` and every nested `role="group"`. */
+  matchAll: string;
+  matchAny: string;
+
+  /** Describes what the and/or button does. Never rendered as text. */
+  conjunctionHint: string;
+
+  addCondition: string;
+  addGroup: string;
+  turnIntoGroup: string;
+  ungroup: string;
+  remove: string;
+  removeGroup: string;
+  empty: string;
+
+  /** Accessible names for the row and group menus. Never rendered as text. */
+  rowActions: string;
+  groupActions: string;
+
+  /** Names for the three cells of the built-in leaf. Never rendered as text. */
+  field: string;
+  operator: string;
+  value: string;
+
+  fieldsError: string;
+  retryFields: string;
+
+  /** Functions, so the sentence is built in the host's language rather than
+   *  assembled here from English fragments. */
+  removed: (remaining: number, groupRemoved: boolean) => string;
+  moved: (name: string, from: number, to: number, total: number) => string;
+  movedToGroup: (name: string, to: number, total: number) => string;
+}
+
+/**
+ * `label` / `description` / `error` / `required` are the shared labeling contract
+ * every input control in this package exposes (frappe-ui P5). The tree is a value
+ * the user enters, so the rule applies here as it does to Link and Phone.
+ */
+export interface ConditionBuilderProps<TLeaf = FieldConditionValue>
+  extends InputLabelingProps {
+  /** The tree, as `v-model`. `null` is an empty tree, which is what a nullable
+   *  backend field bound straight to `v-model` arrives as. */
+  modelValue: ConditionGroup<TLeaf> | null;
+
+  /** The Python expression the tree compiles to. Write-only: never read back. */
+  expression?: string;
+
+  /** Prefixes every fieldname in the expression: `doc` for an SLA, nothing for
+   *  an Assignment Rule. Affects nothing on screen. */
+  fieldPrefix?: string;
+
+  /** Doctype whose Meta drives the built-in leaf. Ignored when `fields` is
+   *  supplied, unused when `#condition` replaces the leaf. */
+  doctype?: string;
+
+  fields?: ConditionField[];
+  columns?: ConditionColumns;
+
+  /** Root group is depth 0. Defaults to 4; past that a row has too little width. */
+  maxDepth?: number;
+
+  newCondition?: () => TLeaf;
+
+  /** Read-only, not disabled: the rows keep their tab stops. */
+  readonly?: boolean;
+
+  /** For changing the wording. The defaults already go through the host's `__`. */
+  labels?: Partial<ConditionBuilderLabels>;
+
+  bordered?: ConditionBorders;
+
+  /** Defaults to false. Turns off dragging between groups as well as within. */
+  reorderable?: boolean;
+}
+
+export interface ConditionSlotProps<TLeaf = FieldConditionValue> {
+  condition: TLeaf;
+  path: ConditionPath;
+  depth: number;
+  readonly: boolean;
+  update: (leaf: TLeaf) => void;
+}
+
+export interface ValueSlotProps {
+  field: ConditionField | undefined;
+  operator: ConditionOperator;
+  modelValue: ConditionValue;
+
+  /** True for a read-only builder, an unknown field, or a fieldtype with no
+   *  value control. The slot renders in all of them and must not call `update`. */
+  readonly: boolean;
+  update: (value: ConditionValue) => void;
+}
+
+/** Props for `#group`, which wraps a **nested** group. The root is the builder
+ *  itself, so a host wraps it where it mounts it rather than through a slot. */
+export interface GroupSlotProps<TLeaf = FieldConditionValue> {
+  group: ConditionGroup<TLeaf>;
+
+  /** Child indices from the root. Never `[]`. */
+  path: ConditionPath;
+  depth: number;
+  readonly: boolean;
+
+  /** The default rendering. `<component :is="Group" />` puts the real recursive
+   *  group wherever the host renders it, a teleported dialog included. Takes no
+   *  props: the node is read from the tree on each render. */
+  Group: Component;
+}
+
+export interface WhereSlotProps {
+  groupPath: ConditionPath;
+  conjunction: Conjunction;
+}
+
+export interface ConjunctionSlotProps {
+  conjunction: Conjunction;
+
+  /** This row's index within its group. Always 1 or greater. */
+  index: number;
+  groupPath: ConditionPath;
+  toggle: () => void;
+
+  /** Exactly one cell in a group is live: row 1. A cell that is not should
+   *  render the word as text, not as a disabled button. */
+  canToggle: boolean;
+}
+
+export interface ActionsSlotProps {
+  path: ConditionPath;
+  isGroup: boolean;
+  readonly: boolean;
+
+  /** Whether `turnIntoGroup` would do anything: false for a group, and false
+   *  where nesting here would exceed `maxDepth`. */
+  canGroup: boolean;
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  moveUp: () => void;
+  moveDown: () => void;
+  turnIntoGroup: () => void;
+  ungroup: () => void;
+  remove: () => void;
+}
+
+export interface AddConditionSlotProps {
+  groupPath: ConditionPath;
+  addCondition: () => void;
+  addGroup: () => void;
+  canAddGroup: boolean;
+}
+
+export interface ConditionBuilderSlots<TLeaf = FieldConditionValue> {
+  /** Replaces the entire leaf row. */
+  condition?: (props: ConditionSlotProps<TLeaf>) => unknown;
+
+  /**
+   * Wraps or replaces a nested group. An empty template renders the default;
+   * `<span />` renders no group at all, leaving its rows unreachable.
+   */
+  group?: (props: GroupSlotProps<TLeaf>) => unknown;
+
+  /** Replaces only the value control inside the built-in leaf. */
+  "condition-value"?: (props: ValueSlotProps) => unknown;
+
+  /** Replaces the empty-state content. */
+  empty?: () => unknown;
+
+  /** Render a `<span />` to draw nothing. */
+  "condition-where"?: (props: WhereSlotProps) => unknown;
+  "condition-conjunction"?: (props: ConjunctionSlotProps) => unknown;
+  "condition-actions"?: (props: ActionsSlotProps) => unknown;
+  "add-condition"?: (props: AddConditionSlotProps) => unknown;
+}

--- a/ui/src/components/Filter/Filter.vue
+++ b/ui/src/components/Filter/Filter.vue
@@ -9,14 +9,11 @@
   `crm.api.doc.get_filterable_fields` + `getOperators` (ADR-0001, ADR-0003).
 
   The value inputs are the shared `Fields` module's components (ADR-0004), not CRM's
-  bespoke Link/Duration/Rating trio. The gaps the shared inputs don't cover are
-  operator-driven swaps handled here, in the `.vue`: `is`/`is not` → a Set/Not-Set
-  select, `timespan` → a preset select, `like`/`not like` → a plain text box, and
-  Date `between` → a range picker. `in`/`not in` over an option field (Select /
-  Autocomplete / Link) is a MultiSelect of the field's values (`MultiSelectInput` /
-  `MultiLinkInput`) so values are picked, not typed as an error-prone comma string;
-  over a free-text field it stays a comma text box. Field pickers use frappe-ui's
-  `Combobox`; icons are lucide names.
+  bespoke Link/Duration/Rating trio. Which control a condition gets — the
+  operator-driven swaps as well as the fieldtype ones — is decided by
+  `valueControl.ts`, a sibling module rather than this file, so the nested
+  ConditionBuilder renders the same inputs from the same rules. Field pickers use
+  frappe-ui's `Combobox`; icons are lucide names.
 -->
 <template>
 	<!-- Empty: a plain "Filter" button that opens the field picker (the first
@@ -100,7 +97,7 @@
 							</div>
 							<div class="w-[180px]">
 								<component
-									:is="valueControl(f).is"
+									:is="VALUE_CONTROLS[valueControl(f).control]"
 									v-bind="valueControl(f).props"
 									class="w-full"
 									:modelValue="f.value"
@@ -153,33 +150,17 @@
 
 <script setup lang="ts">
 import { computed, nextTick, ref } from "vue";
-import { Button, Combobox, Popover, Select, TextInput, DateRangePicker } from "frappe-ui";
+import { Button, Combobox, Popover, Select } from "frappe-ui";
 import { useDoctypeMeta } from "../../composables/useDoctypeMeta";
 import { getFilterableFields } from "./getFilterableFields";
-import {
-	getOperators,
-	conditionFor,
-	carryOver,
-	defaultValueFor,
-	isOptionField,
-} from "./operators";
+import { getOperators, conditionFor, carryOver, defaultValueFor } from "./operators";
 import type { Filter, FilterField, FilterOperator, FilterProps, FilterValue } from "./types";
-// `in` / `not in` over an option field picks values from a MultiSelect rather than
-// typing a comma string: a static list for Select/Autocomplete, a live link search
-// for Link.
-import MultiSelectInput from "./MultiSelectInput.vue";
-import MultiLinkInput from "./MultiLinkInput.vue";
-// The shared, fieldtype-aware value inputs (ADR-0004). Filter mounts only the
-// zero-coupling subset; it never provides the form-context injections, so the
-// deep-injection inputs (Number resolving currency) fall back to site defaults.
-import SelectField from "../Fields/SelectField.vue";
-import LinkField from "../Fields/LinkField.vue";
-import NumberField from "../Fields/NumberField.vue";
-import DateField from "../Fields/DateField.vue";
-import DatetimeField from "../Fields/DatetimeField.vue";
-import DurationField from "../Fields/DurationField.vue";
-import RatingField from "../Fields/RatingField.vue";
-import type { FieldMeta } from "../Fields/types";
+// The operator/fieldtype → value-input dispatch. Lives in its own module so the
+// nested ConditionBuilder can render the same value inputs from the same rules
+// without duplicating them; it returns an id, and VALUE_CONTROLS maps that id to
+// the component (see valueControl.ts for why the two are separate files).
+import { valueControl } from "./valueControl";
+import { VALUE_CONTROLS } from "./valueControlComponents";
 
 const props = defineProps<FilterProps>();
 
@@ -248,145 +229,5 @@ function removeFilter(index: number) {
 function clearAll(close: () => void) {
 	model.value = [];
 	close();
-}
-
-// --- Value-control dispatch -------------------------------------------------
-// Mirrors CRM's `getValueControl`: operator-driven swaps first, then fieldtype.
-// Fieldtype controls are the shared `Fields` components; the swaps reuse frappe-ui
-// primitives. (Type groups are re-declared here, as CRM does, so `operators.ts`
-// stays a pure helper.)
-const CHECK_TYPES = ["Check"];
-const LINK_TYPES = ["Link", "Dynamic Link"];
-const NUMBER_TYPES = ["Float", "Int", "Currency", "Percent"];
-const SELECT_TYPES = ["Select", "Autocomplete"];
-const DATE_TYPES = ["Date", "Datetime"];
-const DURATION_TYPES = ["Duration"];
-const RATING_TYPES = ["Rating"];
-const TEXT_OPERATORS = ["like", "not like", "in", "not in"];
-
-const SET_OPTIONS = [
-	{ label: "Set", value: "set" },
-	{ label: "Not Set", value: "not set" },
-];
-
-const TIMESPAN_OPTIONS = [
-	"last week",
-	"last month",
-	"last quarter",
-	"last 6 months",
-	"last year",
-	"yesterday",
-	"today",
-	"tomorrow",
-	"this week",
-	"this month",
-	"this quarter",
-	"this year",
-	"next week",
-	"next month",
-	"next quarter",
-	"next 6 months",
-	"next year",
-].map((v) => ({ label: titleCase(v), value: v }));
-
-function titleCase(s: string): string {
-	return s.replace(/\b\w/g, (c) => c.toUpperCase());
-}
-
-interface ValueControl {
-	is: unknown;
-	props: Record<string, unknown>;
-}
-
-/** Field meta passed to a `Fields` value input — no label/description so the
- *  control renders bare inside the compact filter row. */
-function bareField(field: FilterField, overrides: Partial<FieldMeta> = {}): FieldMeta {
-	return {
-		fieldname: field.fieldname,
-		fieldtype: field.fieldtype,
-		options: field.options,
-		...overrides,
-	};
-}
-
-function valueControl(f: Filter): ValueControl {
-	const operator = f.operator;
-	const field = f.field;
-	const fieldtype = field?.fieldtype ?? "Data";
-	const ph = placeholder(f);
-
-	// Operator-driven swaps (handled here, not in the field components).
-	if (operator === "is" || operator === "is not") {
-		return { is: Select, props: { options: SET_OPTIONS, placeholder: ph } };
-	}
-	if (operator === "timespan") {
-		return { is: Select, props: { options: TIMESPAN_OPTIONS, placeholder: ph } };
-	}
-	// `in` / `not in` over an option field → a MultiSelect of the field's values
-	// (picked, not typed comma-separated). Link searches its target doctype; Select
-	// and Autocomplete read their options from meta. Dynamic Link and free-text
-	// fields fall through to the comma TextInput below.
-	if ((operator === "in" || operator === "not in") && isOptionField(fieldtype)) {
-		if (LINK_TYPES.includes(fieldtype)) {
-			return { is: MultiLinkInput, props: { field: field! } };
-		}
-		return { is: MultiSelectInput, props: { field: field! } };
-	}
-	if (TEXT_OPERATORS.includes(operator)) {
-		return { is: TextInput, props: { type: "text", placeholder: ph } };
-	}
-
-	// Fieldtype-driven value inputs from the shared Fields module.
-	if (SELECT_TYPES.includes(fieldtype) || CHECK_TYPES.includes(fieldtype)) {
-		// Check filters on Yes/No; Select on its own meta options.
-		const options = CHECK_TYPES.includes(fieldtype) ? "Yes\nNo" : field?.options;
-		return {
-			is: SelectField,
-			props: { field: bareField(field!, { options, placeholder: ph }) },
-		};
-	}
-	if (LINK_TYPES.includes(fieldtype)) {
-		// Dynamic Link has no fixed target doctype to pick against — plain text.
-		if (fieldtype === "Dynamic Link")
-			return { is: TextInput, props: { type: "text", placeholder: ph } };
-		return { is: LinkField, props: { field: bareField(field!, { placeholder: ph }) } };
-	}
-	if (NUMBER_TYPES.includes(fieldtype)) {
-		return { is: NumberField, props: { field: bareField(field!, { placeholder: ph }) } };
-	}
-	if (DATE_TYPES.includes(fieldtype) && operator === "between") {
-		return { is: DateRangePicker, props: { iconLeft: "" } };
-	}
-	if (DURATION_TYPES.includes(fieldtype)) {
-		return { is: DurationField, props: { field: bareField(field!, { placeholder: ph }) } };
-	}
-	if (RATING_TYPES.includes(fieldtype)) {
-		return { is: RatingField, props: { field: bareField(field!) } };
-	}
-	if (DATE_TYPES.includes(fieldtype)) {
-		const is = fieldtype === "Date" ? DateField : DatetimeField;
-		return { is, props: { field: bareField(field!, { placeholder: ph }) } };
-	}
-	return { is: TextInput, props: { type: "text", placeholder: ph } };
-}
-
-/** Per-operator / per-fieldtype placeholder copy. A port of CRM's `placeholder`,
- *  except `like`/`not like` show a bare term (not `%John%`): `serializeFilters`
- *  wraps the value in `%` itself, so prompting for the wildcards would mislead. */
-function placeholder(f: Filter): string {
-	const fieldtype = f.field?.fieldtype ?? "Data";
-	if (f.operator === "between") return "01/01/2022 to 01/31/2022";
-	if (f.operator === "in" || f.operator === "not in")
-		return NUMBER_TYPES.includes(fieldtype) ? "100, 200, 300" : "John, Jane, Doe";
-	if (f.operator === "like" || f.operator === "not like")
-		return NUMBER_TYPES.includes(fieldtype) ? "100" : "John";
-	if (f.operator === "is" || f.operator === "is not") return "Set";
-	if (f.operator === "timespan") return "Last Week";
-	if (NUMBER_TYPES.includes(fieldtype)) return "1000";
-	if (DATE_TYPES.includes(fieldtype)) return "01/01/2022";
-	if (CHECK_TYPES.includes(fieldtype)) return "Yes";
-	if (LINK_TYPES.includes(fieldtype)) return "Select a Value";
-	if (SELECT_TYPES.includes(fieldtype)) return "Select an Option";
-	return "John Doe";
 }
 </script>

--- a/ui/src/components/Filter/operators.ts
+++ b/ui/src/components/Filter/operators.ts
@@ -71,9 +71,8 @@ const RATING_OPERATORS = [
 const ASSIGN_OPERATORS = [LIKE, NOT_LIKE, IS];
 
 /**
- * The operators a field offers, by fieldtype (with field-name special cases).
- * A pure port of CRM's `getOperators`: each fieldtype maps to one operator set,
- * and the `_assign` field overrides to like/not like/is regardless of type.
+ * The operators a field offers: each fieldtype maps to one operator set, and
+ * the `_assign` field overrides to like/not like/is regardless of type.
  */
 export function getOperators(
   fieldtype: string,
@@ -91,8 +90,7 @@ export function getOperators(
   return [];
 }
 
-/** The operator a freshly-added condition starts on, by fieldtype. Ported from
- *  CRM's `getDefaultOperator`. */
+/** The operator a freshly-added condition starts on, by fieldtype. */
 export function getDefaultOperator(fieldtype: string): FilterOperator {
   if (SELECT_TYPES.includes(fieldtype)) return "equals";
   if (CHECK_TYPES.includes(fieldtype) || NUMBER_TYPES.includes(fieldtype))
@@ -101,9 +99,8 @@ export function getDefaultOperator(fieldtype: string): FilterOperator {
   return "like";
 }
 
-/** The value a freshly-added condition starts with, by field. Ported from CRM's
- *  `getDefaultValue`: Select seeds to its first option, Check to `Yes`, Date to
- *  an empty (null) value, everything else to an empty string. */
+/** The value a freshly-added condition starts with: Select seeds to its first
+ *  option, Check to `Yes`, Date to null, everything else to an empty string. */
 export function getDefaultValue(field: FilterField): FilterValue | null {
   if (SELECT_TYPES.includes(field.fieldtype)) {
     return (field.options ?? "").split("\n")[0];
@@ -114,11 +111,9 @@ export function getDefaultValue(field: FilterField): FilterValue | null {
 }
 
 /**
- * Whether `in`/`not in` over this fieldtype picks from a known option set — so the
- * value control is a MultiSelect (and the value a `string[]`) instead of a free,
- * comma-separated text box. Select/Autocomplete carry their options inline; a Link
- * resolves them from its target doctype. Dynamic Link has no fixed target, so it
- * (and every free-text/number fieldtype) stays on the comma TextInput.
+ * Whether `in`/`not in` over this fieldtype picks from a known option set — a
+ * MultiSelect holding a `string[]` rather than a comma-separated text box.
+ * Dynamic Link has no fixed target, so it stays on the comma TextInput.
  */
 export function isOptionField(fieldtype: string): boolean {
   return (
@@ -129,10 +124,8 @@ export function isOptionField(fieldtype: string): boolean {
 
 /**
  * The value a condition resets to for a given operator on a field. `is`/`is not`
- * seed to `set`; `in`/`not in` seed to an empty multi-select list (`[]`) on an
- * option field or an empty comma box (`''`) otherwise; everything else falls back
- * to the field's by-type default. Used when an operator change or a field change
- * invalidates the previous value.
+ * seed to `set`; `in`/`not in` to an empty list on an option field or an empty
+ * comma box otherwise; everything else to the field's by-type default.
  */
 export function defaultValueFor(
   field: FilterField,
@@ -156,18 +149,14 @@ export function conditionFor(field: FilterField): Filter {
 }
 
 // --- Field-change carry-over -------------------------------------------------
-// When a row's field changes we keep its operator (and value) where they still
-// make sense for the new field, instead of snapping back to the fieldtype
-// defaults — so refining "Status equals Open" into "Priority equals …" doesn't
-// drop the "equals". A UX nicety over CRM, which always resets on field change.
+// A row keeps its operator and value where they still make sense for the new
+// field, so refining "Status equals Open" into "Priority equals …" doesn't drop
+// the "equals".
 
 /**
- * Operators whose value carries verbatim across a field change because it isn't
- * bound to the field's option set: `like`/`not like` are free text. `in`/`not in`
- * are deliberately excluded — their value is an option list tied to one field (a
- * `string[]` on option fields), so it resets via {@link defaultValueFor} unless
- * {@link valueCarries} finds the new field shares the domain (e.g. two `User`
- * Links keep their picks).
+ * Operators whose value carries verbatim because it isn't bound to the field's
+ * option set. `in`/`not in` are excluded: their value is a list tied to one
+ * field, so it carries only where {@link valueCarries} finds a shared domain.
  */
 const CARRYING_OPERATORS: FilterOperator[] = ["like", "not like"];
 
@@ -187,10 +176,21 @@ function valueDomain(fieldtype: string): string {
 /** Whether `prev`'s value still applies to `field`, given a kept operator. */
 function valueCarries(prev: Filter, field: FilterField): boolean {
   if (prev.value === "" || prev.value == null) return false;
-  if (
-    valueDomain(prev.field?.fieldtype ?? "Data") !==
-    valueDomain(field.fieldtype)
-  ) {
+  // A condition whose own field is gone has no domain to compare. Keep the
+  // stored value unless the new field's own option list proves it cannot hold it.
+  if (!prev.field) {
+    if (SELECT_TYPES.includes(field.fieldtype)) {
+      return (field.options ?? "").split("\n").includes(prev.value as string);
+    }
+    if (CHECK_TYPES.includes(field.fieldtype)) {
+      return prev.value === "Yes" || prev.value === "No";
+    }
+    // What a deleted field left behind is text, so only a text field can still
+    // hold it. Carrying it further hands a Date, number, Link, Duration or
+    // Rating control a word it cannot render or compare.
+    return valueDomain(field.fieldtype) === "text";
+  }
+  if (valueDomain(prev.field.fieldtype) !== valueDomain(field.fieldtype)) {
     return false;
   }
   // Select values must exist in the new field's options; Link values belong to
@@ -199,20 +199,25 @@ function valueCarries(prev: Filter, field: FilterField): boolean {
     return (field.options ?? "").split("\n").includes(prev.value as string);
   }
   if (LINK_TYPES.includes(field.fieldtype))
-    return prev.field?.options === field.options;
+    return prev.field.options === field.options;
   return true;
 }
 
 /**
  * The next condition when a row's field changes. Keeps the operator if the new
- * field still offers it (else the field's default), then keeps the value when it
- * still applies — operator-driven (set/not-set or free text), or the new field
- * shares the old one's value domain (with Select options / Link doctype matched).
+ * field offers it (else the field's default), then keeps the value when it still
+ * applies — operator-driven, or the two fields share a value domain.
  */
-export function carryOver(prev: Filter, field: FilterField): Filter {
-  const keepOperator = getOperators(field.fieldtype, field.fieldname).some(
-    (o) => o.value === prev.operator
-  );
+export function carryOver(
+  prev: Filter,
+  field: FilterField,
+  // What the new field is actually offered, for a caller whose vocabulary is not
+  // this module's: `ConditionBuilder` adds `is not` and withholds `timespan`, and
+  // checking against `getOperators` would read its own operators as unavailable
+  // and reset the row on every field change.
+  offered: OperatorOption[] = getOperators(field.fieldtype, field.fieldname)
+): Filter {
+  const keepOperator = offered.some((o) => o.value === prev.operator);
   if (!keepOperator) return conditionFor(field);
 
   const operator = prev.operator;

--- a/ui/src/components/Filter/valueControl.ts
+++ b/ui/src/components/Filter/valueControl.ts
@@ -1,0 +1,186 @@
+import { isOptionField } from "./operators";
+import type { Filter, FilterField } from "./types";
+import type { FieldMeta } from "../Fields/types";
+
+// Type groups are declared here rather than imported from `operators.ts` so that
+// module stays a pure operator helper.
+const CHECK_TYPES = ["Check"];
+const LINK_TYPES = ["Link", "Dynamic Link"];
+const NUMBER_TYPES = ["Float", "Int", "Currency", "Percent"];
+const SELECT_TYPES = ["Select", "Autocomplete"];
+const DATE_TYPES = ["Date", "Datetime"];
+const DURATION_TYPES = ["Duration"];
+const RATING_TYPES = ["Rating"];
+const TEXT_OPERATORS = ["like", "not like", "in", "not in"];
+
+/**
+ * Which input a condition's value renders in. Naming the control rather than
+ * importing it keeps this module free of `.vue` imports, and so loadable by the
+ * test runner; `valueControlComponents.ts` maps the ids to components.
+ */
+export type ValueControlId =
+  | "set"
+  | "timespan"
+  | "multiSelect"
+  | "multiLink"
+  | "text"
+  | "select"
+  | "link"
+  | "number"
+  | "dateRange"
+  | "date"
+  | "datetime"
+  | "duration"
+  | "rating";
+
+export interface ValueControlSpec {
+  control: ValueControlId;
+  props: Record<string, unknown>;
+}
+
+const SET_OPTIONS = [
+  { label: "Set", value: "set" },
+  { label: "Not Set", value: "not set" },
+];
+
+const TIMESPAN_OPTIONS = [
+  "last week",
+  "last month",
+  "last quarter",
+  "last 6 months",
+  "last year",
+  "yesterday",
+  "today",
+  "tomorrow",
+  "this week",
+  "this month",
+  "this quarter",
+  "this year",
+  "next week",
+  "next month",
+  "next quarter",
+  "next 6 months",
+  "next year",
+].map((v) => ({ label: titleCase(v), value: v }));
+
+function titleCase(s: string): string {
+  return s.replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Field meta passed to a `Fields` value input — no label/description so the
+ *  control renders bare inside a compact condition row. */
+function bareField(
+  field: FilterField,
+  overrides: Partial<FieldMeta> = {},
+): FieldMeta {
+  return {
+    fieldname: field.fieldname,
+    fieldtype: field.fieldtype,
+    options: field.options,
+    ...overrides,
+  };
+}
+
+/**
+ * Pick the control for a condition's value: operator first, then fieldtype. The
+ * operator wins — `is` means Set/Not Set and the like/in family means free text
+ * whatever the fieldtype is — so no control is handed an unrepresentable value.
+ */
+export function valueControl(f: Filter): ValueControlSpec {
+  const operator = f.operator;
+  const field = f.field;
+  const fieldtype = field?.fieldtype ?? "Data";
+  const ph = placeholder(f);
+
+  if (operator === "is" || operator === "is not") {
+    return { control: "set", props: { options: SET_OPTIONS, placeholder: ph } };
+  }
+  if (operator === "timespan") {
+    return {
+      control: "timespan",
+      props: { options: TIMESPAN_OPTIONS, placeholder: ph },
+    };
+  }
+  // `in` / `not in` over an option field picks the field's values rather than
+  // typing a comma string; Dynamic Link and free text fall through to the
+  // TextInput below.
+  if (
+    (operator === "in" || operator === "not in") &&
+    isOptionField(fieldtype)
+  ) {
+    if (LINK_TYPES.includes(fieldtype)) {
+      return { control: "multiLink", props: { field: field! } };
+    }
+    return { control: "multiSelect", props: { field: field! } };
+  }
+  if (TEXT_OPERATORS.includes(operator)) {
+    return { control: "text", props: { type: "text", placeholder: ph } };
+  }
+
+  if (SELECT_TYPES.includes(fieldtype) || CHECK_TYPES.includes(fieldtype)) {
+    const options = CHECK_TYPES.includes(fieldtype)
+      ? "Yes\nNo"
+      : field?.options;
+    return {
+      control: "select",
+      props: { field: bareField(field!, { options, placeholder: ph }) },
+    };
+  }
+  if (LINK_TYPES.includes(fieldtype)) {
+    // Dynamic Link has no fixed target doctype to pick against — plain text.
+    if (fieldtype === "Dynamic Link")
+      return { control: "text", props: { type: "text", placeholder: ph } };
+    return {
+      control: "link",
+      props: { field: bareField(field!, { placeholder: ph }) },
+    };
+  }
+  if (NUMBER_TYPES.includes(fieldtype)) {
+    return {
+      control: "number",
+      props: { field: bareField(field!, { placeholder: ph }) },
+    };
+  }
+  if (DATE_TYPES.includes(fieldtype) && operator === "between") {
+    return { control: "dateRange", props: { iconLeft: "" } };
+  }
+  if (DURATION_TYPES.includes(fieldtype)) {
+    return {
+      control: "duration",
+      props: { field: bareField(field!, { placeholder: ph }) },
+    };
+  }
+  if (RATING_TYPES.includes(fieldtype)) {
+    return { control: "rating", props: { field: bareField(field!) } };
+  }
+  if (DATE_TYPES.includes(fieldtype)) {
+    const control = fieldtype === "Date" ? "date" : "datetime";
+    return {
+      control,
+      props: { field: bareField(field!, { placeholder: ph }) },
+    };
+  }
+  return { control: "text", props: { type: "text", placeholder: ph } };
+}
+
+/** Per-operator / per-fieldtype placeholder copy. `like` / `not like` prompt
+ *  for a bare term rather than `%John%`: `serializeFilters` wraps the value in
+ *  `%` itself, so prompting for the wildcards would mislead. */
+export function placeholder(f: Filter): string {
+  const fieldtype = f.field?.fieldtype ?? "Data";
+  if (f.operator === "between") return "01/01/2022 to 01/31/2022";
+  if (f.operator === "in" || f.operator === "not in")
+    return NUMBER_TYPES.includes(fieldtype)
+      ? "100, 200, 300"
+      : "John, Jane, Doe";
+  if (f.operator === "like" || f.operator === "not like")
+    return NUMBER_TYPES.includes(fieldtype) ? "100" : "John";
+  if (f.operator === "is" || f.operator === "is not") return "Set";
+  if (f.operator === "timespan") return "Last Week";
+  if (NUMBER_TYPES.includes(fieldtype)) return "1000";
+  if (DATE_TYPES.includes(fieldtype)) return "01/01/2022";
+  if (CHECK_TYPES.includes(fieldtype)) return "Yes";
+  if (LINK_TYPES.includes(fieldtype)) return "Select a Value";
+  if (SELECT_TYPES.includes(fieldtype)) return "Select an Option";
+  return "John Doe";
+}

--- a/ui/src/components/Filter/valueControlComponents.ts
+++ b/ui/src/components/Filter/valueControlComponents.ts
@@ -1,0 +1,36 @@
+import type { Component } from "vue";
+import { Select, TextInput, DateRangePicker } from "frappe-ui";
+// A static list for Select/Autocomplete, a live link search for Link.
+import MultiSelectInput from "./MultiSelectInput.vue";
+import MultiLinkInput from "./MultiLinkInput.vue";
+// The shared, fieldtype-aware value inputs. Only the subset that needs no form
+// context is mounted here, so an input that would resolve currency from a form
+// falls back to site defaults.
+import SelectField from "../Fields/SelectField.vue";
+import LinkField from "../Fields/LinkField.vue";
+import NumberField from "../Fields/NumberField.vue";
+import DateField from "../Fields/DateField.vue";
+import DatetimeField from "../Fields/DatetimeField.vue";
+import DurationField from "../Fields/DurationField.vue";
+import RatingField from "../Fields/RatingField.vue";
+import type { ValueControlId } from "./valueControl";
+
+/**
+ * The component behind each {@link ValueControlId}. Kept apart from
+ * `valueControl.ts` so the dispatch rules stay free of `.vue` imports.
+ */
+export const VALUE_CONTROLS: Record<ValueControlId, Component> = {
+  set: Select,
+  timespan: Select,
+  multiSelect: MultiSelectInput,
+  multiLink: MultiLinkInput,
+  text: TextInput,
+  select: SelectField,
+  link: LinkField,
+  number: NumberField,
+  dateRange: DateRangePicker,
+  date: DateField,
+  datetime: DatetimeField,
+  duration: DurationField,
+  rating: RatingField,
+};


### PR DESCRIPTION
PR for adding **`ConditionBuilder`**: an editor for nested and/or condition trees. It builds on the operator and value-control logic that `Filter` already has.

https://github.com/user-attachments/assets/0cb66b3c-c6f2-4b40-aaf5-cdd8fe17bc18

## API

### Props

| Prop | Type · default | Does |
| --- | --- | --- |
| `modelValue` | `ConditionGroup \| null` · required | The tree, as `v-model="tree"`. `null` is an empty tree. It does not mean uncontrolled. Only leaving the prop off entirely does that. |
| `expression` | `string` | The compiled Python, as `v-model:expression="doc.condition"`. Write-only. The component never reads it back. |
| `fieldPrefix` | `string` | `field-prefix="doc"` puts `doc.` in front of every fieldname in that expression. An SLA needs it, an Assignment Rule does not. Nothing changes on screen. |
| `doctype` | `string` | `doctype="HD Ticket"` takes the fields from Meta, the way `Filter` does. It reads the prop once at setup, so remount with `:key` to switch doctype. |
| `fields` | `ConditionField[]` | `:fields="hdTicketFields"` passes the fields in directly. Wins over `doctype`. |
| `columns` | `ConditionColumns` | Grid track sizes for the three cells, like `:columns="{ value: '1fr' }"`. |
| `maxDepth` | `number` · `4` | How deep you can nest, like `:max-depth="1"`. Past that depth, "Add Condition Group" and "Turn into a Group" stop showing. |
| `newCondition` | `() => TLeaf` · empty leaf | `:new-condition="newRule"` builds a new leaf. You need it once `#condition` replaces the built-in row. |
| `readonly` | `boolean` · `false` | Nothing is editable, and the tree renders as text. |
| `reorderable` | `boolean` · `false` | Whether rows can move, by drag or from the row menu. Covers moves inside a group and between groups, since those are the same edit. |
| `labels` | `Partial<ConditionBuilderLabels>` · translated | Every string it renders, like `:labels="{ empty: __('Add a rule') }"`. The defaults already run through the host's `__`. |
| `bordered` | `'all' \| 'root' \| 'none'` · `'all'` | Which groups draw a card, like `bordered="root"`. |
| `label` | `string` | Names the group, like `label="Escalation conditions"`. Renders as the fieldset's legend and wires up `aria-labelledby`. |
| `description` | `string` | Help text under the label. Wires up `aria-describedby`. |
| `error` | `string \| Error` | Error text under the control. Sets `aria-invalid` on the fieldset. |
| `required` | `boolean` · `false` | Marks the group required. |

**There is no `disabled` prop.** To stop people adding rows, fill `#add-condition` and disable your own button. Existing rows stay editable and removable, which is what a form failing validation needs.

**`readonly` renders text, not disabled controls.** A screen reader skips disabled controls in forms mode, and disabled controls are also exempt from the contrast minimum. A tree you can only read would lose the operators that say what it means.

### Emits

| Event | Payload |
| --- | --- |
| `update:modelValue` | `ConditionGroup<TLeaf>` |
| `update:expression` | `string`, the compiled Python |

### Slots

| Slot | Replaces |
| --- | --- |
| `#condition` | The whole row, for a leaf of your own shape |
| `#group` | How a **nested** group renders. Wrap it, or move it elsewhere |
| `#condition-value` | Only the value control inside the built-in row |
| `#condition-where` / `#condition-conjunction` | The leading cell of a row |
| `#condition-actions` | The row's overflow menu |
| `#add-condition` | A group's add button |
| `#empty` | The empty state's content |

Vue matches slot names literally. It will not read `#addCondition` as `#add-condition`, and you get the built-in fallback with no error and no warning.

Removing a cell:

- `<template #condition-where />` does **not** remove the cell. Vue falls back to the slot's default whenever your slot produces no node, so the built-in cell comes back.
- `<template #condition-where><span /></template>` removes it. A node that draws nothing is still a node.
- Either way the row keeps that column's width, and the group's bracket still draws through it. Both belong to the row, not to the cell.

## Usage

Three shapes cover almost everything. Each one is a live route in the demo.

**1. A saved Frappe condition array**, like Helpdesk's SLA or CRM's Assignment Rule.

```vue
<script setup lang="ts">
import { ref } from "vue"
import {
  ConditionBuilder,
  fromFrappeConditions,
  toFrappeConditions,
} from "@framework/ui/ConditionBuilder"
import type { ConditionGroup } from "@framework/ui/ConditionBuilder"

// Read the saved record in at the persistence boundary.
const tree = ref<ConditionGroup>(
  fromFrappeConditions(JSON.parse(doc.condition_json || "[]"))
)

// ...and write it back out the same way.
function save() {
  doc.condition_json = JSON.stringify(toFrappeConditions(tree.value))
}
</script>

<template>
  <!-- Either hand it the fields... -->
  <ConditionBuilder v-model="tree" :fields="hdTicketFields" />

  <!-- ...or name the doctype and let it read them from Meta. -->
  <ConditionBuilder v-model="tree" doctype="HD Ticket" />
</template>
```

`fields` wins when you pass both. Use it when the list is fixed or trimmed, and `doctype` when you want whatever Meta has.

**2. The compiled expression, saved beside the tree.** Bind `expression` and you get the Python already compiled, with the fieldtypes the component fetched.

```vue
<ConditionBuilder
  v-model="tree"
  v-model:expression="doc.condition"
  doctype="HD Ticket"
  field-prefix="doc"
/>
```

**3. A leaf of your own shape.** Pass `newCondition` so the add button knows what to build, and `#condition` to render it. Nothing reads `doctype` or `fields` once the row is yours.

```vue
<script setup lang="ts">
interface RavenRule {
  provider: string
  rule_type: string
  status: "Active" | "Paused"
  config: Record<string, unknown>
}

const tree = ref<ConditionGroup<RavenRule>>({ conjunction: "or", conditions: rules })

function newRule(): RavenRule {
  return { provider: "LMS", rule_type: "All Enrolled Students", status: "Active", config: {} }
}
</script>

<template>
  <ConditionBuilder v-model="tree" :new-condition="newRule">
    <template #condition="{ condition, update }">
      <!-- A whole new object every time. Writing into `condition` never reaches the tree. -->
      <RuleRow :rule="condition" @update="update" />
    </template>
  </ConditionBuilder>
</template>
```

## How it works

### Structure

- A leaf is a full condition. It can be the built-in shape or your own.
    - By default a leaf is `{ fieldname, operator, value }`. The fields come from either
        - 1. the doctype's Meta, or
        - 2. a `fields` array you hand it.
    - The operators come from the same rules `Filter` uses, so the two cannot drift apart.
- And/or joins leaves together. The joiner plus the leaves is a group, so a group is `{ conjunction, conditions }`.
    - One operator for the whole group, not one per gap. A level reads `A and B and C`, never `A and B or C`.
    - To say `A and (B or C)`, nest a group. That is the only way to say it.
    - So one cell per group is a live control, the first gap. Every cell below it repeats the same word as text.
- A group is anything with a `conditions` array. Everything else is a leaf.
    - This is structural on purpose. There is no discriminator field to keep in sync, so the tree survives a JSON round-trip untouched.
    - A group written with no `conjunction` is still a group, and reads as `and`.
- A group can nest another group. `maxDepth` sets how far, and it starts at 0, meaning no nesting.
> Every group draws inline, at every depth. A group used to escape into a dialog past a certain depth. That bought row width but cost a boundary a drag could not cross. Now the width is just spent. Each level takes about 111px of the start edge, so a deep row in a narrow column has little left. `bordered="root"` gives most of it back.
- Rows can drag between groups as well as inside one, once `reorderable` is on.

### Storage and conversion

The data exists in three forms: the tree, the array and the Python.

```ts
// the tree, what the component edits
{
  conjunction: "and",
  conditions: [
    { fieldname: "status",  operator: "equals", value: "Open" },   // <- LEAF
    { fieldname: "subject", operator: "like",   value: "refund" },
    {
      conjunction: "or",
      conditions: [{ fieldname: "priority", operator: "equals", value: "High" }],
    },
  ],
}

// the list, to be read back
  [["status","equals","Open"],"and",["subject","like","refund"],"and",[["priority","equals","High"]]]

// the code, to be run
 doc.status == "Open" and (doc.subject and "refund" in doc.subject) and (doc.priority == "High")
```

The component edits a tree. Your app stores a flat array. Assignment Rule and SLA save these with the operators sitting between the conditions, as `[A, "and", B]`. Convert at the persistence boundary:

- `toFrappeConditions` writes the array.
- `toConditionExpression` compiles the expression that `safe_eval` runs.
- Bind `v-model:expression` and you get the second one for free, compiled with the fieldtypes the component already fetched. `fieldPrefix="doc"` is what an SLA wants. An Assignment Rule wants none.

### What gets dropped, and when

A leaf with no field on it is not a decision yet, so the tree lets it go on save. In full:

- Dropped on write:
    - a row with no fieldname
    - an empty group
- Dropped on read:
    - any entry the parser cannot model, such as a doctype-qualified filter, an unlisted operator or a stray token. The conjunction beside it goes too, so a level never re-joins on an operator nobody wrote.
    - every operator on a level but the first, when reading a record written elsewhere, because a level now holds one. `A and B or C` loads and re-saves as `A and B and C`. That loss is deliberate. Refusing to read the record would leave it uneditable from every screen built on this component.
- Dropped at compile:
    - any operator with no rule, including a `between` missing an end

`modelValue` is required. The built-in leaf needs either `doctype` or `fields`, and nothing reads either once `#condition` replaces it. `expression` is optional and write-only.

###  screenshots 

| empty state | read only |
| --- | --- |
| <img width="1934" height="141" alt="image" src="https://github.com/user-attachments/assets/9f9b1f52-f541-46f4-8e82-1460fcc23946" /> | <img width="1934" height="141" alt="image" src="https://github.com/user-attachments/assets/67515c27-95ff-417c-a900-6c9041f695cd" /> |
|custom conditions (lms) |used as filter (would not recommend) |
| <img width="1303" height="588" alt="image" src="https://github.com/user-attachments/assets/70605508-c35d-490a-aca4-1bef63e6a222" /> |<img width="1024" height="353" alt="image" src="https://github.com/user-attachments/assets/df162c7e-0ffe-46ed-a010-04f7aa026065" /> |
