### PR TITLE
fix: evaluate row dependencies on row docfields

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -736,7 +736,7 @@ export default class GridRow {
 
 		this.grid.visible_columns.forEach((col, ci) => {
 			// to get update df for the row
-			let df = fields.find((field) => field?.fieldname === col[0].fieldname);
+			let df = this.get_column_docfield(fields, col[0].fieldname);
 
 			this.set_dependant_property(df);
 
@@ -821,6 +821,18 @@ export default class GridRow {
 			this.doc &&
 			!column.df.hidden
 		);
+	}
+
+	get_column_docfield(fields, fieldname) {
+		const column_df = fields.find((field) => field?.fieldname === fieldname);
+		const row_df = this.docfields?.find((df) => df.fieldname === fieldname);
+
+		if (!column_df || !row_df || column_df === row_df) return column_df;
+
+		row_df.sticky = column_df.sticky;
+		row_df.in_list_view = column_df.in_list_view;
+
+		return row_df;
 	}
 
 	set_dependant_property(df) {
@@ -1582,9 +1594,7 @@ export default class GridRow {
 				? this.grid.user_defined_columns
 				: this.docfields;
 
-		let df = fields.find((col) => {
-			return col?.fieldname === fieldname;
-		});
+		let df = this.get_column_docfield(fields, fieldname);
 
 		// format values if no frm
 		if (df && this.doc) {


### PR DESCRIPTION
Issue: [75874](https://support.frappe.io/helpdesk/tickets/75874)
Editable grid field dependency state can leak across rows when grid columns are configured.

If a child table has fields with row-level depends_on, mandatory_depends_on, or read_only_depends_on conditions, the editable grid may evaluate those conditions against the configured column DocField instead of the row-specific DocField. This can cause a field to appear hidden, read-only, or mandatory incorrectly for other rows.

For example, in Quality Inspection, after selecting a Quality Inspection Template with mixed numeric and non-numeric readings, Acceptance Criteria Value and Reading Value may not be editable directly in the grid even when their row-level conditions are satisfied. Opening and closing the child row refreshes the row-specific state and makes the field editable.

Steps to Replicate the Issue:

1. Create a Purchase Receipt.
2. Create a Quality Inspection from the Purchase Receipt.
3. Fill in all mandatory fields.
4. Select the Quality Inspection Template
5. Observe that the Acceptance Criteria Value and Reading Value fields are not editable directly from the main form.
6. Open the respective row in the child table.
7. Click inside the Acceptance Criteria Value (or Reading Value) field.
8. Close the child row and return to the main form.
9. Observe that the field is now editable.


Before:

[75874_before.webm](https://github.com/user-attachments/assets/67558c6f-fc02-4002-b99d-d9f8ea4d75d5)

After:

[75874_after.webm](https://github.com/user-attachments/assets/22f952a4-d424-46e6-aef7-23830f4989c0)

