### PR TITLE
fix(ui): populate only the selected dashboard link field

### DIFF
--- a/cypress/fixtures/doctype_with_child_table.js
+++ b/cypress/fixtures/doctype_with_child_table.js
@@ -21,6 +21,12 @@ export default {
 			options: "Doctype to Link",
 		},
 		{
+			fieldname: "secondary_link",
+			fieldtype: "Link",
+			label: "Secondary Link",
+			options: "Doctype to Link",
+		},
+		{
 			fieldname: "child_table",
 			fieldtype: "Table",
 			label: "Child Table",

--- a/cypress/fixtures/doctype_with_child_table.js
+++ b/cypress/fixtures/doctype_with_child_table.js
@@ -15,6 +15,12 @@ export default {
 			unique: 1,
 		},
 		{
+			fieldname: "doctype_to_link",
+			fieldtype: "Link",
+			label: "Doctype to Link",
+			options: "Doctype to Link",
+		},
+		{
 			fieldname: "child_table",
 			fieldtype: "Table",
 			label: "Child Table",

--- a/cypress/integration/dashboard_links.js
+++ b/cypress/integration/dashboard_links.js
@@ -98,6 +98,9 @@ context("Dashboard links", () => {
 		cy.fill_field("title", "Test Direct Linking");
 		cy.findByRole("button", { name: "Save" }).click();
 
+		// wait for the dashboard to render before mutating its data
+		cy.get('.document-link[data-doctype="Doctype With Child Table"]');
+
 		cy.window()
 			.its("frappe")
 			.then((frappe) => {
@@ -118,10 +121,8 @@ context("Dashboard links", () => {
 			.should("have.attr", "data-fieldname", "doctype_to_link")
 			.click({ force: true });
 
-		cy.get('.frappe-control[data-fieldname="doctype_to_link"]').should(
-			"contain.text",
-			"Test Direct Linking"
-		);
+		cy.get_field("doctype_to_link").should("have.value", "Test Direct Linking");
+		cy.get_field("secondary_link").should("have.value", "");
 		cy.get(
 			'.frappe-control[data-fieldname="child_table"] .rows .data-row .col[data-fieldname="doctype_to_link"]'
 		).should("not.contain.text", "Test Direct Linking");

--- a/cypress/integration/dashboard_links.js
+++ b/cypress/integration/dashboard_links.js
@@ -65,15 +65,17 @@ context("Dashboard links", () => {
 		cy.select_form_tab("Connections");
 		cy.get('.document-link[data-doctype="Contact"]').contains("Contact");
 		cy.window()
-			.its("cur_frm")
-			.then((cur_frm) => {
-				cur_frm.dashboard.data.reports = [
+			.its("frappe")
+			.then((frappe) => {
+				const frm = frappe.views.formview.User.frm;
+
+				frm.dashboard.data.reports = [
 					{
 						label: "Reports",
 						items: ["Website Analytics"],
 					},
 				];
-				cur_frm.dashboard.render_report_links();
+				frm.dashboard.render_report_links();
 				cy.get('.document-link[data-report="Website Analytics"]')
 					.contains("Website Analytics")
 					.click();
@@ -97,18 +99,19 @@ context("Dashboard links", () => {
 		cy.findByRole("button", { name: "Save" }).click();
 
 		cy.window()
-			.its("cur_frm")
-			.then((cur_frm) => {
-				const group = cur_frm.dashboard.data.transactions.find((group) =>
+			.its("frappe")
+			.then((frappe) => {
+				const frm = frappe.views.formview[doctype_to_link_name].frm;
+				const group = frm.dashboard.data.transactions.find((group) =>
 					group.items.includes("Doctype With Child Table")
 				);
 
 				delete group.fieldnames;
-				cur_frm.dashboard.data.non_standard_fieldnames["Doctype With Child Table"] =
+				frm.dashboard.data.non_standard_fieldnames["Doctype With Child Table"] =
 					"doctype_to_link";
-				cur_frm.dashboard.transactions_area.empty();
-				cur_frm.dashboard.data_rendered = false;
-				cur_frm.dashboard.render_links();
+				frm.dashboard.transactions_area.empty();
+				frm.dashboard.data_rendered = false;
+				frm.dashboard.render_links();
 			});
 
 		cy.get('.document-link[data-doctype="Doctype With Child Table"] .btn-new')

--- a/cypress/integration/dashboard_links.js
+++ b/cypress/integration/dashboard_links.js
@@ -90,4 +90,37 @@ context("Dashboard links", () => {
 			'.frappe-control[data-fieldname="child_table"] .rows .data-row .col[data-fieldname="doctype_to_link"]'
 		).should("contain.text", "Test Linking");
 	});
+
+	it("only populates the selected parent link field", () => {
+		cy.new_form(doctype_to_link_name);
+		cy.fill_field("title", "Test Direct Linking");
+		cy.findByRole("button", { name: "Save" }).click();
+
+		cy.window()
+			.its("cur_frm")
+			.then((cur_frm) => {
+				const group = cur_frm.dashboard.data.transactions.find((group) =>
+					group.items.includes("Doctype With Child Table")
+				);
+
+				delete group.fieldnames;
+				cur_frm.dashboard.data.non_standard_fieldnames["Doctype With Child Table"] =
+					"doctype_to_link";
+				cur_frm.dashboard.transactions_area.empty();
+				cur_frm.dashboard.data_rendered = false;
+				cur_frm.dashboard.render_links();
+			});
+
+		cy.get('.document-link[data-doctype="Doctype With Child Table"] .btn-new')
+			.should("have.attr", "data-fieldname", "doctype_to_link")
+			.click({ force: true });
+
+		cy.get('.frappe-control[data-fieldname="doctype_to_link"]').should(
+			"contain.text",
+			"Test Direct Linking"
+		);
+		cy.get(
+			'.frappe-control[data-fieldname="child_table"] .rows .data-row .col[data-fieldname="doctype_to_link"]'
+		).should("not.contain.text", "Test Direct Linking");
+	});
 });

--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -250,6 +250,8 @@ frappe.ui.form.Dashboard = class FormDashboard {
 		if (!this.data.transactions) this.data.transactions = [];
 		if (!this.data.internal_links) this.data.internal_links = {};
 		if (!this.data.internal_and_external_links) this.data.internal_and_external_links = {};
+		if (!this.data.non_standard_fieldnames) this.data.non_standard_fieldnames = {};
+		if (!this.data.fieldname) this.data.fieldname = "";
 		this.filter_permissions();
 	}
 

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -2224,13 +2224,21 @@ frappe.ui.form.Form = class FrappeForm {
 
 	set_link_field(doctype, new_doc, fieldname) {
 		let me = this;
-		frappe.get_meta(doctype).fields.forEach(function (df) {
+		const fields = frappe.get_meta(doctype).fields;
+		const link_field = fields.find(
+			(df) =>
+				df.fieldname === fieldname && df.fieldtype === "Link" && df.options === me.doctype
+		);
+
+		if (link_field) {
+			new_doc[link_field.fieldname] = me.doc.name;
+			return;
+		}
+
+		fields.forEach(function (df) {
 			const isLinkToParent = df.fieldtype === "Link" && df.options === me.doctype;
 
 			if (fieldname) {
-				if (df.fieldname === fieldname && isLinkToParent) {
-					new_doc[df.fieldname] = me.doc.name;
-				}
 				if (df.fieldtype === "Table" && df.options && df.reqd) {
 					me.set_link_field(df.options, new_doc[df.fieldname][0]);
 				}

--- a/frappe/public/js/frappe/form/templates/form_links.html
+++ b/frappe/public/js/frappe/form/templates/form_links.html
@@ -9,9 +9,14 @@
 				</div>
 				{% for (let j=0; j < transactions[i].items.length; j++) { %}
 					{% let doctype = transactions[i].items[j]; %}
-					{% let fieldname = (transactions[i].fieldnames && transactions[i].fieldnames[doctype]) || transactions[i].fieldname; %}
+					{% let link_fieldname =
+						(transactions[i].fieldnames && transactions[i].fieldnames[doctype]) ||
+						(non_standard_fieldnames && non_standard_fieldnames[doctype]) ||
+						transactions[i].fieldname ||
+						fieldname;
+					%}
 					<div class="document-link" data-doctype="{{ doctype }}">
-						<div class="document-link-badge" data-doctype="{{ doctype }}" data-fieldname="{{ fieldname }}">
+						<div class="document-link-badge" data-doctype="{{ doctype }}" data-fieldname="{{ link_fieldname }}">
 							<a class="badge-link">{{ __(doctype) }}</a>
 							<span class="count hidden"></span>
 						</div>
@@ -21,7 +26,7 @@
 						{% if !internal_links[doctype] %}
 							<button class="btn btn-new btn-secondary btn-xs icon-btn hidden"
 								data-doctype="{{ doctype }}"
-								data-fieldname="{{ fieldname }}">
+								data-fieldname="{{ link_fieldname }}">
 								<svg class="icon icon-sm"><use href="#icon-plus"></use></svg>
 							</button>
 						{% endif %}


### PR DESCRIPTION
## Problem

Creating a linked document from a form dashboard can fill more than one matching Link field.

For example, creating a BOM from an Item sets the Item to Manufacture. It also adds the same Item as a component.

The dashboard template did not use `non_standard_fieldnames` for the new-document button. The form also scanned required child tables after it found the selected parent field.

## Change

- Use `non_standard_fieldnames` when the dashboard builds the new-document button.
- Stop the child-table fallback after the form finds the selected parent Link field.
- Keep the fallback for links that exist only in required child tables.
- Add UI regression coverage for both paths.

## Result

Creating a BOM from an Item now sets only the Item to Manufacture. The component table stays empty.

## Validation

- `pre-commit run prettier --files ...`
- `pre-commit run eslint --files ...`
- `yarn build`
- `git diff --check origin/develop...HEAD`

The Cypress regression test was not run locally because the test server was unavailable.

## Reference

https://discuss.frappe.io/t/creating-a-bom-from-the-item-connections/164131


## Behavior changes

- Dashboards driven by `_dashboard.py` data previously rendered no button fieldname, so the new document got every matching Link field, same-named Link values, and prefilled required child tables. These buttons now populate only the selected link field.
- `non_standard_fieldnames` now takes precedence over a group-level `fieldname` for the button and badge. This matches how `frappe.desk.notifications` resolves fieldnames for counts.
