### PR TITLE
ci: record cypress video only when 'record-video' label is set

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -112,16 +112,16 @@ jobs:
           CYPRESS_RECORD_KEY: 4a48f41c-11b3-425b-aa88-c58048fa69eb
           SPLIT: 4
           SPLIT_INDEX: ${{ strategy.job-index }}
-          RECORD_VIDEO: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'record-video') }}
+          RECORD_VIDEO: ${{ contains(github.event.pull_request.labels.*.name, 'record-video') }}
 
       - name: Compress Cypress Videos
-        if: always() && steps.ui-tests.outcome == 'failure' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'record-video'))
+        if: always() && steps.ui-tests.outcome == 'failure' && contains(github.event.pull_request.labels.*.name, 'record-video')
         run: |
             if find ./cypressVideos -mindepth 1 | read; then
               zip -r cypress_recordings.zip ./cypressVideos
             fi
       - name: Upload Cypress Videos
-        if: always() && steps.ui-tests.outcome == 'failure' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'record-video'))
+        if: always() && steps.ui-tests.outcome == 'failure' && contains(github.event.pull_request.labels.*.name, 'record-video')
         uses: actions/upload-artifact@v7
         with:
           name: Cypress CI Video Recordings

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -112,15 +112,16 @@ jobs:
           CYPRESS_RECORD_KEY: 4a48f41c-11b3-425b-aa88-c58048fa69eb
           SPLIT: 4
           SPLIT_INDEX: ${{ strategy.job-index }}
+          RECORD_VIDEO: ${{ contains(github.event.pull_request.labels.*.name, 'record-video') }}
 
       - name: Compress Cypress Videos
-        if: always() && steps.ui-tests.outcome == 'failure'
+        if: always() && steps.ui-tests.outcome == 'failure' && contains(github.event.pull_request.labels.*.name, 'record-video')
         run: |
             if find ./cypressVideos -mindepth 1 | read; then
               zip -r cypress_recordings.zip ./cypressVideos
             fi
       - name: Upload Cypress Videos
-        if: always() && steps.ui-tests.outcome == 'failure'
+        if: always() && steps.ui-tests.outcome == 'failure' && contains(github.event.pull_request.labels.*.name, 'record-video')
         uses: actions/upload-artifact@v7
         with:
           name: Cypress CI Video Recordings

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -112,16 +112,16 @@ jobs:
           CYPRESS_RECORD_KEY: 4a48f41c-11b3-425b-aa88-c58048fa69eb
           SPLIT: 4
           SPLIT_INDEX: ${{ strategy.job-index }}
-          RECORD_VIDEO: ${{ contains(github.event.pull_request.labels.*.name, 'record-video') }}
+          RECORD_VIDEO: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'record-video') }}
 
       - name: Compress Cypress Videos
-        if: always() && steps.ui-tests.outcome == 'failure' && contains(github.event.pull_request.labels.*.name, 'record-video')
+        if: always() && steps.ui-tests.outcome == 'failure' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'record-video'))
         run: |
             if find ./cypressVideos -mindepth 1 | read; then
               zip -r cypress_recordings.zip ./cypressVideos
             fi
       - name: Upload Cypress Videos
-        if: always() && steps.ui-tests.outcome == 'failure' && contains(github.event.pull_request.labels.*.name, 'record-video')
+        if: always() && steps.ui-tests.outcome == 'failure' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'record-video'))
         uses: actions/upload-artifact@v7
         with:
           name: Cypress CI Video Recordings

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -9,7 +9,7 @@ module.exports = defineConfig({
 	testUser: "frappe@example.com",
 	defaultCommandTimeout: 20000,
 	pageLoadTimeout: 15000,
-	video: true,
+	video: process.env.RECORD_VIDEO === "true",
 	videosFolder: path.resolve(__dirname, "..", "..") + "/cypressVideos/",
 	viewportHeight: 960,
 	viewportWidth: 1400,


### PR DESCRIPTION
- `video` now defaults to off in `cypress.config.js`, driven by a `RECORD_VIDEO` env flag
- CI sets that flag (and compresses/uploads the recordings) only when the PR carries a `record-video` label

Why: recording + compressing video on every shard adds overhead for artifacts nobody looks at unless a run is being debugged.