### PR TITLE
Fix/attendance calendar sorting

### DIFF
--- a/frappe/desk/calendar.py
+++ b/frappe/desk/calendar.py
@@ -6,7 +6,6 @@ from datetime import date
 import frappe
 from frappe import _
 from frappe.query_builder import functions
-from frappe.query_builder.terms import ValueWrapper
 
 
 @frappe.whitelist()
@@ -38,6 +37,7 @@ def get_events(
 	field_map: str | dict,
 	filters: str | list | dict | None = None,
 	fields: str | list[str] | None = None,
+	order_by: str | None = None,
 ):
 	field_map = frappe._dict(frappe.parse_json(field_map))
 	fields = frappe.parse_json(fields)
@@ -61,8 +61,8 @@ def get_events(
 			frappe.throw(_("{0} is not a valid field of {1}").format(field_map.get(key), doctype))
 
 	dt = frappe.qb.DocType(doctype)
-	start_field = functions.IfNull(dt[field_map.start], ValueWrapper("0001-01-01 00:00:00"))
-	end_field = functions.IfNull(dt[field_map.end], ValueWrapper("2199-12-31 00:00:00"))
+	start_field = functions.IfNull(dt[field_map.start], dt[field_map.end])
+	end_field = functions.IfNull(dt[field_map.end], dt[field_map.start])
 
 	filters += [
 		[start_field, "<=", end],
@@ -70,4 +70,4 @@ def get_events(
 	]
 
 	fields = list({field for field in fields if field})
-	return frappe.get_list(doctype, fields=fields, filters=filters)
+	return frappe.get_list(doctype, fields=fields, filters=filters, order_by=order_by)

--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -329,6 +329,16 @@ frappe.views.Calendar = class Calendar {
 			eventDisplay: "block",
 			eventOrder: "_calendar_order",
 			eventOrderStrict: true,
+			eventDidMount: (info) => {
+				const missing_time = info.event.extendedProps._calendar_missing_time;
+				if (missing_time) {
+					const time = info.view.calendar.formatDate(
+						info.event.start,
+						this.cal_options.eventTimeFormat
+					);
+					$(info.el).find(".fc-event-time").text(`${time} · ${missing_time}`);
+				}
+			},
 			// the toolbar is ours (make_toolbar), not FullCalendar's — no
 			// more stripping fc-button classes and re-adding them after every
 			// re-render
@@ -516,9 +526,8 @@ frappe.views.Calendar = class Calendar {
 				const missing_field = missing_start ? me.field_map.start : me.field_map.end;
 				if (missing_start) d.start = d.end;
 				d.end = null;
-				d.title = __("{0} missing: {1}", [
+				d._calendar_missing_time = __("{0} missing", [
 					frappe.meta.get_label(me.doctype, missing_field),
-					d.title,
 				]);
 			} else if (missing_start) {
 				d.start = frappe.datetime.add_days(d.end, -1);

--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -68,10 +68,11 @@ frappe.views.CalendarView = class CalendarView extends frappe.views.ListView {
 			list_view: this,
 		};
 		const calendar_name = this.calendar_name;
+		const calendar_settings = frappe.views.calendar[this.doctype];
 
 		return new Promise((resolve) => {
 			if (calendar_name === "default") {
-				Object.assign(options, frappe.views.calendar[this.doctype]);
+				Object.assign(options, calendar_settings);
 				resolve(options);
 			} else {
 				frappe.model.with_doc("Calendar View", calendar_name, () => {
@@ -84,6 +85,10 @@ frappe.views.CalendarView = class CalendarView extends frappe.views.ListView {
 						);
 						frappe.set_route("List", this.doctype, "Calendar", "default");
 						return;
+					}
+					if (calendar_settings?.apply_to_custom_calendar_views) {
+						options.fields = calendar_settings.fields;
+						options.get_css_class = calendar_settings.get_css_class;
 					}
 					Object.assign(options, {
 						field_map: {
@@ -322,6 +327,8 @@ frappe.views.Calendar = class Calendar {
 			},
 			firstDay: frappe.datetime.get_first_day_of_the_week_index(),
 			eventDisplay: "block",
+			eventOrder: "_calendar_order",
+			eventOrderStrict: true,
 			// the toolbar is ours (make_toolbar), not FullCalendar's — no
 			// more stripping fc-button classes and re-adding them after every
 			// re-render
@@ -433,13 +440,24 @@ frappe.views.Calendar = class Calendar {
 		}
 	}
 	get_args(start, end) {
+		const fields = this.fields && [
+			...new Set(
+				this.fields.concat(
+					this.field_map.start,
+					this.field_map.end,
+					this.field_map.title,
+					"name"
+				)
+			),
+		];
 		var args = {
 			doctype: this.doctype,
 			start: this.get_system_datetime(start),
 			end: this.get_system_datetime(end),
-			fields: this.fields,
+			fields,
 			filters: this.list_view.filter_area.get(),
 			field_map: this.field_map,
+			order_by: this.list_view.sort_selector?.get_sql_string(),
 		};
 		return args;
 	}
@@ -449,8 +467,9 @@ frappe.views.Calendar = class Calendar {
 	prepare_events(events) {
 		var me = this;
 
-		return (events || []).map((d) => {
+		return (events || []).map((d, index) => {
 			d.id = d.name;
+			d._calendar_order = index;
 			d.editable = frappe.model.can_write(d.doctype || me.doctype);
 
 			// do not allow submitted/cancelled events to be moved / extended
@@ -483,12 +502,27 @@ frappe.views.Calendar = class Calendar {
 				d.end = frappe.datetime.convert_to_user_tz(d.end);
 			}
 
-			// show event on single day if start or end date is invalid
-			if (!frappe.datetime.validate(d.start) && d.end) {
-				d.start = frappe.datetime.add_days(d.end, -1);
-			}
+			const missing_start = !frappe.datetime.validate(d.start) && d.end;
+			const missing_end = d.start && !frappe.datetime.validate(d.end);
+			const uses_datetime_fields =
+				(missing_start || missing_end) &&
+				[me.field_map.start, me.field_map.end].some(
+					(fieldname) =>
+						frappe.meta.get_docfield(me.doctype, fieldname)?.fieldtype === "Datetime"
+				);
 
-			if (d.start && !frappe.datetime.validate(d.end)) {
+			// Timed events with one missing boundary are shown at the known time.
+			if (uses_datetime_fields) {
+				const missing_field = missing_start ? me.field_map.start : me.field_map.end;
+				if (missing_start) d.start = d.end;
+				d.end = null;
+				d.title = __("{0} missing: {1}", [
+					frappe.meta.get_label(me.doctype, missing_field),
+					d.title,
+				]);
+			} else if (missing_start) {
+				d.start = frappe.datetime.add_days(d.end, -1);
+			} else if (missing_end) {
 				d.end = frappe.datetime.add_days(d.start, 1);
 			}
 


### PR DESCRIPTION
Related to : https://github.com/frappe/hrms/pull/5088
Changes:
 - Preserve List View sorting in Calendar View.
 - Display single-boundary datetime events at their known time and mark the missing boundary beside it.
 - Include single-day events when only one date boundary exists; exclude events with neither boundary.
 - Allow apps to share extra fields and colour logic with custom Calendar Views.
 
 Before changes:
 
<img width="2312" height="1794" alt="image" src="https://github.com/user-attachments/assets/2256a5a2-0994-4281-815b-61e7a1b294ea" />

After changes:
<img width="2372" height="1970" alt="image" src="https://github.com/user-attachments/assets/538950d6-338b-4baf-a502-559c8bfbae1a" />
