### PR TITLE
test(ui): add cy.desk_ready() to replace blind desk-load waits

### DIFF
--- a/cypress/integration/control_autocomplete.js
+++ b/cypress/integration/control_autocomplete.js
@@ -2,7 +2,7 @@ context("Control Autocomplete", () => {
 	before(() => {
 		cy.login();
 		cy.visit("/desk");
-		cy.wait(4000);
+		cy.desk_ready();
 	});
 
 	const get_dialog_with_autocomplete = (fieldname, options) => {

--- a/cypress/integration/file_uploader.js
+++ b/cypress/integration/file_uploader.js
@@ -5,7 +5,7 @@ context("FileUploader", () => {
 
 	beforeEach(() => {
 		cy.visit("/desk");
-		cy.desk_ready();
+		cy.wait(2000); // workspace can load async and clear active dialog
 	});
 
 	function open_upload_dialog() {
@@ -14,7 +14,7 @@ context("FileUploader", () => {
 			.then((frappe) => {
 				new frappe.ui.FileUploader();
 			});
-		cy.get_open_dialog().should("be.visible");
+		cy.wait(500);
 	}
 
 	it("upload dialog api works", () => {
@@ -73,14 +73,14 @@ context("FileUploader", () => {
 			// Clean up test user
 			cy.login("Administrator", Cypress.env("adminPassword") || "admin");
 			cy.visit("/desk");
-			cy.desk_ready();
+			cy.wait(1000);
 			cy.remove_doc("User", test_user, true); // true = ignore_missing
 		});
 
 		it("should show checkbox and toggle when setting is disabled for System Manager", () => {
 			cy.login("Administrator", Cypress.env("adminPassword") || "admin");
 			cy.visit("/desk");
-			cy.desk_ready();
+			cy.wait(1000);
 
 			// Disable the setting
 			cy.set_value("System Settings", "System Settings", {
@@ -93,7 +93,7 @@ context("FileUploader", () => {
 					frappe.boot.sysdefaults.only_allow_system_managers_to_upload_public_files = 0;
 				});
 			cy.visit("/desk");
-			cy.desk_ready();
+			cy.wait(2000);
 
 			open_upload_dialog();
 
@@ -125,19 +125,19 @@ context("FileUploader", () => {
 		it("should show checkbox and toggle when setting is disabled for non-System Manager", () => {
 			cy.login("Administrator", Cypress.env("adminPassword") || "admin");
 			cy.visit("/desk");
-			cy.desk_ready();
+			cy.wait(1000);
 
 			// Disable the setting
 			cy.set_value("System Settings", "System Settings", {
 				only_allow_system_managers_to_upload_public_files: 0,
 			});
 			cy.visit("/desk");
-			cy.desk_ready();
+			cy.wait(1000);
 
 			// Login as non-System Manager
 			cy.login(test_user, test_password);
 			cy.visit("/desk");
-			cy.desk_ready();
+			cy.wait(2000);
 			// Update sysdefaults in window
 			cy.window()
 				.its("frappe")
@@ -175,7 +175,7 @@ context("FileUploader", () => {
 		it("should show checkbox and toggle when setting is enabled for System Manager", () => {
 			cy.login("Administrator", Cypress.env("adminPassword") || "admin");
 			cy.visit("/desk");
-			cy.desk_ready();
+			cy.wait(1000);
 
 			// Enable the setting
 			cy.set_value("System Settings", "System Settings", {
@@ -188,7 +188,7 @@ context("FileUploader", () => {
 					frappe.boot.sysdefaults.only_allow_system_managers_to_upload_public_files = 1;
 				});
 			cy.visit("/desk");
-			cy.desk_ready();
+			cy.wait(2000);
 
 			open_upload_dialog();
 
@@ -220,19 +220,19 @@ context("FileUploader", () => {
 		it("should show disabled checkbox and hide toggle when setting is enabled for non-System Manager", () => {
 			cy.login("Administrator", Cypress.env("adminPassword") || "admin");
 			cy.visit("/desk");
-			cy.desk_ready();
+			cy.wait(1000);
 
 			// Enable the setting
 			cy.set_value("System Settings", "System Settings", {
 				only_allow_system_managers_to_upload_public_files: 1,
 			});
 			cy.visit("/desk");
-			cy.desk_ready();
+			cy.wait(1000);
 
 			// Login as non-System Manager
 			cy.login(test_user, test_password);
 			cy.visit("/desk");
-			cy.desk_ready();
+			cy.wait(2000);
 			// Update sysdefaults in window
 			cy.window()
 				.its("frappe")

--- a/cypress/integration/file_uploader.js
+++ b/cypress/integration/file_uploader.js
@@ -5,7 +5,7 @@ context("FileUploader", () => {
 
 	beforeEach(() => {
 		cy.visit("/desk");
-		cy.wait(2000); // workspace can load async and clear active dialog
+		cy.desk_ready();
 	});
 
 	function open_upload_dialog() {
@@ -14,7 +14,7 @@ context("FileUploader", () => {
 			.then((frappe) => {
 				new frappe.ui.FileUploader();
 			});
-		cy.wait(500);
+		cy.get_open_dialog().should("be.visible");
 	}
 
 	it("upload dialog api works", () => {
@@ -73,14 +73,14 @@ context("FileUploader", () => {
 			// Clean up test user
 			cy.login("Administrator", Cypress.env("adminPassword") || "admin");
 			cy.visit("/desk");
-			cy.wait(1000);
+			cy.desk_ready();
 			cy.remove_doc("User", test_user, true); // true = ignore_missing
 		});
 
 		it("should show checkbox and toggle when setting is disabled for System Manager", () => {
 			cy.login("Administrator", Cypress.env("adminPassword") || "admin");
 			cy.visit("/desk");
-			cy.wait(1000);
+			cy.desk_ready();
 
 			// Disable the setting
 			cy.set_value("System Settings", "System Settings", {
@@ -93,7 +93,7 @@ context("FileUploader", () => {
 					frappe.boot.sysdefaults.only_allow_system_managers_to_upload_public_files = 0;
 				});
 			cy.visit("/desk");
-			cy.wait(2000);
+			cy.desk_ready();
 
 			open_upload_dialog();
 
@@ -125,19 +125,19 @@ context("FileUploader", () => {
 		it("should show checkbox and toggle when setting is disabled for non-System Manager", () => {
 			cy.login("Administrator", Cypress.env("adminPassword") || "admin");
 			cy.visit("/desk");
-			cy.wait(1000);
+			cy.desk_ready();
 
 			// Disable the setting
 			cy.set_value("System Settings", "System Settings", {
 				only_allow_system_managers_to_upload_public_files: 0,
 			});
 			cy.visit("/desk");
-			cy.wait(1000);
+			cy.desk_ready();
 
 			// Login as non-System Manager
 			cy.login(test_user, test_password);
 			cy.visit("/desk");
-			cy.wait(2000);
+			cy.desk_ready();
 			// Update sysdefaults in window
 			cy.window()
 				.its("frappe")
@@ -175,7 +175,7 @@ context("FileUploader", () => {
 		it("should show checkbox and toggle when setting is enabled for System Manager", () => {
 			cy.login("Administrator", Cypress.env("adminPassword") || "admin");
 			cy.visit("/desk");
-			cy.wait(1000);
+			cy.desk_ready();
 
 			// Enable the setting
 			cy.set_value("System Settings", "System Settings", {
@@ -188,7 +188,7 @@ context("FileUploader", () => {
 					frappe.boot.sysdefaults.only_allow_system_managers_to_upload_public_files = 1;
 				});
 			cy.visit("/desk");
-			cy.wait(2000);
+			cy.desk_ready();
 
 			open_upload_dialog();
 
@@ -220,19 +220,19 @@ context("FileUploader", () => {
 		it("should show disabled checkbox and hide toggle when setting is enabled for non-System Manager", () => {
 			cy.login("Administrator", Cypress.env("adminPassword") || "admin");
 			cy.visit("/desk");
-			cy.wait(1000);
+			cy.desk_ready();
 
 			// Enable the setting
 			cy.set_value("System Settings", "System Settings", {
 				only_allow_system_managers_to_upload_public_files: 1,
 			});
 			cy.visit("/desk");
-			cy.wait(1000);
+			cy.desk_ready();
 
 			// Login as non-System Manager
 			cy.login(test_user, test_password);
 			cy.visit("/desk");
-			cy.wait(2000);
+			cy.desk_ready();
 			// Update sysdefaults in window
 			cy.window()
 				.its("frappe")

--- a/cypress/integration/list_saved_layouts.js
+++ b/cypress/integration/list_saved_layouts.js
@@ -53,7 +53,7 @@ context("List View — Saved Layouts", () => {
 
 	it("shows default layout and action rows in the menu", () => {
 		cy.visit(LIST_URL);
-		cy.wait(500);
+		cy.desk_ready();
 		cy.clear_filters();
 
 		openLayoutSubmenu();
@@ -70,14 +70,14 @@ context("List View — Saved Layouts", () => {
 		});
 
 		cy.visit(LIST_URL);
-		cy.wait(500);
+		cy.desk_ready();
 		cy.clear_filters();
 
 		selectLayout("_cypress_layout_empty");
 		assertActiveLayout("_cypress_layout_empty");
 
 		cy.visit(LIST_URL);
-		cy.wait(1000);
+		cy.desk_ready();
 		cy.clear_filters();
 
 		assertActiveLayout("_cypress_layout_empty");
@@ -90,7 +90,7 @@ context("List View — Saved Layouts", () => {
 		});
 
 		cy.visit(LIST_URL);
-		cy.wait(1000);
+		cy.desk_ready();
 		cy.clear_filters();
 
 		assertActiveLayout("Default Layout");
@@ -104,6 +104,7 @@ context("List View — Saved Layouts", () => {
 		});
 
 		cy.visit(`${LIST_URL}?status=Open`);
+		cy.desk_ready();
 
 		assertActiveLayout("_cypress_layout_open");
 	});
@@ -116,7 +117,7 @@ context("List View — Saved Layouts", () => {
 		});
 
 		cy.visit(LIST_URL);
-		cy.wait(500);
+		cy.desk_ready();
 		cy.clear_filters();
 
 		selectLayout("_cypress_layout_switch");
@@ -132,7 +133,7 @@ context("List View — Saved Layouts", () => {
 		});
 
 		cy.visit(LIST_URL);
-		cy.wait(500);
+		cy.desk_ready();
 
 		openLayoutSubmenu();
 		cy.contains(".es-menu__item", "Manage Layouts").click();

--- a/cypress/integration/list_view_column_width.js
+++ b/cypress/integration/list_view_column_width.js
@@ -62,7 +62,7 @@ context("List View — Column Widths", () => {
 	beforeEach(() => {
 		resetListViewSettings();
 		cy.visit(LIST_URL);
-		cy.wait(500);
+		cy.desk_ready();
 		cy.clear_filters();
 	});
 
@@ -84,6 +84,7 @@ context("List View — Column Widths", () => {
 
 		// Reload so fresh render applies the persisted width via setup_columns()
 		cy.reload();
+		cy.desk_ready();
 
 		getColumnWidth("module").should("be.closeTo", 180, 15);
 	});
@@ -106,6 +107,7 @@ context("List View — Column Widths", () => {
 		);
 
 		cy.reload();
+		cy.desk_ready();
 
 		getColumnWidth("module").should("be.closeTo", 220, 15);
 	});
@@ -129,6 +131,7 @@ context("List View — Column Widths", () => {
 			cy.wait(600);
 
 			cy.reload();
+			cy.desk_ready();
 
 			getColumnWidth("module").should("be.greaterThan", initialWidth + 30);
 		});

--- a/cypress/integration/list_view_settings.js
+++ b/cypress/integration/list_view_settings.js
@@ -3,7 +3,7 @@ context("List View Settings", () => {
 		cy.login();
 		cy.visit("/desk/website");
 		cy.visit("/desk/List/DocType/List");
-		cy.wait(300);
+		cy.desk_ready();
 		cy.clear_filters();
 		cy.wait(300);
 		cy.get(".menu-btn-group button").click({ force: true });

--- a/cypress/integration/view_routing.js
+++ b/cypress/integration/view_routing.js
@@ -6,7 +6,7 @@ context("View", () => {
 
 	it("Route to ToDo List View", () => {
 		cy.visit("/desk/todo/view/list");
-		cy.wait(500);
+		cy.desk_ready();
 		cy.window()
 			.its("cur_list")
 			.then((list) => {
@@ -16,7 +16,7 @@ context("View", () => {
 
 	it("Route to ToDo Report View", () => {
 		cy.visit("/desk/todo/view/report");
-		cy.wait(500);
+		cy.desk_ready();
 		cy.window()
 			.its("cur_list")
 			.then((list) => {
@@ -26,7 +26,7 @@ context("View", () => {
 
 	it("Route to ToDo Dashboard View", () => {
 		cy.visit("/desk/todo/view/dashboard");
-		cy.wait(500);
+		cy.desk_ready();
 		cy.window()
 			.its("cur_list")
 			.then((list) => {
@@ -36,7 +36,7 @@ context("View", () => {
 
 	it("Route to ToDo Gantt View", () => {
 		cy.visit("/desk/todo/view/gantt");
-		cy.wait(500);
+		cy.desk_ready();
 		cy.window()
 			.its("cur_list")
 			.then((list) => {
@@ -47,7 +47,7 @@ context("View", () => {
 	it("Route to ToDo Kanban View", () => {
 		cy.call("frappe.tests.ui_test_helpers.create_kanban").then(() => {
 			cy.visit("/desk/note/view/kanban/_Note _Kanban");
-			cy.wait(500);
+			cy.desk_ready();
 			cy.window()
 				.its("cur_list")
 				.then((list) => {
@@ -58,7 +58,7 @@ context("View", () => {
 
 	it("Route to ToDo Calendar View", () => {
 		cy.visit("/desk/todo/view/calendar");
-		cy.wait(500);
+		cy.desk_ready();
 		cy.window()
 			.its("cur_list")
 			.then((list) => {
@@ -69,7 +69,7 @@ context("View", () => {
 	it("Route to Custom Tree View", () => {
 		cy.call("frappe.tests.ui_test_helpers.setup_tree_doctype").then(() => {
 			cy.visit("/desk/custom-tree/view/tree");
-			cy.wait(500);
+			cy.desk_ready();
 			cy.window()
 				.its("cur_tree")
 				.then((list) => {
@@ -81,7 +81,7 @@ context("View", () => {
 	it("Route to Custom Image View", () => {
 		cy.call("frappe.tests.ui_test_helpers.setup_image_doctype").then(() => {
 			cy.visit("app/custom-image/view/image");
-			cy.wait(500);
+			cy.desk_ready();
 			cy.window()
 				.its("cur_list")
 				.then((list) => {
@@ -93,7 +93,7 @@ context("View", () => {
 	it("Route to Communication Inbox View", () => {
 		cy.call("frappe.tests.ui_test_helpers.setup_inbox").then(() => {
 			cy.visit("app/communication/view/inbox");
-			cy.wait(500);
+			cy.desk_ready();
 			cy.window()
 				.its("cur_list")
 				.then((list) => {
@@ -126,7 +126,7 @@ context("View", () => {
 	it("Re-route to default view", () => {
 		cy.call("frappe.tests.ui_test_helpers.setup_default_view", { view: "Report" }).then(() => {
 			cy.visit("app/event");
-			cy.wait(500);
+			cy.desk_ready();
 			cy.window()
 				.its("cur_list")
 				.then((list) => {
@@ -138,7 +138,7 @@ context("View", () => {
 	it("Route to default view from app/{doctype}", () => {
 		cy.call("frappe.tests.ui_test_helpers.setup_default_view", { view: "Report" }).then(() => {
 			cy.visit("/desk/event");
-			cy.wait(500);
+			cy.desk_ready();
 			cy.window()
 				.its("cur_list")
 				.then((list) => {
@@ -150,7 +150,7 @@ context("View", () => {
 	it("Route to default view from app/{doctype}/view", () => {
 		cy.call("frappe.tests.ui_test_helpers.setup_default_view", { view: "Report" }).then(() => {
 			cy.visit("/desk/event/view");
-			cy.wait(500);
+			cy.desk_ready();
 			cy.window()
 				.its("cur_list")
 				.then((list) => {
@@ -165,7 +165,7 @@ context("View", () => {
 			force_reroute: true,
 		}).then(() => {
 			cy.visit("/desk/event");
-			cy.wait(500);
+			cy.desk_ready();
 			cy.window()
 				.its("cur_list")
 				.then((list) => {
@@ -180,7 +180,7 @@ context("View", () => {
 			force_reroute: true,
 		}).then(() => {
 			cy.visit("/desk/event/view");
-			cy.wait(500);
+			cy.desk_ready();
 			cy.window()
 				.its("cur_list")
 				.then((list) => {
@@ -195,7 +195,7 @@ context("View", () => {
 			force_reroute: true,
 		}).then(() => {
 			cy.visit("/desk/event/view/list");
-			cy.wait(500);
+			cy.desk_ready();
 			cy.window()
 				.its("cur_list")
 				.then((list) => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -293,7 +293,7 @@ Cypress.Commands.add("desk_ready", () => {
 		expect(win.frappe && win.frappe.app, "desk booted").to.be.ok;
 		expect(win.frappe.request.ajax_count, "no pending requests").to.eq(0);
 	});
-	cy.get(".layout-main-section", { timeout: 30000 }).should("exist");
+	cy.get(".layout-main-section").should("exist");
 });
 
 Cypress.Commands.add("dialog", (opts) => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -291,7 +291,6 @@ Cypress.Commands.add("clear_cache", () => {
 Cypress.Commands.add("desk_ready", () => {
 	cy.window({ log: false }).should((win) => {
 		expect(win.frappe && win.frappe.app, "desk booted").to.be.ok;
-		expect(win.frappe.get_route_str(), "route resolved").to.not.be.empty;
 		expect(win.frappe.request.ajax_count, "requests settled").to.eq(0);
 	});
 	cy.get(".layout-main-section:visible").should("not.be.empty");

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -288,6 +288,14 @@ Cypress.Commands.add("clear_cache", () => {
 		});
 });
 
+Cypress.Commands.add("desk_ready", () => {
+	cy.window({ log: false }).should((win) => {
+		expect(win.frappe && win.frappe.app, "desk booted").to.be.ok;
+		expect(win.frappe.request.ajax_count, "no pending requests").to.eq(0);
+	});
+	cy.get(".layout-main-section", { timeout: 30000 }).should("exist");
+});
+
 Cypress.Commands.add("dialog", (opts) => {
 	return cy
 		.window({ log: false })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -291,9 +291,10 @@ Cypress.Commands.add("clear_cache", () => {
 Cypress.Commands.add("desk_ready", () => {
 	cy.window({ log: false }).should((win) => {
 		expect(win.frappe && win.frappe.app, "desk booted").to.be.ok;
-		expect(win.frappe.request.ajax_count, "no pending requests").to.eq(0);
+		expect(win.frappe.get_route_str(), "route resolved").to.not.be.empty;
+		expect(win.frappe.request.ajax_count, "requests settled").to.eq(0);
 	});
-	cy.get(".layout-main-section").should("exist");
+	cy.get(".layout-main-section:visible").should("not.be.empty");
 });
 
 Cypress.Commands.add("dialog", (opts) => {


### PR DESCRIPTION
- add `cy.desk_ready()`: waits for the desk to boot, in-flight requests to settle (`frappe.request.ajax_count === 0`), and page content to render — a real signal instead of a fixed sleep
- convert `file_uploader.js` (13 sites, ~17s of `cy.wait()`) to use it; the two `cy.wait('@upload_file')` alias waits stay

Pilot for retiring the ~37s of `visit + fixed wait` desk-load races across the suite. Draft until CI confirms it's stable.