### PR TITLE
fix(kanban): show column indicator as colored dot, not column background

### DIFF
--- a/frappe/public/js/frappe/views/kanban/kanban_board.bundle.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_board.bundle.js
@@ -1710,12 +1710,12 @@ if (frappe.views.KanbanView) {
 		return col.status !== "Archived";
 	}
 
-	/** Update column background and badge theme without rebuilding cards. */
+	/** Update column dot indicator without rebuilding cards. */
 	function apply_column_indicator($column, indicator) {
 		if (!$column?.length) return;
 		const theme = frappe.scrub(indicator || "gray", "-");
-		$column.css("background-color", `var(--bg-${theme})`);
-		$column.find(".kanban-column-header .es-badge").attr("data-theme", theme);
+		const $dot = $column.find(".kanban-col-dot");
+		$dot.attr("class", `kanban-col-dot indicator ${theme}`);
 	}
 
 	/** Align card column fields with saved board column order (mutates cards in place). */

--- a/frappe/public/js/frappe/views/kanban/kanban_column.html
+++ b/frappe/public/js/frappe/views/kanban/kanban_column.html
@@ -1,9 +1,9 @@
-<div class="kanban-column" data-column-value="{{title}}" style="background-color: var(--bg-{{indicator}});">
+<div class="kanban-column" data-column-value="{{title}}" style="background-color: var(--kanban-column-bg);">
 	<div class="kanban-column-header">
 		<span class="kanban-column-title">
-			{%= frappe.ui.badge.html({ theme: indicator, icon: "circle" }) %}
+			<span class="kanban-col-dot indicator {{indicator}}"></span>
 			<span class="kanban-title ellipsis" title="{{title}}">{{ __(title) }}</span>
-			<span class="kanban-column-count es-badge" data-theme="{{indicator}}" data-variant="subtle" data-size="sm">0</span>
+			<span class="kanban-column-count es-badge" data-variant="subtle" data-size="sm">0</span>
 		</span>
 		<div class="column-options dropdown pull-right">
 			<a data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
### Reason

The kanban column indicator color was being applied as a background fill on the entire column div. This caused the column to be visually tinted with the indicator color, which does not match Frappe's Espresso design, the indicator should only appear as a small colored dot in the column header. 
<img width="3024" height="1564" alt="image" src="https://github.com/user-attachments/assets/11c6102f-b61c-4d96-b778-d0b40fa9228a" />


### Changes Done
- Column background now stays neutral regardless of the indicator color set.
- Indicator color is shown only as a small colored dot in the column header. 
<img width="2876" height="1584" alt="image" src="https://github.com/user-attachments/assets/eb6f32cb-76c4-4c71-8362-761af52a5616" />
