### PR TITLE
fix(report): handle missing json when updating a custom report

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -871,7 +871,7 @@ def save_report(reference_report: str, report_name: str, columns: str | list, fi
 
 	if docname:
 		report = frappe.get_doc("Report", docname)
-		existing_jd = json.loads(report.json)
+		existing_jd = frappe.parse_json(report.json or "{}")
 		existing_jd["columns"] = frappe.parse_json(columns)
 		existing_jd["filters"] = frappe.parse_json(filters)
 		report.update({"json": json.dumps(existing_jd, separators=(",", ":"))})


### PR DESCRIPTION
A custom report created outside `save_report` has no `json` value, so updating its columns crashed with 

> `TypeError: the JSON object must be str, bytes or bytearray, not NoneType`.


---

Ref: https://support.frappe.io/helpdesk/tickets/76051?view=VIEW-HD+Ticket-1252