### PR TITLE
perf: reuse cached web form doc when building link options

### DIFF
--- a/frappe/website/doctype/web_form/test_web_form.py
+++ b/frappe/website/doctype/web_form/test_web_form.py
@@ -5,7 +5,7 @@ import json
 import frappe
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import set_request
-from frappe.website.doctype.web_form.web_form import accept
+from frappe.website.doctype.web_form.web_form import accept, get_link_options
 from frappe.website.serve import get_response_content
 
 test_dependencies = ["Web Form"]
@@ -76,3 +76,31 @@ class TestWebForm(FrappeTestCase):
 			self.normalize_html('<meta property="og:image" content="https://frappe.io/files/frappe.png">'),
 			content,
 		)
+
+	def test_link_options_do_not_reload_web_form(self):
+		web_form = frappe.get_doc(
+			{
+				"doctype": "Web Form",
+				"title": "Team Meeting Signup",
+				"route": "team-meeting-signup",
+				"doc_type": "Event",
+				"published": 1,
+				"login_required": 1,
+				"web_form_fields": [
+					{
+						"doctype": "Web Form Field",
+						"fieldname": "reference_doctype",
+						"fieldtype": "Link",
+						"label": "Reference Document Type",
+						"options": "DocType",
+					}
+				],
+			}
+		).insert()
+		self.addCleanup(frappe.clear_document_cache, "Web Form", web_form.name)
+
+		get_link_options(web_form.name, "DocType")
+
+		with self.assertQueryCount(6):
+			for _ in range(5):
+				get_link_options(web_form.name, "DocType")

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -840,7 +840,7 @@ def has_link_option(fields, doctype):
 
 
 def get_link_options(web_form_name, doctype, allow_read_on_all_link_options=False):
-	web_form: WebForm = frappe.get_doc("Web Form", web_form_name)
+	web_form: WebForm = frappe.get_cached_doc("Web Form", web_form_name)
 
 	if web_form.login_required and frappe.session.user == "Guest":
 		frappe.throw(_("You must be logged in to use this form."), frappe.PermissionError)


### PR DESCRIPTION
Backport #41617 to version-15 