### PR TITLE
feat: show_search option for EmbeddedList

### DIFF
--- a/frappe/public/js/frappe/ui/embedded_list.js
+++ b/frappe/public/js/frappe/ui/embedded_list.js
@@ -16,6 +16,7 @@ frappe.ui.EmbeddedList = class EmbeddedList {
 				no_match_icon: "search-x",
 				loading_message: __("Loading..."),
 				error_message: __("Failed to load data."),
+				show_search: true,
 				columns: [],
 				filters: {},
 				fields: ["name"],
@@ -69,9 +70,11 @@ frappe.ui.EmbeddedList = class EmbeddedList {
 					attrs: { "data-action": "add-row" },
 			  })
 			: "";
-		const search = `<input type="text" class="form-control form-control-sm embedded-list-search" data-action="search" placeholder="${__(
-			"Search"
-		)}">`;
+		const search = this.show_search
+			? `<input type="text" class="form-control form-control-sm embedded-list-search" data-action="search" placeholder="${__(
+					"Search"
+			  )}">`
+			: "";
 
 		if (!title && !description && !add) {
 			this.$header.hide();


### PR DESCRIPTION
`EmbeddedList` hardcoded the search input into its header, so consumers with a handful of fixed rows had no way to drop it.

Adds `show_search`, defaulting to `true` — existing lists (Role, DocType Settings) are unchanged.

```js
new frappe.ui.EmbeddedList({ show_search: false, ... });
```

Used by frappe/erpnext#58096.

`no-docs`