### PR TITLE
fix(attachments): respect field permlevel in sidebar and docinfo

### DIFF
--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -182,11 +182,31 @@ def get_milestones(doctype, name):
 
 
 def get_attachments(dt, dn):
-	return frappe.get_all(
+	attachments = frappe.get_all(
 		"File",
-		fields=["name", "file_name", "file_url", "is_private"],
+		fields=["name", "file_name", "file_url", "is_private", "attached_to_field"],
 		filters={"attached_to_name": str(dn), "attached_to_doctype": dt},
 	)
+
+	# Hide files uploaded through an Attach / Attach Image field the user has no
+	# permlevel access to. Files attached generically (no `attached_to_field`) or
+	# through a permlevel-0 field stay visible.
+	meta = frappe.get_meta(dt)
+	high_permlevel_fields = {df.fieldname for df in meta.get_high_permlevel_fields()}
+	if high_permlevel_fields:
+		permitted_fieldnames = set(meta.get_permitted_fieldnames())
+		attachments = [
+			a
+			for a in attachments
+			if not a.attached_to_field
+			or a.attached_to_field not in high_permlevel_fields
+			or a.attached_to_field in permitted_fieldnames
+		]
+
+	for a in attachments:
+		a.pop("attached_to_field", None)
+
+	return attachments
 
 
 def get_versions(doc: "Document") -> list[dict]:


### PR DESCRIPTION
Attach and Attach Image files were listed in the form sidebar and docinfo regardless of the permlevel of the field they were uploaded through. Users without permlevel read access to that field could still see the attached file.

get_attachments() now filters files whose source field (attached_to_field) is a high-permlevel field the user has no read access to. Generically attached files and files from permlevel-0 fields remain visible.

<!--

Note: Your PR will be automatically closed if you're not in list of [vouched users](https://github.com/frappe/frappe/blob/develop/.github/VOUCHED.td).

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](https://www.conventionalcommits.org/en/v1.0.0/).
 3. All tests pass locally, UI and Unit tests.
 4. All business logic and validations must be on the server-side.
 5. Update necessary documentation.
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation
- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md
- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->
