### PR TITLE
fix(attachments): respect field permlevel in sidebar and docinfo

### DIFF
--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -190,7 +190,7 @@ def get_milestones(doctype, name, start=0, limit=20):
 
 
 def get_attachments(dt, dn):
-	return frappe.get_all(
+	attachments = frappe.get_all(
 		"File",
 		fields=[
 			"name",
@@ -204,6 +204,26 @@ def get_attachments(dt, dn):
 		],
 		filters={"attached_to_name": str(dn), "attached_to_doctype": dt},
 	)
+
+	# Hide files uploaded through an Attach / Attach Image field the user has no
+	# permlevel access to. Files attached generically (no `attached_to_field`) or
+	# through a permlevel-0 field stay visible.
+	meta = frappe.get_meta(dt)
+	high_permlevel_fields = {df.fieldname for df in meta.get_high_permlevel_fields()}
+	if high_permlevel_fields:
+		permitted_fieldnames = set(meta.get_permitted_fieldnames())
+		attachments = [
+			a
+			for a in attachments
+			if not a.attached_to_field
+			or a.attached_to_field not in high_permlevel_fields
+			or a.attached_to_field in permitted_fieldnames
+		]
+
+	for a in attachments:
+		a.pop("attached_to_field", None)
+
+	return attachments
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Attach and Attach Image files were listed in the form sidebar and docinfo regardless of the permlevel of the field they were uploaded through. Users without permlevel read access to that field could still see the attached file.
