### PR TITLE
fix(desk): keep notification unread count and indicator in sync

### DIFF
--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -8,7 +8,6 @@ from frappe.desk.doctype.notification_settings.notification_settings import (
 	is_notifications_enabled,
 )
 from frappe.model.document import Document
-from frappe.utils.caching import http_cache
 
 
 class NotificationLog(Document):
@@ -249,7 +248,6 @@ def format_email_header(header_map, language, docname):
 
 
 @frappe.whitelist()
-@http_cache(max_age=60, stale_while_revalidate=60 * 60)
 def get_notification_logs(limit: int = 20):
 	notification_logs = frappe.db.get_list(
 		"Notification Log", fields=["*"], limit=limit, order_by="creation desc"
@@ -262,7 +260,15 @@ def get_notification_logs(limit: int = 20):
 	for user in users:
 		frappe.utils.add_user_info(user, user_info)
 
-	return {"notification_logs": notification_logs, "user_info": user_info}
+	unread_count = frappe.db.count(
+		"Notification Log", {"read": 0, "for_user": frappe.session.user}
+	)
+
+	return {
+		"notification_logs": notification_logs,
+		"user_info": user_info,
+		"unread_count": unread_count,
+	}
 
 
 @frappe.whitelist()

--- a/frappe/public/js/frappe/ui/notifications/notifications.js
+++ b/frappe/public/js/frappe/ui/notifications/notifications.js
@@ -131,7 +131,13 @@ frappe.ui.Notifications = class Notifications {
 		e.stopImmediatePropagation();
 		this.dropdown_list.find(".unread").removeClass("unread");
 		frappe.call("frappe.desk.doctype.notification_log.notification_log.mark_all_as_read");
-		this.tabs.notifications?.update_count_badge(0);
+		const notifications = this.tabs.notifications;
+		if (notifications) {
+			notifications.settings.seen = 1;
+			notifications.update_count_badge(0);
+			notifications.toggle_notification_icon(true);
+		}
+		frappe.boot.notification_unread_count = 0;
 	}
 
 	setup_dropdown_events() {
@@ -237,15 +243,21 @@ class NotificationsView extends BaseNotificationsView {
 
 		this.unread_count = frappe.boot.notification_unread_count || 0;
 		this.update_count_badge(this.unread_count);
+		this.refresh_notifications();
+	}
 
-		this.get_notifications_list(this.max_length).then((r) => {
+	refresh_notifications() {
+		return this.get_notifications_list(this.max_length).then((r) => {
 			if (!r.message) return;
-			this.dropdown_items = r.message.notification_logs;
+			this.dropdown_items = r.message.notification_logs || [];
 			frappe.update_user_info(r.message.user_info);
 			this.render_notifications_dropdown();
-			if (this.settings.seen == 0 && this.dropdown_items.length > 0) {
-				this.toggle_notification_icon(false);
-			}
+
+			const unread =
+				r.message.unread_count != null
+					? cint(r.message.unread_count)
+					: this.dropdown_items.filter((n) => !n.read).length;
+			this.update_count_badge(unread);
 		});
 	}
 
@@ -276,14 +288,19 @@ class NotificationsView extends BaseNotificationsView {
 	}
 
 	mark_as_read(docname, $el) {
-		frappe
-			.call("frappe.desk.doctype.notification_log.notification_log.mark_as_read", {
-				docname: docname,
-			})
-			.then(() => {
-				$el.removeClass("unread");
-				this.update_count_badge(Math.max(this.unread_count - 1, 0));
-			});
+		// Optimistic UI so navigation / stale GETs don't keep items unread.
+		$el?.removeClass("unread");
+		const item = this.dropdown_items?.find((n) => n.name === docname);
+		if (item) {
+			item.read = 1;
+		}
+		const next = Math.max(this.unread_count - 1, 0);
+		this.update_count_badge(next);
+		frappe.boot.notification_unread_count = next;
+
+		frappe.call("frappe.desk.doctype.notification_log.notification_log.mark_as_read", {
+			docname: docname,
+		});
 	}
 
 	insert_into_dropdown() {
@@ -345,8 +362,10 @@ class NotificationsView extends BaseNotificationsView {
 		}
 
 		item_html.on("click", () => {
-			!notification_log.read && this.mark_as_read(notification_log.name, item_html);
-			this.notifications_icon.trigger("click");
+			if (!notification_log.read) {
+				this.mark_as_read(notification_log.name, item_html);
+			}
+			this.parent.addClass("hidden");
 		});
 
 		return item_html;
@@ -387,7 +406,9 @@ class NotificationsView extends BaseNotificationsView {
 			method: "frappe.desk.doctype.notification_log.notification_log.get_notification_logs",
 			args: { limit: limit },
 			type: "GET",
-			cache: true,
+			// Must not cache: mark_as_read updates `read`, and a cached GET would
+			// keep rendering items as unread after clicks / reload.
+			cache: false,
 		});
 	}
 
@@ -405,24 +426,32 @@ class NotificationsView extends BaseNotificationsView {
 	}
 
 	toggle_notification_icon(seen) {
+		if (!this.bell_indicator?.length) {
+			this.bell_indicator = $(".sidebar-notification .sidebar-item-icon");
+		}
 		this.bell_indicator?.toggleClass("indicator blue", !seen);
 	}
 
 	update_count_badge(count) {
 		this.unread_count = count;
-		const $suffix = this.parent
-			.closest(".body-sidebar")
-			?.find(".sidebar-notification .sidebar-notification-count");
-		if (!$suffix?.length) return;
+		frappe.boot.notification_unread_count = count;
 
-		if (count > 0) {
-			$suffix
-				.text(count > 99 ? "99+" : count)
-				.attr("aria-label", __("{0} unread notifications", [count]))
-				.removeClass("hidden");
-		} else {
-			$suffix.removeAttr("aria-label").addClass("hidden");
+		const $count = $(
+			".sidebar-notification .sidebar-notification-count, .sidebar-notification .notification-count, .notification-count"
+		);
+		if ($count.length) {
+			if (count > 0) {
+				$count
+					.text(count > 99 ? "99+" : String(count))
+					.attr("aria-label", __("{0} unread notifications", [count]))
+					.removeClass("hidden");
+			} else {
+				$count.text("").removeAttr("aria-label").addClass("hidden");
+			}
 		}
+
+		// Blue bell dot tracks remaining unread logs (not only the "seen" flag).
+		this.toggle_notification_icon(count === 0);
 	}
 
 	toggle_seen(flag) {
@@ -445,17 +474,17 @@ class NotificationsView extends BaseNotificationsView {
 
 		frappe.realtime.on("indicator_hide", () => {
 			this.settings.seen = 1;
-			this.toggle_notification_icon(true);
+			if (!this.unread_count) {
+				this.toggle_notification_icon(true);
+			}
 		});
 
 		this.parent.on("show.bs.dropdown", () => {
 			this.toggle_seen(true);
-			if (this.bell_indicator?.hasClass("indicator")) {
-				this.toggle_notification_icon(true);
-				frappe.call(
-					"frappe.desk.doctype.notification_log.notification_log.trigger_indicator_hide"
-				);
-			}
+			this.settings.seen = 1;
+			// Opening marks as "seen" but does not clear unread — keep indicator
+			// while unread_count > 0 and refresh list/badge from the server.
+			this.refresh_notifications();
 		});
 	}
 }

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -522,7 +522,7 @@ frappe.ui.Sidebar = class Sidebar {
 			standard: true,
 			type: "Button",
 			class: "sidebar-notification hidden",
-			suffix: "<span class='sidebar-notification-count hidden' aria-live='polite'></span>",
+			suffix: "<span class='sidebar-notification-count notification-count hidden' aria-live='polite'></span>",
 			onClick: () => {
 				const $dropdown = this.wrapper.find(".dropdown-notifications");
 				$dropdown.toggleClass("hidden");

--- a/frappe/public/scss/desk/notification.scss
+++ b/frappe/public/scss/desk/notification.scss
@@ -69,13 +69,20 @@
 	height: 5.5px;
 	width: 5.5px;
 	transition: opacity 0.2s ease-in-out;
+	opacity: 1;
+}
+
+/* Expanded sidebar: keep the blue unread dot visible next to the bell. */
+.body-sidebar-container.expanded .sidebar-notification .sidebar-item-icon.indicator::before {
+	opacity: 1;
 }
 
 .sidebar-notification:hover .sidebar-item-icon.indicator::before {
 	opacity: 0;
 }
 
-.sidebar-notification-count {
+.sidebar-notification-count,
+.sidebar-notification .notification-count {
 	min-width: 20px;
 	padding: 1px 7px;
 	background-color: var(--bg-gray-100);
@@ -84,10 +91,54 @@
 	line-height: 1.2;
 	text-align: center;
 	border-radius: 10px;
+	font-variant-numeric: tabular-nums;
 }
 
 .sidebar-notification .standard-sidebar-item .item-anchor {
 	overflow: visible;
+}
+
+/* Keep the unread count pinned to the right of the Notification row. */
+.sidebar-notification {
+	position: relative;
+
+	.sidebar-item-suffix {
+		margin-left: auto;
+		flex-shrink: 0;
+		padding-right: 4px;
+	}
+}
+
+/* Collapsed sidebar (icon-only): show the count on the bell corner. */
+.body-sidebar-container:not(.expanded) .sidebar-notification {
+	.sidebar-item-label,
+	.sidebar-item-control {
+		display: none;
+	}
+
+	.sidebar-item-suffix {
+		position: absolute;
+		top: 0;
+		right: 0;
+		margin: 0;
+		padding: 0;
+		z-index: 2;
+	}
+
+	.sidebar-notification-count,
+	.notification-count {
+		min-width: 16px;
+		padding: 0 4px;
+		font-size: 10px;
+		line-height: 16px;
+		background-color: var(--bg-red-400, #e86c60);
+		color: #fff;
+	}
+
+	/* Number badge replaces the blue unseen dot while collapsed. */
+	.sidebar-item-icon.indicator::before {
+		opacity: 0;
+	}
 }
 
 .mark-read {


### PR DESCRIPTION
### Explain the details for making this change. What existing problem does the pull request solve?

On Frappe v16, the sidebar notification bell unread affordance is unreliable:

- `get_notification_logs` is HTTP-cached, so after mark-as-read / reload the panel can still show unread items
- the count badge is not re-synced from the server on panel open/load
- the blue indicator follows `Notification Settings.seen` (cleared when opening the panel) instead of remaining unread `Notification Log` rows

Users can therefore open the panel and see unread notifications while a refresh makes the bell look empty (or the reverse).

### What this PR changes

Built on top of the existing v16 notification badge backport already in `version-16-hotfix`.

- Remove HTTP caching from `get_notification_logs` and return `unread_count`
- Refresh the panel and sync the badge from server unread count on load/open
- Mark items read optimistically on click
- Drive the blue indicator from remaining unread count (not only `seen`)
- Improve sidebar count badge layout (expanded + collapsed)

### Diff size

4 files only (no locale/translation noise). Base: `version-16-hotfix`.

### Test plan

- [ ] Hard refresh with unread notifications → correct count + blue indicator
- [ ] Open panel → list/count match server unread state
- [ ] Click one unread item → count decreases; item no longer unread after reopen
- [ ] Mark all as read → count + indicator clear; still clear after reload
- [ ] New realtime notification → count increments and indicator returns
