### PR TITLE
fix(attachments): respect field permlevel in sidebar and docinfo

### DIFF
--- a/frappe/core/doctype/comment/comment.json
+++ b/frappe/core/doctype/comment/comment.json
@@ -15,6 +15,7 @@
   "reference_doctype",
   "reference_name",
   "reference_owner",
+  "attached_to_field",
   "section_break_10",
   "content",
   "ip_address"
@@ -81,6 +82,12 @@
    "read_only": 1
   },
   {
+   "fieldname": "attached_to_field",
+   "fieldtype": "Data",
+   "label": "Attached To Field",
+   "read_only": 1
+  },
+  {
    "fieldname": "section_break_10",
    "fieldtype": "Section Break"
   },
@@ -99,7 +106,7 @@
   }
  ],
  "links": [],
- "modified": "2024-08-14 16:10:15.413830",
+ "modified": "2026-08-12 16:10:15.413830",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Comment",

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -774,7 +774,7 @@ class File(Document):
 		if self.attached_to_doctype and self.attached_to_name:
 			try:
 				doc = frappe.get_doc(self.attached_to_doctype, self.attached_to_name)
-				doc.add_comment(comment_type, text)
+				doc.add_comment(comment_type, text, attached_to_field=self.attached_to_field)
 			except frappe.DoesNotExistError:
 				frappe.clear_messages()
 

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -184,7 +184,16 @@ def get_milestones(doctype, name):
 def get_attachments(dt, dn):
 	attachments = frappe.get_all(
 		"File",
-		fields=["name", "file_name", "file_url", "is_private", "attached_to_field"],
+		fields=[
+			"name",
+			"file_name",
+			"file_url",
+			"file_type",
+			"file_size",
+			"is_private",
+			"attached_to_field",
+			"folder",
+		],
 		filters={"attached_to_name": str(dn), "attached_to_doctype": dt},
 	)
 
@@ -202,9 +211,6 @@ def get_attachments(dt, dn):
 			or a.attached_to_field not in high_permlevel_fields
 			or a.attached_to_field in permitted_fieldnames
 		]
-
-	for a in attachments:
-		a.pop("attached_to_field", None)
 
 	return attachments
 

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -182,11 +182,31 @@ def get_milestones(doctype, name):
 
 
 def get_attachments(dt, dn):
-	return frappe.get_all(
+	attachments = frappe.get_all(
 		"File",
-		fields=["name", "file_name", "file_url", "is_private"],
+		fields=["name", "file_name", "file_url", "is_private", "attached_to_field"],
 		filters={"attached_to_name": str(dn), "attached_to_doctype": dt},
 	)
+
+	# Hide files uploaded through an Attach / Attach Image field the user has no
+	# permlevel access to. Files attached generically (no `attached_to_field`) or
+	# through a permlevel-0 field stay visible.
+	meta = frappe.get_meta(dt)
+	high_permlevel_fields = {df.fieldname for df in meta.get_high_permlevel_fields()}
+	if high_permlevel_fields:
+		permitted_fieldnames = set(meta.get_permitted_fieldnames())
+		attachments = [
+			a
+			for a in attachments
+			if not a.attached_to_field
+			or a.attached_to_field not in high_permlevel_fields
+			or a.attached_to_field in permitted_fieldnames
+		]
+
+	for a in attachments:
+		a.pop("attached_to_field", None)
+
+	return attachments
 
 
 def get_versions(doc: "Document") -> list[dict]:

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -148,9 +148,22 @@ def add_comments(doc, docinfo):
 
 	comments = frappe.get_all(
 		"Comment",
-		fields=["name", "creation", "content", "owner", "comment_type", "published"],
+		fields=[
+			"name",
+			"creation",
+			"content",
+			"owner",
+			"comment_type",
+			"published",
+			"attached_to_field",
+		],
 		filters={"reference_doctype": doc.doctype, "reference_name": doc.name},
 	)
+
+	# Attachment comments that reference an Attach / Attach Image field the user
+	# has no permlevel access to should be hidden, mirroring get_attachments().
+	high_permlevel_fields = {df.fieldname for df in doc.meta.get_high_permlevel_fields()}
+	permitted_fieldnames = set(doc.meta.get_permitted_fieldnames()) if high_permlevel_fields else set()
 
 	for c in comments:
 		match c.comment_type:
@@ -162,6 +175,13 @@ def add_comments(doc, docinfo):
 			case "Assignment Completed" | "Assigned":
 				docinfo.assignment_logs.append(c)
 			case "Attachment" | "Attachment Removed":
+				if (
+					c.attached_to_field
+					and c.attached_to_field in high_permlevel_fields
+					and c.attached_to_field not in permitted_fieldnames
+				):
+					continue
+				c.pop("attached_to_field", None)
 				docinfo.attachment_logs.append(c)
 			case "Info" | "Edit" | "Label":
 				docinfo.info_logs.append(c)

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1599,6 +1599,7 @@ class Document(BaseDocument, DocRef):
 		text=None,
 		comment_email=None,
 		comment_by=None,
+		attached_to_field: str | None = None,
 	):
 		"""Add a comment to this document.
 
@@ -1613,6 +1614,7 @@ class Document(BaseDocument, DocRef):
 				"reference_doctype": self.doctype,
 				"reference_name": self.name,
 				"content": text or comment_type,
+				"attached_to_field": attached_to_field,
 			}
 		).insert(ignore_permissions=True)
 


### PR DESCRIPTION
Attach and Attach Image files were listed in the form sidebar and docinfo regardless of the permlevel of the field they were uploaded through. Users without permlevel read access to that field could still see the attached file.