### PR TITLE
fix: honour ignore_user_permissions on link fields with a custom query

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -278,6 +278,9 @@ class Engine:
 
 		assert isinstance(self.doctype, str) and self.doctype, "doctype must be a non-empty string"
 
+		if frappe.flags.get("ignore_user_permissions_for_doctype") == self.doctype:
+			self.ignore_user_permissions = True
+
 		if self.apply_permissions:
 			self.check_select_permission()
 			self.permission_doctype = parent_doctype or self.doctype

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -158,6 +158,9 @@ def search_widget(
 		if sbool(query_filters_as_dict) and isinstance(filters, list):
 			filters = make_dict_from_filter_list(filters)
 
+		if ignore_user_permissions:
+			frappe.flags.ignore_user_permissions_for_doctype = doctype
+
 		try:
 			is_whitelisted(frappe.get_attr(query))
 			values = frappe.call(
@@ -184,6 +187,8 @@ def search_widget(
 					http_status_code=404,
 				)
 				return []
+		finally:
+			frappe.flags.ignore_user_permissions_for_doctype = None
 
 		if not for_link_validation:
 			if meta.translated_doctype:

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -286,6 +286,22 @@ class TestSearch(IntegrationTestCase):
 		self.assertIn(allowed_doc.name, result_values)
 		self.assertNotIn(restricted_doc.name, result_values)
 
+		# a custom query runs its own frappe.get_list, the flag should still apply
+		results_from_custom_query = search_link(
+			doctype="Test Search Linked",
+			txt="Document",
+			query="frappe.tests.test_search.query_by_title",
+			ignore_user_permissions=True,
+			reference_doctype="Test Search Form",
+			link_fieldname="linked_doc",
+		)
+		result_values = [r["value"] for r in results_from_custom_query]
+		self.assertIn(allowed_doc.name, result_values)
+		self.assertIn(restricted_doc.name, result_values)
+
+		# and should not outlive the search call
+		self.assertEqual([d.name for d in frappe.get_list("Test Search Linked")], [allowed_doc.name])
+
 	def test_search_link_ignore_user_permissions_validation(self):
 		"""Test that ignore_user_permissions is validated correctly"""
 
@@ -570,6 +586,19 @@ def query_with_reference_doctype(
 	reference_doctype: str | None = None,
 ):
 	return []
+
+
+@whitelist_for_tests()
+@frappe.validate_and_sanitize_search_inputs
+def query_by_title(
+	doctype: str,
+	txt: str,
+	searchfield: str,
+	start: int,
+	page_len: int,
+	filters: str | list | dict[str, Any],
+):
+	return frappe.get_list(doctype, filters={"title": ("like", f"%{txt}%")}, as_list=True)
 
 
 def setup_test_link_field_order(TestCase):


### PR DESCRIPTION
## Description

Link fields with `Ignore User Permissions` enabled still applied user permissions when using a custom query.

`search_widget` passes the flag through `frappe.call`, but the kwarg is dropped when the custom query does not declare it. As a result, the flag never reaches the `frappe.get_list` used by the query.

Set a request-scoped flag around custom query and honour it in the query engine for the searched doctype. The flag is cleared in `finally` to prevent leakage between searches.

**Queries that explicitly declare the kwarg continue to receive it as before.**

---

Ref: https://support.frappe.io/helpdesk/tickets/75984?view=VIEW-HD+Ticket-1252