### PR TITLE
fix: show unique assignees in Assigned To sidebar

### DIFF
--- a/frappe/desk/doctype/todo/todo.py
+++ b/frappe/desk/doctype/todo/todo.py
@@ -101,6 +101,7 @@ class ToDo(Document):
 				"allocated_to",
 				pluck=True,
 				for_update=True,
+				distinct=True,
 			)
 			assignments.reverse()
 

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -354,7 +354,7 @@ def get_communication_data(
 
 
 def get_assignments(dt, dn):
-	return frappe.get_all(
+	todos = frappe.get_all(
 		"ToDo",
 		fields=["name", "allocated_to as owner", "description", "status"],
 		filters={
@@ -364,6 +364,13 @@ def get_assignments(dt, dn):
 			"allocated_to": ("is", "set"),
 		},
 	)
+
+	unique_owners = {}
+
+	for todo in todos:
+		unique_owners[todo.owner] = todo
+
+	return list(unique_owners.values())
 
 
 def run_onload(doc):


### PR DESCRIPTION
## Details

Creating multiple open ToDos for the same user on a document resulted in duplicate entries in the **Assigned To** sidebar. The same issue was also reflected in the `_assign` field, causing duplicate assignees in the **List View**, **Kanban Board**, and assignment count.

This change ensures that assignees are unique across the document form and list view.

### Changes

* Updated `ToDo.update_in_reference` to fetch distinct `allocated_to` values so `_assign` stores each assignee only once.
* Updated `get_assignments` to deduplicate assignment owners before returning them to the **Assigned To** sidebar.
* Prevents duplicate assignees when multiple ToDos are created for the same user on a document.

## Screenshots/GIFs

### Document Form

**Before:**
The same assignee appears multiple times in the **Assigned To** sidebar.
<img width="1470" height="800" alt="Screenshot 2026-08-12 at 10 48 01 PM" src="https://github.com/user-attachments/assets/410d8217-51d3-4d83-a246-50f5a38aae8e" />



**After:**
Each assignee appears only once in the **Assigned To** sidebar.
<img width="1470" height="800" alt="Screenshot 2026-08-12 at 10 51 40 PM" src="https://github.com/user-attachments/assets/04857bd5-8630-40e0-809f-dd562275f270" />

### List View

**Before:**
Duplicate assignees are shown when multiple ToDos are assigned to the same user.
<img width="1470" height="800" alt="Screenshot 2026-08-12 at 11 51 50 PM" src="https://github.com/user-attachments/assets/a34ee648-e01d-4dbc-a7bf-19513a8950b6" />



**After:**
Only unique assignees are displayed.
<img width="1470" height="800" alt="Screenshot 2026-08-12 at 11 51 14 PM" src="https://github.com/user-attachments/assets/b9755213-1f6b-4f86-96f9-8873ac5a5e89" />

