### PR TITLE
fix(search): base get_document_to_index() declares 0 args, its only caller passes 1

### DIFF
--- a/frappe/search/full_text_search.py
+++ b/frappe/search/full_text_search.py
@@ -33,7 +33,14 @@ class FullTextSearch:
 		"""Get all documents to be indexed conforming to the schema"""
 		return []
 
-	def get_document_to_index(self):
+	def get_document_to_index(self, doc_name):
+		"""Fetch and shape the document named `doc_name` for indexing.
+
+		The base implementation is a stub returning an empty (falsy) document,
+		so a subclass that doesn't override this is a no-op rather than an
+		error — every real subclass (`WebsiteSearch`, and `TestWrapper` in
+		test_full_text_search.py) overrides it with this same signature.
+		"""
 		return {}
 
 	def build(self):

--- a/frappe/search/test_full_text_search.py
+++ b/frappe/search/test_full_text_search.py
@@ -63,6 +63,21 @@ class TestFullTextSearch(IntegrationTestCase):
 		res = self.index.search("DesktopAccounting")
 		self.assertEqual(res[0], "sw/frappebooks")
 
+	def test_base_get_document_to_index_accepts_a_name(self):
+		# update_index_by_name always calls get_document_to_index(doc_name).
+		# A subclass that doesn't override it should fall through to the base
+		# stub (falsy, so no-op) rather than raise a TypeError from an arity
+		# mismatch between the 0-arg base declaration and the 1-arg call site.
+		bare = BareWrapper("test_frappe_bare_index")
+		bare.update_index_by_name("anything")
+
+
+class BareWrapper(FullTextSearch):
+	"""Deliberately does not override get_document_to_index — exercises the
+	base class's own default, which test_base_get_document_to_index_accepts_a_name
+	covers.
+	"""
+
 
 class TestWrapper(FullTextSearch):
 	def get_items_to_index(self):


### PR DESCRIPTION
## What

`FullTextSearch.get_document_to_index` declares zero arguments:

```python
def get_document_to_index(self):
    return {}
```

Its only caller passes one:

```python
def update_index_by_name(self, doc_name):
    document = self.get_document_to_index(doc_name)
    if document:
        self.update_index(document)
```

So instantiating `FullTextSearch` directly, or any subclass that doesn't override the method, and calling `update_index_by_name` raises:

```
TypeError: get_document_to_index() takes 1 positional argument but 2 were given
```

instead of falling through to the documented no-op default.

I checked every place this method is defined or called (a GitHub code search for `get_document_to_index` in this repo returns exactly three files) — `WebsiteSearch.get_document_to_index(self, route: str)` and `TestWrapper.get_document_to_index(self, name)` in `test_full_text_search.py` both already override it with a one-argument signature. The base class is the only implementation still declaring zero, and nothing anywhere calls it with zero arguments — so widening the signature isn't a compatibility break for anything in the tree.

## Fix

Give the base its own callers' signature:

```python
def get_document_to_index(self, doc_name):
    return {}
```

## Testing

I don't have a live Frappe site to run the integration test suite this file lives in (`IntegrationTestCase`), so I want to be upfront about what I actually verified rather than claim more:

- Added `test_base_get_document_to_index_accepts_a_name`, exercising a `BareWrapper(FullTextSearch)` that doesn't override the method, calling `update_index_by_name` on it. This runs under the existing `TestFullTextSearch` suite's fixtures.
- Independently, I reproduced just the two methods involved standalone (no whoosh/frappe imports needed, since `update_index_by_name` never reaches whoosh when the returned document is falsy — the base stub's `{}` is falsy, so it doesn't). That confirms the `TypeError` before this change and its absence after:

```
BEFORE: TypeError — FullTextSearchBefore.get_document_to_index() takes 1 positional argument but 2 were given
AFTER: update_index_by_name succeeded (no-op, as intended)
```

Happy to adjust the test if there's a lighter-weight way to exercise this that doesn't need `IntegrationTestCase`'s site fixture.
