### PR TITLE
fix(form_builder): re-evaluate adjust_column_size's loop condition per pass

### DIFF
--- a/frappe/public/js/form_builder/utils.js
+++ b/frappe/public/js/form_builder/utils.js
@@ -152,9 +152,16 @@ export async function get_table_columns(df, child_doctype) {
 
 	function adjust_column_size(total_colsize, increase) {
 		let passes = 0;
-		let start_condition = increase ? total_colsize < 11 : total_colsize >= 11;
 
-		while (start_condition && passes < 11) {
+		// Evaluated fresh each iteration, not captured once before the loop.
+		// total_colsize changes inside the loop body below, so a value frozen
+		// at the top stays true (for increase) or true (for decrease) long
+		// after the per-pass break has already reached its target — the loop
+		// then burns the rest of its `passes < 11` budget re-scanning
+		// table_columns and breaking on the first field every time, without
+		// changing anything further. Output is unaffected either way; this
+		// only removes the wasted scans.
+		while ((increase ? total_colsize < 11 : total_colsize >= 11) && passes < 11) {
 			for (var i in table_columns) {
 				var _df = table_columns[i][0];
 				var colsize = table_columns[i][1];


### PR DESCRIPTION
## What, and what this is not

`adjust_column_size` (`frappe/public/js/form_builder/utils.js`), used by `get_table_columns` to spread Grid/Table field widths for the Form Builder, freezes its loop condition before entering the loop:

```js
function adjust_column_size(total_colsize, increase) {
    let passes = 0;
    let start_condition = increase ? total_colsize < 11 : total_colsize >= 11;

    while (start_condition && passes < 11) {
        for (var i in table_columns) {
            ...
            if (increase && total_colsize > 9) break;
            if (!increase && total_colsize < 11) break;
        }
        passes++;
    }
}
```

`total_colsize` changes inside the loop body; `start_condition` doesn't, because it's read once. A static-analysis-style report this came from claimed this pushes `total_colsize` past its own target and produces a wrong final layout. **Before writing a fix I reproduced the function standalone and that claim doesn't hold** — I want to lead with that rather than bury it, since it changes what this PR is.

Reproduction (both directions, columns with `colsize > 1` so they're eligible for adjustment — that gate matters, an all-`colsize: 1` fixture never exercises the loop body at all regardless of this bug):

```
BEFORE increase: while-iterations=11  final total_colsize=10  widths=[3,2,2,2]
AFTER  increase: while-iterations=11  final total_colsize=10  widths=[3,2,2,2]

BEFORE decrease: while-iterations=11  final total_colsize=10  widths=[1,1,2,2]
AFTER  decrease: while-iterations= 1  final total_colsize=10  widths=[1,1,2,2]
```

Final `total_colsize` and every column's width are **identical** whether the condition is frozen or re-evaluated. The inner per-field break (`total_colsize > 9` / `< 11`) always reaches its own threshold before the frozen-vs-live distinction on the outer condition could matter — once that break has fired once, every subsequent pass re-scans the array and breaks on the very first field checked (which is never itself adjustable — it's the reserved "No." column at `colsize: 1`), touching nothing. So this does not change what gets rendered.

What it does do, confirmed by the iteration counts above: the decrease direction runs the full `table_columns` scan **11 times where 1 would do**. Increase happens to run all 11 in both versions here, because its target (9) sits strictly inside the outer boundary (11) and is never actually exceeded — but the wasted-scan mechanism is the same defect, just not observable via iteration count in that direction with this fixture.

## Fix

Re-evaluate the condition each pass instead of capturing it once:

```js
while ((increase ? total_colsize < 11 : total_colsize >= 11) && passes < 11) {
```

Functionally a no-op relative to today's output (see above); it removes confirmed wasted work — a form with a large table field currently re-scans its full column list up to 10 extra times on every column-size adjustment for no effect.

## Testing

Standalone reproduction only (script available on request) — this is pure client-side layout logic with no `frappe.*` runtime dependency once `is_non_std_field` is stubbed permissive, so I didn't need a bench for it, but I also haven't run it inside an actual Form Builder session. If there's a component/UI test convention for this file I should add to instead, point me at it and I'll follow it.
