### PR TITLE
fix(link): fall back to docname when title lookup target is missing

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -520,8 +520,11 @@ def get_link_title(doctype: str, docname: str | int):
 	meta = frappe.get_meta(doctype)
 
 	if meta.show_title_field_in_link:
-		doc = frappe.get_lazy_doc(doctype, docname)
-		doc.check_permission()
-		return doc.get(meta.title_field)
+		try:
+			doc = frappe.get_lazy_doc(doctype, docname)
+			doc.check_permission()
+			return doc.get(meta.title_field)
+		except frappe.DoesNotExistError:
+			frappe.clear_last_message()
 
 	return docname

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1921,21 +1921,16 @@ Object.assign(frappe.utils, {
 		if (!doctype || !name) {
 			return;
 		}
-		try {
-			return frappe
-				.xcall("frappe.desk.search.get_link_title", {
-					doctype: doctype,
-					docname: name,
-				})
-				.then((title) => {
-					frappe.utils.add_link_title(doctype, name, title);
-					return title;
-				});
-		} catch (error) {
-			console.log("Error while fetching link title.");
-			console.log(error);
-			return Promise.resolve(name);
-		}
+		return frappe
+			.xcall("frappe.desk.search.get_link_title", {
+				doctype: doctype,
+				docname: name,
+			})
+			.then((title) => {
+				frappe.utils.add_link_title(doctype, name, title);
+				return title;
+			})
+			.catch(() => name);
 	},
 
 	only_allow_num_decimal(input) {

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -1258,6 +1258,29 @@ class TestLinkTitle(IntegrationTestCase):
 		user.delete()
 		prop_setter.delete()
 
+	def test_link_title_of_missing_document(self):
+		"""
+		Test that a link value with no target returns the docname without raising
+		"""
+		prop_setter = frappe.get_doc(
+			{
+				"doctype": "Property Setter",
+				"doc_type": "User",
+				"property": "show_title_field_in_link",
+				"property_type": "Check",
+				"doctype_or_field": "DocType",
+				"value": "1",
+			}
+		).insert()
+
+		from frappe.desk.search import get_link_title
+
+		frappe.clear_messages()
+		self.assertEqual(get_link_title("User", "meera.iyer@example.com"), "meera.iyer@example.com")
+		self.assertEqual(frappe.get_message_log(), [])
+
+		prop_setter.delete()
+
 
 class TestAppParser(MockedRequestTestCase):
 	def test_app_name_parser(self):


### PR DESCRIPTION
## Bug

Report view shows a "Not found" dialog and redirects when a Link column contains a value whose target document no longer exists.

## Cause

`get_link_title` loads the linked document to get its title. A missing document raises `DoesNotExistError`, which becomes a 404 and causes `frappe.request` to redirect the user.

`fetch_link_title` also used `try/catch` around an async call, so rejected promises were not handled.

## Fix

`get_link_title` now falls back to the docname when the linked document is missing, while permission errors still raise normally. `clear_last_message()` prevents the missing-document error from being shown as a dialog.

`fetch_link_title` now uses `.catch()` to fall back to the raw value if the request still fails.

---

Ref: https://support.frappe.io/helpdesk/tickets/76012?view=VIEW-HD+Ticket-1252