### PR TITLE
fix(report): key link title lookups by doctype and value

### DIFF
--- a/cypress/fixtures/custom_link_title_doctype.js
+++ b/cypress/fixtures/custom_link_title_doctype.js
@@ -27,6 +27,13 @@ export default {
 			options: "Custom Link Title DocType",
 			in_list_view: 1,
 		},
+		{
+			fieldname: "language",
+			fieldtype: "Link",
+			label: "Language",
+			options: "Language",
+			in_list_view: 1,
+		},
 	],
 	links: [],
 	modified: "2026-08-17 09:11:24.000000",

--- a/cypress/integration/report_view_link_title.js
+++ b/cypress/integration/report_view_link_title.js
@@ -24,6 +24,24 @@ context("Report View Link Titles", () => {
 			},
 			true
 		);
+		cy.insert_doc(
+			doctype_name,
+			{
+				title: "en",
+				display_name: "English localization review",
+			},
+			true
+		);
+		cy.insert_doc(
+			doctype_name,
+			{
+				title: "Localization Handover",
+				display_name: "Localization handover",
+				parent_entry: "en",
+				language: "en",
+			},
+			true
+		);
 	});
 
 	it("skips the link title lookup for a blank Link column", () => {
@@ -39,4 +57,21 @@ context("Report View Link Titles", () => {
 			expect(requested_docnames).to.include("Renewal Reminder");
 		});
 	});
+
+	it("resolves the title of each link against its own doctype", () => {
+		cy.visit(`/desk/List/${doctype_name}/Report`);
+
+		expect_link_titles(`a[data-doctype="Language"][data-name="en"]`, "English");
+		expect_link_titles(
+			`a[data-doctype="${doctype_name}"][data-name="en"]`,
+			"English localization review"
+		);
+	});
 });
+
+function expect_link_titles(selector, title) {
+	cy.get(selector).should((links) => {
+		expect(links).to.have.length.at.least(1);
+		links.each((i, link) => expect(link).to.have.text(title));
+	});
+}

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -26,7 +26,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 		}
 		this.view = "Report";
 
-		this.link_title_doctype_fields = [];
+		this.link_title_values = new Map();
 
 		const route = frappe.get_route();
 		if (route.length === 4) {
@@ -149,31 +149,36 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 
 	set_link_title_field_value() {
 		let rows = this.datatable?.datamanager?.rows;
-		let link_col_indices = this.datatable?.datamanager?.columns
+		let col_indices_by_doctype = {};
+		this.datatable?.datamanager?.columns
 			?.filter((c) => c.docfield?.fieldtype === "Link")
-			.map((c) => c.colIndex);
+			.forEach((c) => {
+				col_indices_by_doctype[c.docfield.options] = (
+					col_indices_by_doctype[c.docfield.options] || []
+				).concat(c.colIndex);
+			});
 
-		Object.keys(this.link_title_doctype_fields).forEach(async (key) => {
-			let link_title = await this.get_link_title_field_value(
-				this.link_title_doctype_fields[key],
-				key
-			);
+		this.link_title_values.forEach(async ({ doctype, value }) => {
+			let link_title = await this.get_link_title_field_value(doctype, value);
 
 			if (link_title === undefined) return;
 
 			// update visible DOM elements and cell tooltip
-			document.querySelectorAll(`a[data-name="${key}"]`).forEach((el) => {
-				if (el.textContent === link_title) return;
-				el.textContent = link_title;
+			document
+				.querySelectorAll(`a[data-doctype="${doctype}"][data-name="${value}"]`)
+				.forEach((el) => {
+					if (el.textContent === link_title) return;
+					el.textContent = link_title;
 
-				$(el).closest(".dt-cell__content").attr("title", link_title);
-			});
+					$(el).closest(".dt-cell__content").attr("title", link_title);
+				});
 
-			if (rows?.length && link_col_indices?.length) {
+			let col_indices = col_indices_by_doctype[doctype];
+			if (rows?.length && col_indices?.length) {
 				for (let row of rows) {
-					for (let ci of link_col_indices) {
+					for (let ci of col_indices) {
 						let cell = row[ci];
-						if (cell?.content === key && cell.html) {
+						if (cell?.content === value && cell.html) {
 							cell.html = null;
 						}
 					}
@@ -1310,8 +1315,11 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 							curr.column.docfield.fieldtype == "Link" &&
 							frappe.boot.link_title_doctypes.includes(curr.column.docfield.options)
 						) {
-							this.link_title_doctype_fields[curr.content] =
-								curr.column.docfield.options;
+							const doctype = curr.column.docfield.options;
+							this.link_title_values.set(`${doctype}::${curr.content}`, {
+								doctype,
+								value: curr.content,
+							});
 						}
 						acc[curr.column.docfield.fieldname] = curr.content;
 						return acc;

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -164,14 +164,13 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			if (link_title === undefined) return;
 
 			// update visible DOM elements and cell tooltip
-			document
-				.querySelectorAll(`a[data-doctype="${doctype}"][data-name="${value}"]`)
-				.forEach((el) => {
-					if (el.textContent === link_title) return;
-					el.textContent = link_title;
+			document.querySelectorAll("a[data-doctype][data-name]").forEach((el) => {
+				if (el.dataset.doctype !== doctype || el.dataset.name !== value) return;
+				if (el.textContent === link_title) return;
+				el.textContent = link_title;
 
-					$(el).closest(".dt-cell__content").attr("title", link_title);
-				});
+				$(el).closest(".dt-cell__content").attr("title", link_title);
+			});
 
 			let col_indices = col_indices_by_doctype[doctype];
 			if (rows?.length && col_indices?.length) {


### PR DESCRIPTION
## Bug

Report view can show the wrong Link title when two Link columns contain the same value but point to different doctypes.

For example, a `Language` link with value `en` could incorrectly display `Kenya Coastal Region` instead of `English`.

## Cause

`report_view.js` keyed link titles only by the cell value. When different Link columns had the same value, the last processed doctype overwrote the previous one, and the title was applied to every matching cell.

## Fix

Key link titles by both doctype and value, and update DOM cells using both `data-doctype` and `data-name`.

Cell invalidation is also limited to columns belonging to the relevant doctype.

Link titles now resolve correctly across different doctypes while preserving support for multiple Link columns pointing to the same doctype.