### PR TITLE
fix: remove duplicate assignees in `_assign` field

### DIFF
--- a/frappe/desk/doctype/todo/todo.py
+++ b/frappe/desk/doctype/todo/todo.py
@@ -106,6 +106,15 @@ class ToDo(Document):
 			)
 			assignments.reverse()
 
+			# A single user can have more than one open ToDo against the same
+			# reference document (e.g. assigned again while a previous ToDo was
+			# still open). Without de-duplicating here, that user's name is
+			# written into `_assign` once per open ToDo, which then shows up as
+			# a repeated avatar/name in the Assigned To sidebar, List View, and
+			# Kanban board. dict.fromkeys() drops the repeats while keeping the
+			# existing most-recent-first ordering intact.
+			assignments = list(dict.fromkeys(assignments))
+
 			if frappe.get_meta(self.reference_type).issingle:
 				frappe.db.set_single_value(
 					self.reference_type,


### PR DESCRIPTION
## Description of the issue

When multiple open ToDos are assigned to the same user on a document, the
same assignee appears multiple times in the **Assigned To** sidebar. The
duplicate entries are also written into the `_assign` field, which causes
duplicate assignees to show up in the **List View**, **Kanban Board**, and
in the assignment count.

## Root cause

`ToDo.update_in_reference()` rebuilds the reference document's `_assign`
field by querying `allocated_to` across all open ToDos for that document.
This query returns **one row per ToDo**, not one row per user — so a user
with more than one open ToDo on the same document (e.g. re-assigned while
a previous ToDo was still open) ends up listed multiple times in `_assign`.

## Fix

De-duplicate the `allocated_to` list in `update_in_reference()` before it
is written to `_assign`, while preserving the existing most-recent-first
ordering (`dict.fromkeys()` keeps first-seen order and drops repeats).

## Steps to reproduce (from the issue)

1. Open any document (Opportunity / Lead / Prospect).
2. Create multiple ToDos for the same user.
3. Keep the ToDos in an open status.
4. Check the Assigned To sidebar.

**Before:** the same assignee appears multiple times, based on the number
of open ToDos assigned to them.
**After:** each assignee appears only once, regardless of how many open
ToDos are assigned to them.

## Note

This fixes the issue going forward. Documents that already have duplicate
entries baked into their `_assign` field will only self-correct the next
time a ToDo against them is created/updated/cancelled. A separate data-fix
patch can be added if cleaning up existing records is also required.

Fixes #41824