### PR TITLE
feat: user permissions in DocType settings

### DIFF
--- a/frappe/core/doctype/user_permission/test_user_permission.py
+++ b/frappe/core/doctype/user_permission/test_user_permission.py
@@ -4,6 +4,7 @@ import frappe
 from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.core.doctype.user_permission.user_permission import (
 	add_user_permissions,
+	get_user_permission_list,
 	remove_applicable,
 )
 from frappe.permissions import add_permission, has_user_permission
@@ -71,6 +72,19 @@ class TestUserPermission(IntegrationTestCase):
 		param = get_params(user, "User", user.name)
 		is_created = add_user_permissions(param)
 		self.assertEqual(is_created, 1)
+
+	def test_get_user_permission_list(self):
+		"""get_user_permission_list returns joined rows for `allow`."""
+		user = create_user("test_user_perm1@example.com")
+		add_user_permissions(get_params(user, "User", user.name))
+
+		rows = get_user_permission_list("User")
+		row = next((r for r in rows if r.get("user") == user.name), None)
+		self.assertIsNotNone(row, "created permission should be returned")
+		# joined User field + permission fields are present
+		self.assertEqual(row.get("for_value"), user.name)
+		self.assertIn("full_name", row)
+		self.assertTrue(row.get("apply_to_all_doctypes"))
 
 	def test_for_apply_to_all_on_update_from_apply_all(self):
 		user = create_user("test_bulk_creation_update@example.com")

--- a/frappe/core/doctype/user_permission/user_permission.py
+++ b/frappe/core/doctype/user_permission/user_permission.py
@@ -9,6 +9,7 @@ from frappe import _
 from frappe.core.utils import find
 from frappe.desk.form.linked_with import get_linked_doctypes
 from frappe.model.document import Document
+from frappe.query_builder import Order
 from frappe.utils import cstr
 
 
@@ -244,6 +245,38 @@ def clear_user_permissions(user: str, for_doctype: str):
 		frappe.clear_cache()
 
 	return total
+
+
+@frappe.whitelist()
+def get_user_permission_list(allow: str):
+	"""User Permissions for `allow`, joined with each user's name + image in one query.
+
+	Used by the DocType Settings "User Permissions" tab (frappe.ui.EmbeddedList), which
+	handles search and paging client-side (same model as the form grid for child tables).
+	The left join resolves the user display info in a single round-trip instead of a second
+	batched lookup.
+	"""
+	frappe.only_for("System Manager")
+
+	up = frappe.qb.DocType("User Permission")
+	user = frappe.qb.DocType("User")
+	return (
+		frappe.qb.from_(up)
+		.left_join(user)
+		.on(up.user == user.name)
+		.select(
+			up.name,
+			up.user,
+			up.for_value,
+			up.applicable_for,
+			up.apply_to_all_doctypes,
+			user.full_name,
+			user.user_image,
+		)
+		.where(up.allow == allow)
+		.orderby(up.modified, order=Order.desc)
+		.run(as_dict=True)
+	)
 
 
 @frappe.whitelist()

--- a/frappe/public/js/frappe/form/doctype_settings/doctype_settings.js
+++ b/frappe/public/js/frappe/form/doctype_settings/doctype_settings.js
@@ -9,7 +9,8 @@ import "./tabs/naming";
 import "./tabs/global_search";
 import "./tabs/workflow";
 import "./tabs/print_format";
-import "./tabs/permissions";
+import "./tabs/roles";
+import "./tabs/user_permissions";
 import "./tabs/settings_map";
 
 /**

--- a/frappe/public/js/frappe/form/doctype_settings/list_panel.js
+++ b/frappe/public/js/frappe/form/doctype_settings/list_panel.js
@@ -104,7 +104,7 @@ class ListPanel {
 		if (!this.rows.length) return this.render_empty();
 
 		this.apply_header(true);
-		const $list = $('<div class="dts-list"></div>').appendTo(this.$body);
+		const $list = $('<div class="flex flex-col"></div>').appendTo(this.$body);
 		if (this.config.show_header) $list.append(this.make_head());
 
 		this._row_els = new Map();
@@ -117,7 +117,9 @@ class ListPanel {
 
 	make_head() {
 		const c = this.config;
-		const $head = $('<div class="dts-list-row dts-list-head text-sm-medium"></div>');
+		const $head = $(
+			'<div class="flex items-center gap-4 pb-2 border-b text-ink-gray-5 text-sm-medium"></div>'
+		);
 
 		// The title column owns the leading media, so its header label sits at the
 		// column's left edge (above the thumbnail) and the rest stays aligned.
@@ -126,7 +128,7 @@ class ListPanel {
 			.appendTo($head);
 
 		(c.columns || []).forEach((col) => {
-			const $cell = $('<div class="dts-list-cell"></div>')
+			const $cell = $('<div class="dts-list-cell flex-1 min-w-0"></div>')
 				.text(col.label || "")
 				.appendTo($head);
 			if (col.width) $cell.css("flex", `0 0 ${col.width}`);
@@ -146,17 +148,19 @@ class ListPanel {
 
 	make_row(row) {
 		const c = this.config;
-		const $row = $('<div class="dts-list-row"></div>');
+		const $row = $('<div class="flex items-center gap-4 py-4 border-b"></div>');
 
 		// Title column = (primary / secondary) text.
 		const tc = c.title_column || {};
 		const $title = $('<div class="dts-list-cell dts-list-cell-title"></div>').appendTo($row);
 
-		const $text = $('<div class="dts-list-text"></div>').appendTo($title);
+		const $text = $('<div class="min-w-0"></div>').appendTo($title);
 
 		// Primary line: name + inline tags (attributes of the row, e.g. Default / Global).
-		const $primaryRow = $('<div class="dts-list-primary-row"></div>').appendTo($text);
-		const $primary = $('<div class="dts-list-primary text-base-medium ellipsis"></div>')
+		const $primaryRow = $('<div class="flex items-center gap-2 min-w-0"></div>').appendTo(
+			$text
+		);
+		const $primary = $('<div class="text-ink-gray-8 text-base-medium min-w-0 truncate"></div>')
 			.text(tc.primary ? tc.primary(row) : "")
 			.appendTo($primaryRow);
 		if (tc.onclick) {
@@ -171,14 +175,14 @@ class ListPanel {
 		);
 
 		if (tc.secondary && tc.secondary(row)) {
-			$('<div class="dts-list-secondary text-p-sm"></div>')
+			$('<div class="dts-list-secondary text-ink-gray-5 text-p-sm"></div>')
 				.text(tc.secondary(row))
 				.appendTo($text);
 		}
 
 		// Middle columns: text or badge.
 		(c.columns || []).forEach((col) => {
-			const $cell = $('<div class="dts-list-cell"></div>').appendTo($row);
+			const $cell = $('<div class="dts-list-cell flex-1 min-w-0"></div>').appendTo($row);
 			if (col.width) $cell.css("flex", `0 0 ${col.width}`);
 			if (col.align) $cell.css("text-align", col.align);
 
@@ -208,7 +212,7 @@ class ListPanel {
 		const disabled = t.disabled ? t.disabled(row) : false;
 
 		const $label = $(`
-			<label class="switch-control dts-switch">
+			<label class="switch-control m-0 cursor-pointer">
 				<span class="input-area">
 					<input type="checkbox" role="switch" />
 				</span>
@@ -273,8 +277,8 @@ class ListPanel {
 			});
 			return;
 		}
-		const $err = $('<div class="dts-list-state"></div>').appendTo(this.$body);
-		$('<div class="text-muted text-p-sm"></div>')
+		const $err = $('<div class="flex items-center gap-3 py-5"></div>').appendTo(this.$body);
+		$('<div class="text-ink-gray-5 text-p-sm"></div>')
 			.text(__("Could not load this tab."))
 			.appendTo($err);
 		frappe.ui

--- a/frappe/public/js/frappe/form/doctype_settings/list_panel.js
+++ b/frappe/public/js/frappe/form/doctype_settings/list_panel.js
@@ -237,7 +237,7 @@ class ListPanel {
 				.catch(() => {
 					// Revert to the last confirmed state on failure.
 					$input.prop("checked", last_good).prop("disabled", false);
-					frappe.show_alert({ message: __("Could not update"), indicator: "red" });
+					frappe.ui.toast({ message: __("Could not update"), type: "error" });
 				});
 		});
 

--- a/frappe/public/js/frappe/form/doctype_settings/registry.js
+++ b/frappe/public/js/frappe/form/doctype_settings/registry.js
@@ -96,6 +96,24 @@ frappe.doctype_settings.empty_state = function ($container, opts) {
 	return $empty;
 };
 
+frappe.doctype_settings.section = function ($parent, { title, description } = {}) {
+	const $section = $('<div class="dts-section"></div>').appendTo($parent);
+	const $header = $(`
+		<div class="flex justify-between items-start gap-4 mb-4">
+			<div class="flex flex-col gap-1 w-full min-w-0">
+				<div class="dts-section-title text-xl-semibold"></div>
+				<div class="dts-section-description text-base text-ink-gray-6"></div>
+			</div>
+			<div class="dts-section-actions flex items-center gap-2 shrink-0"></div>
+		</div>
+	`).appendTo($section);
+	$header.find(".dts-section-title").text(title || "");
+	const $desc = $header.find(".dts-section-description");
+	description ? $desc.text(description) : $desc.remove();
+	const $body = $('<div class="dts-section-body"></div>').appendTo($section);
+	return { $section, $body, $actions: $header.find(".dts-section-actions") };
+};
+
 frappe.doctype_settings.render_error = function (panel, retry_fn, err) {
 	if (frappe.doctype_settings.is_permission_error(err)) {
 		panel.body.empty();

--- a/frappe/public/js/frappe/form/doctype_settings/registry.js
+++ b/frappe/public/js/frappe/form/doctype_settings/registry.js
@@ -66,8 +66,12 @@ frappe.doctype_settings.overflow_menu = function (items) {
 };
 
 // Shared loading placeholder: a few skeleton lines instead of bare "Loading" text.
+// Layout via utility classes — no custom CSS.
 frappe.doctype_settings.render_loading = function ($container) {
-	const $wrap = $('<div class="dts-loading" aria-label="' + __("Loading") + '"></div>');
+	const $wrap = $('<div class="flex flex-col gap-3 py-4"></div>').attr(
+		"aria-label",
+		__("Loading")
+	);
 	["40%", "70%", "55%"].forEach((width) => {
 		$wrap.append(frappe.ui.skeleton({ width, height: "14px" }));
 	});
@@ -125,7 +129,7 @@ frappe.doctype_settings.render_error = function (panel, retry_fn, err) {
 		return;
 	}
 	const $err = panel.body.empty();
-	$('<div class="text-muted text-p-sm"></div>')
+	$('<div class="text-ink-gray-5 text-p-sm"></div>')
 		.text(__("Could not load this tab."))
 		.appendTo($err);
 	frappe.ui.button({ label: __("Retry"), size: "xs", onclick: () => retry_fn() }).appendTo($err);

--- a/frappe/public/js/frappe/form/doctype_settings/registry.js
+++ b/frappe/public/js/frappe/form/doctype_settings/registry.js
@@ -157,7 +157,7 @@ frappe.doctype_settings.set_property = function (doctype, property, value) {
 			property_type: "Data",
 			value,
 		})
-		.then(() => frappe.show_alert({ message: __("Default updated"), indicator: "green" }));
+		.then(() => frappe.ui.toast({ message: __("Default updated"), type: "success" }));
 };
 
 frappe.doctype_settings.clear_property = function (doctype, property) {
@@ -170,7 +170,7 @@ frappe.doctype_settings.clear_property = function (doctype, property) {
 		.then((rows) =>
 			rows && rows.length ? frappe.db.delete_doc("Property Setter", rows[0].name) : null
 		)
-		.then(() => frappe.show_alert({ message: __("Default removed"), indicator: "green" }));
+		.then(() => frappe.ui.toast({ message: __("Default removed"), type: "success" }));
 };
 
 // Each `condition` hides a tab the user could never load anyway (boot perms are a

--- a/frappe/public/js/frappe/form/doctype_settings/registry.js
+++ b/frappe/public/js/frappe/form/doctype_settings/registry.js
@@ -160,6 +160,19 @@ frappe.doctype_settings.set_property = function (doctype, property, value) {
 		.then(() => frappe.show_alert({ message: __("Default updated"), indicator: "green" }));
 };
 
+frappe.doctype_settings.clear_property = function (doctype, property) {
+	return frappe.db
+		.get_list("Property Setter", {
+			filters: { doc_type: doctype, property },
+			fields: ["name"],
+			limit: 1,
+		})
+		.then((rows) =>
+			rows && rows.length ? frappe.db.delete_doc("Property Setter", rows[0].name) : null
+		)
+		.then(() => frappe.show_alert({ message: __("Default removed"), indicator: "green" }));
+};
+
 // Each `condition` hides a tab the user could never load anyway (boot perms are a
 // client-side hint; the server still enforces). A tab that is guaranteed to 403
 // shouldn't be offered at all — see render_error for the residual failure path.
@@ -180,17 +193,27 @@ frappe.doctype_settings.groups = [
 				condition: () => frappe.model.can_read("Workflow"),
 			},
 			{
-				id: "permissions",
-				label: __("Permissions"),
-				icon: "shield-check",
-				// Role permission APIs are System-Manager-only; hide the tab otherwise.
-				condition: () => frappe.user.has_role("System Manager"),
-			},
-			{
 				id: "print-format",
 				label: __("Print Formats"),
 				icon: "printer",
 				condition: () => frappe.model.can_read("Print Format"),
+			},
+		],
+	},
+	{
+		group: __("Permissions"),
+		items: [
+			{
+				id: "roles",
+				label: __("Roles"),
+				icon: "users",
+				condition: () => frappe.user.has_role("System Manager"),
+			},
+			{
+				id: "user-permissions",
+				label: __("User Permissions"),
+				icon: "user-lock",
+				condition: () => frappe.user.has_role("System Manager"),
 			},
 		],
 	},

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/email_template.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/email_template.js
@@ -47,6 +47,12 @@ frappe.doctype_settings.register("email-template", function (panel, doctype) {
 					icon: "star",
 					onclick: (list) => set_default(doctype, r.name).then(() => list.reload()),
 				});
+			} else {
+				items.push({
+					label: __("Remove Default"),
+					icon: "star-off",
+					onclick: (list) => remove_default(doctype).then(() => list.reload()),
+				});
 			}
 			items.push({ label: __("Edit"), icon: "pencil", onclick: () => open(r.name) });
 			items.push({
@@ -72,4 +78,8 @@ frappe.doctype_settings.register("email-template", function (panel, doctype) {
 
 function set_default(doctype, template) {
 	return frappe.doctype_settings.set_property(doctype, "default_email_template", template);
+}
+
+function remove_default(doctype) {
+	return frappe.doctype_settings.clear_property(doctype, "default_email_template");
 }

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/email_template.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/email_template.js
@@ -61,7 +61,7 @@ frappe.doctype_settings.register("email-template", function (panel, doctype) {
 				danger: true,
 				onclick: (list) =>
 					frappe.model.delete_doc("Email Template", r.name, () => {
-						frappe.show_alert({ message: __("Deleted"), indicator: "green" });
+						frappe.ui.toast({ message: __("Deleted"), type: "success" });
 						list.reload();
 					}),
 			});

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/global_search.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/global_search.js
@@ -122,11 +122,11 @@ function set_included(doctype, included) {
 			: rows.filter((r) => r.document_type !== doctype);
 
 		return frappe.call({ method: "frappe.client.save", args: { doc: settings } }).then(() => {
-			frappe.show_alert({
+			frappe.ui.toast({
 				message: included
 					? __("Added to global search")
 					: __("Removed from global search"),
-				indicator: "green",
+				type: "success",
 			});
 		});
 	});
@@ -141,7 +141,7 @@ function save(panel, doctype, state) {
 		freeze: true,
 		freeze_message: __("Updating global search"),
 		callback: () => {
-			frappe.show_alert({ message: __("Global search updated"), indicator: "green" });
+			frappe.ui.toast({ message: __("Global search updated"), type: "success" });
 			load(panel, doctype);
 		},
 	});

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/global_search.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/global_search.js
@@ -84,9 +84,9 @@ function draw(panel, doctype, state) {
 
 	if (!state.included) return;
 
-	$(`<div class="text-base pb-3 font-medium">${__("Configure fields")}</div>`).appendTo($body);
+	$(`<div class="text-base-medium pb-3">${__("Configure fields")}</div>`).appendTo($body);
 
-	const $input = $('<input type="text" class="form-control input-sm dts-gs-search" />')
+	const $input = $('<input type="text" class="form-control input-sm max-w-xs mb-4" />')
 		.attr("placeholder", __("Search fields"))
 		.appendTo($body);
 
@@ -104,7 +104,7 @@ function draw(panel, doctype, state) {
 	$input.on("input", () => {
 		const q = ($input.val() || "").toLowerCase().trim();
 		$grid.find(".dts-gs-item").each((i, el) => {
-			$(el).toggleClass("hide", !!q && !$(el).attr("data-search").includes(q));
+			$(el).toggleClass("hidden", !!q && !$(el).attr("data-search").includes(q));
 		});
 	});
 }
@@ -173,7 +173,7 @@ function make_switch(label, description, checked, onchange) {
 function make_check(label, checked, onchange) {
 	const $label = $(`<label class="dts-check">
 			<input type="checkbox" />
-			<span class="dts-check-label ellipsis"></span>
+			<span class="dts-check-label text-ink-gray-7 min-w-0 truncate"></span>
 		</label>`);
 	$label.find(".dts-check-label").text(label);
 	$label

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/naming.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/naming.js
@@ -59,13 +59,13 @@ function make_series_section($body, doctype) {
 				[doctype]
 			),
 			add_label: __("Add Series"),
-			on_add: (refresh) => add_series(doctype, refresh),
+			on_add: (refresh) => series_dialog(doctype, null, refresh),
 		},
 		{
 			empty_message: __("This doctype isn't named by a series."),
 			// Clicking a row edits that one series — rename its prefix and/or set the next
 			// number — reusing the Document Naming Settings methods (no bulk dialog).
-			on_row_click: (row) => edit_series(doctype, row, () => list.refresh()),
+			on_row_click: (row) => series_dialog(doctype, row, () => list.refresh()),
 			// Reuse the settings methods: read the options, then preview each series. Calls
 			// share one locals doc, so they run sequentially.
 			get_data: async () => {
@@ -112,129 +112,101 @@ function make_series_section($body, doctype) {
 	return list;
 }
 
-// Add a series by appending to the options list and reusing update_series (the same
-// path the Naming Settings page uses — it validates the series and rejects duplicates).
-function add_series(doctype, refresh) {
-	frappe.prompt(
+// One dialog for both adding and editing a series (`row` is null for add)
+// Naming Settings methods (get_current / preview_series / update_series /
+// update_series_start) — the same the Naming Settings page uses.
+async function series_dialog(doctype, row, refresh) {
+	const is_edit = !!row;
+	const original = is_edit ? row.series : "";
+
+	const doc = await load_settings();
+	doc.transaction_type = doctype;
+	if (is_edit) doc.prefix = original;
+	const current = is_edit ? await settings_call(doc, "get_current") : 0;
+
+	const hint = __("e.g. {0}", ["SO-.YYYY.-"]);
+	const preview_label = (next) => (next ? __("Next: {0}", [next]) : hint);
+
+	const fields = [
 		{
 			fieldtype: "Data",
-			label: __("New series"),
 			fieldname: "series",
+			label: __("Series"),
 			reqd: 1,
-			description: __("e.g. {0}", ["SO-.YYYY.-"]),
+			default: original,
+			// Seed from the row we already have (edit) or the hint (add); refresh live.
+			description: is_edit ? preview_label(row.next) : hint,
+			async onchange() {
+				const value = dialog.get_value("series");
+				if (!value) {
+					dialog.set_df_property("series", "description", hint);
+					return;
+				}
+				doc.try_naming_series = value;
+				const next =
+					((await settings_call(doc, "preview_series")) || "").split("\n")[0] || "";
+				dialog.set_df_property("series", "description", preview_label(next));
+			},
 		},
-		async ({ series }) => {
-			const doc = await load_settings();
-			doc.transaction_type = doctype;
-			const options = (await settings_call(doc, "get_options")) || "";
-			const list_options = options
+	];
+	if (is_edit) {
+		fields.push({
+			fieldtype: "Int",
+			fieldname: "current_value",
+			label: __("Current value"),
+			default: current,
+			description: __("The next generated name continues after this number."),
+		});
+	}
+	fields.push(
+		{ fieldtype: "Section Break", label: __("Rules for configuring series"), collapsible: 1 },
+		{
+			fieldtype: "HTML",
+			fieldname: "series_help",
+			options: frappe.ui.NamingSeriesDialog.help_html(),
+		}
+	);
+
+	const dialog = new frappe.ui.Dialog({
+		title: is_edit ? __("Edit Series") : __("Add Series"),
+		fields,
+		primary_action_label: is_edit ? __("Update") : __("Add"),
+		primary_action: async ({ series, current_value }) => {
+			series = (series || "").trim();
+			if (!series) return;
+
+			const options = ((await settings_call(doc, "get_options")) || "")
 				.split("\n")
 				.map((s) => s.trim())
 				.filter(Boolean);
-			if (list_options.includes(series.trim())) {
-				frappe.show_alert({ message: __("Series already exists"), indicator: "orange" });
-				return;
-			}
-			doc.naming_series_options = [...list_options, series.trim()].join("\n");
-			frappe.call({
-				method: "update_series",
-				doc,
-				callback: () => {
-					frappe.show_alert({ message: __("Series added"), indicator: "green" });
-					refresh();
-				},
-			});
-		},
-		__("Add series")
-	);
-}
 
-// Edit a single series: rename its prefix and/or set its current counter, with a live
-// preview shown in the Series field's description and the shared "rules" help. Reuses the
-// Document Naming Settings methods (get_current / preview_series / update_series /
-// update_series_start) — the same the Naming Settings page uses — instead of the bulk dialog.
-async function edit_series(doctype, row, refresh) {
-	const series = row.series;
-	const doc = await load_settings();
-	doc.transaction_type = doctype;
-	doc.prefix = series;
-	const current = await settings_call(doc, "get_current");
-
-	const preview_label = (next) => (next ? __("Next: {0}", [next]) : "");
-
-	const dialog = new frappe.ui.Dialog({
-		title: __("Edit Series"),
-		fields: [
-			{
-				fieldtype: "Data",
-				fieldname: "series",
-				label: __("Series"),
-				reqd: 1,
-				default: series,
-				// Seed the preview from the row we already have; refresh it live on change.
-				description: preview_label(row.next),
-				async onchange() {
-					const value = dialog.get_value("series");
-					if (!value) {
-						dialog.set_df_property("series", "description", "");
-						return;
-					}
-					doc.try_naming_series = value;
-					const next =
-						((await settings_call(doc, "preview_series")) || "").split("\n")[0] || "";
-					dialog.set_df_property("series", "description", preview_label(next));
-				},
-			},
-			{
-				fieldtype: "Int",
-				fieldname: "current_value",
-				label: __("Current value"),
-				default: current,
-				description: __("The next generated name continues after this number."),
-			},
-			{
-				fieldtype: "Section Break",
-				label: __("Rules for configuring series"),
-				collapsible: 1,
-			},
-			{
-				fieldtype: "HTML",
-				fieldname: "series_help",
-				options: frappe.ui.NamingSeriesDialog.help_html(),
-			},
-		],
-		primary_action_label: __("Update"),
-		primary_action: async ({ series: new_series, current_value }) => {
-			new_series = (new_series || "").trim();
-
-			// Rename: swap the prefix in the options list and reuse update_series (it validates).
-			if (new_series && new_series !== series) {
-				const options = ((await settings_call(doc, "get_options")) || "")
-					.split("\n")
-					.map((s) => s.trim())
-					.filter(Boolean);
-				if (options.includes(new_series)) {
+			if (series !== original) {
+				if (options.includes(series)) {
 					frappe.show_alert({
 						message: __("Series already exists"),
 						indicator: "orange",
 					});
 					return;
 				}
-				doc.naming_series_options = options
-					.map((s) => (s === series ? new_series : s))
-					.join("\n");
+				doc.naming_series_options = (
+					is_edit
+						? options.map((s) => (s === original ? series : s))
+						: [...options, series]
+				).join("\n");
 				await settings_call(doc, "update_series");
 			}
 
-			// Counter: set the current value on the (possibly renamed) series.
-			if (cint(current_value) !== cint(current)) {
-				doc.prefix = new_series || series;
+			if (is_edit && cint(current_value) !== cint(current)) {
+				doc.prefix = series;
 				doc.current_value = cint(current_value);
 				await settings_call(doc, "update_series_start");
 			}
 
 			dialog.hide();
-			frappe.show_alert({ message: __("Series updated"), indicator: "green" });
+			frappe.show_alert({
+				message: is_edit ? __("Series updated") : __("Series added"),
+				indicator: "green",
+			});
 			refresh();
 		},
 	});

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/naming.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/naming.js
@@ -183,9 +183,9 @@ async function series_dialog(doctype, row, refresh) {
 
 			if (series !== original) {
 				if (options.includes(series)) {
-					frappe.show_alert({
+					frappe.ui.toast({
 						message: __("Series already exists"),
-						indicator: "orange",
+						type: "warning",
 					});
 					return;
 				}
@@ -204,9 +204,9 @@ async function series_dialog(doctype, row, refresh) {
 			}
 
 			dialog.hide();
-			frappe.show_alert({
+			frappe.ui.toast({
 				message: is_edit ? __("Series updated") : __("Series added"),
-				indicator: "green",
+				type: "success",
 			});
 			refresh();
 		},
@@ -226,7 +226,7 @@ async function remove_series(doctype, series, refresh) {
 		.filter((s) => s !== series);
 	doc.naming_series_options = options.join("\n");
 	await settings_call(doc, "update_series");
-	frappe.show_alert({ message: __("Series removed"), indicator: "green" });
+	frappe.ui.toast({ message: __("Series removed"), type: "success" });
 	refresh();
 }
 
@@ -315,9 +315,9 @@ function make_rules_section($body, doctype, panel) {
 							confirm_field: "prefix",
 							action: (row, refresh) =>
 								frappe.db.delete_doc("Document Naming Rule", row.name).then(() => {
-									frappe.show_alert({
+									frappe.ui.toast({
 										message: __("Deleted"),
-										indicator: "green",
+										type: "success",
 									});
 									refresh();
 								}),

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/naming.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/naming.js
@@ -31,6 +31,7 @@ function make_section($parent, { title, description, add_label, on_add }, list_o
 
 	const list = new frappe.ui.EmbeddedList({
 		wrapper: $("<div></div>").appendTo($body),
+		show_search: false,
 		...list_opts,
 	});
 	list.refresh();

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/naming.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/naming.js
@@ -1,7 +1,7 @@
 // Naming tab: two stacked sections — naming series (with live previews) and Document
-// Naming Rules. Each section renders its own header (matching the dialog's panel-title
-// style) over a frappe.ui.EmbeddedList table (used for the list only — its built-in
-// header/search are intentionally not used here). Series reuse the Document Naming
+// Naming Rules. Each is a shared `frappe.doctype_settings.section` scaffold over a
+// frappe.ui.EmbeddedList table (used for the list only — its built-in header/search
+// are intentionally not used here). Series reuse the Document Naming
 // Settings instance methods (the same the settings page uses) by loading that Single
 // into locals; rules use generic db APIs. No custom backend.
 const NAMING_SETTINGS = "Document Naming Settings";
@@ -24,24 +24,13 @@ frappe.doctype_settings.register("naming", function (panel, doctype) {
 	});
 });
 
-// Render a section header (reusing the dialog's panel-title classes for a consistent
-// look) + an EmbeddedList table beneath it. Returns the list so callers can refresh().
+// A titled section (shared scaffold) + an EmbeddedList table beneath it. Returns the
+// list so callers can refresh().
 function make_section($parent, { title, description, add_label, on_add }, list_opts) {
-	const $section = $('<div class="dts-section"></div>').appendTo($parent);
-	const $header = $(`
-		<div class="settings-dialog-panel-header">
-			<div class="settings-dialog-panel-heading">
-				<div class="settings-dialog-panel-title"></div>
-				<div class="settings-dialog-panel-description"></div>
-			</div>
-			<div class="settings-dialog-panel-actions"></div>
-		</div>
-	`).appendTo($section);
-	$header.find(".settings-dialog-panel-title").text(title);
-	$header.find(".settings-dialog-panel-description").text(description);
+	const { $body, $actions } = frappe.doctype_settings.section($parent, { title, description });
 
 	const list = new frappe.ui.EmbeddedList({
-		wrapper: $("<div></div>").appendTo($section),
+		wrapper: $("<div></div>").appendTo($body),
 		...list_opts,
 	});
 	list.refresh();
@@ -53,7 +42,7 @@ function make_section($parent, { title, description, add_label, on_add }, list_o
 				icon: "plus",
 				onclick: () => on_add(() => list.refresh()),
 			})
-			.appendTo($header.find(".settings-dialog-panel-actions"));
+			.appendTo($actions);
 	}
 	return list;
 }

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/notification.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/notification.js
@@ -66,9 +66,9 @@ frappe.doctype_settings.register("notifications", function (panel, doctype) {
 					frappe.db
 						.set_value("Notification", r.name, { enabled: r.enabled ? 0 : 1 })
 						.then(() => {
-							frappe.show_alert({
+							frappe.ui.toast({
 								message: r.enabled ? __("Disabled") : __("Enabled"),
-								indicator: "green",
+								type: "success",
 							});
 							list.reload();
 						}),
@@ -84,7 +84,7 @@ frappe.doctype_settings.register("notifications", function (panel, doctype) {
 				// locals cleanup; the callback runs only on success.
 				onclick: (list) =>
 					frappe.model.delete_doc("Notification", r.name, () => {
-						frappe.show_alert({ message: __("Deleted"), indicator: "green" });
+						frappe.ui.toast({ message: __("Deleted"), type: "success" });
 						list.reload();
 					}),
 			},

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/permissions.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/permissions.js
@@ -41,7 +41,7 @@ function draw(panel, doctype) {
 			});
 		})
 		.catch((err) =>
-			frappe.doctype_settings.render_error(panel, () => draw(panel, doctype), err),
+			frappe.doctype_settings.render_error(panel, () => draw(panel, doctype), err)
 		);
 }
 
@@ -118,14 +118,13 @@ function render_roles_list($container, doctype, roles, reload) {
 					cint(row.permlevel) > 0 && !frappe.perm_editor.PERMLEVEL_FLAGS.includes(r)
 						? ""
 						: cint(row[r])
-							? flag_badge()
-							: "",
+						? flag_badge()
+						: "",
 			})),
 		],
 	});
 	list.refresh();
 }
-
 
 function render_user_perms(panel, $parent, doctype) {
 	const sec = frappe.doctype_settings.section($parent, {
@@ -182,8 +181,8 @@ function render_user_perms(panel, $parent, doctype) {
 					cint(row.apply_to_all_doctypes)
 						? frappe.ui.badge.html({ label: __("All doctypes") })
 						: row.applicable_for
-							? frappe.utils.escape_html(row.applicable_for)
-							: "",
+						? frappe.utils.escape_html(row.applicable_for)
+						: "",
 			},
 			{
 				type: "actions",
@@ -266,8 +265,8 @@ function perm_tab(doctype, reload) {
 					frappe.db.get_value(
 						"Custom DocPerm",
 						{ parent: doctype, role: values.role, permlevel, if_owner: 0 },
-						"name",
-					),
+						"name"
+					)
 				)
 				.then((r) => {
 					const name = r.message && r.message.name;
@@ -279,7 +278,7 @@ function perm_tab(doctype, reload) {
 		perm_data(values) {
 			const data = {};
 			["if_owner", ...frappe.perm_editor.ALL_PERM_FLAGS].forEach(
-				(flag) => (data[flag] = values[flag] ? 1 : 0),
+				(flag) => (data[flag] = values[flag] ? 1 : 0)
 			);
 			return data;
 		},
@@ -307,14 +306,14 @@ function perm_tab(doctype, reload) {
 							permlevel: row.permlevel,
 							if_owner: row.if_owner || 0,
 						},
-						"name",
-					),
+						"name"
+					)
 				)
 				.then((r) => {
 					const name = r.message && r.message.name;
 					if (!name)
 						frappe.throw(
-							__("Permission row not found after conversion. Please refresh."),
+							__("Permission row not found after conversion. Please refresh.")
 						);
 					return frappe.db.set_value("Custom DocPerm", name, data);
 				});
@@ -350,7 +349,7 @@ function customized_banner(panel, doctype, reload) {
 				perm_call("reset", { doctype }).then(() => {
 					frappe.show_alert({ message: __("Permissions reset"), indicator: "green" });
 					reload();
-				}),
+				})
 		);
 
 	return frappe.ui
@@ -368,9 +367,12 @@ function customized_banner(panel, doctype, reload) {
 }
 
 function footer(panel, doctype) {
-	const $footer = $('<div class="dts-perm-footer"></div>');
-	$("<span></span>").appendTo($footer); // spacer to keep the link right-aligned
-	$('<a href="#" class="dts-perm-footer-link text-base-medium"></a>')
+	const $footer = $(
+		'<div class="flex items-center justify-end gap-4 mt-3 pt-4 border-t"></div>'
+	);
+	$(
+		'<a href="#" class="inline-flex items-center gap-1 text-ink-gray-7 text-base-medium whitespace-nowrap"></a>'
+	)
 		.append($("<span></span>").text(__("Open Role Permissions Manager")))
 		.append(frappe.utils.icon("external-link", "sm"))
 		.appendTo($footer)

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/permissions.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/permissions.js
@@ -9,21 +9,7 @@ const DOC_RIGHTS = ["read", "write", "create", "delete"];
 const SUBMIT_RIGHTS = ["submit", "cancel", "amend"];
 
 frappe.doctype_settings.register("permissions", function (panel, doctype) {
-	const reload = () => draw(panel, doctype);
-	panel.set_view({
-		title: __("Permissions"),
-		description: __("Control who can access {0}.", [doctype]),
-		actions: [
-			{
-				label: __("Add role"),
-				icon: "plus",
-				// Add mode of the shared editor (doctype-centric: doctype fixed, pick the role)
-				// — sets the role + all its rights in one dialog.
-				click: () => new frappe.ui.PermissionDialog(perm_tab(doctype, reload), {}).show(),
-			},
-		],
-		render: reload,
-	});
+	panel.set_view({ render: (p) => draw(p, doctype) });
 });
 
 function perm_call(method, args) {
@@ -42,32 +28,62 @@ function draw(panel, doctype) {
 			fields: ["name"],
 			limit: 1,
 		}),
+		user_perms_apply(doctype),
 	])
-		.then(([r, custom]) => {
+		.then(([r, custom, show_user_perms]) => {
 			const perms = r.message || [];
 			const is_customized = (custom || []).length > 0;
 			render(panel, doctype, {
 				is_customized,
+				show_user_perms,
 				// `source` (Standard vs Custom) drives the edit dialog title + save path.
 				roles: perms.map((p) => ({ ...p, source: is_customized ? "Custom" : "Standard" })),
 			});
 		})
 		.catch((err) =>
-			frappe.doctype_settings.render_error(panel, () => draw(panel, doctype), err)
+			frappe.doctype_settings.render_error(panel, () => draw(panel, doctype), err),
 		);
 }
 
-function render(panel, doctype, { roles, is_customized }) {
+function user_perms_apply(doctype) {
+	return frappe
+		.xcall("frappe.desk.form.linked_with.get_linked_doctypes", {
+			doctype,
+			without_ignore_user_permissions_enabled: 1,
+		})
+		.then((map) => !!map && Object.keys(map).length > 0)
+		.catch(() => false);
+}
+
+function render(panel, doctype, { roles, is_customized, show_user_perms }) {
 	const reload = () => draw(panel, doctype);
 	const $body = panel.body.empty();
 
-	if (is_customized) $body.append(customized_banner(panel, doctype, reload));
+	// ── Roles: who can access this doctype, by role ──
+	const roles_sec = frappe.doctype_settings.section($body, {
+		title: __("Roles"),
+		description: __("Control who can access {0}, by role.", [doctype]),
+	});
+	frappe.ui
+		.button({
+			label: __("Add role"),
+			icon: "plus",
+			onclick: () => new frappe.ui.PermissionDialog(perm_tab(doctype, reload), {}).show(),
+		})
+		.appendTo(roles_sec.$actions);
+	if (is_customized) roles_sec.$body.append(customized_banner(panel, doctype, reload));
+	render_roles_list(roles_sec.$body, doctype, roles, reload);
+	roles_sec.$body.append(footer(panel, doctype));
 
+	if (show_user_perms) render_user_perms(panel, $body, doctype);
+}
+
+function render_roles_list($container, doctype, roles, reload) {
 	const is_submittable = !!(frappe.get_meta(doctype) || {}).is_submittable;
 	const rights = is_submittable ? DOC_RIGHTS.concat(SUBMIT_RIGHTS) : DOC_RIGHTS;
 
 	const list = new frappe.ui.EmbeddedList({
-		wrapper: $("<div></div>").appendTo($body),
+		wrapper: $("<div></div>").appendTo($container),
 		empty_message: __("No roles have access yet."),
 		get_data: () => Promise.resolve(roles),
 		// Clicking a row opens the shared permission editor for that role (same dialog
@@ -102,14 +118,135 @@ function render(panel, doctype, { roles, is_customized }) {
 					cint(row.permlevel) > 0 && !frappe.perm_editor.PERMLEVEL_FLAGS.includes(r)
 						? ""
 						: cint(row[r])
-						? flag_badge()
-						: "",
+							? flag_badge()
+							: "",
 			})),
 		],
 	});
 	list.refresh();
+}
 
-	$body.append(footer(panel, doctype));
+
+function render_user_perms(panel, $parent, doctype) {
+	const sec = frappe.doctype_settings.section($parent, {
+		title: __("User Permissions"),
+		description: __("Restrict specific users to specific {0} records.", [doctype]),
+	});
+	let list;
+	const refresh = () => list.refresh();
+	frappe.ui
+		.button({
+			label: __("Add"),
+			icon: "plus",
+			onclick: () => add_user_permission(doctype, refresh),
+		})
+		.appendTo(sec.$actions);
+
+	list = new frappe.ui.EmbeddedList({
+		wrapper: $("<div></div>").appendTo(sec.$body),
+		empty_message: __("No user is restricted to specific {0} records yet.", [doctype]),
+		get_data: () =>
+			frappe.doctype_settings.get_list("User Permission", {
+				filters: { allow: doctype },
+				fields: [
+					"name",
+					"user",
+					"for_value",
+					"applicable_for",
+					"apply_to_all_doctypes",
+					"is_default",
+				],
+				limit: 0,
+			}),
+		// Row click opens the full User Permission form for editing.
+		on_row_click: (row) => {
+			panel.dialog.hide();
+			frappe.set_route("Form", "User Permission", row.name);
+		},
+		columns: [
+			{
+				label: __("User"),
+				fieldname: "user",
+				// Flag the user's default value with a badge beside their id.
+				render: (row) =>
+					`${frappe.utils.escape_html(row.user)}${
+						cint(row.is_default)
+							? ` ${frappe.ui.badge.html({ label: __("Default"), theme: "green" })}`
+							: ""
+					}`,
+			},
+			{ label: __("For Value"), fieldname: "for_value" },
+			{
+				label: __("Applicable For"),
+				render: (row) =>
+					cint(row.apply_to_all_doctypes)
+						? frappe.ui.badge.html({ label: __("All doctypes") })
+						: row.applicable_for
+							? frappe.utils.escape_html(row.applicable_for)
+							: "",
+			},
+			{
+				type: "actions",
+				actions: [
+					{
+						icon: "trash-2",
+						label: __("Delete"),
+						danger: true,
+						confirm: __("Delete this user permission?"),
+						action: (row, refresh) =>
+							frappe.db.delete_doc("User Permission", row.name).then(() => {
+								frappe.show_alert({ message: __("Deleted"), indicator: "green" });
+								refresh();
+							}),
+					},
+				],
+			},
+		],
+	});
+	list.refresh();
+}
+
+// Quick-add a User Permission (user + a record of this doctype). Standard insert.
+function add_user_permission(doctype, refresh) {
+	const dialog = new frappe.ui.Dialog({
+		title: __("Add User Permission"),
+		fields: [
+			{ fieldtype: "Link", fieldname: "user", label: __("User"), options: "User", reqd: 1 },
+			{
+				fieldtype: "Link",
+				fieldname: "for_value",
+				label: __("For Value"),
+				options: doctype,
+				reqd: 1,
+			},
+			{
+				fieldtype: "Check",
+				fieldname: "is_default",
+				label: __("Mark as default"),
+				description: __("Use this value by default in new documents."),
+			},
+		],
+		primary_action_label: __("Add"),
+		primary_action: (values) => {
+			frappe.db
+				.insert({
+					doctype: "User Permission",
+					user: values.user,
+					allow: doctype,
+					for_value: values.for_value,
+					is_default: values.is_default ? 1 : 0,
+				})
+				.then(() => {
+					dialog.hide();
+					frappe.show_alert({
+						message: __("User permission added"),
+						indicator: "green",
+					});
+					refresh();
+				});
+		},
+	});
+	dialog.show();
 }
 
 // Adapter the shared PermissionDialog drives: doctype-scoped (role varies per row),
@@ -129,8 +266,8 @@ function perm_tab(doctype, reload) {
 					frappe.db.get_value(
 						"Custom DocPerm",
 						{ parent: doctype, role: values.role, permlevel, if_owner: 0 },
-						"name"
-					)
+						"name",
+					),
 				)
 				.then((r) => {
 					const name = r.message && r.message.name;
@@ -142,7 +279,7 @@ function perm_tab(doctype, reload) {
 		perm_data(values) {
 			const data = {};
 			["if_owner", ...frappe.perm_editor.ALL_PERM_FLAGS].forEach(
-				(flag) => (data[flag] = values[flag] ? 1 : 0)
+				(flag) => (data[flag] = values[flag] ? 1 : 0),
 			);
 			return data;
 		},
@@ -170,14 +307,14 @@ function perm_tab(doctype, reload) {
 							permlevel: row.permlevel,
 							if_owner: row.if_owner || 0,
 						},
-						"name"
-					)
+						"name",
+					),
 				)
 				.then((r) => {
 					const name = r.message && r.message.name;
 					if (!name)
 						frappe.throw(
-							__("Permission row not found after conversion. Please refresh.")
+							__("Permission row not found after conversion. Please refresh."),
 						);
 					return frappe.db.set_value("Custom DocPerm", name, data);
 				});
@@ -213,7 +350,7 @@ function customized_banner(panel, doctype, reload) {
 				perm_call("reset", { doctype }).then(() => {
 					frappe.show_alert({ message: __("Permissions reset"), indicator: "green" });
 					reload();
-				})
+				}),
 		);
 
 	return frappe.ui

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/print_format.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/print_format.js
@@ -116,8 +116,16 @@ frappe.doctype_settings.register("print-format", function (panel, doctype) {
 			return;
 		}
 
+		// Default format first (top-left); the rest keep their server order.
+		const ordered = default_pf
+			? [
+					...formats.filter((f) => f.name === default_pf),
+					...formats.filter((f) => f.name !== default_pf),
+			  ]
+			: formats;
+
 		const $grid = $('<div class="dts-pf-grid"></div>').appendTo(panel.body);
-		formats.forEach((f) => $grid.append(make_card(f)));
+		ordered.forEach((f) => $grid.append(make_card(f)));
 
 		// The first screenful renders straight away — waiting on the observer would leave
 		// the visible cards blank until something scrolls. The rest load as they're reached.

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/print_format.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/print_format.js
@@ -137,7 +137,7 @@ frappe.doctype_settings.register("print-format", function (panel, doctype) {
 					${frappe.ui.badge.html({
 						label: __("Custom"),
 						theme: "blue",
-						css_class: "dts-pf-badge hide",
+						css_class: "dts-pf-badge hidden",
 					})}
 					<button type="button" class="dts-pf-star" data-selected="${
 						is_default ? "true" : "false"
@@ -147,7 +147,7 @@ frappe.doctype_settings.register("print-format", function (panel, doctype) {
 					</div>
 				</div>
 				<div class="dts-pf-footer">
-					<span class="dts-pf-name ellipsis"></span>
+					<span class="dts-pf-name truncate"></span>
 				</div>
 			</div>
 		`);
@@ -155,7 +155,7 @@ frappe.doctype_settings.register("print-format", function (panel, doctype) {
 		const $thumb = $card.find(".dts-pf-thumb");
 		const $star = $card.find(".dts-pf-star");
 
-		if (is_custom) $card.find(".dts-pf-badge").removeClass("hide");
+		if (is_custom) $card.find(".dts-pf-badge").removeClass("hidden");
 
 		$thumb.data("pf", f.name);
 

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/roles.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/roles.js
@@ -204,7 +204,7 @@ function customized_banner(panel, doctype, reload) {
 			]),
 			() =>
 				perm_call("reset", { doctype }).then(() => {
-					frappe.show_alert({ message: __("Permissions reset"), indicator: "green" });
+					frappe.ui.toast({ message: __("Permissions reset"), type: "success" });
 					reload();
 				})
 		);

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/roles.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/roles.js
@@ -1,15 +1,22 @@
-// Per-role permissions for this doctype, rendered with frappe.ui.EmbeddedList (the same
-// component the Role form's Documents tab uses). Each granted right shows as a badge.
-// Reuses the Role Permissions Manager page methods — no custom backend. System-Manager-
-// gated in the registry.
-
-// Document-level rights, always shown.
 const DOC_RIGHTS = ["read", "write", "create", "delete"];
-// Submit-flow rights, only meaningful for submittable doctypes.
 const SUBMIT_RIGHTS = ["submit", "cancel", "amend"];
 
-frappe.doctype_settings.register("permissions", function (panel, doctype) {
-	panel.set_view({ render: (p) => draw(p, doctype) });
+frappe.doctype_settings.register("roles", function (panel, doctype) {
+	const reload = () => draw(panel, doctype);
+	panel.set_view({
+		title: __("Roles"),
+		description: __("Control who can access {0}, by role.", [doctype]),
+		actions: [
+			{
+				label: __("Add role"),
+				icon: "plus",
+				// Add mode of the shared editor (doctype fixed, pick the role) — sets the role
+				// and all its rights in one dialog.
+				click: () => new frappe.ui.PermissionDialog(perm_tab(doctype, reload), {}).show(),
+			},
+		],
+		render: reload,
+	});
 });
 
 function perm_call(method, args) {
@@ -28,15 +35,12 @@ function draw(panel, doctype) {
 			fields: ["name"],
 			limit: 1,
 		}),
-		user_perms_apply(doctype),
 	])
-		.then(([r, custom, show_user_perms]) => {
+		.then(([r, custom]) => {
 			const perms = r.message || [];
 			const is_customized = (custom || []).length > 0;
 			render(panel, doctype, {
 				is_customized,
-				show_user_perms,
-				// `source` (Standard vs Custom) drives the edit dialog title + save path.
 				roles: perms.map((p) => ({ ...p, source: is_customized ? "Custom" : "Standard" })),
 			});
 		})
@@ -45,46 +49,19 @@ function draw(panel, doctype) {
 		);
 }
 
-function user_perms_apply(doctype) {
-	return frappe
-		.xcall("frappe.desk.form.linked_with.get_linked_doctypes", {
-			doctype,
-			without_ignore_user_permissions_enabled: 1,
-		})
-		.then((map) => !!map && Object.keys(map).length > 0)
-		.catch(() => false);
-}
-
-function render(panel, doctype, { roles, is_customized, show_user_perms }) {
+function render(panel, doctype, { roles, is_customized }) {
 	const reload = () => draw(panel, doctype);
 	const $body = panel.body.empty();
 
-	// ── Roles: who can access this doctype, by role ──
-	const roles_sec = frappe.doctype_settings.section($body, {
-		title: __("Roles"),
-		description: __("Control who can access {0}, by role.", [doctype]),
-	});
-	frappe.ui
-		.button({
-			label: __("Add role"),
-			icon: "plus",
-			onclick: () => new frappe.ui.PermissionDialog(perm_tab(doctype, reload), {}).show(),
-		})
-		.appendTo(roles_sec.$actions);
-	if (is_customized) roles_sec.$body.append(customized_banner(panel, doctype, reload));
-	render_roles_list(roles_sec.$body, doctype, roles, reload);
-	roles_sec.$body.append(footer(panel, doctype));
+	if (is_customized) $body.append(customized_banner(panel, doctype, reload));
 
-	if (show_user_perms) render_user_perms(panel, $body, doctype);
-}
-
-function render_roles_list($container, doctype, roles, reload) {
 	const is_submittable = !!(frappe.get_meta(doctype) || {}).is_submittable;
 	const rights = is_submittable ? DOC_RIGHTS.concat(SUBMIT_RIGHTS) : DOC_RIGHTS;
 
 	const list = new frappe.ui.EmbeddedList({
-		wrapper: $("<div></div>").appendTo($container),
+		wrapper: $("<div></div>").appendTo($body),
 		empty_message: __("No roles have access yet."),
+		show_search: false,
 		get_data: () => Promise.resolve(roles),
 		// Clicking a row opens the shared permission editor for that role (same dialog
 		// the Role form's Documents tab uses).
@@ -124,128 +101,8 @@ function render_roles_list($container, doctype, roles, reload) {
 		],
 	});
 	list.refresh();
-}
 
-function render_user_perms(panel, $parent, doctype) {
-	const sec = frappe.doctype_settings.section($parent, {
-		title: __("User Permissions"),
-		description: __("Restrict specific users to specific {0} records.", [doctype]),
-	});
-	let list;
-	const refresh = () => list.refresh();
-	frappe.ui
-		.button({
-			label: __("Add"),
-			icon: "plus",
-			onclick: () => add_user_permission(doctype, refresh),
-		})
-		.appendTo(sec.$actions);
-
-	list = new frappe.ui.EmbeddedList({
-		wrapper: $("<div></div>").appendTo(sec.$body),
-		empty_message: __("No user is restricted to specific {0} records yet.", [doctype]),
-		get_data: () =>
-			frappe.doctype_settings.get_list("User Permission", {
-				filters: { allow: doctype },
-				fields: [
-					"name",
-					"user",
-					"for_value",
-					"applicable_for",
-					"apply_to_all_doctypes",
-					"is_default",
-				],
-				limit: 0,
-			}),
-		// Row click opens the full User Permission form for editing.
-		on_row_click: (row) => {
-			panel.dialog.hide();
-			frappe.set_route("Form", "User Permission", row.name);
-		},
-		columns: [
-			{
-				label: __("User"),
-				fieldname: "user",
-				// Flag the user's default value with a badge beside their id.
-				render: (row) =>
-					`${frappe.utils.escape_html(row.user)}${
-						cint(row.is_default)
-							? ` ${frappe.ui.badge.html({ label: __("Default"), theme: "green" })}`
-							: ""
-					}`,
-			},
-			{ label: __("For Value"), fieldname: "for_value" },
-			{
-				label: __("Applicable For"),
-				render: (row) =>
-					cint(row.apply_to_all_doctypes)
-						? frappe.ui.badge.html({ label: __("All doctypes") })
-						: row.applicable_for
-						? frappe.utils.escape_html(row.applicable_for)
-						: "",
-			},
-			{
-				type: "actions",
-				actions: [
-					{
-						icon: "trash-2",
-						label: __("Delete"),
-						danger: true,
-						confirm: __("Delete this user permission?"),
-						action: (row, refresh) =>
-							frappe.db.delete_doc("User Permission", row.name).then(() => {
-								frappe.show_alert({ message: __("Deleted"), indicator: "green" });
-								refresh();
-							}),
-					},
-				],
-			},
-		],
-	});
-	list.refresh();
-}
-
-// Quick-add a User Permission (user + a record of this doctype). Standard insert.
-function add_user_permission(doctype, refresh) {
-	const dialog = new frappe.ui.Dialog({
-		title: __("Add User Permission"),
-		fields: [
-			{ fieldtype: "Link", fieldname: "user", label: __("User"), options: "User", reqd: 1 },
-			{
-				fieldtype: "Link",
-				fieldname: "for_value",
-				label: __("For Value"),
-				options: doctype,
-				reqd: 1,
-			},
-			{
-				fieldtype: "Check",
-				fieldname: "is_default",
-				label: __("Mark as default"),
-				description: __("Use this value by default in new documents."),
-			},
-		],
-		primary_action_label: __("Add"),
-		primary_action: (values) => {
-			frappe.db
-				.insert({
-					doctype: "User Permission",
-					user: values.user,
-					allow: doctype,
-					for_value: values.for_value,
-					is_default: values.is_default ? 1 : 0,
-				})
-				.then(() => {
-					dialog.hide();
-					frappe.show_alert({
-						message: __("User permission added"),
-						indicator: "green",
-					});
-					refresh();
-				});
-		},
-	});
-	dialog.show();
+	$body.append(footer(panel, doctype));
 }
 
 // Adapter the shared PermissionDialog drives: doctype-scoped (role varies per row),

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/settings_map.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/settings_map.js
@@ -159,7 +159,7 @@ function save(group, field, value, revert) {
 		.then(() => {
 			field.value = value;
 			group.doc[field.fieldname] = value;
-			frappe.show_alert({ message: __("{0} updated", [group.label]), indicator: "green" });
+			frappe.ui.toast({ message: __("{0} updated", [group.label]), type: "success" });
 		})
 		.catch(() => revert && revert());
 }

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/settings_map.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/settings_map.js
@@ -82,10 +82,10 @@ function render_field($body, group, field) {
 	const $row = $('<div class="dts-setting"></div>').appendTo($body);
 	field.$row = $row; // referenced by apply_dependencies() to show/hide the field
 
-	const $text = $('<div class="dts-setting-text"></div>').appendTo($row);
-	$('<div class="dts-setting-label text-base-medium"></div>').text(field.label).appendTo($text);
+	const $text = $('<div class="min-w-0"></div>').appendTo($row);
+	$('<div class="text-base-medium text-ink-gray-8"></div>').text(field.label).appendTo($text);
 	if (field.description) {
-		$('<div class="dts-setting-description text-p-sm"></div>')
+		$('<div class="dts-setting-description text-p-sm text-ink-gray-5"></div>')
 			.text(field.description)
 			.appendTo($text);
 	}

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/user_permissions.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/user_permissions.js
@@ -1,0 +1,177 @@
+frappe.doctype_settings.register("user-permissions", function (panel, doctype) {
+	let list;
+	panel.set_view({
+		title: __("User Permissions"),
+		description: __("Restrict specific users to specific {0} records.", [doctype]),
+		// Add sits top-right by the title (like the Roles tab); the list keeps its search box.
+		actions: [
+			{
+				label: __("Add"),
+				icon: "plus",
+				click: () => add_user_permission(doctype, () => list && list.refresh()),
+			},
+		],
+		render: (p) => {
+			list = draw(p, doctype);
+		},
+	});
+});
+
+function draw(panel, doctype) {
+	const open = (name) => {
+		panel.dialog.hide();
+		frappe.set_route("Form", "User Permission", name);
+	};
+
+	const list = new frappe.ui.EmbeddedList({
+		wrapper: $('<div class="dts-user-permissions-list"></div>').appendTo(panel.body.empty()),
+		empty_icon: "user-lock",
+		empty_message: __("No user permissions yet."),
+		get_data: () =>
+			frappe
+				.call({
+					method: "frappe.core.doctype.user_permission.user_permission.get_user_permission_list",
+					args: { allow: doctype },
+				})
+				.then((r) => r.message || []),
+		columns: [
+			{
+				label: __("User"),
+				render: (row) => user_cell(row),
+				on_click: (row) => open(row.name),
+			},
+			{ label: __("For Value"), fieldname: "for_value" },
+			{
+				label: __("Applicable For"),
+				render: (row) => applicable_badge(row),
+			},
+			{
+				type: "actions",
+				label: "",
+				actions: [
+					{
+						label: __("Delete"),
+						icon: "trash-2",
+						danger: true,
+						confirm: __("Delete this user permission?"),
+						action: (row, refresh) =>
+							frappe.db.delete_doc("User Permission", row.name).then(() => {
+								frappe.show_alert({ message: __("Deleted"), indicator: "green" });
+								refresh();
+							}),
+					},
+				],
+			},
+		],
+	});
+	list.refresh();
+	return list;
+}
+
+function user_cell(row) {
+	const esc = frappe.utils.escape_html;
+	const name = row.full_name || row.user;
+	const avatar = frappe.ui.avatar.html({ label: name, image: row.user_image, size: "lg" });
+	const email = row.full_name
+		? `<div class="text-ink-gray-5 text-xs truncate">${esc(row.user)}</div>`
+		: "";
+	return `<div class="flex items-center gap-2">
+		${avatar}
+		<div class="min-w-0">
+			<div class="text-ink-gray-8 text-base-medium truncate">${esc(name)}</div>
+			${email}
+		</div>
+	</div>`;
+}
+
+function applicable_badge(row) {
+	if (cint(row.apply_to_all_doctypes)) {
+		return frappe.ui.badge.html({ label: __("All doctypes"), theme: "blue" });
+	}
+	if (row.applicable_for) {
+		return frappe.ui.badge.html({ label: frappe.utils.escape_html(row.applicable_for) });
+	}
+	return "";
+}
+
+function add_user_permission(doctype, refresh) {
+	const dialog = new frappe.ui.Dialog({
+		title: __("Add User Permission"),
+		fields: [
+			{ fieldtype: "Link", fieldname: "user", label: __("User"), options: "User", reqd: 1 },
+			{
+				fieldtype: "Link",
+				fieldname: "for_value",
+				label: __("For Value"),
+				options: doctype,
+				reqd: 1,
+			},
+			{ fieldtype: "Section Break", label: __("Advanced Control"), collapsible: 1 },
+			{
+				fieldtype: "Check",
+				fieldname: "apply_to_all_doctypes",
+				label: __("Apply To All Document Types"),
+				default: 1,
+			},
+			{
+				fieldtype: "Link",
+				fieldname: "applicable_for",
+				label: __("Applicable For"),
+				options: "DocType",
+				depends_on: "eval:!doc.apply_to_all_doctypes",
+				mandatory_depends_on: "eval:!doc.apply_to_all_doctypes",
+				get_query: () => ({
+					query: "frappe.core.doctype.user_permission.user_permission.get_applicable_for_doctype_list",
+					filters: { doctype },
+				}),
+			},
+			// Hide Descendants only applies to tree (nested-set) doctypes — same gate as the form.
+			...((frappe.boot.nested_set_doctypes || []).includes(doctype)
+				? [
+						{
+							fieldtype: "Check",
+							fieldname: "hide_descendants",
+							label: __("Hide Descendants"),
+						},
+				  ]
+				: []),
+		],
+		primary_action_label: __("Add"),
+		primary_action: (values) => {
+			const apply_to_all = values.apply_to_all_doctypes ? 1 : 0;
+			// Reuse the canonical create path: it clears rows that would go stale on the
+			// apply-to-all ↔ specific-doctype switch (remove_applicable / remove_apply_to_all).
+			frappe
+				.call({
+					method: "frappe.core.doctype.user_permission.user_permission.add_user_permissions",
+					args: {
+						data: {
+							user: values.user,
+							doctype: doctype,
+							docname: values.for_value,
+							apply_to_all_doctypes: apply_to_all,
+							applicable_doctypes:
+								!apply_to_all && values.applicable_for
+									? [values.applicable_for]
+									: [],
+							is_default: 0,
+							hide_descendants: values.hide_descendants ? 1 : 0,
+						},
+					},
+				})
+				.then((r) => {
+					dialog.hide();
+					frappe.show_alert(
+						r.message
+							? { message: __("User permission added"), indicator: "green" }
+							: {
+									message: __("User permission already exists"),
+									indicator: "orange",
+							  }
+					);
+					refresh();
+				});
+		},
+	});
+	dialog.show();
+}

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/user_permissions.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/user_permissions.js
@@ -56,7 +56,7 @@ function draw(panel, doctype) {
 						confirm: __("Delete this user permission?"),
 						action: (row, refresh) =>
 							frappe.db.delete_doc("User Permission", row.name).then(() => {
-								frappe.show_alert({ message: __("Deleted"), indicator: "green" });
+								frappe.ui.toast({ message: __("Deleted"), type: "success" });
 								refresh();
 							}),
 					},
@@ -161,12 +161,12 @@ function add_user_permission(doctype, refresh) {
 				})
 				.then((r) => {
 					dialog.hide();
-					frappe.show_alert(
+					frappe.ui.toast(
 						r.message
-							? { message: __("User permission added"), indicator: "green" }
+							? { message: __("User permission added"), type: "success" }
 							: {
 									message: __("User permission already exists"),
-									indicator: "orange",
+									type: "warning",
 							  }
 					);
 					refresh();

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/workflow.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/workflow.js
@@ -40,9 +40,9 @@ frappe.doctype_settings.register("workflow", function (panel, doctype) {
 					frappe.db
 						.set_value("Workflow", r.name, { is_active: r.is_active ? 0 : 1 })
 						.then(() => {
-							frappe.show_alert({
+							frappe.ui.toast({
 								message: r.is_active ? __("Disabled") : __("Enabled"),
-								indicator: "green",
+								type: "success",
 							});
 							list.reload();
 						}),
@@ -54,7 +54,7 @@ frappe.doctype_settings.register("workflow", function (panel, doctype) {
 				danger: true,
 				onclick: (list) =>
 					frappe.model.delete_doc("Workflow", r.name, () => {
-						frappe.show_alert({ message: __("Deleted"), indicator: "green" });
+						frappe.ui.toast({ message: __("Deleted"), type: "success" });
 						list.reload();
 					}),
 			},

--- a/frappe/public/js/frappe/ui/embedded_list.js
+++ b/frappe/public/js/frappe/ui/embedded_list.js
@@ -76,7 +76,8 @@ frappe.ui.EmbeddedList = class EmbeddedList {
 			  )}">`
 			: "";
 
-		if (!title && !description && !add) {
+		// Header shows when there's a title/description/Add, or a search box to offer.
+		if (!title && !description && !add && !this.show_search) {
 			this.$header.hide();
 			return;
 		}

--- a/frappe/public/js/frappe/ui/settings_dialog.js
+++ b/frappe/public/js/frappe/ui/settings_dialog.js
@@ -39,7 +39,9 @@ frappe.ui.SettingsDialogPanel = class SettingsDialogPanel {
 				<div class="settings-dialog-panel-actions"></div>
 			</div>
 		`).appendTo(this.$el);
-		this.$body = $('<div class="settings-dialog-panel-body"></div>').appendTo(this.$el);
+		this.$body = $('<div class="settings-dialog-panel-body pt-2 px-2"></div>').appendTo(
+			this.$el
+		);
 		// `body` is the public handle consumers render into.
 		this.body = this.$body;
 	}

--- a/frappe/public/scss/desk/doctype_settings.scss
+++ b/frappe/public/scss/desk/doctype_settings.scss
@@ -3,6 +3,11 @@
 // tabs render into panel bodies: the shared list panel, the global-search field
 // grid, the print-format card grid, and the shared empty state.
 
+.dts-user-permissions-list.embedded-list .embedded-list-header {
+	justify-content: flex-start;
+	gap: 0;
+}
+
 // ── Global Search tab: inclusion toggle + searchable-field checkbox grid ──
 // The inclusion row is a plain flex container (layout via utilities); only the switch
 // itself is a `.switch-control` label, so clicking the row's empty space does nothing.

--- a/frappe/public/scss/desk/doctype_settings.scss
+++ b/frappe/public/scss/desk/doctype_settings.scss
@@ -19,11 +19,6 @@
 	padding: 0;
 }
 
-.dts-gs-search {
-	max-width: 320px;
-	margin-bottom: var(--margin-md);
-}
-
 .dts-gs-grid {
 	display: grid;
 	grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
@@ -31,6 +26,7 @@
 }
 
 // Checkbox row (label + native checkbox), reused for the doctype-name option too.
+// Off-grid gap/padding stay here; label color/width/truncation are utilities in markup.
 .dts-check {
 	display: flex;
 	align-items: center;
@@ -43,27 +39,13 @@
 		margin: 0;
 		cursor: pointer;
 	}
-
-	// Truncation comes from the shared `.ellipsis` utility on the element.
-	.dts-check-label {
-		color: var(--ink-gray-7);
-		min-width: 0;
-	}
 }
 
 // ── Stacked sections within a tab (e.g. Naming's Series + Rules) ──
-.dts-section {
-	// Space between the section header and its content (table / controls). The header
-	// reuses .settings-dialog-panel-header, whose 0.5rem inline padding would double up
-	// with the panel body's own padding and push the title in — zero it here.
-	.settings-dialog-panel-header {
-		margin-bottom: var(--margin-md);
-		padding: 0;
-	}
-
-	& + & {
-		margin-top: var(--margin-xl);
-	}
+// Header layout/type is utility classes in the markup (frappe.doctype_settings.section);
+// only the gap between repeated sections (a sibling selector) isn't utility-expressible.
+.dts-section + .dts-section {
+	margin-top: var(--margin-xl);
 }
 
 .dts-settings-group-heading {
@@ -106,17 +88,10 @@
 	}
 }
 
-.dts-setting-text {
-	min-width: 0;
-}
-
-.dts-setting-label {
-	color: var(--ink-gray-8);
-}
-
+// Label/text color and min-width are utilities in the markup; only the off-grid
+// description offset stays here.
 .dts-setting-description {
 	margin-top: 2px;
-	color: var(--ink-gray-5);
 }
 
 // Right column: the control. Inputs/selects get a fixed width so they line up; the
@@ -140,47 +115,23 @@
 }
 
 // ── Shared list panel (CRM-style: header + table + inline switch + overflow) ──
-.dts-list {
-	display: flex;
-	flex-direction: column;
+// Row/cell layout, text, and the toggle are utility classes in the markup; only what
+// utilities can't express stays here.
+
+// Badge icon (e.g. the notification channel glyph) — badge.css's default ~10px reads
+// too small next to the label; bump it up a notch.
+.dts-list-cell .es-badge > svg {
+	width: 14px;
+	height: 14px;
 }
 
-.dts-list-row {
-	display: flex;
-	align-items: center;
-	gap: var(--margin-md);
-	padding: var(--padding-md) 0;
-	border-bottom: 1px solid var(--border-color);
-}
-
-.dts-list-head {
-	padding: 0 0 var(--padding-sm);
-	color: var(--ink-gray-5);
-	border-bottom: 1px solid var(--border-color);
-}
-
-.dts-list-cell {
-	flex: 1;
-	min-width: 0;
-
-	// Badge icon (e.g. the notification channel glyph) — badge.css's default ~10px
-	// reads too small next to the label; bump it up a notch.
-	.es-badge > svg {
-		width: 14px;
-		height: 14px;
-	}
-}
-
+// Fixed-width cells (bases not on the utility spacing scale).
 .dts-list-cell-title {
 	flex: 2;
+	min-width: 0;
 	display: flex;
 	align-items: center;
 	gap: var(--margin-md);
-}
-
-// Text block (primary + secondary) sitting next to the optional leading media.
-.dts-list-text {
-	min-width: 0;
 }
 
 .dts-list-cell-toggle {
@@ -196,52 +147,19 @@
 	justify-content: flex-end;
 }
 
-// Primary line: name + inline tags.
-.dts-list-primary-row {
-	display: flex;
-	align-items: center;
-	gap: var(--padding-sm);
-	min-width: 0;
-}
+// Row title, when clickable (tc.onclick) — hover feedback isn't utility-expressible.
+.dts-list-link {
+	cursor: pointer;
 
-.dts-list-primary {
-	color: var(--ink-gray-8);
-	min-width: 0;
-
-	&.dts-list-link {
-		cursor: pointer;
-
-		&:hover {
-			color: var(--ink-gray-9);
-			text-decoration: underline;
-		}
+	&:hover {
+		color: var(--ink-gray-9);
+		text-decoration: underline;
 	}
 }
 
+// margin-top: 2px sits between the utility spacing steps.
 .dts-list-secondary {
 	margin-top: 2px;
-	color: var(--ink-gray-5);
-}
-
-.dts-list-state {
-	display: flex;
-	align-items: center;
-	gap: var(--margin-sm);
-	padding: var(--padding-lg) 0;
-}
-
-// Inline switch reuses ControlSwitch markup (.switch-control / .input-area /
-// .switch-visual) from controls.scss; nothing extra needed beyond a margin reset.
-.dts-switch {
-	margin: 0;
-	cursor: pointer;
-}
-
-.dts-loading {
-	display: flex;
-	flex-direction: column;
-	gap: var(--margin-sm);
-	padding: var(--padding-md) 0;
 }
 
 // ── Permissions tab: EmbeddedList of roles with rights badges + customized banner
@@ -257,25 +175,6 @@
 
 	.icon {
 		margin: 0;
-	}
-}
-
-.dts-perm-footer {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: var(--margin-md);
-	margin-top: var(--margin-sm);
-	padding-top: var(--padding-md);
-	border-top: 1px solid var(--border-color);
-
-	// Weight comes from the espresso `text-base-medium` utility in the markup.
-	.dts-perm-footer-link {
-		display: inline-flex;
-		align-items: center;
-		gap: var(--padding-xs);
-		color: var(--ink-gray-7);
-		white-space: nowrap;
 	}
 }
 
@@ -382,7 +281,6 @@
 	padding: var(--padding-md) var(--padding-lg);
 }
 
-// Truncation comes from the shared `.ellipsis` utility on the element.
 .dts-pf-name {
 	display: block;
 	color: var(--ink-gray-8);

--- a/frappe/public/scss/desk/settings_dialog.scss
+++ b/frappe/public/scss/desk/settings_dialog.scss
@@ -134,7 +134,7 @@
 	display: flex;
 	flex-direction: column;
 	flex: 1;
-	overflow-y: auto;
+	overflow: clip;
 	background-color: var(--bg-color);
 }
 
@@ -195,7 +195,6 @@
 	display: flex;
 	flex-direction: column;
 	overflow-y: auto;
-	padding: 0 0.5rem;
 }
 
 .settings-dialog-section-heading {


### PR DESCRIPTION
Introduces a Permissions group in the DocType Settings dialog and migrates the feature's styling to shared utility classes.

What changed

- New Permissions group with two tabs: Roles and user restriction
- Naming tab — merged the add/edit series flows into one dialog that shows the live "Next value" preview and configuration help in both modes.
- Styling cleanup — replaced most custom dts-* SCSS with shared utility classes across the tabs (doctype_settings.scss down ~150 lines); reused the espresso frappe.ui.* components (button, badge, alert, dropdown, skeleton, empty state).

User permission tab

<img width="1439" height="811" alt="Screenshot 2026-08-14 at 11 29 06 AM" src="https://github.com/user-attachments/assets/20c34db0-2955-4a55-9e21-7004410e088a" />


`no-docs`