### PR TITLE
ci: remove unused JS coverage instrumentation from UI tests

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -81,14 +81,6 @@ jobs:
           path: ~/.cache/Cypress
           key: ${{ runner.os }}-cypress
 
-      - name: Instrument Source Code
-        run: |
-          cd ${GITHUB_WORKSPACE}/apps/${{ github.event.repository.name }}
-          npx nyc instrument \
-            -x '${{ github.event.repository.name }}/public/dist/**' \
-            -x '${{ github.event.repository.name }}/public/js/lib/**' \
-            -x '**/*.bundle.js' --compact=false --in-place ${{ github.event.repository.name }}
-
       - name: Site Setup
         run: |
           bench --site test_site execute frappe.utils.install.complete_setup_wizard
@@ -103,7 +95,6 @@ jobs:
         run: |
           bench --site test_site \
             run-ui-tests ${{ github.event.repository.name }} \
-              --with-coverage \
               --headless \
               --browser ${{ env.BROWSER_PATH }} \
               --ci-build-id $GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT \


### PR DESCRIPTION
UI tests instrument all JS (`nyc instrument`) and run with `--with-coverage`, but that frontend coverage is never uploaded anywhere:
- `ui-tests.yml` has no coverage upload step
- `codecov.yml` only has `server`/`server-ui` flags, both scoped to `**/*.py`; no JS flag
- the only codecov upload is `server-tests.yml` (Python)

So it's computed on every PR and thrown away. This removes the instrument step and the flag.

Measured: no meaningful change to shard times (JS execution isn't the Cypress bottleneck) — this is dead-code cleanup, not a speedup. Python/server coverage is untouched.