### PR TITLE
test(ui): use desk_ready() for file_uploader desk-load waits

### DIFF
--- a/cypress/integration/file_uploader.js
+++ b/cypress/integration/file_uploader.js
@@ -5,7 +5,7 @@ context("FileUploader", () => {
 
 	beforeEach(() => {
 		cy.visit("/desk");
-		cy.wait(2000); // workspace can load async and clear active dialog
+		cy.desk_ready();
 	});
 
 	function open_upload_dialog() {
@@ -73,14 +73,14 @@ context("FileUploader", () => {
 			// Clean up test user
 			cy.login("Administrator", Cypress.env("adminPassword") || "admin");
 			cy.visit("/desk");
-			cy.wait(1000);
+			cy.desk_ready();
 			cy.remove_doc("User", test_user, true); // true = ignore_missing
 		});
 
 		it("should show checkbox and toggle when setting is disabled for System Manager", () => {
 			cy.login("Administrator", Cypress.env("adminPassword") || "admin");
 			cy.visit("/desk");
-			cy.wait(1000);
+			cy.desk_ready();
 
 			// Disable the setting
 			cy.set_value("System Settings", "System Settings", {
@@ -93,7 +93,7 @@ context("FileUploader", () => {
 					frappe.boot.sysdefaults.only_allow_system_managers_to_upload_public_files = 0;
 				});
 			cy.visit("/desk");
-			cy.wait(2000);
+			cy.desk_ready();
 
 			open_upload_dialog();
 
@@ -125,19 +125,19 @@ context("FileUploader", () => {
 		it("should show checkbox and toggle when setting is disabled for non-System Manager", () => {
 			cy.login("Administrator", Cypress.env("adminPassword") || "admin");
 			cy.visit("/desk");
-			cy.wait(1000);
+			cy.desk_ready();
 
 			// Disable the setting
 			cy.set_value("System Settings", "System Settings", {
 				only_allow_system_managers_to_upload_public_files: 0,
 			});
 			cy.visit("/desk");
-			cy.wait(1000);
+			cy.desk_ready();
 
 			// Login as non-System Manager
 			cy.login(test_user, test_password);
 			cy.visit("/desk");
-			cy.wait(2000);
+			cy.desk_ready();
 			// Update sysdefaults in window
 			cy.window()
 				.its("frappe")
@@ -175,7 +175,7 @@ context("FileUploader", () => {
 		it("should show checkbox and toggle when setting is enabled for System Manager", () => {
 			cy.login("Administrator", Cypress.env("adminPassword") || "admin");
 			cy.visit("/desk");
-			cy.wait(1000);
+			cy.desk_ready();
 
 			// Enable the setting
 			cy.set_value("System Settings", "System Settings", {
@@ -188,7 +188,7 @@ context("FileUploader", () => {
 					frappe.boot.sysdefaults.only_allow_system_managers_to_upload_public_files = 1;
 				});
 			cy.visit("/desk");
-			cy.wait(2000);
+			cy.desk_ready();
 
 			open_upload_dialog();
 
@@ -220,19 +220,19 @@ context("FileUploader", () => {
 		it("should show disabled checkbox and hide toggle when setting is enabled for non-System Manager", () => {
 			cy.login("Administrator", Cypress.env("adminPassword") || "admin");
 			cy.visit("/desk");
-			cy.wait(1000);
+			cy.desk_ready();
 
 			// Enable the setting
 			cy.set_value("System Settings", "System Settings", {
 				only_allow_system_managers_to_upload_public_files: 1,
 			});
 			cy.visit("/desk");
-			cy.wait(1000);
+			cy.desk_ready();
 
 			// Login as non-System Manager
 			cy.login(test_user, test_password);
 			cy.visit("/desk");
-			cy.wait(2000);
+			cy.desk_ready();
 			// Update sysdefaults in window
 			cy.window()
 				.its("frappe")


### PR DESCRIPTION
Follow-up to #41805. Converts file_uploader's 12 `visit("/desk") + fixed wait` desk-load races to `cy.desk_ready()` — the `beforeEach` 2000ms fired before all 7 tests, so this is the bulk of the win.

**Measured: file_uploader.js 00:58 → 00:33 (~25s), 7/7 passing.** These 2000ms waits genuinely overshot real load time (unlike the 500ms desk-load waits elsewhere), so it's actual recovered time.

Deliberately keeps `open_upload_dialog`'s `cy.wait(500)` — it guards the FileUploader Vue component mounting (the `close_dialog` ref that hides the modal on upload success is wired during mount). Removing it earlier raced ahead of Vue and the Upload modal wouldn't close after #41444; keeping it fixes that.