### PR TITLE
perf: lazy-import heavy dependencies to reduce memory usage in worker and cli

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -83,7 +83,10 @@ runs:
       start_time=$(date +%s)
 
       install_system_deps() {
-        curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | sudo bash -s -- --mariadb-server-version="mariadb-11.8.5" --skip-maxscale
+        # --skip-verify: the version check does its own request to dlm.mariadb.com, which
+        # answers 502 often enough to break the build. apt fetches the repo anyway, so a
+        # version that does not exist still fails, and it fails where the cause is clear.
+        curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | sudo bash -s -- --mariadb-server-version="mariadb-11.8.5" --skip-maxscale --skip-verify
 
         sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
         wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -

--- a/frappe/_optimizations.py
+++ b/frappe/_optimizations.py
@@ -47,6 +47,28 @@ def optimize_regex_cache():
 	os.register_at_fork(before=re.purge)
 
 
+def preload_database_drivers():
+	"""Import database drivers before forking so that workers share their memory.
+
+	`FRAPPE_PRELOAD_DATABASE_DRIVERS` takes a comma separated list of driver names, e.g.
+	"mariadb,postgres". Blank loads mariadb, "none" loads nothing.
+	"""
+	value = os.environ.get("FRAPPE_PRELOAD_DATABASE_DRIVERS", "").strip().lower() or "mariadb"
+	if value == "none":
+		return
+
+	drivers = {driver.strip() for driver in value.split(",") if driver.strip()}
+
+	if "mariadb" in drivers:
+		import frappe.database.mariadb.mysqlclient
+
+	if "postgres" in drivers:
+		import frappe.database.postgres.database
+
+	if "sqlite" in drivers:
+		import frappe.database.sqlite.database
+
+
 def register_fault_handler():
 	# Some libraries monkey patch stderr, we need actual fd
 	if isinstance(sys.__stderr__, io.TextIOWrapper):

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -8,7 +8,6 @@ import sys
 
 import orjson
 from werkzeug.exceptions import HTTPException, NotFound
-from werkzeug.middleware.profiler import ProfilerMiddleware
 from werkzeug.middleware.proxy_fix import ProxyFix
 from werkzeug.middleware.shared_data import SharedDataMiddleware
 from werkzeug.wrappers import Request, Response  # nosemgrep: frappe-monkey-patching-not-allowed
@@ -40,7 +39,7 @@ _sites_path = os.environ.get("SITES_PATH", ".")
 import gettext
 
 import babel
-import babel.messages
+import babel.dates
 import nh3
 import num2words
 import pydantic
@@ -579,6 +578,8 @@ def serve(
 	from werkzeug.serving import run_simple
 
 	if profile or os.environ.get("USE_PROFILER"):
+		from werkzeug.middleware.profiler import ProfilerMiddleware
+
 		application = ProfilerMiddleware(application, sort_by=("cumtime", "calls"), restrictions=(200,))
 
 	if not os.environ.get("NO_STATICS"):

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -40,6 +40,7 @@ import gettext
 
 import babel
 import babel.dates
+import bs4
 import nh3
 import num2words
 import pydantic

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -48,11 +48,6 @@ import frappe.boot
 import frappe.client
 import frappe.core.doctype.file.file
 import frappe.core.doctype.user.user
-
-# Skipped under the companion manager: the gevent socketio companion forks this
-# master and refuses to start if MySQLdb is already imported. Loaded lazily there.
-if not os.environ.get("FRAPPE_GUNICORN_COMPANION"):
-	import frappe.database.mariadb.mysqlclient  # Load database related utils
 import frappe.database.query
 import frappe.desk.desktop  # workspace
 import frappe.desk.form.save
@@ -68,6 +63,9 @@ import frappe.utils.typing_validations  # any whitelisted method uses this
 import frappe.website.path_resolver  # all the page types and resolver
 import frappe.website.router  # Website router
 import frappe.website.website_generator  # web page doctypes
+from frappe._optimizations import preload_database_drivers
+
+preload_database_drivers()
 
 # end: module pre-loading
 

--- a/frappe/core/doctype/duckdb_sync/duckdb_sync.py
+++ b/frappe/core/doctype/duckdb_sync/duckdb_sync.py
@@ -3,8 +3,6 @@
 
 from datetime import time, timedelta
 
-import pyarrow as pa
-
 import frappe
 from frappe import qb
 from frappe.database import get_duckdb
@@ -108,6 +106,8 @@ def start_data_sync(docname: str):
 
 
 def sync_using_pyarrow(conn, dt, duck_tb):
+	import pyarrow as pa
+
 	conn.execute(f'delete from "{duck_tb.table_name}";').fetchall()
 
 	_dt = qb.DocType(dt)

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -10,7 +10,6 @@ import zipfile
 from urllib.parse import quote, unquote
 
 import filetype
-from PIL import Image, ImageFile, ImageOps
 
 import frappe
 from frappe import _
@@ -27,8 +26,6 @@ from frappe.utils import (
 )
 from frappe.utils.file_manager import is_safe_path
 from frappe.utils.html_utils import escape_html
-from frappe.utils.image import optimize_image, strip_exif_data
-from frappe.utils.pdf import pdf_contains_js
 
 from .exceptions import (
 	AttachmentLimitReached,
@@ -39,8 +36,6 @@ from .exceptions import (
 from .utils import *
 
 exclude_from_linked_with = True
-
-ImageFile.LOAD_TRUNCATED_IMAGES = True  # nosemgrep
 
 URL_PREFIXES = ("http://", "https://", "/api/method/")
 FILE_ENCODING_OPTIONS = ("utf-8-sig", "utf-8", "windows-1250", "windows-1252")
@@ -484,6 +479,8 @@ class File(Document):
 			)
 
 	def check_content(self):
+		from frappe.utils.pdf import pdf_contains_js
+
 		if self.file_type == "PDF" and self._content and pdf_contains_js(self._content):
 			frappe.throw(_("This PDF cannot be uploaded as it contains unsafe content."))
 
@@ -548,6 +545,8 @@ class File(Document):
 		crop: bool = False,
 	) -> str:
 		from requests.exceptions import HTTPError, SSLError
+
+		from frappe.utils.image import Image, ImageOps
 
 		if not self.file_url:
 			return
@@ -880,6 +879,8 @@ class File(Document):
 			and self.content_type == "image/jpeg"
 			and frappe.get_system_settings("strip_exif_metadata_from_uploaded_images")
 		):
+			from frappe.utils.image import strip_exif_data
+
 			self._content = strip_exif_data(self._content, self.content_type)
 
 		self.file_size = self.check_max_file_size()
@@ -1004,6 +1005,8 @@ class File(Document):
 
 		if is_svg:
 			raise TypeError("Optimization of SVG images is not supported")
+
+		from frappe.utils.image import optimize_image
 
 		original_content = self.get_content()
 		optimized_content = optimize_image(

--- a/frappe/core/doctype/file/utils.py
+++ b/frappe/core/doctype/file/utils.py
@@ -83,7 +83,7 @@ def get_extension(
 
 
 def get_local_image(file_url: str) -> tuple["ImageFile", str, str]:
-	from PIL import Image
+	from frappe.utils.image import Image
 
 	if file_url.startswith("/private"):
 		file_url_path = (file_url.lstrip("/"),)
@@ -117,9 +117,9 @@ def get_local_image(file_url: str) -> tuple["ImageFile", str, str]:
 def get_web_image(file_url: str) -> tuple["ImageFile", str, str]:
 	import requests
 	import requests.exceptions
-	from PIL import Image
 
 	from frappe.utils.data import validate_egress_url
+	from frappe.utils.image import Image
 
 	file_url = frappe.utils.get_url(file_url)
 	site_url = frappe.utils.get_url().rstrip("/")

--- a/frappe/core/doctype/page/page.py
+++ b/frappe/core/doctype/page/page.py
@@ -6,7 +6,6 @@ import shutil
 
 import frappe
 from frappe import _, conf, get_module_path, safe_decode
-from frappe.build import html_to_js_template
 from frappe.core.doctype.custom_role.custom_role import get_custom_allowed_roles
 from frappe.desk.form.meta import get_code_files_via_hooks, get_js
 from frappe.desk.utils import validate_route_conflict
@@ -145,6 +144,7 @@ class Page(Document):
 	def load_assets(self):
 		import os
 
+		from frappe.build import html_to_js_template
 		from frappe.modules import get_module_path, scrub
 
 		self.script = ""

--- a/frappe/core/utils.py
+++ b/frappe/core/utils.py
@@ -2,8 +2,6 @@
 # License: MIT. See LICENSE
 
 
-from markdownify import markdownify as md
-
 import frappe
 
 
@@ -87,6 +85,8 @@ def ljust_list(_list, length, fill_word=None):
 
 def html2text(html: str, strip_links=False, wrap=True) -> str:
 	"""Return the given `html` as markdown text."""
+	from markdownify import markdownify as md
+
 	strip = ["a"] if strip_links else None
 	return md(html, heading_style="ATX", strip=strip, wrap=wrap)
 

--- a/frappe/database/duckdb/schema.py
+++ b/frappe/database/duckdb/schema.py
@@ -1,7 +1,5 @@
 from collections import OrderedDict
 
-import pyarrow as pa
-
 import frappe
 from frappe.database.schema import DbColumn, DBTable, get_definition
 from frappe.utils import cint, cstr, flt
@@ -210,6 +208,8 @@ class DuckDBTable(DBTable):
 		conn.sql(query)
 
 	def get_arrow_schema(self):
+		import pyarrow as pa
+
 		from frappe.database.duckdb.database import get_pyarrow_type_map
 
 		arrow_typemap = get_pyarrow_type_map()

--- a/frappe/desk/form/meta.py
+++ b/frappe/desk/form/meta.py
@@ -5,7 +5,6 @@ import os
 import frappe
 from frappe import _
 from frappe.app_state import get_disabled_modules
-from frappe.build import scrub_html_template
 from frappe.model.meta import Meta
 from frappe.model.utils import render_include
 from frappe.modules import get_module_path, load_doctype_module, scrub
@@ -128,6 +127,9 @@ class FormMeta(Meta):
 	def add_html_templates(self, path):
 		if self.custom:
 			return
+
+		from frappe.build import scrub_html_template
+
 		templates = dict()
 		for fname in os.listdir(path):
 			if fname.endswith(".html"):

--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -3,8 +3,6 @@
 
 from typing import Literal
 
-from bs4 import BeautifulSoup
-
 import frappe
 from frappe import _
 from frappe.desk.doctype.notification_log.notification_log import (
@@ -444,6 +442,8 @@ def notify_mentions(ref_doctype, ref_name, content, source_doctype=None, source_
 
 def extract_mentions(txt):
 	"""Find all instances of @mentions in the html."""
+	from bs4 import BeautifulSoup
+
 	soup = BeautifulSoup(txt, "html.parser")
 	emails = []
 	for mention in soup.find_all(class_="mention"):

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -5,7 +5,7 @@ import datetime
 import json
 import os
 from datetime import timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import frappe
 import frappe.desk.reportview
@@ -19,7 +19,9 @@ from frappe.monitor import add_data_to_monitor
 from frappe.permissions import get_role_permissions, get_roles, has_permission
 from frappe.utils import cint, cstr, flt, format_datetime, format_duration, formatdate, get_html_format, sbool
 from frappe.utils.caching import request_cache
-from frappe.utils.xlsxutils import XLSXMetadata, XLSXStyleBuilder, handle_html, make_xlsx
+
+if TYPE_CHECKING:
+	from frappe.utils.xlsxutils import XLSXMetadata
 
 
 def get_report_doc(report_name):
@@ -420,6 +422,7 @@ def run_export_query_job(user_email: str, form_params, csv_params):
 
 def _export_query(form_params, csv_params, populate_response=True):
 	from frappe.desk.utils import get_csv_bytes, provide_binary_file
+	from frappe.utils.xlsxutils import handle_html, make_xlsx
 
 	report_name = form_params.report_name
 	file_format_type = form_params.file_format_type
@@ -587,6 +590,8 @@ def build_xlsx_data(
 			- column_widths: List of column widths for the Excel sheet
 			- styles: Dictionary of styles for Excel formatting (if applicable)
 	"""
+	from frappe.utils.xlsxutils import XLSXMetadata
+
 	metadata = None
 
 	EXCEL_TYPES = (
@@ -717,12 +722,14 @@ def build_xlsx_data(
 	return result, column_widths, get_xlsx_styles(metadata, data.report_name) if build_styles else None
 
 
-def get_xlsx_styles(metadata: XLSXMetadata, report_name: str | None = None) -> dict | None:
+def get_xlsx_styles(metadata: "XLSXMetadata", report_name: str | None = None) -> dict | None:
 	"""
 	Returns styles for XLSX export.
 
 	If report_name is provided, it tries to fetch styles defined in the report's module.
 	"""
+	from frappe.utils.xlsxutils import XLSXStyleBuilder
+
 	styles = None
 	if report_name:
 		report = frappe.get_doc("Report", report_name)

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -19,7 +19,6 @@ from frappe.permissions import check_doctype_permission
 from frappe.utils import cint, get_files_path
 from frappe.utils.csvutils import build_csv_response
 from frappe.utils.deprecations import deprecated
-from frappe.utils.image import optimize_image
 from frappe.utils.response import build_response
 
 if TYPE_CHECKING:
@@ -128,7 +127,7 @@ def web_logout():
 	)
 
 
-@frappe.whitelist(allow_guest=True, methods=["POST"])
+@frappe.whitelist(allow_guest=True, methods=["POST"])  # nosemgrep: guest-whitelisted-method
 def upload_file():
 	user = None
 	if frappe.session.user == "Guest":
@@ -202,6 +201,8 @@ def upload_file():
 		temp_path.unlink()
 		content_type = guess_type(filename)[0]
 		if optimize and content_type and content_type.startswith("image/"):
+			from frappe.utils.image import optimize_image
+
 			args = {"content": content, "content_type": content_type}
 			if frappe.form_dict.max_width:
 				args["max_width"] = int(frappe.form_dict.max_width)

--- a/frappe/integrations/doctype/google_calendar/google_calendar.py
+++ b/frappe/integrations/doctype/google_calendar/google_calendar.py
@@ -8,11 +8,8 @@ from math import ceil
 from typing import TYPE_CHECKING, TypedDict
 from zoneinfo import ZoneInfo
 
-import google.oauth2.credentials
 import requests
 from dateutil import parser
-from googleapiclient.discovery import build
-from googleapiclient.errors import HttpError
 
 import frappe
 from frappe import _, _lt
@@ -221,6 +218,9 @@ def sync(g_calendar: str | None = None):
 
 def get_google_calendar_object(g_calendar):
 	"""Return an object of Google Calendar along with Google Calendar doc."""
+	import google.oauth2.credentials
+	from googleapiclient.discovery import build
+
 	google_settings = frappe.get_cached_doc("Google Settings")
 	account: GoogleCalendar = frappe.get_doc("Google Calendar", g_calendar)
 
@@ -246,6 +246,8 @@ def check_google_calendar(account: GoogleCalendar, google_calendar):
 	Checks if Google Calendar is present with the specified name.
 	If not, creates one.
 	"""
+	from googleapiclient.errors import HttpError
+
 	if account.google_calendar_id:
 		try:
 			return google_calendar.calendars().get(calendarId=account.google_calendar_id).execute()
@@ -280,6 +282,8 @@ def sync_events_from_google_calendar(g_calendar, method=None):
 	nextSyncToken is returned at the very last page
 	https://developers.google.com/calendar/v3/sync
 	"""
+	from googleapiclient.errors import HttpError
+
 	google_calendar, account = get_google_calendar_object(g_calendar)
 
 	if not account.pull_from_google_calendar:
@@ -444,6 +448,8 @@ def insert_event_in_google_calendar(doc, method=None):
 	"""
 	Insert Events in Google Calendar if sync_with_google_calendar is checked.
 	"""
+	from googleapiclient.errors import HttpError
+
 	if (
 		not doc.sync_with_google_calendar
 		or doc.pulled_from_google_calendar
@@ -506,6 +512,8 @@ def update_event_in_google_calendar(doc, method=None):
 	"""
 	Updates Events in Google Calendar if any existing event is modified in Frappe Calendar
 	"""
+	from googleapiclient.errors import HttpError
+
 	# Workaround to avoid triggering updation when Event is being inserted since
 	# creation and modified are same when inserting doc
 	if (
@@ -590,6 +598,7 @@ def delete_event_from_google_calendar(doc, method=None):
 	"""
 	Delete Events from Google Calendar if Frappe Event is deleted.
 	"""
+	from googleapiclient.errors import HttpError
 
 	if not frappe.db.exists("Google Calendar", {"name": doc.google_calendar, "push_to_google_calendar": 1}):
 		return

--- a/frappe/integrations/doctype/google_contacts/google_contacts.py
+++ b/frappe/integrations/doctype/google_contacts/google_contacts.py
@@ -4,8 +4,6 @@
 
 from urllib.parse import quote
 
-from googleapiclient.errors import HttpError
-
 import frappe
 from frappe import _
 from frappe.integrations.google_oauth import GoogleOAuth
@@ -107,6 +105,8 @@ def sync_contacts_from_google_contacts(g_contact):
 	Syncs Contacts from Google Contacts.
 	https://developers.google.com/people/api/rest/v1/people.connections/list
 	"""
+	from googleapiclient.errors import HttpError
+
 	google_contacts, account = get_google_contacts_object(g_contact)
 
 	if not account.pull_from_google_contacts:
@@ -203,6 +203,8 @@ def insert_contacts_to_google_contacts(doc, method=None):
 	Syncs Contacts from Google Contacts.
 	https://developers.google.com/people/api/rest/v1/people/createContact
 	"""
+	from googleapiclient.errors import HttpError
+
 	if (
 		not frappe.db.exists("Google Contacts", {"name": doc.google_contacts})
 		or doc.pulled_from_google_contacts
@@ -242,6 +244,8 @@ def update_contacts_to_google_contacts(doc, method=None):
 	Syncs Contacts from Google Contacts.
 	https://developers.google.com/people/api/rest/v1/people/updateContact
 	"""
+	from googleapiclient.errors import HttpError
+
 	# Workaround to avoid triggering updation when Event is being inserted since
 	# creation and modified are same when inserting doc
 	if (

--- a/frappe/integrations/frappe_providers/__init__.py
+++ b/frappe/integrations/frappe_providers/__init__.py
@@ -1,6 +1,7 @@
 # imports - standard imports
 # imports - module imports
 
+
 def migrate_to():
 	from frappe.integrations.frappe_providers.frappecloud import frappecloud_migrator
 

--- a/frappe/integrations/frappe_providers/__init__.py
+++ b/frappe/integrations/frappe_providers/__init__.py
@@ -1,8 +1,7 @@
 # imports - standard imports
 # imports - module imports
 
-from frappe.integrations.frappe_providers.frappecloud import frappecloud_migrator
-
-
 def migrate_to():
+	from frappe.integrations.frappe_providers.frappecloud import frappecloud_migrator
+
 	return frappecloud_migrator()

--- a/frappe/integrations/frappe_providers/cloud_settings.py
+++ b/frappe/integrations/frappe_providers/cloud_settings.py
@@ -4,8 +4,6 @@ HTTP using a site-scoped token both written into site_config on site creation.""
 
 from urllib.parse import quote
 
-import requests
-
 import frappe
 from frappe import _
 from frappe.utils import cint
@@ -49,6 +47,8 @@ class PilotClient:
 		return self.site_path(f"{path}/{suffix.lstrip('/')}" if suffix else path)
 
 	def _request(self, method: str, path: str, data: dict | None = None):
+		import requests
+
 		try:
 			response = requests.request(
 				method,

--- a/frappe/integrations/frappe_providers/frappecloud_billing.py
+++ b/frappe/integrations/frappe_providers/frappecloud_billing.py
@@ -1,7 +1,5 @@
 from typing import Any
 
-import requests
-
 import frappe
 from frappe import _
 
@@ -40,6 +38,13 @@ def get_headers():
 	}
 
 
+def post(method: str, json: dict | None = None):
+	"""POST to a whitelisted method on Frappe Cloud with this site's credentials."""
+	import requests
+
+	return requests.post(f"{get_base_url()}/api/method/{method}", headers=get_headers(), json=json)
+
+
 @frappe.whitelist()
 def current_site_info():
 	from frappe.utils import cint
@@ -52,7 +57,7 @@ def current_site_info():
 		return cached_data
 
 	res = {}
-	request = requests.post(f"{get_base_url()}/api/method/press.saas.api.site.info", headers=get_headers())
+	request = post("press.saas.api.site.info")
 	if request.status_code == 200:
 		res = request.json().get("message")
 		if not res or not isinstance(res, dict):
@@ -74,11 +79,7 @@ def current_site_info():
 def api(method: str, data: str | dict[str, Any] | None = None):
 	if data is None:
 		data = {}
-	request = requests.post(
-		f"{get_base_url()}/api/method/press.saas.api.{method}",
-		headers=get_headers(),
-		json=data,
-	)
+	request = post(f"press.saas.api.{method}", json=data)
 	if request.status_code == 200:
 		return request.json().get("message")
 	else:
@@ -94,9 +95,8 @@ def is_fc_site() -> bool:
 # login to frappe cloud dashboard
 @frappe.whitelist()
 def send_verification_code():
-	request = requests.post(
-		f"{get_base_url()}/api/method/press.api.developer.saas.send_verification_code",
-		headers=get_headers(),
+	request = post(
+		"press.api.developer.saas.send_verification_code",
 		json={"domain": get_site_name()},
 	)
 	if request.status_code == 200:
@@ -107,9 +107,8 @@ def send_verification_code():
 
 @frappe.whitelist()
 def verify_verification_code(verification_code: str, route: str):
-	request = requests.post(
-		f"{get_base_url()}/api/method/press.api.developer.saas.verify_verification_code",
-		headers=get_headers(),
+	request = post(
+		"press.api.developer.saas.verify_verification_code",
 		json={"domain": get_site_name(), "verification_code": verification_code, "route": route},
 	)
 

--- a/frappe/integrations/google_oauth.py
+++ b/frappe/integrations/google_oauth.py
@@ -1,5 +1,3 @@
-from google.oauth2.credentials import Credentials
-from googleapiclient.discovery import build
 from requests import get, post
 
 import frappe
@@ -145,6 +143,8 @@ class GoogleOAuth:
 
 	def get_google_service_object(self, access_token: str, refresh_token: str):
 		"""Return Google service object."""
+		from google.oauth2.credentials import Credentials
+		from googleapiclient.discovery import build
 
 		credentials_dict = {
 			"token": access_token,

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -37,7 +37,7 @@ from frappe.utils import (
 	strip_html,
 )
 from frappe.utils.defaults import get_not_null_defaults
-from frappe.utils.html_utils import unescape_html
+from frappe.utils.html_utils import has_html_tags, unescape_html
 
 if TYPE_CHECKING:
 	from frappe.model.document import Document
@@ -1381,8 +1381,6 @@ class BaseDocument:
 
 		- Ignore if 'Ignore XSS Filter' is checked or fieldtype is 'Code'
 		"""
-		from bs4 import BeautifulSoup
-
 		if frappe.flags.in_install:
 			return
 
@@ -1396,7 +1394,7 @@ class BaseDocument:
 				# doesn't look like html so no need
 				continue
 
-			elif "<!-- markdown -->" in value and not bool(BeautifulSoup(value, "html.parser").find()):
+			elif "<!-- markdown -->" in value and not has_html_tags(value):
 				# should be handled separately via the markdown converter function
 				continue
 

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -20,8 +20,6 @@ import os
 import typing
 from datetime import datetime
 
-import click
-
 import frappe
 from frappe import N_, _
 from frappe.app_state import is_disabled_app_filtering_active, is_module_disabled
@@ -1008,6 +1006,8 @@ def trim_tables(doctype=None, dry_run=False, quiet=False):
 	as maintenance since removing a field in a DocType doesn't automatically
 	delete the db field.
 	"""
+	import click
+
 	UPDATED_TABLES = {}
 	filters = {"issingle": 0, "is_virtual": 0}
 	if doctype:

--- a/frappe/model/utils/__init__.py
+++ b/frappe/model/utils/__init__.py
@@ -4,7 +4,6 @@ import re
 from functools import wraps
 
 import frappe
-from frappe.build import html_to_js_template
 from frappe.utils import cstr
 from frappe.utils.caching import site_cache
 
@@ -79,6 +78,8 @@ def render_include(content):
 				with open(resolved_path, encoding="utf-8") as f:
 					include = f.read()
 					if path.endswith(".html"):
+						from frappe.build import html_to_js_template
+
 						include = html_to_js_template(path, include)
 
 					content = re.sub(

--- a/frappe/monitor.py
+++ b/frappe/monitor.py
@@ -7,8 +7,6 @@ import os
 import traceback
 import uuid
 
-import rq
-
 import frappe
 from frappe.utils.data import cint
 from frappe.utils.synchronization import filelock
@@ -78,6 +76,8 @@ class Monitor:
 			self.data.uuid = request_id
 
 	def collect_job_meta(self, method, kwargs):
+		import rq
+
 		self.data.job = frappe._dict({"method": method, "scheduled": False, "wait": 0})
 		if "run_scheduled_job" in method:
 			self.data.job.method = kwargs["job_type"]

--- a/frappe/recorder.py
+++ b/frappe/recorder.py
@@ -1,11 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import cProfile
 import functools
 import inspect
 import io
 import json
-import pstats
 import re
 import time
 import typing
@@ -366,6 +364,8 @@ class Recorder:
 			_install_run_method_tracer()
 
 		if self.config.profile:
+			import cProfile
+
 			self.profiler = cProfile.Profile()
 			self.profiler.enable()
 
@@ -382,6 +382,8 @@ class Recorder:
 
 	def process_profiler(self):
 		if self.config.profile or self.profiler:
+			import pstats
+
 			self.profiler.disable()
 			profiler_output = io.StringIO()
 			pstats.Stats(self.profiler, stream=profiler_output).sort_stats("cumulative").print_stats(200)

--- a/frappe/search/sqlite_search.py
+++ b/frappe/search/sqlite_search.py
@@ -13,8 +13,6 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
-from bs4 import BeautifulSoup
-
 import frappe
 from frappe.model.document import Document
 from frappe.utils import update_progress_bar
@@ -1613,6 +1611,8 @@ class SQLiteSearch(ABC):
 		"""Process content to remove HTML tags, links, and images for better indexing quality."""
 		if not content:
 			return ""
+
+		from bs4 import BeautifulSoup
 
 		# Convert to string in case it's a Mock object or other type
 		content = str(content)

--- a/frappe/tests/test_cloud_settings.py
+++ b/frappe/tests/test_cloud_settings.py
@@ -176,7 +176,7 @@ class TestCloudSettings(_CloudTestCase):
 			patch.dict(frappe.conf, PILOT_CONF),
 			patch("frappe.get_roles", return_value=["System Manager"]),
 			patch(
-				"frappe.integrations.frappe_providers.cloud_settings.requests.request",
+				"requests.request",
 				return_value=Response({"url": "http://central.localhost:8001"}),
 			) as request,
 		):
@@ -212,7 +212,7 @@ class TestCloudSettings(_CloudTestCase):
 			patch.dict(frappe.conf, PILOT_CONF),
 			patch("frappe.get_roles", return_value=["System Manager"]),
 			patch(
-				"frappe.integrations.frappe_providers.cloud_settings.requests.request",
+				"requests.request",
 				return_value=Response({"domains": ["shop.example.com"], "primary": "shop.example.com"}),
 			) as request,
 		):
@@ -235,7 +235,7 @@ class TestCloudSettings(_CloudTestCase):
 			patch.dict(frappe.conf, PILOT_CONF),
 			patch("frappe.get_roles", return_value=["System Manager"]),
 			patch(
-				"frappe.integrations.frappe_providers.cloud_settings.requests.request",
+				"requests.request",
 				return_value=Response({"ok": True, "task_id": "task-1"}),
 			) as request,
 		):
@@ -253,7 +253,7 @@ class TestCloudSettings(_CloudTestCase):
 			patch.dict(frappe.conf, PILOT_CONF),
 			patch("frappe.get_roles", return_value=["System Manager"]),
 			patch(
-				"frappe.integrations.frappe_providers.cloud_settings.requests.request",
+				"requests.request",
 				return_value=Response(payload, ok=False),
 			),
 			self.assertRaises(CloudMigrationConflictError),
@@ -266,7 +266,7 @@ class TestCloudSettings(_CloudTestCase):
 			patch.dict(frappe.conf, PILOT_CONF),
 			patch("frappe.get_roles", return_value=["System Manager"]),
 			patch(
-				"frappe.integrations.frappe_providers.cloud_settings.requests.request",
+				"requests.request",
 				return_value=Response(payload, ok=False),
 			),
 			self.assertRaises(frappe.ValidationError) as caught,
@@ -283,7 +283,7 @@ class TestCloudSettings(_CloudTestCase):
 			patch.dict(frappe.conf, PILOT_CONF),
 			patch("frappe.get_roles", return_value=["System Manager"]),
 			patch(
-				"frappe.integrations.frappe_providers.cloud_settings.requests.request",
+				"requests.request",
 				return_value=Response(payload),
 			) as request,
 		):
@@ -430,7 +430,7 @@ class TestCloudTask(_CloudTestCase):
 			patch.dict(frappe.conf, PILOT_CONF),
 			patch("frappe.get_roles", return_value=["System Manager"]),
 			patch(
-				"frappe.integrations.frappe_providers.cloud_settings.requests.request",
+				"requests.request",
 				# The bench nests task metadata under "task" alongside the log output.
 				return_value=Response(
 					{"output": ["…"], "task": {"task_id": "task-1", "status": "success", "exit_code": 0}}

--- a/frappe/tests/test_html_utils.py
+++ b/frappe/tests/test_html_utils.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# License: MIT. See LICENSE
+
+
+import itertools
+import unittest
+
+from frappe.utils.html_utils import has_html_tags, sanitize_html
+
+# Fragments chosen for the boundaries between "looks like a tag" and "is a tag".
+FRAGMENTS = (
+	"<b>",
+	"</b>",
+	"<br/>",
+	"<!-- c -->",
+	"text",
+	"<3",
+	"a<b",
+	"x>y",
+	"&lt;",
+	"<!doctype html>",
+	'<p class="a">',
+	"<",
+	">",
+	"</ p>",
+	"<_x>",
+	"<1a>",
+)
+
+
+class TestHasHtmlTags(unittest.TestCase):
+	def test_matches_beautifulsoup(self):
+		"""Every combination must agree with the bs4 expression this replaced."""
+		from bs4 import BeautifulSoup
+
+		for length in (1, 2, 3):
+			for combination in itertools.product(FRAGMENTS, repeat=length):
+				html = "".join(combination)
+				with self.subTest(html=html):
+					expected = bool(BeautifulSoup(html, "html.parser").find())
+					self.assertEqual(has_html_tags(html), expected)
+
+	def test_tags_are_detected(self):
+		for html in ("<br>", "<BR/>", "<div>x</div>", '<p class="a">x', "text<b>bold</b>"):
+			with self.subTest(html=html):
+				self.assertTrue(has_html_tags(html))
+
+	def test_text_that_only_looks_like_html(self):
+		for html in ("", "plain text", "a < b and c > d", "<3 love", "<div", "&lt;b&gt;", "x</p>"):
+			with self.subTest(html=html):
+				self.assertFalse(has_html_tags(html))
+
+	def test_markdown_comment_marker_is_not_a_tag(self):
+		"""`_sanitize_content` skips markdown values, and relies on this distinction."""
+		self.assertFalse(has_html_tags("<!-- markdown -->\n# Heading\n\nBody text."))
+		self.assertTrue(has_html_tags("<!-- markdown -->\n<b>bold</b>"))
+
+	def test_sanitize_html_passes_through_plain_text(self):
+		"""The early-out `has_html_tags` guards must not alter tag-free content."""
+		for html in ("plain text", "a < b and c > d", "<!-- markdown -->\n# Heading"):
+			with self.subTest(html=html):
+				self.assertEqual(sanitize_html(html), html)
+
+	def test_sanitize_html_still_strips_scripts(self):
+		self.assertNotIn("<script>", sanitize_html("<div><script>alert(1)</script>ok</div>"))

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -21,10 +21,9 @@ from collections.abc import (
 )
 from email.header import decode_header, make_header
 from email.utils import formataddr, getaddresses, parseaddr
-from typing import Any, Generic, TypeAlias, TypedDict
+from typing import TYPE_CHECKING, Any, Generic, TypeAlias, TypedDict
 
 import orjson
-from werkzeug.test import Client
 
 from frappe.deprecation_dumpster import (
 	get_gravatar,
@@ -38,6 +37,9 @@ from frappe.deprecation_dumpster import (
 # utility functions like cint, int, flt, etc.
 from frappe.utils.data import *
 from frappe.utils.html_utils import sanitize_html
+
+if TYPE_CHECKING:
+	from werkzeug.test import Client
 
 EMAIL_NAME_PATTERN = re.compile(r"[^A-Za-z0-9\u00C0-\u024F\/\_\' ]+")
 EMAIL_STRING_PATTERN = re.compile(r"([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)")
@@ -592,8 +594,10 @@ def touch_file(path):
 	return path
 
 
-def get_test_client(use_cookies=True) -> Client:
+def get_test_client(use_cookies=True) -> "Client":
 	"""Return an test instance of the Frappe WSGI."""
+	from werkzeug.test import Client
+
 	from frappe.app import application
 
 	return Client(application, use_cookies=use_cookies)

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -427,6 +427,8 @@ def start_worker_pool(
 	_start_sentry()
 
 	# If gc.freeze is done then importing modules before forking allows us to share the memory
+	import filelock  # monitor.flush() takes a filelock inside the forked work horse
+
 	import frappe.database.query  # sqlparse and indirect imports
 	import frappe.query_builder  # pypika
 	import frappe.utils  # common utils

--- a/frappe/utils/csvutils.py
+++ b/frappe/utils/csvutils.py
@@ -5,8 +5,6 @@ from csv import Sniffer
 from io import StringIO
 from typing import Any
 
-import requests
-
 import frappe
 from frappe import _, msgprint
 from frappe.core.doctype.file.file import FILE_ENCODING_OPTIONS
@@ -246,6 +244,8 @@ def get_csv_content_from_google_sheets(url):
 	url = url.rsplit("/edit", 1)[0]
 	# add /export path,
 	url = url + f"/export?format=csv&gid={gid}"
+
+	import requests
 
 	headers = {"Accept": "text/csv"}
 	response = requests.get(url, headers=headers)

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -20,7 +20,6 @@ from urllib.parse import parse_qsl, quote, urlencode, urljoin, urlparse, urlunpa
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import orjson
-from click import secho
 from dateutil import parser
 from dateutil.parser import ParserError
 from dateutil.relativedelta import relativedelta
@@ -1032,6 +1031,8 @@ def has_common(l1: typing.Hashable, l2: typing.Hashable) -> bool:
 
 def cast_fieldtype(fieldtype, value, show_warning=True):
 	if show_warning:
+		from click import secho
+
 		message = (
 			"Function `frappe.utils.data.cast_fieldtype` has been deprecated in favour"
 			" of `frappe.utils.data.cast`. Use the newer util for safer type casting."

--- a/frappe/utils/error.py
+++ b/frappe/utils/error.py
@@ -4,6 +4,7 @@
 import functools
 import hashlib
 import inspect
+import os
 import re
 import sys
 import traceback as traceback_module
@@ -44,7 +45,6 @@ def log_error(
 ) -> "ErrorLog":
 	"""Log error to Error Log"""
 	from frappe.monitor import get_trace_id
-	from frappe.utils.sentry import capture_exception
 
 	# Parameter ALERT:
 	# the title and message may be swapped
@@ -91,7 +91,10 @@ def log_error(
 		error_log.insert(ignore_permissions=True)
 
 	# Capture exception data if telemetry is enabled
-	capture_exception(message=f"{title}\n{traceback}")
+	if os.getenv("FRAPPE_SENTRY_DSN"):
+		from frappe.utils.sentry import capture_exception
+
+		capture_exception(message=f"{title}\n{traceback}")
 
 	return error_log
 

--- a/frappe/utils/html_utils.py
+++ b/frappe/utils/html_utils.py
@@ -7,6 +7,11 @@ from bleach_allowlist import bleach_allowlist
 import frappe
 from frappe.utils.data import escape_html
 
+# Matches the first opening tag. Deliberately equivalent to
+# `bool(BeautifulSoup(html, "html.parser").find())`, which treats comments, `<3`
+# and unmatched end tags as text rather than tags — see `test_html_utils.py`.
+HTML_TAG_PATTERN = re.compile(r"<[a-zA-Z][^>]*>")
+
 EMOJI_PATTERN = re.compile(
 	"(\ud83d[\ude00-\ude4f])|"
 	"(\ud83c[\udf00-\uffff])|"
@@ -129,6 +134,11 @@ def clean_email_html(html):
 	)
 
 
+def has_html_tags(html: str) -> bool:
+	"""Return True if `html` contains at least one HTML tag."""
+	return bool(HTML_TAG_PATTERN.search(html))
+
+
 def clean_script_and_style(html):
 	"""
 	Remove script and style tags.
@@ -150,13 +160,11 @@ def sanitize_html(html, linkify=False, always_sanitize=False, disallowed_tags=No
 
 	Content without any HTML tags is returned unchanged; everything else is sanitized.
 	"""
-	from bs4 import BeautifulSoup
-
 	if not isinstance(html, str):
 		return html
 
 	if not always_sanitize:
-		if not bool(BeautifulSoup(html, "html.parser").find()):
+		if not has_html_tags(html):
 			return html
 
 	tags = (

--- a/frappe/utils/image.py
+++ b/frappe/utils/image.py
@@ -3,9 +3,11 @@
 import io
 import os
 
-from PIL import Image, ImageOps
+from PIL import Image, ImageFile, ImageOps  # nosemgrep: frappe-monkey-patching-not-allowed
 
 import frappe
+
+ImageFile.LOAD_TRUNCATED_IMAGES = True  # nosemgrep: frappe-monkey-patching-not-allowed
 
 
 def resize_images(path, maxdim=700):

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -16,8 +16,6 @@ from pdfkit.pdfkit import PDFKit as OriginalPDFKit
 pdfkit.source.unicode = str  # NOTE: upstream bug; PYTHONOPTIMIZE=1 optimized this away
 from bs4 import BeautifulSoup
 from packaging.version import Version
-from pypdf import PdfReader, PdfWriter, errors
-
 import frappe
 from frappe import _
 from frappe.core.doctype.file.utils import find_file_by_url
@@ -103,7 +101,7 @@ def pdf_footer_html(soup, head, content, styles, html_id, css, path=None):
 	)
 
 
-def get_pdf(html, options=None, output: PdfWriter | None = None):
+def get_pdf(html, options=None, output: "PdfWriter" | None = None):
 	html = scrub_urls(html)
 	html, options = prepare_options(html, options)
 
@@ -116,6 +114,8 @@ def get_pdf(html, options=None, output: PdfWriter | None = None):
 	try:
 		# Set filename property to false, so no file is actually created
 		filedata = pdfkit.from_string(html, options=options or {}, verbose=True)
+
+		from pypdf import PdfReader, PdfWriter
 
 		# create in-memory binary streams from filedata and create a PdfReader object
 		reader = PdfReader(io.BytesIO(filedata))
@@ -452,6 +452,8 @@ def pdf_contains_js(file_content: bytes):
 		bool: True if the PDF contains JavaScript, False otherwise and also if the file is encrypted.
 	"""
 	from io import BytesIO
+
+	from pypdf import PdfReader, errors
 
 	reader = PdfReader(BytesIO(file_content))
 

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -6,6 +6,7 @@ import io
 import mimetypes
 import os
 import subprocess
+from typing import TYPE_CHECKING
 from urllib.parse import parse_qs, urlparse
 
 import pdfkit
@@ -15,6 +16,7 @@ from pdfkit.pdfkit import PDFKit as OriginalPDFKit
 pdfkit.source.unicode = str  # NOTE: upstream bug; PYTHONOPTIMIZE=1 optimized this away
 from bs4 import BeautifulSoup
 from packaging.version import Version
+
 import frappe
 from frappe import _
 from frappe.core.doctype.file.utils import find_file_by_url
@@ -22,6 +24,10 @@ from frappe.utils import cstr, scrub_urls
 from frappe.utils.caching import redis_cache
 from frappe.utils.data import get_url
 from frappe.utils.jinja_globals import bundled_asset, is_rtl
+
+if TYPE_CHECKING:
+	import cssutils
+	from pypdf import PdfWriter
 
 PDF_CONTENT_ERRORS = [
 	"ContentNotFoundError",

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -14,7 +14,6 @@ import pdfkit.api
 from pdfkit.pdfkit import PDFKit as OriginalPDFKit
 
 pdfkit.source.unicode = str  # NOTE: upstream bug; PYTHONOPTIMIZE=1 optimized this away
-from bs4 import BeautifulSoup
 from packaging.version import Version
 
 import frappe
@@ -27,6 +26,7 @@ from frappe.utils.jinja_globals import bundled_asset, is_rtl
 
 if TYPE_CHECKING:
 	import cssutils
+	from bs4 import BeautifulSoup
 	from pypdf import PdfWriter
 
 PDF_CONTENT_ERRORS = [
@@ -267,6 +267,8 @@ def get_cookie_options():
 
 def read_options_from_html(html):
 	options = {}
+	from bs4 import BeautifulSoup
+
 	soup = BeautifulSoup(html, "html5lib")
 
 	options.update(prepare_header_footer(soup))
@@ -290,7 +292,7 @@ def read_options_from_html(html):
 	return str(soup), options
 
 
-def get_print_format_styles(soup: BeautifulSoup) -> list["cssutils.css.Property"]:
+def get_print_format_styles(soup: "BeautifulSoup") -> list["cssutils.css.Property"]:
 	"""
 	Get styles purely on class 'print-format'.
 	Valid:
@@ -333,6 +335,8 @@ def get_print_format_styles(soup: BeautifulSoup) -> list["cssutils.css.Property"
 
 
 def inline_private_images(html) -> str:
+	from bs4 import BeautifulSoup
+
 	soup = BeautifulSoup(html, "html.parser")
 	for img in soup.find_all("img"):
 		if b64 := _get_base64_image(img["src"]):
@@ -360,7 +364,7 @@ def _get_base64_image(src):
 		frappe.logger("pdf").error("Failed to convert inline images to base64", exc_info=True)
 
 
-def prepare_header_footer(soup: BeautifulSoup):
+def prepare_header_footer(soup: "BeautifulSoup"):
 	options = {}
 
 	head = soup.find("head").contents

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -8,7 +8,6 @@ import os
 import subprocess
 from urllib.parse import parse_qs, urlparse
 
-import cssutils
 import pdfkit
 import pdfkit.api
 from pdfkit.pdfkit import PDFKit as OriginalPDFKit
@@ -23,8 +22,6 @@ from frappe.utils import cstr, scrub_urls
 from frappe.utils.caching import redis_cache
 from frappe.utils.data import get_url
 from frappe.utils.jinja_globals import bundled_asset, is_rtl
-
-cssutils.log.setLog(frappe.logger("cssutils"))
 
 PDF_CONTENT_ERRORS = [
 	"ContentNotFoundError",
@@ -287,7 +284,7 @@ def read_options_from_html(html):
 	return str(soup), options
 
 
-def get_print_format_styles(soup: BeautifulSoup) -> list[cssutils.css.Property]:
+def get_print_format_styles(soup: BeautifulSoup) -> list["cssutils.css.Property"]:
 	"""
 	Get styles purely on class 'print-format'.
 	Valid:
@@ -301,6 +298,10 @@ def get_print_format_styles(soup: BeautifulSoup) -> list[cssutils.css.Property]:
 	Returns:
 	[cssutils.css.Property(name='margin-top', value='50mm', priority=''), ...]
 	"""
+	import cssutils
+
+	cssutils.log.setLog(frappe.logger("cssutils"))
+
 	stylesheet = ""
 	style_tags = soup.find_all("style")
 

--- a/frappe/utils/print_format.py
+++ b/frappe/utils/print_format.py
@@ -5,8 +5,6 @@ from io import BytesIO
 from typing import Literal
 from urllib.parse import urlparse
 
-from pypdf import PdfWriter
-
 import frappe
 from frappe import _
 from frappe.core.doctype.access_log.access_log import make_access_log
@@ -119,6 +117,8 @@ def _download_multi_pdf(
 	Publishes a link to the PDF to the given task ID
 	"""
 	filename = ""
+
+	from pypdf import PdfWriter
 
 	pdf_writer = PdfWriter()
 
@@ -401,6 +401,9 @@ def print_by_server(
 		cups.setServer(print_settings.server_ip)
 		cups.setPort(print_settings.port)
 		conn = cups.Connection()
+
+		from pypdf import PdfWriter
+
 		output = PdfWriter()
 		output = frappe.get_print(
 			doctype, name, print_format, doc=doc, no_letterhead=no_letterhead, as_pdf=True, output=output

--- a/frappe/utils/scheduler.py
+++ b/frappe/utils/scheduler.py
@@ -14,9 +14,6 @@ import random
 import time
 from typing import NoReturn
 
-from croniter import CroniterBadCronError
-from filelock import FileLock, Timeout
-
 import frappe
 from frappe.utils import cint, get_bench_path, get_datetime, get_sites, now_datetime
 from frappe.utils.background_jobs import set_niceness
@@ -38,6 +35,8 @@ def cprint(*args, **kwargs):
 def start_scheduler() -> NoReturn:
 	"""Run enqueue_events_for_all_sites based on scheduler tick.
 	Specify scheduler_tick_interval in seconds in common_site_config.json"""
+	# Lazy: filelock imports the asyncio stack.
+	from filelock import FileLock, Timeout
 
 	tick = get_scheduler_tick()
 	set_niceness()
@@ -66,6 +65,8 @@ def is_schduler_process_running() -> bool:
 	Note: FLOCK is held by process until it exits, this function just checks if process is
 	running or not. We can't determine if process is stuck somehwere.
 	"""
+	from filelock import FileLock, Timeout
+
 	try:
 		lock = FileLock(_get_scheduler_lock_file())
 		lock.acquire(blocking=False)
@@ -133,6 +134,8 @@ def enqueue_events_for_site(site: str) -> None:
 
 def enqueue_events() -> list[str] | None:
 	if schedule_jobs_based_on_activity():
+		from croniter import CroniterBadCronError
+
 		from frappe.core.doctype.scheduled_job_type.scheduled_job_type import get_disabled_app_job_methods
 
 		enqueued_jobs = []

--- a/frappe/utils/synchronization.py
+++ b/frappe/utils/synchronization.py
@@ -3,9 +3,6 @@
 import os
 from contextlib import contextmanager
 
-from filelock import FileLock as _StrongFileLock
-from filelock import Timeout
-
 import frappe
 from frappe import _
 from frappe.utils import get_bench_path, get_site_path
@@ -29,6 +26,9 @@ def filelock(lock_name: str, *, timeout=30, is_global=False):
 	        site - {bench_dir}/sites/sitename/{name}.lock
 
 	"""
+	# Lazy: filelock imports the asyncio stack.
+	from filelock import FileLock as _StrongFileLock
+	from filelock import Timeout
 
 	lock_filename = lock_name + ".lock"
 	if not is_global:

--- a/frappe/utils/typing_validations.py
+++ b/frappe/utils/typing_validations.py
@@ -1,17 +1,16 @@
 import inspect
+import sys
 from collections.abc import Callable
 from functools import lru_cache, wraps
 from inspect import _empty, isclass
 from types import EllipsisType
-from typing import ForwardRef, TypeVar, Union
-from unittest import mock
-
-from pydantic import ConfigDict, PydanticUserError
-from pydantic import TypeAdapter as PydanticTypeAdapter
-from pydantic import ValidationError as PydanticValidationError
+from typing import TYPE_CHECKING, ForwardRef, TypeVar, Union
 
 import frappe
 from frappe.exceptions import FrappeTypeError
+
+if TYPE_CHECKING:
+	from pydantic import ConfigDict
 
 SLACK_DICT = {
 	bool: (int, bool, float),
@@ -20,7 +19,14 @@ T = TypeVar("T")
 ForwardRefOrStr = ForwardRef | str
 
 
-FrappePydanticConfig = ConfigDict(arbitrary_types_allowed=True)
+# ConfigDict is a TypedDict, so at runtime it's just a plain dict and TypeAdapter accepts
+# this literal. Calling ConfigDict() would drag pydantic (~6MB) into `import frappe`.
+FrappePydanticConfig: "ConfigDict" = {"arbitrary_types_allowed": True}
+
+
+def is_mock(value) -> bool:
+	mock = sys.modules.get("unittest.mock")
+	return mock is not None and isinstance(value, mock.Mock)
 
 
 def validate_argument_types(
@@ -91,6 +97,9 @@ def raise_type_error(
 
 @lru_cache(maxsize=2048)
 def TypeAdapter(type_):
+	from pydantic import PydanticUserError
+	from pydantic import TypeAdapter as PydanticTypeAdapter
+
 	try:
 		return PydanticTypeAdapter(type_, config=FrappePydanticConfig)
 	except PydanticUserError as e:
@@ -131,6 +140,8 @@ def transform_parameter_types(func: Callable, args: tuple, kwargs: dict, force_t
 	):
 		return args, kwargs
 
+	from pydantic import ValidationError as PydanticValidationError
+
 	new_args, new_kwargs = list(args), kwargs
 
 	if args:
@@ -158,7 +169,7 @@ def transform_parameter_types(func: Callable, args: tuple, kwargs: dict, force_t
 		elif any(isinstance(x, ForwardRefOrStr) for x in getattr(current_arg_type, "__args__", [])):
 			continue
 		# ignore unittest.mock objects
-		elif isinstance(current_arg_value, mock.Mock):
+		elif is_mock(current_arg_value):
 			continue
 
 		# allow slack for Frappe types

--- a/frappe/website/doctype/website_settings/google_indexing.py
+++ b/frappe/website/doctype/website_settings/google_indexing.py
@@ -4,8 +4,6 @@
 
 from urllib.parse import quote
 
-from googleapiclient.errors import HttpError
-
 import frappe
 from frappe import _
 from frappe.integrations.google_oauth import GoogleOAuth
@@ -48,6 +46,7 @@ def get_google_indexing_object():
 
 def publish_site(url, operation_type="URL_UPDATED"):
 	"""Send an update/remove url request."""
+	from googleapiclient.errors import HttpError
 
 	google_indexing = get_google_indexing_object()
 	body = {"url": url, "type": operation_type}

--- a/frappe/website/page_renderers/template_page.py
+++ b/frappe/website/page_renderers/template_page.py
@@ -1,8 +1,6 @@
 import os
 from importlib.machinery import all_suffixes
 
-import click
-
 import frappe
 from frappe.website.page_renderers.base_template_page import BaseTemplatePage
 from frappe.website.router import get_base_template, get_page_info
@@ -210,6 +208,8 @@ class TemplatePage(BaseTemplatePage):
 		for comment, (context_key, value) in COMMENT_PROPERTY_KEY_VALUE_MAP.items():
 			comment_tag = f"<!-- {comment} -->"
 			if comment_tag in self.source:
+				import click
+
 				self.context[context_key] = value
 				click.echo(f"\n⚠️  DEPRECATION WARNING: {comment_tag} will be deprecated on 2021-12-31.")
 				click.echo(f"Please remove it from {self.template_path} in {self.app}")

--- a/frappe/website/path_resolver.py
+++ b/frappe/website/path_resolver.py
@@ -1,6 +1,5 @@
 import re
 
-import click
 import werkzeug.routing.exceptions
 from werkzeug.routing import Rule
 
@@ -77,6 +76,8 @@ class PathResolver:
 
 	@staticmethod
 	def get_custom_page_renderers():
+		import click
+
 		custom_renderers = []
 		for renderer_path in frappe.get_hooks("page_renderer") or []:
 			try:

--- a/frappe/website/website_generator.py
+++ b/frappe/website/website_generator.py
@@ -4,7 +4,6 @@
 import frappe
 from frappe.model.document import Document
 from frappe.modules import get_module_name
-from frappe.search.website_search import remove_document_from_index, update_index_for_path
 from frappe.website.utils import cleanup_page_name, clear_cache
 
 
@@ -94,6 +93,8 @@ class WebsiteGenerator(Document):
 		self.send_indexing_request("URL_DELETED")
 		# On deleting the doc, remove the page from the web_routes index
 		if self.allow_website_search_indexing():
+			from frappe.search.website_search import remove_document_from_index
+
 			frappe.enqueue(remove_document_from_index, path=self.route, enqueue_after_commit=True)
 
 	def is_website_published(self):
@@ -160,6 +161,8 @@ class WebsiteGenerator(Document):
 		old_doc = self.get_doc_before_save()
 		# Check if the route is changed
 		if old_doc and old_doc.route != self.route:
+			from frappe.search.website_search import remove_document_from_index
+
 			# Remove the route from index if the route has changed
 			remove_document_from_index(old_doc.route)
 
@@ -171,6 +174,8 @@ class WebsiteGenerator(Document):
 		"""
 		if not self.allow_website_search_indexing() or frappe.in_test:
 			return
+
+		from frappe.search.website_search import remove_document_from_index, update_index_for_path
 
 		if self.is_website_published():
 			frappe.enqueue(update_index_for_path, path=self.route, enqueue_after_commit=True)


### PR DESCRIPTION

-  Moving some of the imports to scoped import. For large sites, it will be eager import anyway. Pilot need to have control over whether to do eager import or not before gc. For trial sites with single process setup, we can avoid doing eager import + gc always. 
- Also by specifying the required driver in  `FRAPPE_PRELOAD_DATABASE_DRIVERS` env var, allow to load only the needed db driver.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>