### PR TITLE
perf: limit client cache size

### DIFF
--- a/frappe/tests/test_client_cache.py
+++ b/frappe/tests/test_client_cache.py
@@ -92,6 +92,54 @@ class TestClientCache(IntegrationTestCase):
 
 		self.assertEqual(len(c.cache), 2)
 
+	def test_client_cache_maxsize_bytes(self):
+		c = ClientCache(maxsize_bytes=50_000)
+		for _ in range(10):
+			c.set_value(frappe.generate_hash(), "z" * 10_000)
+
+		self.assertLessEqual(c._total_size, 50_000 + 10_100)
+		self.assertEqual(c._total_size, sum(e.size for e in c.cache.values()))
+
+	def test_client_cache_no_byte_limit_by_default(self):
+		c = ClientCache()
+		for _ in range(10):
+			c.set_value(frappe.generate_hash(), "z" * 10_000)
+
+		self.assertEqual(c.maxsize_bytes, 0)
+		self.assertEqual(len(c.cache), 10)
+
+	def test_client_cache_size_accounting(self):
+		c = ClientCache()
+		key = frappe.generate_hash()
+
+		c.set_value(key, "z" * 10_000)
+		self.assertEqual(c._total_size, sum(e.size for e in c.cache.values()))
+
+		# overwriting must not double count
+		c.set_value(key, "z" * 10_000)
+		self.assertEqual(c._total_size, sum(e.size for e in c.cache.values()))
+
+		c.delete_value(key)
+		self.assertEqual(c._total_size, sum(e.size for e in c.cache.values()))
+
+	@staticmethod
+	def _expire_entries(cache: ClientCache) -> None:
+		"""Put every entry past its ttl, without a wait on the clock."""
+		with cache.lock:
+			for key, entry in cache.cache.items():
+				cache.cache[key] = entry._replace(expiry=time.monotonic() - 1)
+
+	def test_client_cache_size_not_leaked_on_expiry(self):
+		"""An expired entry is replaced by a placeholder, its size must be released."""
+		c = ClientCache()
+		key = frappe.generate_hash()
+		c.set_value(key, "z" * 10_000)
+
+		for _ in range(3):
+			self._expire_entries(c)
+			c.get_value(key)
+			self.assertEqual(c._total_size, sum(e.size for e in c.cache.values()))
+
 	def test_shared_keyspace(self):
 		val = frappe.generate_hash()
 		frappe.client_cache.set_value(TEST_KEY, val)

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -7,6 +7,7 @@ import threading
 import time
 from collections import namedtuple
 from contextlib import suppress
+from typing import Any
 
 import redis
 import redis.exceptions
@@ -14,7 +15,7 @@ from redis.commands.search import Search
 from redis.exceptions import ResponseError
 
 import frappe
-from frappe.utils import cstr
+from frappe.utils import cint, cstr
 
 # 5 is faster than default which is 4.
 # Python uses old protocol for backward compatibility, we don't support anything <3.10.
@@ -61,20 +62,25 @@ class RedisWrapper(redis.Redis):
 
 		return f"{frappe.local.conf.get('db_name')}|{key}".encode()
 
-	def set_value(self, key, val, user=None, expires_in_sec=None, shared=False):
+	def set_value(self, key, val, user=None, expires_in_sec=None, shared=False) -> int:
 		"""Sets cache value.
 
 		:param key: Cache key
 		:param val: Value to be cached
 		:param user: Prepends key with User
 		:param expires_in_sec: Expire value of this key in X seconds
+
+		Return the size of the serialized value in bytes.
 		"""
 		key = self.make_key(key, user, shared)
 
 		frappe.local.cache[key] = val
+		serialized = pickle.dumps(val, protocol=DEFAULT_PICKLE_PROTOCOL)
 
 		with suppress(redis.exceptions.ConnectionError):
-			self.set(name=key, value=pickle.dumps(val, protocol=DEFAULT_PICKLE_PROTOCOL), ex=expires_in_sec)
+			self.set(name=key, value=serialized, ex=expires_in_sec)
+
+		return len(serialized)
 
 	def get_value(self, key, generator=None, user=None, expires=False, shared=False, *, use_local_cache=True):
 		"""Return cache value. If not found and generator function is
@@ -84,9 +90,26 @@ class RedisWrapper(redis.Redis):
 		:param generator: Function to be called to generate a value if `None` is returned.
 		:param expires: If the key is supposed to be with an expiry, don't store it in frappe.local
 		"""
+		return self._get_value_with_size(
+			key,
+			generator=generator,
+			user=user,
+			expires=expires,
+			shared=shared,
+			use_local_cache=use_local_cache,
+		)[0]
+
+	def _get_value_with_size(
+		self, key, *, generator=None, user=None, expires=False, shared=False, use_local_cache=True
+	) -> tuple[Any, int]:
+		"""Same as `get_value`, and also return the size of the serialized value in bytes.
+
+		The size is 0 if the value did not come from Redis.
+		"""
 		original_key = key
 		key = self.make_key(key, user, shared)
 
+		size = 0
 		local_cache = frappe.local.cache
 		if key in local_cache and use_local_cache:
 			val = local_cache[key]
@@ -99,17 +122,18 @@ class RedisWrapper(redis.Redis):
 				pass
 
 			if val is not None:
+				size = len(val)
 				val = pickle.loads(val)
 
 			if not expires:
 				if val is None and generator:
 					val = generator()
-					self.set_value(original_key, val, user=user, shared=shared)
+					size = self.set_value(original_key, val, user=user, shared=shared)
 
 				else:
 					local_cache[key] = val
 
-		return val
+		return val, size
 
 	def expire_key(self, key, time, *, user=None, shared=False):
 		key = self.make_key(key, user, shared)
@@ -438,11 +462,11 @@ class _TrackedUnixDomainSocketConnection(_ClientTrackingMixin, redis.UnixDomainS
 	pass
 
 
-CachedValue = namedtuple("CachedValue", ["value", "expiry"])
+CachedValue = namedtuple("CachedValue", ["value", "expiry", "size"])
 CacheStatistics = namedtuple(
 	"CacheStatistics", ["hits", "misses", "capacity", "used", "utilization", "hit_ratio", "healthy"]
 )
-_PLACEHOLDER_VALUE = CachedValue(value=None, expiry=-1)
+_PLACEHOLDER_VALUE = CachedValue(value=None, expiry=-1, size=0)
 
 
 class ClientCache:
@@ -475,12 +499,23 @@ class ClientCache:
 		  the worst case behaviour for this policy. E.g. looping over `maxsize` items repeatedly.
 	"""
 
-	def __init__(self, maxsize: int = 1024, ttl=10 * 60, monitor: RedisWrapper | None = None) -> None:
+	def __init__(
+		self,
+		maxsize: int = 1024,
+		ttl=10 * 60,
+		monitor: RedisWrapper | None = None,
+		maxsize_bytes: int = 0,
+	) -> None:
 		self.maxsize = maxsize or 1024  # Expect 1024 * 4kb objects ~ 4MB
+		# As we are storing doctype metadata in client cache also, the 4kb per object assumption is not valid for them.
+		# So, we can limit the client cache size by providing the config
+		# if maxsize_bytes is 0, then we don't enforce the limit
+		self.maxsize_bytes = maxsize_bytes or cint(frappe.conf.get("client_cache_max_bytes"))
 		self.local_ttl = ttl
 		# This guards writes to self.cache, reads are done without a lock.
 		self.lock = threading.RLock()
 		self.cache: dict[bytes, CachedValue] = {}
+		self._total_size = 0
 
 		self.invalidator = frappe.cache
 		self.healthy = True
@@ -531,10 +566,12 @@ class ClientCache:
 		self.misses += 1
 
 		# Store a placeholder value to detect race between GET and parallel invalidation.
+		# Pop first: an expired entry still counts towards _total_size.
 		with self.lock:
+			self._pop(key)
 			self.cache[key] = _PLACEHOLDER_VALUE
 
-		val = self.redis.get_value(key, shared=True, use_local_cache=not self.healthy)
+		val, size = self.redis._get_value_with_size(key, shared=True, use_local_cache=not self.healthy)
 
 		# Note: We should not "cache" the cache-misses in client cache.
 		# This cache is long lived and "misses" are not tracked by redis so they'll never get
@@ -552,16 +589,18 @@ class ClientCache:
 			# Note: If our placeholder value is not present then it's possible that value we just
 			# got is invalidated, so we should not store it in local cache.
 			if key in self.cache:
-				self.cache[key] = CachedValue(value=val, expiry=time.monotonic() + self.local_ttl)
+				self._put(key, val, time.monotonic() + self.local_ttl, size)
 
 		return val
 
 	def set_value(self, key, val, *, shared=False):
 		key = self.redis.make_key(key, shared=shared)
+		size = self.redis.set_value(key, val, shared=True)
+		if not self.healthy:
+			return
 		self.ensure_max_size()
-		self.redis.set_value(key, val, shared=True)
 		with self.lock:
-			self.cache[key] = CachedValue(value=val, expiry=time.monotonic() + self.local_ttl)
+			self._put(key, val, time.monotonic() + self.local_ttl, size)
 		# XXX: We need to tell redis that we indeed read this key we just wrote
 		# This is an edge case:
 		# - Client A writes a key and reads it again from local cache
@@ -583,20 +622,24 @@ class ClientCache:
 	def ensure_max_size(self):
 		if len(self.cache) >= self.maxsize:
 			with self.lock, suppress(RuntimeError):
-				self.cache.pop(next(iter(self.cache)), None)
+				self._pop(next(iter(self.cache)))
+		if self.maxsize_bytes and self._total_size > self.maxsize_bytes:
+			with self.lock, suppress(RuntimeError):
+				while self._total_size > self.maxsize_bytes and self.cache:
+					self._pop(next(iter(self.cache)))
 
 	def delete_value(self, key, *, shared=False):
 		key = self.redis.make_key(key, shared=shared)
 		self.redis.delete_value(key, shared=True)
 		with self.lock:
-			self.cache.pop(key, None)
+			self._pop(key)
 
 	def delete_keys(self, pattern):
 		keys = self.redis.get_keys(pattern)
 		self.redis.delete_value(keys, shared=True, make_keys=False)
 		with self.lock:
 			for key in keys:
-				self.cache.pop(key, None)
+				self._pop(key)
 
 	def run_invalidator_thread(self):
 		self._watcher = self.invalidator.pubsub()
@@ -634,7 +677,7 @@ class ClientCache:
 			return
 		with self.lock:
 			for key in message["data"]:
-				self.cache.pop(key, None)
+				self._pop(key)
 
 	def _handle_persistent_cache_invalidation(self, message):
 		import frappe.utils.caching
@@ -663,7 +706,7 @@ class ClientCache:
 
 	def clear_cache(self):
 		with self.lock:
-			self.cache.clear()
+			self._clear()
 
 	@property
 	def statistics(self) -> CacheStatistics:
@@ -679,3 +722,19 @@ class ClientCache:
 
 	def reset_statistics(self):
 		self.hits = self.misses = 0
+
+	def _put(self, key, value, expiry, size):
+		old = self.cache.get(key)
+		if old is not None:
+			self._total_size -= old.size
+		self.cache[key] = CachedValue(value=value, expiry=expiry, size=size)
+		self._total_size += size
+
+	def _pop(self, key):
+		entry = self.cache.pop(key, None)
+		if entry is not None:
+			self._total_size -= entry.size
+
+	def _clear(self):
+		self.cache.clear()
+		self._total_size = 0


### PR DESCRIPTION
Doctype metadata cache can increase the size of client cache.
By default, it can grow and only limited by existing `maxsize` parameter.

Another parameter `client_cache_max_bytes` has ben introduced which can be configured from `common_site_config.json` as well.
If that's defined, that will limit the size of client cache.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>