### PR TITLE
refactor: port realtime server to asyncio/uvicorn

### DIFF
--- a/frappe/gunicorn_companion.py
+++ b/frappe/gunicorn_companion.py
@@ -18,7 +18,7 @@ def warmup() -> None:
 	worker and scheduler companions can reuse it instead of loading their own copy.
 
 	Called from the gunicorn "on_starting" hook. Socketio is left out on purpose:
-	loading it would pull gevent into the master and break the other companions.
+	the other companions never use it, so loading it here would only cost memory.
 	"""
 	import redis
 	import rq

--- a/frappe/realtime/README.md
+++ b/frappe/realtime/README.md
@@ -1,7 +1,7 @@
 # Realtime handlers for custom apps
 
 This is the Python Socket.IO realtime server (`python -m frappe.realtime.server`).
-It runs as a **separate gevent process** from the web/gunicorn process.
+It runs on asyncio/uvicorn as a **separate process** from the web/gunicorn process.
 
 This guide is for app authors who want to add their own realtime events. You do not need to touch this folder — you register handlers from inside your own app.
 
@@ -18,19 +18,26 @@ The server imports `<app>.realtime.handlers` for every app installed on the site
 ## Writing a handler
 
 ```python
-import frappe
 from frappe.realtime import Socket, realtime
 
 
 @realtime.on("project_subscribe")
-def project_subscribe(socket: Socket, project: str) -> None:
-    if socket.has_permission("Project", project):
-        socket.join(f"project:{project}")
+async def project_subscribe(socket: Socket, project: str) -> None:
+    if await socket.has_permission("Project", project):
+        await socket.join(f"project:{project}")
 ```
 
 - The event name (`"project_subscribe"`) is what the browser emits with `frappe.realtime.on(...)` / the client's `socket.emit(...)`.
 - The first argument is always the typed `Socket`. The rest are the payload the client sent, positionally.
 - The decorator returns the function unchanged — it is a plain function you can also call/test directly.
+
+### async or plain
+
+Write handlers `async def`. They run on the event loop and `await` the socket calls.
+
+A plain `def` handler also works: it runs in a worker thread, and gets a blocking
+`SyncSocket` with the same API minus the awaits. Use it when the body has to block
+(a library with no async client, `frappe_context`).
 
 ### Decorator options
 
@@ -43,6 +50,9 @@ def project_subscribe(socket: Socket, project: str) -> None:
 ```
 
 Defaults: `frappe_context=False`, `allow_guest=False`.
+
+`frappe_context=True` needs the worker thread, so the handler must be a plain
+function. Marking an `async def` handler with it raises at import.
 
 ## Install scoping (important)
 
@@ -63,29 +73,34 @@ socket.installed_apps  # list[str]
 Rooms and emit:
 
 ```python
-socket.join(room)                       # add this socket to a room
-socket.leave(room)                       # remove it
-socket.emit(event, data=None, room=None) # emit to a room, or to this client if room is None
+await socket.join(room)                       # add this socket to a room
+await socket.leave(room)                      # remove it
+await socket.emit(event, data=None, room=None)  # emit to a room, or to this client if room is None
 ```
 
 Permission check (default, cheap — no DB in the realtime process):
 
 ```python
-socket.has_permission(doctype, name=None) -> bool   # HTTP call to the web process
+await socket.has_permission(doctype, name=None) -> bool   # HTTP call to the web process
 ```
+
+It holds no worker thread, so it never queues behind blocking handlers. In a plain
+`def` handler it is the same call without `await`.
 
 Transient per-socket state (cleared when the socket disconnects):
 
 ```python
-socket.set("key", value)
+await socket.set("key", value)
 socket.get("key", default=None)
 ```
+
+In a plain (non-async) handler these are the same calls without `await`.
 
 ## Permission checks: two ways
 
 Pick one per handler; do not mix silently.
 
-1. **HTTP (default, recommended).** `socket.has_permission(doctype, name)` asks the web process — exactly like the core handlers. No DB connection in the realtime process. Cheap. Use this unless you have a reason not to.
+1. **HTTP (default, recommended).** `await socket.has_permission(doctype, name)` asks the web process — exactly like the core handlers. No DB connection in the realtime process. Cheap. Use this unless you have a reason not to.
 
 2. **In-process (`frappe_context=True`).** Opens a full Frappe context for the handler body so you can call `frappe.has_permission(...)`, query the DB, etc. directly:
 
@@ -96,7 +111,7 @@ Pick one per handler; do not mix silently.
            socket.join(f"project:{project}")
    ```
 
-   Cost: **every such event** pays `frappe.init -> connect -> set_user -> commit/rollback -> destroy` and forces a DB connection into the realtime process. Use sparingly. The DB driver is forced to PyMySQL (the mysqlclient C extension would stall the gevent hub).
+   Cost: **every such event** pays `frappe.init -> connect -> set_user -> commit/rollback -> destroy` and forces a DB connection into the realtime process. Use sparingly. The body runs in a worker thread, so the normal DB driver is fine.
 
 ## Pushing events to clients (from the web process)
 
@@ -144,6 +159,5 @@ NOT the cross-site no-room broadcast that build events use — that path stays i
 
 ## Rules of thumb
 
-- Keep handlers small and non-blocking in spirit — gevent yields on I/O (DB, HTTP, Redis), but tight CPU loops block the hub for every other socket.
-- Never import `mysqlclient` / `MySQLdb` anywhere reachable from a handler. It is a C extension whose blocking socket cannot be monkeypatched and will stall the server.
+- Never block the event loop from an `async def` handler. Blocking I/O and tight CPU loops stall every other socket. If the work blocks, write the handler as a plain `def` so it runs in a worker thread.
 - Room and event names are a shared contract with the browser client — keep them stable.

--- a/frappe/realtime/__init__.py
+++ b/frappe/realtime/__init__.py
@@ -235,7 +235,7 @@ def publish_to_room(room: str, event: str, message: dict | None = None, *, after
 # Handler-authoring surface, exposed lazily so the publish helpers above stay
 # import-light. ``Socket`` pulls in the server stack (socketio, via auth); resolving
 # it only on access keeps ``from frappe.realtime import publish_realtime`` (web
-# process) from importing socketio/gevent.
+# process) from importing socketio.
 def __getattr__(name: str) -> object:
 	if name == "realtime":
 		from frappe.realtime.registry import realtime

--- a/frappe/realtime/auth.py
+++ b/frappe/realtime/auth.py
@@ -2,13 +2,14 @@
 # License: MIT. See LICENSE
 
 import logging
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from http.cookiejar import CookieJar
 from http.cookies import SimpleCookie
 from typing import Literal, NoReturn
 
-import redis
-import requests
+import httpx
+from redis import asyncio as aioredis
 from socketio.exceptions import ConnectionRefusedError
 
 from frappe.realtime.config import RealtimeConfig
@@ -19,7 +20,7 @@ logger = logging.getLogger("frappe.realtime")
 SOCKETIO_SECRET_KEY = "socketio_auth_secret"
 
 HttpMethod = Literal["GET", "POST", "PUT", "PATCH", "DELETE"]
-WebRequest = Callable[..., dict]
+WebRequest = Callable[..., Awaitable[dict]]
 
 
 @dataclass(frozen=True)
@@ -43,7 +44,10 @@ class Session:
 
 	Carries the identity plus an authenticated client toward the web process, so
 	handlers (via Socket) can call back without rebuilding auth. ``data`` is a bag
-	for transient per-socket state (e.g. presence tracking)."""
+	for transient per-socket state (e.g. presence tracking).
+
+	The calls are coroutines, so a permission check never occupies a worker
+	thread. Plain handlers reach them without await, through SyncSocket."""
 
 	site: str
 	user: str
@@ -52,19 +56,19 @@ class Session:
 	request: WebRequest  # authenticated client toward the web process
 	data: dict = field(default_factory=dict)
 
-	def get(self, path: str, params: dict | None = None) -> dict:
-		return self.send_request(path, "GET", params=params)
+	async def get(self, path: str, params: dict | None = None) -> dict:
+		return await self.send_request(path, "GET", params=params)
 
-	def post(self, path: str, body: dict | None = None, params: dict | None = None) -> dict:
-		return self.send_request(path, "POST", params=params, body=body)
+	async def post(self, path: str, body: dict | None = None, params: dict | None = None) -> dict:
+		return await self.send_request(path, "POST", params=params, body=body)
 
-	def put(self, path: str, body: dict | None = None, params: dict | None = None) -> dict:
-		return self.send_request(path, "PUT", params=params, body=body)
+	async def put(self, path: str, body: dict | None = None, params: dict | None = None) -> dict:
+		return await self.send_request(path, "PUT", params=params, body=body)
 
-	def delete(self, path: str, params: dict | None = None) -> dict:
-		return self.send_request(path, "DELETE", params=params)
+	async def delete(self, path: str, params: dict | None = None) -> dict:
+		return await self.send_request(path, "DELETE", params=params)
 
-	def send_request(
+	async def send_request(
 		self,
 		path: str,
 		method: HttpMethod = "GET",
@@ -76,12 +80,12 @@ class Session:
 		method: HTTP verb. params: query string. body: JSON body.
 		Prefer get/post/put/delete for the common cases.
 		"""
-		return self.request(path, method=method, params=params, body=body)
+		return await self.request(path, method=method, params=params, body=body)
 
-	def has_permission(self, doctype: str, name: str | None = None, ptype: str = "read") -> bool:
+	async def has_permission(self, doctype: str, name: str | None = None, ptype: str = "read") -> bool:
 		"""HTTP permission check against the web process (no DB in realtime)."""
 		try:
-			body = self.get(
+			body = await self.get(
 				"/api/method/frappe.realtime.has_permission",
 				params={"doctype": doctype, "name": name or "", "ptype": ptype},
 			)
@@ -90,19 +94,19 @@ class Session:
 		return bool(body.get("message"))
 
 
-def authenticate(environ: dict, namespace: str, config: RealtimeConfig) -> Session:
-	"""Authenticate a connection.
+async def authenticate(environ: dict, namespace: str, config: RealtimeConfig) -> Session:
+	"""Authenticate a connection. Port of realtime/middlewares/authenticate.js.
 
-	Port of realtime/middlewares/authenticate.js. Auth is delegated to the web
-	process over HTTP; the realtime process never resumes a session in-process.
-	Runs the checks in order and refuses the connection as soon as one fails.
+	Auth is delegated to the web process over HTTP (async here, so it never
+	blocks the loop). Refuses the connection as soon as one check fails.
 	"""
 	site = _validate_site(environ, namespace, config)
 	_validate_origin(environ)
 
 	credentials = _read_credentials(environ)
-	request = _make_request(environ, credentials, config, site)
-	user_info = _get_user_info(request)
+	secret = await get_socketio_secret(config.redis_queue)
+	request = _make_request(environ, credentials, config, site, secret)
+	user_info = await _get_user_info(request)
 
 	return _make_session(site, user_info, request)
 
@@ -125,9 +129,9 @@ def _validate_origin(environ: dict) -> None:
 	"""Reject cross-site websocket hijacks."""
 	host = read_header(environ, "Host")
 	origin = read_header(environ, "Origin")
-	if not host or not origin:
-		_reject(f"missing host/origin header (host={host!r}, origin={origin!r})", "Invalid origin")
-	if get_hostname(host) != get_hostname(origin):
+	if not host:
+		_reject("missing host header", "Invalid origin")
+	if origin and get_hostname(host) != get_hostname(origin):
 		_reject(f"origin {origin!r} != host {host!r}", "Invalid origin")
 
 
@@ -161,33 +165,27 @@ def _read_sid(cookie_header: str | None) -> str | None:
 	return sid.value if sid else None
 
 
-def _make_request(environ: dict, credentials: Credentials, config: RealtimeConfig, site: str) -> WebRequest:
+def _make_request(
+	environ: dict, credentials: Credentials, config: RealtimeConfig, site: str, secret: str | None
+) -> WebRequest:
 	"""Build the authenticated request helper toward the web (socket.frappe_request port).
 
-	Forwards the client's credential plus the shared socketio secret (get_user_info
-	returns {} without it); returns the decoded JSON body, raises on non-2xx."""
+	Connect auth and every later permission check share this one coroutine, so
+	their timeout / redirect / cookie handling cannot drift apart."""
 	origin = read_header(environ, "Origin")
-	secret = get_socketio_secret(config.redis_queue)
 
-	def request(
+	async def request(
 		path: str,
 		method: HttpMethod = "GET",
 		params: dict | None = None,
 		body: dict | None = None,
 	) -> dict:
-		headers = credentials.headers()
-		# Carry the tenant so loopback requests route to the right site.
-		headers["X-Frappe-Site-Name"] = site
-		if secret:
-			headers["X-Frappe-Socket-Secret"] = secret
-
-		res = requests.request(
+		res = await get_http_client().request(
 			method,
 			get_url(origin, path, config),
 			params=params or {},
 			json=body,
-			headers=headers,
-			timeout=10,
+			headers=_auth_headers(credentials, site, secret),
 		)
 		res.raise_for_status()
 		return res.json()
@@ -195,14 +193,24 @@ def _make_request(environ: dict, credentials: Credentials, config: RealtimeConfi
 	return request
 
 
-def _get_user_info(request: WebRequest) -> dict:
-	"""Ask the web who the user is; reject on failure or an empty (unauthorized) result."""
+def _auth_headers(credentials: Credentials, site: str, secret: str | None) -> dict[str, str]:
+	"""Web-process request headers: client credential + tenant + shared secret."""
+	headers = credentials.headers()
+	# Carry the tenant so loopback requests route to the right site.
+	headers["X-Frappe-Site-Name"] = site
+	if secret:
+		headers["X-Frappe-Socket-Secret"] = secret
+	return headers
+
+
+async def _get_user_info(request: WebRequest) -> dict:
+	"""Ask the web who the user is; reject on failure or an empty result."""
+	method = "/api/method/frappe.realtime.get_user_info"
 	try:
-		method = "/api/method/frappe.realtime.get_user_info"
-		message = request(method).get("message") or {}
+		message = (await request(method)).get("message") or {}
 		# Non-Guest with empty installed_apps: retry once (matches Node).
 		if message.get("user") and message.get("user") != "Guest" and not message.get("installed_apps"):
-			message = request(method).get("message") or {}
+			message = (await request(method)).get("message") or {}
 	except Exception as e:
 		_reject(f"auth failure ({e})", "Unauthorized")
 
@@ -222,15 +230,50 @@ def _make_session(site: str, user_info: dict, request: WebRequest) -> Session:
 	)
 
 
-_secret_client = None
+_secret_client: aioredis.Redis | None = None
+_http_client: httpx.AsyncClient | None = None
 
 
-def get_socketio_secret(redis_url: str) -> str | None:
+async def get_socketio_secret(redis_url: str) -> str | None:
 	"""Read socketio_auth_secret from the no-auth queue redis (same key the web sets)."""
 	global _secret_client
 	if _secret_client is None:
-		_secret_client = redis.from_url(redis_url)
-	value = _secret_client.get(SOCKETIO_SECRET_KEY)
+		_secret_client = aioredis.from_url(redis_url)
+	value = await _secret_client.get(SOCKETIO_SECRET_KEY)
 	if value is None:
 		return None
 	return value.decode() if isinstance(value, bytes) else value
+
+
+class DiscardingCookieJar(CookieJar):
+	"""Cookie jar that drops every Set-Cookie.
+
+	The client is shared by every connection, so a real jar would replay one
+	user's ``sid`` onto the next connect and authenticate it as that user."""
+
+	def extract_cookies(self, response, request) -> None:
+		pass
+
+
+def get_http_client() -> httpx.AsyncClient:
+	"""Shared process-wide AsyncClient (lazy init, one pool).
+
+	Redirects are followed: httpx otherwise returns the 30x, which
+	raise_for_status turns into a refused connect."""
+	global _http_client
+	if _http_client is None or _http_client.is_closed:
+		_http_client = httpx.AsyncClient(timeout=10, follow_redirects=True, cookies=DiscardingCookieJar())
+	return _http_client
+
+
+async def close_clients() -> None:
+	"""Release the shared HTTP and redis clients.
+
+	Both are bound to the loop that created them, so a restart must rebuild them."""
+	global _http_client, _secret_client
+	if _http_client is not None:
+		await _http_client.aclose()
+		_http_client = None
+	if _secret_client is not None:
+		await _secret_client.aclose()
+		_secret_client = None

--- a/frappe/realtime/bridge.py
+++ b/frappe/realtime/bridge.py
@@ -3,17 +3,18 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
+from contextlib import suppress
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, NoReturn
+from typing import TYPE_CHECKING, Any
 
-import gevent
-import redis
+import redis.asyncio
+from redis.exceptions import RedisError
 
 if TYPE_CHECKING:
-	from gevent.greenlet import Greenlet
-	from socketio.server import Server as SocketIOServer
+	from socketio import AsyncServer
 
 logger = logging.getLogger("frappe.realtime")
 
@@ -53,39 +54,55 @@ class RedisBridge:
 	- with ``room``: emit to that room in namespace ``/{namespace}``
 	- without ``room``: broadcast to every connected site namespace (build events)
 
-	Runs in its own greenlet; reconnects on redis failure and skips malformed
+	Runs as its own asyncio task; reconnects on redis failure and skips malformed
 	messages without crashing.
 	"""
 
-	def __init__(self, sio: SocketIOServer, redis_url: str):
-		self.sio: SocketIOServer = sio
+	def __init__(self, sio: AsyncServer, redis_url: str):
+		self.sio: AsyncServer = sio
 		self.redis_url = redis_url
-		self._greenlet: Greenlet | None = None
+		self._task: asyncio.Task | None = None
 
-	def start(self) -> Greenlet:
-		"""Spawn the subscriber greenlet. Returns the greenlet."""
-		self._greenlet = gevent.spawn(self._run)
-		return self._greenlet
+	def start(self) -> asyncio.Task:
+		"""Spawn the subscriber task on the running loop. Returns the task."""
+		self._task = asyncio.create_task(self._run())
+		return self._task
 
-	def _run(self) -> NoReturn:
+	async def stop(self) -> None:
+		if not self._task:
+			return
+		self._task.cancel()
+		with suppress(asyncio.CancelledError):
+			await self._task
+		self._task = None
+
+	async def _run(self) -> None:
 		while True:
 			try:
-				client = redis.from_url(self.redis_url)
-				pubsub = client.pubsub(ignore_subscribe_messages=True)
-				pubsub.subscribe(EVENTS_CHANNEL)
-				logger.info("Redis bridge subscribed to %r on %s", EVENTS_CHANNEL, self.redis_url)
-				for message in pubsub.listen():
-					if message.get("type") != "message":
-						continue
-					self._handle(message.get("data"))
-			except redis.exceptions.RedisError as e:
+				await self._listen()
+			except asyncio.CancelledError:
+				raise
+			except RedisError as e:
 				logger.warning("Redis bridge connection lost (%s); reconnecting in %ss", e, RECONNECT_DELAY)
-				gevent.sleep(RECONNECT_DELAY)
 			except Exception:
 				logger.exception("Redis bridge crashed; reconnecting in %ss", RECONNECT_DELAY)
-				gevent.sleep(RECONNECT_DELAY)
+			await asyncio.sleep(RECONNECT_DELAY)
 
-	def _handle(self, raw: str | bytes | bytearray | None) -> None:
+	async def _listen(self) -> None:
+		"""Subscribe and pump messages until the connection drops."""
+		client = redis.asyncio.from_url(self.redis_url)
+		try:
+			pubsub = client.pubsub(ignore_subscribe_messages=True)
+			await pubsub.subscribe(EVENTS_CHANNEL)
+			logger.info("Redis bridge subscribed to %r on %s", EVENTS_CHANNEL, self.redis_url)
+			async for message in pubsub.listen():
+				if message.get("type") == "message":
+					await self._handle(message.get("data"))
+		finally:
+			with suppress(Exception):
+				await client.aclose()
+
+	async def _handle(self, raw: str | bytes | bytearray | None) -> None:
 		try:
 			evt = RealtimeEvent.from_raw(raw)
 		except (ValueError, TypeError, KeyError) as e:
@@ -96,14 +113,8 @@ class RedisBridge:
 			if not evt.namespace:
 				logger.warning("Redis bridge skipping room message with no namespace: %r", raw)
 				return
-			self.sio.emit(evt.event, evt.message, room=evt.room, namespace="/" + evt.namespace)
+			await self.sio.emit(evt.event, evt.message, room=evt.room, namespace="/" + evt.namespace)
 		else:
 			# No room -> broadcast to every connected site namespace (build events).
 			for ns in list(self.sio.manager.rooms.keys()):
-				self.sio.emit(evt.event, evt.message, namespace=ns)
-
-
-def start_bridge(sio: SocketIOServer, redis_url: str) -> RedisBridge:
-	bridge = RedisBridge(sio, redis_url)
-	bridge.start()
-	return bridge
+				await self.sio.emit(evt.event, evt.message, namespace=ns)

--- a/frappe/realtime/config.py
+++ b/frappe/realtime/config.py
@@ -7,9 +7,10 @@ the Node ``node_utils.get_conf`` reads) instead of re-porting the JSON parse.
 Config comes only from common_site_config.json / site_config.json — no env vars.
 
 ``frappe`` is imported lazily so this module can be imported in tests without a
-configured bench, and so import never precedes the gevent monkeypatch in server.py.
+configured bench.
 """
 
+import os
 from dataclasses import dataclass
 
 # node_utils default
@@ -29,13 +30,21 @@ class RealtimeConfig:
 	developer_mode: bool = False
 	webserver_port: int | None = None
 	webserver_host: str | None = None
+	# Only set this if an app registers blocking handlers. Every core handler is
+	# async, and permission checks are coroutines, so nothing built in uses threads.
+	# Each frappe_context handler also holds a DB connection for its whole cycle.
+	# Unset leaves the loop's default executor (min(32, cpu + 4)) in place.
+	worker_threads: int | None = None
+	# Absolute, because serve() changes into sites/ before it builds the server, and a
+	# relative path would then point one level too deep.
+	sites_path: str = "sites"
 
 
 def get_config(sites_path: str | None = None) -> RealtimeConfig:
 	"""Build the realtime config from common_site_config.json."""
 	import frappe
 
-	sites_path = sites_path or getattr(frappe.local, "sites_path", None) or "sites"
+	sites_path = os.path.abspath(sites_path or getattr(frappe.local, "sites_path", None) or "sites")
 	conf = frappe.get_common_site_config(sites_path=sites_path)
 
 	webserver_port = conf.get("webserver_port")
@@ -47,4 +56,6 @@ def get_config(sites_path: str | None = None) -> RealtimeConfig:
 		developer_mode=bool(conf.get("developer_mode")),
 		webserver_port=int(webserver_port) if webserver_port else None,
 		webserver_host=conf.get("webserver_host") or None,
+		worker_threads=int(conf["socketio_worker_threads"]) if conf.get("socketio_worker_threads") else None,
+		sites_path=sites_path,
 	)

--- a/frappe/realtime/context.py
+++ b/frappe/realtime/context.py
@@ -17,14 +17,13 @@ def frappe_context(site: str, user: str):
 	forces a DB connection into the realtime process, so use it sparingly; the cheap
 	default is the HTTP permission check on Socket.
 
-	The DB connection is forced onto the pure-python PyMySQL driver (see
-	server.force_pymysql) — the mysqlclient C extension would stall the gevent hub.
+	Runs on a worker thread, never on the event loop, so a blocking driver is fine.
+	force=True is required: frappe.local is a shared mutable dict behind a
+	ContextVar, and only init(force=True) rebinds a fresh one for this call.
 	"""
 	import frappe
-	from frappe.realtime.server import force_pymysql
 
-	frappe.init(site)
-	force_pymysql(frappe.local.conf)
+	frappe.init(site, force=True)
 	frappe.connect()
 	frappe.set_user(user)  # nosemgrep
 	try:

--- a/frappe/realtime/dispatch.py
+++ b/frappe/realtime/dispatch.py
@@ -9,7 +9,8 @@ same handlers. Per event, dispatch:
 - loads the session stored at connect and builds a typed Socket
 - install-scoping: runs a handler only if its app is on the site's installed_apps
 - guest gate: skips a handler when user == "Guest" and the handler is not allow_guest
-- context wrap: opens frappe_context for handlers registered with frappe_context=True
+- offloads blocking handlers: a plain (non-async) handler and every
+  frappe_context handler run in a worker thread with a SyncSocket
 
 Handler errors are logged and swallowed so one bad handler never drops the socket.
 Concrete events are bound (rather than a combined catch-all) to avoid ambiguity in
@@ -18,26 +19,51 @@ python-socketio's argument order; the namespace is always prepended for namespac
 
 from __future__ import annotations
 
+import asyncio
+import inspect
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING
 
 from frappe.realtime.auth import authenticate
 from frappe.realtime.config import RealtimeConfig
 from frappe.realtime.context import frappe_context
-from frappe.realtime.registry import realtime
-from frappe.realtime.socket import Socket
+from frappe.realtime.registry import Handler, is_async_callable, realtime
+from frappe.realtime.socket import Socket, SyncSocket
 
 if TYPE_CHECKING:
-	from socketio.server import Server as SocketIOServer
+	from socketio import AsyncServer
 
 logger = logging.getLogger("frappe.realtime")
 
 RESERVED_EVENTS = ("connect", "disconnect")
 
 
-def _run_handlers(
-	sio: SocketIOServer,
+def _run_in_context(handler: Handler, socket: SyncSocket, args: tuple[object, ...]) -> None:
+	"""Run a handler inside a Frappe context. Called on a worker thread."""
+	with frappe_context(socket.site, socket.user):
+		handler.fn(socket, *args)
+
+
+async def _call(handler: Handler, socket: Socket, args: tuple[object, ...]) -> None:
+	"""Run one handler, moving it off the loop if it blocks."""
+	if is_async_callable(handler.fn):
+		await handler.fn(socket, *args)
+		return
+
+	sync_socket = SyncSocket(socket, asyncio.get_running_loop())
+	if handler.frappe_context:
+		await asyncio.to_thread(_run_in_context, handler, sync_socket, args)
+		return
+
+	result = await asyncio.to_thread(handler.fn, sync_socket, *args)
+	# A decorator can hide a coroutine function behind a plain wrapper.
+	if inspect.isawaitable(result):
+		await result
+
+
+async def _run_handlers(
+	sio: AsyncServer,
 	event: str,
 	namespace: str,
 	sid: str,
@@ -48,7 +74,7 @@ def _run_handlers(
 		return
 
 	try:
-		session = sio.get_session(sid, namespace=namespace)
+		session = await sio.get_session(sid, namespace=namespace)
 	except KeyError:
 		return
 
@@ -60,34 +86,30 @@ def _run_handlers(
 		if socket.user == "Guest" and not handler.allow_guest:
 			continue
 		try:
-			if handler.frappe_context:
-				with frappe_context(socket.site, socket.user):
-					handler.fn(socket, *args)
-			else:
-				handler.fn(socket, *args)
+			await _call(handler, socket, args)
 		except Exception:
 			logger.exception("handler error: event=%s app=%s", event, handler.app)
 
 
-def _make_dispatcher(sio: SocketIOServer, event: str) -> Callable[..., None]:
-	def dispatcher(namespace: str, sid: str, *args: object) -> None:
-		_run_handlers(sio, event, namespace, sid, args)
+def _make_dispatcher(sio: AsyncServer, event: str) -> Callable[..., Coroutine]:
+	async def dispatcher(namespace: str, sid: str, *args: object) -> None:
+		await _run_handlers(sio, event, namespace, sid, args)
 
 	return dispatcher
 
 
-def wire(sio: SocketIOServer, config: RealtimeConfig) -> None:
+def wire(sio: AsyncServer, config: RealtimeConfig) -> None:
 	"""Bind connect / disconnect and every registered event onto namespace '*'."""
 
-	def connect(namespace: str, sid: str, environ: dict, auth: object | None = None) -> None:
-		session = authenticate(environ, namespace, config)
-		sio.save_session(sid, session, namespace=namespace)
-		_run_handlers(sio, "connect", namespace, sid, ())
+	async def connect(namespace: str, sid: str, environ: dict, auth: object | None = None) -> None:
+		session = await authenticate(environ, namespace, config)
+		await sio.save_session(sid, session, namespace=namespace)
+		await _run_handlers(sio, "connect", namespace, sid, ())
 
-	def disconnect(namespace: str, sid: str, reason: object | None = None) -> None:
+	async def disconnect(namespace: str, sid: str, reason: object | None = None) -> None:
 		# socketio 5.11+ passes a disconnect reason; accept and ignore it so the
 		# handler binds directly instead of relying on the library's TypeError retry.
-		_run_handlers(sio, "disconnect", namespace, sid, ())
+		await _run_handlers(sio, "disconnect", namespace, sid, ())
 
 	sio.on("connect", connect, namespace="*")
 	sio.on("disconnect", disconnect, namespace="*")

--- a/frappe/realtime/handlers.py
+++ b/frappe/realtime/handlers.py
@@ -3,6 +3,8 @@
 
 import json
 
+import redis.asyncio
+
 from frappe.realtime import Socket, realtime
 from frappe.realtime.config import get_config
 
@@ -31,96 +33,100 @@ def open_doc_room(doctype: str, docname: str) -> str:
 
 
 @realtime.on("connect", allow_guest=True)
-def on_connect(socket: Socket) -> None:
-	socket.join(user_room(socket.user))
-	socket.join(WEBSITE_ROOM)
+async def on_connect(socket: Socket) -> None:
+	await socket.join(user_room(socket.user))
+	await socket.join(WEBSITE_ROOM)
 	if socket.user_type == "System User":
-		socket.join(SITE_ROOM)
+		await socket.join(SITE_ROOM)
 
 
 @realtime.on("ping", allow_guest=True)
-def ping(socket: Socket) -> None:
-	socket.emit("pong")
+async def ping(socket: Socket) -> None:
+	await socket.emit("pong")
 
 
 @realtime.on("doctype_subscribe", allow_guest=True)
-def doctype_subscribe(socket: Socket, doctype: str) -> None:
-	if socket.has_permission(doctype):
-		socket.join(doctype_room(doctype))
+async def doctype_subscribe(socket: Socket, doctype: str) -> None:
+	if await socket.has_permission(doctype):
+		await socket.join(doctype_room(doctype))
 
 
 @realtime.on("doctype_unsubscribe", allow_guest=True)
-def doctype_unsubscribe(socket: Socket, doctype: str) -> None:
-	socket.leave(doctype_room(doctype))
+async def doctype_unsubscribe(socket: Socket, doctype: str) -> None:
+	await socket.leave(doctype_room(doctype))
 
 
 @realtime.on("task_subscribe", allow_guest=True)
-def task_subscribe(socket: Socket, task_id: str) -> None:
-	socket.join(task_room(task_id))
+async def task_subscribe(socket: Socket, task_id: str) -> None:
+	await socket.join(task_room(task_id))
 
 
 @realtime.on("task_unsubscribe", allow_guest=True)
-def task_unsubscribe(socket: Socket, task_id: str) -> None:
-	socket.leave(task_room(task_id))
+async def task_unsubscribe(socket: Socket, task_id: str) -> None:
+	await socket.leave(task_room(task_id))
 
 
 @realtime.on("progress_subscribe", allow_guest=True)
-def progress_subscribe(socket: Socket, task_id: str) -> None:
-	socket.join(task_room(task_id))
+async def progress_subscribe(socket: Socket, task_id: str) -> None:
+	await socket.join(task_room(task_id))
 
 
 @realtime.on("doc_subscribe", allow_guest=True)
-def doc_subscribe(socket: Socket, doctype: str, docname: str) -> None:
-	if socket.has_permission(doctype, docname):
-		socket.join(doc_room(doctype, docname))
+async def doc_subscribe(socket: Socket, doctype: str, docname: str) -> None:
+	if await socket.has_permission(doctype, docname):
+		await socket.join(doc_room(doctype, docname))
 
 
 @realtime.on("doc_unsubscribe", allow_guest=True)
-def doc_unsubscribe(socket: Socket, doctype: str, docname: str) -> None:
-	socket.leave(doc_room(doctype, docname))
+async def doc_unsubscribe(socket: Socket, doctype: str, docname: str) -> None:
+	await socket.leave(doc_room(doctype, docname))
 
 
 @realtime.on("doc_open", allow_guest=True)
-def doc_open(socket: Socket, doctype: str, docname: str) -> None:
-	if not socket.has_permission(doctype, docname):
+async def doc_open(socket: Socket, doctype: str, docname: str) -> None:
+	if not await socket.has_permission(doctype, docname):
 		return
-	socket.join(open_doc_room(doctype, docname))
+	await socket.join(open_doc_room(doctype, docname))
 
 	tracked = socket.get("subscribed_documents", [])
 	pair = [doctype, docname]
 	if pair not in tracked:
 		tracked.append(pair)
-		socket.set("subscribed_documents", tracked)
-	notify_doc_viewers(socket, doctype, docname)
+		await socket.set("subscribed_documents", tracked)
+	await notify_doc_viewers(socket, doctype, docname)
 
 
 @realtime.on("doc_close", allow_guest=True)
-def doc_close(socket: Socket, doctype: str, docname: str) -> None:
-	socket.leave(open_doc_room(doctype, docname))
+async def doc_close(socket: Socket, doctype: str, docname: str) -> None:
+	await socket.leave(open_doc_room(doctype, docname))
 	# Fix Node bug (handlers.js:91-93): the filter callback never returned, so the
 	# pair was never dropped. Actually remove it here.
 	tracked = socket.get("subscribed_documents", [])
 	tracked = [pair for pair in tracked if not (pair[0] == doctype and pair[1] == docname)]
-	socket.set("subscribed_documents", tracked)
-	notify_doc_viewers(socket, doctype, docname)
+	await socket.set("subscribed_documents", tracked)
+	await notify_doc_viewers(socket, doctype, docname)
 
 
 @realtime.on("disconnect", allow_guest=True)
-def on_disconnect(socket: Socket) -> None:
+async def on_disconnect(socket: Socket) -> None:
 	for doctype, docname in socket.get("subscribed_documents", []):
-		notify_doc_viewers(socket, doctype, docname)
+		await notify_doc_viewers(socket, doctype, docname)
 
 
-def notify_doc_viewers(socket: Socket, doctype: str, docname: str) -> None:
+async def notify_doc_viewers(socket: Socket, doctype: str, docname: str) -> None:
 	"""Emit doc_viewers to everyone in the open-doc room. Port of notify_subscribed_doc_users."""
 	if not (doctype and docname):
 		return
 	room = open_doc_room(doctype, docname)
-	users = [u for u in (socket.user_of(sid) for sid in socket.participants(room)) if u]
+	users = []
+	for sid in socket.participants(room):
+		user = await socket.user_of(sid)
+		if user:
+			users.append(user)
 	# Don't send an update to a lone viewer about themselves.
 	if len(users) == 1 and users[0] == socket.user:
 		return
-	socket.emit(
+	await socket.emit(
 		"doc_viewers",
 		{"doctype": doctype, "docname": docname, "users": list(dict.fromkeys(users))},
 		room=room,
@@ -128,16 +134,14 @@ def notify_doc_viewers(socket: Socket, doctype: str, docname: str) -> None:
 
 
 @realtime.on("open_in_editor")
-def open_in_editor(socket: Socket, data: object) -> None:
+async def open_in_editor(socket: Socket, data: object) -> None:
 	"""Dev-only: forward esbuild "open in editor" to the redis open_in_editor channel."""
 	config = get_config()
 	if not config.developer_mode:
 		return
 
-	import redis
-
-	client = redis.from_url(config.redis_queue)
+	client = redis.asyncio.from_url(config.redis_queue)
 	try:
-		client.publish("open_in_editor", json.dumps(data))
+		await client.publish("open_in_editor", json.dumps(data))
 	finally:
-		client.close()
+		await client.aclose()

--- a/frappe/realtime/registry.py
+++ b/frappe/realtime/registry.py
@@ -7,16 +7,21 @@ App authors register handlers declaratively::
     from frappe.realtime import Socket, realtime
 
 
-    @realtime.on("doc_subscribe", frappe_context=True)
-    def doc_subscribe(socket: Socket, doctype: str, docname: str) -> None: ...
+    @realtime.on("doc_subscribe")
+    async def doc_subscribe(socket: Socket, doctype: str, docname: str) -> None: ...
+
+A handler may be async (runs on the event loop) or plain (runs in a worker thread,
+with a blocking SyncSocket). frappe_context needs the thread, so those handlers
+must be plain.
 
 Each registration stores the callable, its frappe_context / allow_guest flags, and
-the owning app. Several apps may bind the same event; dispatch (task 9) runs each
-handler only if its app is installed on the connecting site. The owning app is
-taken from importing_app(), which the per-app discovery step wraps each import in;
-core handlers default to "frappe".
+the owning app. Several apps may bind the same event; dispatch runs each handler
+only if its app is installed on the connecting site. The owning app is taken from
+importing_app(), which the per-app discovery step wraps each import in; core
+handlers default to "frappe".
 """
 
+import inspect
 import logging
 from collections.abc import Callable, Iterable
 from contextlib import contextmanager
@@ -25,6 +30,17 @@ from dataclasses import dataclass
 logger = logging.getLogger("frappe.realtime")
 
 CORE_APP = "frappe"
+
+
+def is_async_callable(fn: Callable) -> bool:
+	"""True for coroutine functions and for objects whose __call__ is one.
+
+	iscoroutinefunction alone misses the latter, which would then run in a worker
+	thread with its coroutine dropped unawaited."""
+	if inspect.iscoroutinefunction(fn):
+		return True
+	call = getattr(fn, "__call__", None)  # noqa: B004
+	return call is not None and inspect.iscoroutinefunction(call)
 
 
 @dataclass(frozen=True)
@@ -45,6 +61,11 @@ class Registry:
 		"""Register a handler for an event. Returns the function unchanged."""
 
 		def decorator(fn: Callable) -> Callable:
+			if frappe_context and is_async_callable(fn):
+				raise TypeError(
+					f"{getattr(fn, '__name__', fn)!r}: frappe_context runs in a worker thread, so the handler "
+					f"must be a plain function, not 'async def'."
+				)
 			handler = Handler(
 				event=event,
 				fn=fn,

--- a/frappe/realtime/server.py
+++ b/frappe/realtime/server.py
@@ -1,73 +1,44 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 # License: MIT. See LICENSE
-"""Standalone Python Socket.IO realtime server (gevent).
+"""Standalone Python Socket.IO realtime server (asyncio + uvicorn).
 
 Run with::
 
     python -m frappe.realtime.server
 
-This process is fully separate from the web/gunicorn process. It runs on gevent
-and forces the pure-python PyMySQL driver — the mysqlclient C extension has a
-blocking socket that cannot be monkeypatched and would stall the gevent hub.
+This process is fully separate from the web/gunicorn process. Calls back into the
+web process (connect auth, permission checks) are async; blocking work (plain
+handlers, frappe_context) is moved off the event loop into a worker thread.
 
-HARD REQUIREMENT: gevent.monkey.patch_all() must run before anything imports
-frappe / redis / pymysql / socketio. It is therefore the very first statement in
-this module, ahead of every other import.
+To embed it instead, build a RealtimeServer and call run() on a thread you own::
+
+    server = RealtimeServer()
+    threading.Thread(target=server.run, daemon=True).start()
+    ...
+    server.stop()
+
+Frappe itself never creates that thread.
 """
 
-# ---------------------------------------------------------------------------
-# MUST BE FIRST. Do not move imports above this block.
-from gevent import monkey
+from __future__ import annotations
 
-monkey.patch_all()
-# ---------------------------------------------------------------------------
-
+import asyncio
 import logging
-import sys
+import os
+from concurrent.futures import ThreadPoolExecutor
 
 import socketio
-from gevent.pywsgi import WSGIServer
-from geventwebsocket.handler import WebSocketHandler
+import uvicorn
 
-from frappe.realtime.bridge import start_bridge
+from frappe.realtime.auth import close_clients
+from frappe.realtime.bridge import RedisBridge
 from frappe.realtime.config import RealtimeConfig, get_config
 from frappe.realtime.dispatch import wire
 
 logger = logging.getLogger("frappe.realtime")
 
 
-def assert_no_mysqlclient() -> None:
-	"""Fail loudly if the mysqlclient C extension was imported.
-
-	Its blocking socket cannot be monkeypatched and will stall the gevent hub.
-	The realtime process must use PyMySQL only (see force_pymysql)."""
-	if "MySQLdb" in sys.modules:
-		raise RuntimeError(
-			"mysqlclient (MySQLdb) is imported in the realtime process. "
-			"It is a C extension whose blocking socket stalls the gevent hub. "
-			"The realtime process must use PyMySQL only."
-		)
-
-
-def force_pymysql(conf) -> None:
-	"""Force the pure-python PyMySQL driver on a site conf.
-
-	frappe.database.get_db selects mysqlclient when conf.use_mysqlclient is truthy
-	(the default). Flip it off so any DB connection opened inside a handler context
-	uses the gevent-patchable PyMySQL path instead. Called by context.py per context."""
-	conf["use_mysqlclient"] = 0
-
-
-def health_app(environ, start_response):
-	"""Minimal WSGI app for non-socket.io routes. Serves GET /health."""
-	if environ.get("PATH_INFO") == "/health":
-		start_response("200 OK", [("Content-Type", "text/plain")])
-		return [b"ok"]
-	start_response("404 Not Found", [("Content-Type", "text/plain")])
-	return [b"not found"]
-
-
-class TolerantManager(socketio.manager.Manager):
+class TolerantManager(socketio.AsyncManager):
 	"""Re-ack a duplicate namespace connect instead of rejecting it.
 
 	Default connect() returns None when the eio session is already on the namespace,
@@ -76,17 +47,17 @@ class TolerantManager(socketio.manager.Manager):
 	old Node server tolerated it. Reuse the existing sid so the connect is idempotent.
 	"""
 
-	def connect(self, eio_sid: str, namespace: str) -> str | None:
-		return super().connect(eio_sid, namespace) or self.sid_from_eio_sid(eio_sid, namespace)
+	async def connect(self, eio_sid: str, namespace: str) -> str | None:
+		return await super().connect(eio_sid, namespace) or self.sid_from_eio_sid(eio_sid, namespace)
 
 
-def create_sio() -> socketio.Server:
-	"""Build the gevent-mode Socket.IO server.
+def create_sio() -> socketio.AsyncServer:
+	"""Build the asgi-mode Socket.IO server.
 
-	Origin / namespace / auth enforcement lives in auth.py (task 6); CORS is left
-	open here so python-socketio does not pre-reject before that gate runs."""
-	return socketio.Server(
-		async_mode="gevent",
+	Origin / namespace / auth enforcement lives in auth.py; CORS is left open here
+	so python-socketio does not pre-reject before that gate runs."""
+	return socketio.AsyncServer(
+		async_mode="asgi",
 		cors_allowed_origins="*",
 		cors_credentials=True,
 		namespaces="*",
@@ -96,60 +67,92 @@ def create_sio() -> socketio.Server:
 	)
 
 
-def create_app(sio: socketio.Server) -> socketio.WSGIApp:
-	"""Wrap the Socket.IO server in a WSGI app, with /health alongside."""
-	return socketio.WSGIApp(sio, wsgi_app=health_app)
+def load_handlers(sites_path: str | None = None) -> None:
+	"""Import core handlers, then per-app handlers, so every @realtime.on
+	registration runs before wire() binds events.
+
+	None leaves the sites path to discover_app_handlers. Callers that know it, such
+	as RealtimeServer, give the absolute path from the config: a relative one is read
+	against the cwd, which serve() moves into sites/ and an embedder does not."""
+	import frappe.realtime.handlers
+	from frappe.realtime.registry import discover_app_handlers
+
+	discover_app_handlers(sites_path=sites_path)
 
 
-# Module-level server instance other modules (bridge, auth, handlers) attach to.
-sio = create_sio()
-app = create_app(sio)
+class RealtimeServer:
+	"""Socket.IO realtime server on asyncio.
 
+	Owns the Socket.IO server, the ASGI app, and the redis bridge. The bridge is
+	started and stopped through the ASGI lifespan, so it always lives on the same
+	loop uvicorn runs.
+	"""
 
-def _make_listener(config: RealtimeConfig):
-	"""Build the WSGIServer listener: a bound AF_UNIX socket for UDS, else (host, port)."""
-	if config.uds:
-		import os
-		import socket as _socket
+	def __init__(self, config: RealtimeConfig | None = None):
+		self.config = config or get_config()
+		self.sio = create_sio()
+		self.bridge = RedisBridge(self.sio, self.config.redis_queue)
+		# No other_asgi_app: engineio answers non-socket.io traffic with its own 404.
+		self.app = socketio.ASGIApp(
+			self.sio,
+			on_startup=self._on_startup,
+			on_shutdown=self._on_shutdown,
+		)
+		# wire() binds what is registered now, so handlers must be imported first.
+		load_handlers(self.config.sites_path)
+		wire(self.sio, self.config)
+		self._server = uvicorn.Server(self._get_uvicorn_config())
 
-		if os.path.exists(config.uds):
-			os.remove(config.uds)
-		sock = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
-		sock.bind(config.uds)
-		sock.listen(256)
-		return sock
-	return ("0.0.0.0", config.port)
+	def run(self) -> None:
+		"""Serve until stop(). Blocks, and works on any thread — uvicorn installs
+		signal handlers only on the main thread."""
+		if self.config.uds:
+			# uvicorn binds without unlinking, so a leftover socket file would fail.
+			if os.path.exists(self.config.uds):
+				os.remove(self.config.uds)
+			logger.info("Realtime service listening on UDS: %s", self.config.uds)
+		else:
+			logger.info("Realtime service listening on: ws://0.0.0.0:%s", self.config.port)
+
+		self._server.run()
+
+	def stop(self) -> None:
+		"""Ask the server to shut down. run() returns once shutdown completes."""
+		self._server.should_exit = True
+
+	async def _on_startup(self) -> None:
+		# Only when asked: this replaces the executor for the whole loop, and nothing
+		# built in dispatches to a thread.
+		if self.config.worker_threads:
+			asyncio.get_running_loop().set_default_executor(
+				ThreadPoolExecutor(
+					max_workers=self.config.worker_threads, thread_name_prefix="realtime-worker"
+				)
+			)
+		self.bridge.start()
+
+	async def _on_shutdown(self) -> None:
+		await self.bridge.stop()
+		await close_clients()
+
+	def _get_uvicorn_config(self) -> uvicorn.Config:
+		"""Bind to the UDS path if configured, else to the port on all interfaces."""
+		if self.config.uds:
+			binding = {"uds": self.config.uds}
+		else:
+			binding = {"host": "0.0.0.0", "port": self.config.port}
+		# log_config=None keeps the caller's logging setup; access logs would record
+		# every polling request.
+		return uvicorn.Config(self.app, log_config=None, access_log=False, **binding)
 
 
 def serve(config: RealtimeConfig | None = None) -> None:
-	import os
-
-	assert_no_mysqlclient()
 	config = config or get_config()
 
 	if os.path.isdir("sites"):
 		os.chdir("sites")
 
-	# Import core handlers, then discover per-app handlers, so every @realtime.on
-	# registration runs before wire() binds events.
-	import frappe.realtime.handlers
-	from frappe.realtime.registry import discover_app_handlers
-
-	discover_app_handlers(sites_path=".")
-
-	wire(sio, config)
-
-	start_bridge(sio, config.redis_queue)
-
-	listener = _make_listener(config)
-	server = WSGIServer(listener, app, handler_class=WebSocketHandler, log=logger, error_log=logger)
-
-	if config.uds:
-		logger.info("Realtime service listening on UDS: %s", config.uds)
-	else:
-		logger.info("Realtime service listening on: ws://0.0.0.0:%s", config.port)
-
-	server.serve_forever()
+	RealtimeServer(config).run()
 
 
 def main() -> None:

--- a/frappe/realtime/socket.py
+++ b/frappe/realtime/socket.py
@@ -3,12 +3,16 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 
 from frappe.realtime.auth import Session
 
 if TYPE_CHECKING:
-	from socketio.server import Server as SocketIOServer
+	from socketio import AsyncServer
+
+# Seconds. A backstop against a wedged worker thread, not a latency budget.
+LOOP_CALL_TIMEOUT = 120
 
 
 class Socket:
@@ -18,9 +22,12 @@ class Socket:
 	plus the authenticated Session stored at connect. Read-only identity fields
 	and emit/room helpers; identity + has_permission delegate to the Session, so
 	the wrapper carries no auth/HTTP logic itself.
+
+	The methods are coroutines because the underlying AsyncServer calls are.
+	Handlers written as plain functions get SyncSocket instead.
 	"""
 
-	def __init__(self, sio: SocketIOServer, sid: str, namespace: str, session: Session):
+	def __init__(self, sio: AsyncServer, sid: str, namespace: str, session: Session):
 		self._sio = sio
 		self.sid = sid
 		self.namespace = namespace
@@ -45,40 +52,40 @@ class Socket:
 	def _connected(self) -> bool:
 		"""Is this sid still attached to its namespace?
 
-		Events dispatch in their own greenlet (async_handlers), and a handler can
-		yield the gevent hub mid-body (e.g. has_permission does an HTTP call). The
-		client may disconnect in that window, after which the namespace is gone from
-		the manager — enter_room then raises "sid is not connected to requested
-		namespace" and save_session raises KeyError (eio_sid resolves to None).
-		Re-check before any sio call that would raise; mutating a gone socket is a
-		no-op. Safe against TOCTOU because the guarded call does not yield the hub."""
+		A handler yields the loop at every await (e.g. has_permission does an HTTP
+		round-trip to the web process). The client may disconnect in that window, after
+		which the namespace is gone from the manager — enter_room then raises "sid is
+		not connected to requested namespace" and save_session raises KeyError
+		(eio_sid resolves to None). Re-check before any sio call that would raise;
+		mutating a gone socket is a no-op. Safe against TOCTOU because the guarded
+		call does not yield the loop before it reads the manager."""
 		return self._sio.manager.is_connected(self.sid, self.namespace)
 
-	def join(self, room: str) -> None:
+	async def join(self, room: str) -> None:
 		if not self._connected():
 			return
-		self._sio.enter_room(self.sid, room, namespace=self.namespace)
+		await self._sio.enter_room(self.sid, room, namespace=self.namespace)
 
-	def leave(self, room: str) -> None:
+	async def leave(self, room: str) -> None:
 		if not self._connected():
 			return
 
-		self._sio.leave_room(self.sid, room, namespace=self.namespace)
+		await self._sio.leave_room(self.sid, room, namespace=self.namespace)
 
-	def emit(self, event: str, data: object | None = None, room: str | None = None) -> None:
+	async def emit(self, event: str, data: object | None = None, room: str | None = None) -> None:
 		"""Emit to a room, or to this client (default)."""
-		self._sio.emit(event, data, to=room or self.sid, namespace=self.namespace)
+		await self._sio.emit(event, data, to=room or self.sid, namespace=self.namespace)
 
 	def get(self, key: str, default: object = None) -> object:
 		"""Read transient per-socket state from the session."""
 		return self._session.data.get(key, default)
 
-	def set(self, key: str, value: object) -> None:
+	async def set(self, key: str, value: object) -> None:
 		"""Persist transient per-socket state onto the session."""
 		self._session.data[key] = value
 		if not self._connected():
 			return
-		self._sio.save_session(self.sid, self._session, namespace=self.namespace)
+		await self._sio.save_session(self.sid, self._session, namespace=self.namespace)
 
 	def participants(self, room: str) -> list[str]:
 		"""sids currently in ``room`` of this namespace."""
@@ -87,16 +94,93 @@ class Socket:
 			sids.append(item[0] if isinstance(item, tuple) else item)
 		return sids
 
-	def user_of(self, sid: str) -> str | None:
+	async def user_of(self, sid: str) -> str | None:
 		"""User on another socket's session, or None if it has none."""
 		try:
-			return self._sio.get_session(sid, namespace=self.namespace).user
+			return (await self._sio.get_session(sid, namespace=self.namespace)).user
 		except KeyError:
 			return None
 
-	def has_permission(self, doctype: str, name: str | None = None) -> bool:
+	async def has_permission(self, doctype: str, name: str | None = None) -> bool:
 		"""HTTP permission check via the web process (no DB in realtime).
 
-		For in-process checks use frappe.has_permission inside a
-		frappe_context=True handler."""
-		return self._session.has_permission(doctype, name)
+		Async, so it holds no worker thread. For in-process checks use
+		frappe.has_permission inside a frappe_context=True handler."""
+		return await self._session.has_permission(doctype, name)
+
+
+class SyncSocket:
+	"""Blocking Socket facade for handlers that run in a worker thread.
+
+	Same API as Socket, minus the awaits: each coroutine is submitted back to the
+	server's event loop and waited on from this thread. Handed to plain (non-async)
+	handlers and to every frappe_context handler.
+	"""
+
+	def __init__(self, socket: Socket, loop: asyncio.AbstractEventLoop):
+		self._socket = socket
+		self._loop = loop
+
+	@property
+	def sid(self) -> str:
+		return self._socket.sid
+
+	@property
+	def namespace(self) -> str:
+		return self._socket.namespace
+
+	@property
+	def site(self) -> str:
+		return self._socket.site
+
+	@property
+	def user(self) -> str:
+		return self._socket.user
+
+	@property
+	def user_type(self) -> str:
+		return self._socket.user_type
+
+	@property
+	def installed_apps(self) -> list[str]:
+		return self._socket.installed_apps
+
+	def join(self, room: str) -> None:
+		self._run(self._socket.join(room))
+
+	def leave(self, room: str) -> None:
+		self._run(self._socket.leave(room))
+
+	def emit(self, event: str, data: object | None = None, room: str | None = None) -> None:
+		self._run(self._socket.emit(event, data, room))
+
+	def get(self, key: str, default: object = None) -> object:
+		return self._socket.get(key, default)
+
+	def set(self, key: str, value: object) -> None:
+		self._run(self._socket.set(key, value))
+
+	def participants(self, room: str) -> list[str]:
+		return self._socket.participants(room)
+
+	def user_of(self, sid: str) -> str | None:
+		return self._run(self._socket.user_of(sid))
+
+	def has_permission(self, doctype: str, name: str | None = None) -> bool:
+		return self._run(self._socket.has_permission(doctype, name))
+
+	def _run(self, coro):
+		"""Submit a coroutine to the server loop and block this thread on it.
+
+		Bounded: a loop that stops mid-handler would never resolve the future,
+		wedging the thread and the executor join that process exit waits on."""
+		if self._loop.is_closed():
+			coro.close()
+			raise RuntimeError("realtime event loop is closed")
+
+		future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+		try:
+			return future.result(LOOP_CALL_TIMEOUT)
+		except TimeoutError:
+			future.cancel()
+			raise

--- a/frappe/tests/test_realtime_py.py
+++ b/frappe/tests/test_realtime_py.py
@@ -13,16 +13,26 @@ here — they need a running realtime process, redis, and web server, and belong
 in an integration run.
 """
 
+import asyncio
+import os
 import sys
+import threading
 import types
 import unittest
-from collections.abc import Callable, Iterator
+from collections.abc import Awaitable, Callable, Iterator
 from contextlib import contextmanager
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _socketio_is_installed() -> bool:
+	import importlib.util
+
+	return importlib.util.find_spec("socketio") is not None
+
 
 # Inject a minimal fake socketio so auth/dispatch import without the real dep.
-# Guarded so a real install (CI) is used instead.
-if "socketio" not in sys.modules:
+# Guarded so a real install is used instead: the server tests need it.
+if "socketio" not in sys.modules and not _socketio_is_installed():
 	_sio_mod = types.ModuleType("socketio")
 	_exc_mod = types.ModuleType("socketio.exceptions")
 
@@ -34,20 +44,34 @@ if "socketio" not in sys.modules:
 	sys.modules["socketio"] = _sio_mod
 	sys.modules["socketio.exceptions"] = _exc_mod
 
+import httpx
+
 from frappe.realtime import auth as auth_mod
 from frappe.realtime import bridge as bridge_mod
 from frappe.realtime import dispatch as dispatch_mod
 from frappe.realtime import handlers as handlers_mod
 from frappe.realtime.auth import Session
-from frappe.realtime.config import RealtimeConfig
+from frappe.realtime.config import RealtimeConfig, get_config
+from frappe.realtime.context import frappe_context
 from frappe.realtime.registry import Registry
-from frappe.realtime.socket import Socket
+from frappe.realtime.socket import Socket, SyncSocket
 
 ConnectionRefusedError = auth_mod.ConnectionRefusedError
 
 
+def make_request(message: object = 1, record: list | None = None) -> Callable[..., Awaitable[dict]]:
+	"""Stand-in for the authenticated web-process client, which is a coroutine."""
+
+	async def request(path: str, method: str = "GET", params: dict | None = None, body: dict | None = None):
+		if record is not None:
+			record.append((path, method, params, threading.current_thread().name))
+		return {"message": message}
+
+	return request
+
+
 def make_session(
-	request: Callable[..., dict] | None = None,
+	request: Callable[..., Awaitable[dict]] | None = None,
 	data: dict | None = None,
 	**identity: object,
 ) -> Session:
@@ -58,13 +82,13 @@ def make_session(
 		user=base["user"],
 		user_type=base["user_type"],
 		installed_apps=base["installed_apps"],
-		request=request or (lambda path, method="GET", params=None, body=None: {"message": 1}),
+		request=request or make_request(),
 		data=data if data is not None else {},
 	)
 
 
 class FakeSio:
-	"""In-memory stand-in for the python-socketio Server (single namespace)."""
+	"""In-memory stand-in for the python-socketio AsyncServer (single namespace)."""
 
 	def __init__(self) -> None:
 		self.rooms: dict[str, set[str]] = {}
@@ -75,13 +99,13 @@ class FakeSio:
 	def is_connected(self, sid: str, namespace: str | None = None) -> bool:
 		return sid in self.sessions or sid in self.rooms
 
-	def enter_room(self, sid: str, room: str, namespace: str | None = None) -> None:
+	async def enter_room(self, sid: str, room: str, namespace: str | None = None) -> None:
 		self.rooms.setdefault(sid, set()).add(room)
 
-	def leave_room(self, sid: str, room: str, namespace: str | None = None) -> None:
+	async def leave_room(self, sid: str, room: str, namespace: str | None = None) -> None:
 		self.rooms.setdefault(sid, set()).discard(room)
 
-	def emit(
+	async def emit(
 		self,
 		event: str,
 		data: object | None = None,
@@ -91,10 +115,10 @@ class FakeSio:
 	) -> None:
 		self.emits.append({"event": event, "data": data, "to": to or room, "namespace": namespace})
 
-	def save_session(self, sid: str, session: Session, namespace: str | None = None) -> None:
+	async def save_session(self, sid: str, session: Session, namespace: str | None = None) -> None:
 		self.sessions[sid] = session
 
-	def get_session(self, sid: str, namespace: str | None = None) -> Session:
+	async def get_session(self, sid: str, namespace: str | None = None) -> Session:
 		return self.sessions[sid]
 
 	def get_participants(self, namespace: str, room: str) -> Iterator[tuple[str, str]]:
@@ -131,17 +155,6 @@ def make_environ(
 	if authorization:
 		env["HTTP_AUTHORIZATION"] = authorization
 	return env
-
-
-class FakeResponse:
-	def __init__(self, payload: dict):
-		self._payload = payload
-
-	def raise_for_status(self) -> None:
-		pass
-
-	def json(self) -> dict:
-		return self._payload
 
 
 class TestAuthHelpers(unittest.TestCase):
@@ -192,47 +205,162 @@ class TestAuthHelpers(unittest.TestCase):
 		self.assertEqual(auth_mod.get_url("http://x.local", "/p", cfg), "http://[::1]:8000/p")
 
 
-class TestAuthenticate(unittest.TestCase):
+class TestAuthenticate(unittest.IsolatedAsyncioTestCase):
 	def setUp(self):
-		patcher = patch.object(auth_mod, "get_socketio_secret", return_value="secret")
+		patcher = patch.object(auth_mod, "get_socketio_secret", new=AsyncMock(return_value="secret"))
 		patcher.start()
 		self.addCleanup(patcher.stop)
 
-	def _ok_response(self):
-		return FakeResponse(
-			{"message": {"user": "a@b.com", "user_type": "System User", "installed_apps": ["frappe"]}}
-		)
+	def _patch_web(self, message: object):
+		"""Replace the authenticated client so no HTTP is attempted."""
+		return patch.object(auth_mod, "_make_request", lambda *a: make_request(message))
 
-	def test_namespace_mismatch_rejected(self):
+	def _ok_payload(self):
+		return {"user": "a@b.com", "user_type": "System User", "installed_apps": ["frappe"]}
+
+	async def test_namespace_mismatch_rejected(self):
 		env = make_environ(site_header="s1")
 		with self.assertRaises(ConnectionRefusedError):
-			auth_mod.authenticate(env, "/other", make_config())
+			await auth_mod.authenticate(env, "/other", make_config())
 
-	def test_origin_mismatch_rejected(self):
+	async def test_origin_mismatch_rejected(self):
 		env = make_environ(host="s1", origin="http://evil", site_header="s1")
 		with self.assertRaises(ConnectionRefusedError):
-			auth_mod.authenticate(env, "/s1", make_config())
+			await auth_mod.authenticate(env, "/s1", make_config())
 
-	def test_missing_credentials_rejected(self):
+	async def test_absent_origin_allowed(self):
+		# Browsers omit Origin on same-origin polling, which is every embedded
+		# connect. A cross-site attempt always carries one.
+		env = make_environ(host="s1", origin=None, site_header="s1")
+		with self._patch_web(self._ok_payload()):
+			session = await auth_mod.authenticate(env, "/s1", make_config())
+
+		self.assertEqual(session.user, "a@b.com")
+
+	async def test_missing_host_rejected(self):
+		env = make_environ(host=None, origin=None, site_header="s1")
+		with self.assertRaises(ConnectionRefusedError):
+			await auth_mod.authenticate(env, "/s1", make_config())
+
+	async def test_missing_credentials_rejected(self):
 		env = make_environ(site_header="s1", cookie=None, authorization=None)
 		with self.assertRaises(ConnectionRefusedError):
-			auth_mod.authenticate(env, "/s1", make_config())
+			await auth_mod.authenticate(env, "/s1", make_config())
 
-	def test_empty_user_info_rejected(self):
+	async def test_empty_user_info_rejected(self):
 		env = make_environ(site_header="s1")
-		with patch.object(auth_mod.requests, "request", return_value=FakeResponse({"message": {}})):
-			with self.assertRaises(ConnectionRefusedError):
-				auth_mod.authenticate(env, "/s1", make_config())
+		with self._patch_web({}), self.assertRaises(ConnectionRefusedError):
+			await auth_mod.authenticate(env, "/s1", make_config())
 
-	def test_success_returns_session(self):
+	async def test_success_returns_session(self):
 		env = make_environ(site_header="s1")
-		with patch.object(auth_mod.requests, "request", return_value=self._ok_response()):
-			session = auth_mod.authenticate(env, "/s1", make_config())
+		with self._patch_web(self._ok_payload()):
+			session = await auth_mod.authenticate(env, "/s1", make_config())
 		self.assertEqual(session.site, "s1")
 		self.assertEqual(session.user, "a@b.com")
 		self.assertEqual(session.user_type, "System User")
 		self.assertEqual(session.installed_apps, ["frappe"])
 		self.assertTrue(callable(session.request))
+
+	async def test_session_reuses_the_connect_time_client(self):
+		# One request helper serves connect auth and every later call, so their
+		# timeout / redirect / cookie handling can never diverge.
+		env = make_environ(site_header="s1")
+		calls = []
+		with patch.object(auth_mod, "_make_request", lambda *a: make_request(self._ok_payload(), calls)):
+			session = await auth_mod.authenticate(env, "/s1", make_config())
+			self.assertTrue(await session.has_permission("DT", "n1"))
+
+		self.assertEqual(
+			[path for path, *_ in calls],
+			[
+				"/api/method/frappe.realtime.get_user_info",
+				"/api/method/frappe.realtime.has_permission",
+			],
+		)
+
+
+class TestSharedHttpClient(unittest.IsolatedAsyncioTestCase):
+	"""The AsyncClient is shared by every connection, so it must stay stateless."""
+
+	def setUp(self):
+		patcher = patch.object(auth_mod, "_http_client", None)
+		patcher.start()
+		self.addCleanup(patcher.stop)
+
+	async def asyncTearDown(self):
+		await auth_mod.close_clients()
+
+	def _client(self, handle: Callable[[httpx.Request], httpx.Response]) -> httpx.AsyncClient:
+		client = auth_mod.get_http_client()
+		# Swap only the transport; the rest is the production configuration.
+		client._transport = httpx.MockTransport(handle)
+		return client
+
+	async def test_response_cookies_are_never_replayed(self):
+		sent = []
+
+		def handle(request: httpx.Request) -> httpx.Response:
+			sent.append(request.headers.get("cookie"))
+			return httpx.Response(200, headers={"set-cookie": "sid=user_a; Path=/"}, json={})
+
+		client = self._client(handle)
+		await client.get("http://web/api/method/x", headers={"Cookie": "sid=user_a"})
+		# A token-authenticated connect must not inherit the previous user's session.
+		await client.get("http://web/api/method/x", headers={"Authorization": "token key:secret"})
+
+		self.assertEqual(sent, ["sid=user_a", None])
+		self.assertEqual(len(client.cookies.jar), 0)
+
+	def _web_request(self, handle: Callable[[httpx.Request], httpx.Response]):
+		"""The production request helper, pointed at a mock transport."""
+		self._client(handle)
+		return auth_mod._make_request(
+			make_environ(site_header="s1"),
+			auth_mod.Credentials(sid="abc"),
+			make_config(),
+			"s1",
+			"shared-secret",
+		)
+
+	async def test_redirects_are_followed(self):
+		def handle(request: httpx.Request) -> httpx.Response:
+			if request.url.path == "/api/method/x":
+				return httpx.Response(302, headers={"location": "http://s1/final"})
+			return httpx.Response(200, json={"message": {"user": "a@b.com"}})
+
+		body = await self._web_request(handle)("/api/method/x")
+		self.assertEqual(body["message"]["user"], "a@b.com")
+
+	async def test_request_carries_credential_site_and_secret(self):
+		seen = {}
+
+		def handle(request: httpx.Request) -> httpx.Response:
+			seen.update(request.headers)
+			seen["method"] = request.method
+			seen["query"] = request.url.params.get("doctype")
+			return httpx.Response(200, json={"message": 1})
+
+		await self._web_request(handle)("/api/method/x", "POST", params={"doctype": "ToDo"})
+
+		self.assertEqual(seen["method"], "POST")
+		self.assertEqual(seen["query"], "ToDo")
+		self.assertEqual(seen["cookie"], "sid=abc")
+		self.assertEqual(seen["x-frappe-site-name"], "s1")
+		self.assertEqual(seen["x-frappe-socket-secret"], "shared-secret")
+
+	async def test_close_clients_drops_both(self):
+		http_client, secret_client = AsyncMock(), AsyncMock()
+		with (
+			patch.object(auth_mod, "_http_client", http_client),
+			patch.object(auth_mod, "_secret_client", secret_client),
+		):
+			await auth_mod.close_clients()
+			self.assertIsNone(auth_mod._http_client)
+			self.assertIsNone(auth_mod._secret_client)
+
+		http_client.aclose.assert_awaited_once()
+		secret_client.aclose.assert_awaited_once()
 
 
 class TestRegistry(unittest.TestCase):
@@ -266,12 +394,31 @@ class TestRegistry(unittest.TestCase):
 		reg.on("evt")(lambda s: None)
 		self.assertEqual(len(reg.handlers_for("evt")), 2)
 
+	def test_async_handler_with_frappe_context_rejected(self):
+		reg = Registry()
 
-class TestSocket(unittest.TestCase):
+		async def handler(socket: Socket) -> None:
+			pass
+
+		with self.assertRaises(TypeError):
+			reg.on("evt", frappe_context=True)(handler)
+
+	def test_async_callable_object_with_frappe_context_rejected(self):
+		reg = Registry()
+
+		class Handler:
+			async def __call__(self, socket: Socket) -> None:
+				pass
+
+		with self.assertRaises(TypeError):
+			reg.on("evt", frappe_context=True)(Handler())
+
+
+class TestSocket(unittest.IsolatedAsyncioTestCase):
 	def _socket(
 		self,
 		sio: FakeSio | None = None,
-		request: Callable[..., dict] | None = None,
+		request: Callable[..., Awaitable[dict]] | None = None,
 		data: dict | None = None,
 		**identity: object,
 	) -> Socket:
@@ -287,31 +434,75 @@ class TestSocket(unittest.TestCase):
 		self.assertEqual(s.user_type, "System User")
 		self.assertEqual(s.installed_apps, ["frappe"])
 
-	def test_join_leave_emit(self):
+	async def test_join_leave_emit(self):
 		sio = FakeSio()
 		s = self._socket(sio=sio)
-		s.join("room1")
+		await s.join("room1")
 		self.assertIn("room1", sio.rooms_of("sid1"))
-		s.leave("room1")
+		await s.leave("room1")
 		self.assertNotIn("room1", sio.rooms_of("sid1"))
-		s.emit("e", {"x": 1})
+		await s.emit("e", {"x": 1})
 		self.assertEqual(sio.emits[-1], {"event": "e", "data": {"x": 1}, "to": "sid1", "namespace": "/s1"})
 
-	def test_get_set_persists(self):
+	async def test_get_set_persists(self):
 		sio = FakeSio()
 		s = self._socket(sio=sio)
 		self.assertEqual(s.get("missing", []), [])
-		s.set("subscribed_documents", [["DT", "n1"]])
+		await s.set("subscribed_documents", [["DT", "n1"]])
 		self.assertEqual(sio.sessions["sid1"].data["subscribed_documents"], [["DT", "n1"]])
 
-	def test_has_permission_http(self):
-		s = self._socket(request=lambda path, method="GET", params=None, body=None: {"message": 1})
-		self.assertTrue(s.has_permission("DT", "n1"))
-		s = self._socket(request=lambda path, method="GET", params=None, body=None: {"message": 0})
-		self.assertFalse(s.has_permission("DT", "n1"))
+	async def test_has_permission_http(self):
+		self.assertTrue(await self._socket(request=make_request(1)).has_permission("DT", "n1"))
+		self.assertFalse(await self._socket(request=make_request(0)).has_permission("DT", "n1"))
+
+	async def test_has_permission_stays_on_the_loop(self):
+		# The check is async end to end, so it must not burn a worker thread — those
+		# are all held by blocking handlers under load.
+		calls = []
+		s = self._socket(request=make_request(1, record=calls))
+		await s.has_permission("DT", "n1")
+		self.assertEqual([thread for *_, thread in calls], [threading.current_thread().name])
+
+	async def test_sync_socket_has_permission_bridges_to_loop(self):
+		# A plain handler still calls it without await; the request runs on the loop.
+		calls = []
+		s = self._socket(request=make_request(1, record=calls))
+		sync = SyncSocket(s, asyncio.get_running_loop())
+		loop_thread = threading.current_thread().name
+
+		allowed = await asyncio.to_thread(sync.has_permission, "DT", "n1")
+
+		self.assertTrue(allowed)
+		self.assertEqual([thread for *_, thread in calls], [loop_thread])
+
+	async def test_sync_socket_bridges_to_loop(self):
+		# A plain handler runs in a worker thread and drives the socket through
+		# SyncSocket; the mutations must land on the loop's server state.
+		sio = FakeSio()
+		s = self._socket(sio=sio)
+		sync = SyncSocket(s, asyncio.get_running_loop())
+
+		def handler() -> None:
+			sync.join("room1")
+			sync.set("k", "v")
+			sync.emit("e", {"x": 1})
+
+		await asyncio.to_thread(handler)
+		self.assertIn("room1", sio.rooms_of("sid1"))
+		self.assertEqual(sio.sessions["sid1"].data["k"], "v")
+		self.assertEqual(sio.emits[-1]["event"], "e")
+		self.assertEqual(sync.user, "a@b.com")
+
+	def test_sync_socket_refuses_a_closed_loop(self):
+		# Shutdown must surface as an error on the worker thread, not a forever block.
+		loop = asyncio.new_event_loop()
+		loop.close()
+		sync = SyncSocket(self._socket(), loop)
+		with self.assertRaises(RuntimeError):
+			sync.join("room1")
 
 
-class TestDispatch(unittest.TestCase):
+class TestDispatch(unittest.IsolatedAsyncioTestCase):
 	def setUp(self):
 		self.reg = Registry()
 		patcher = patch.object(dispatch_mod, "realtime", self.reg)
@@ -324,37 +515,90 @@ class TestDispatch(unittest.TestCase):
 		self.sio.sessions["sid1"] = session
 		return session
 
-	def test_install_scoping_skips_uninstalled_app(self):
+	async def test_install_scoping_skips_uninstalled_app(self):
 		calls = []
 		with self.reg.importing_app("otherapp"):
 			self.reg.on("evt")(lambda s: calls.append("ran"))
 		self._session(installed_apps=("frappe",))
-		dispatch_mod._run_handlers(self.sio, "evt", "/s1", "sid1", ())
+		await dispatch_mod._run_handlers(self.sio, "evt", "/s1", "sid1", ())
 		self.assertEqual(calls, [])
 
-	def test_install_scoping_runs_installed_app(self):
+	async def test_install_scoping_runs_installed_app(self):
 		calls = []
 		with self.reg.importing_app("otherapp"):
 			self.reg.on("evt")(lambda s: calls.append("ran"))
 		self._session(installed_apps=("frappe", "otherapp"))
-		dispatch_mod._run_handlers(self.sio, "evt", "/s1", "sid1", ())
+		await dispatch_mod._run_handlers(self.sio, "evt", "/s1", "sid1", ())
 		self.assertEqual(calls, ["ran"])
 
-	def test_guest_gate(self):
+	async def test_guest_gate(self):
 		calls = []
 		self.reg.on("evt", allow_guest=False)(lambda s: calls.append("ran"))
 		self._session(user="Guest")
-		dispatch_mod._run_handlers(self.sio, "evt", "/s1", "sid1", ())
+		await dispatch_mod._run_handlers(self.sio, "evt", "/s1", "sid1", ())
 		self.assertEqual(calls, [])
 
-	def test_guest_allowed(self):
+	async def test_guest_allowed(self):
 		calls = []
 		self.reg.on("evt", allow_guest=True)(lambda s: calls.append("ran"))
 		self._session(user="Guest")
-		dispatch_mod._run_handlers(self.sio, "evt", "/s1", "sid1", ())
+		await dispatch_mod._run_handlers(self.sio, "evt", "/s1", "sid1", ())
 		self.assertEqual(calls, ["ran"])
 
-	def test_frappe_context_wrap(self):
+	async def test_async_handler_runs_on_loop(self):
+		calls = []
+
+		async def handler(socket: Socket) -> None:
+			await socket.join("room1")
+			calls.append(type(socket).__name__)
+
+		self.reg.on("evt")(handler)
+		self._session()
+		await dispatch_mod._run_handlers(self.sio, "evt", "/s1", "sid1", ())
+		self.assertEqual(calls, ["Socket"])
+		self.assertIn("room1", self.sio.rooms_of("sid1"))
+
+	async def test_async_callable_object_runs_on_loop(self):
+		seen = []
+
+		class Handler:
+			async def __call__(self, socket: Socket) -> None:
+				seen.append(type(socket).__name__)
+
+		self.reg.on("evt")(Handler())
+		self._session()
+		await dispatch_mod._run_handlers(self.sio, "evt", "/s1", "sid1", ())
+		self.assertEqual(seen, ["Socket"])
+
+	async def test_coroutine_returned_by_a_wrapper_is_awaited(self):
+		ran = []
+
+		async def inner(socket: Socket) -> None:
+			ran.append("ran")
+
+		# An opaque decorator hides the coroutine function behind a plain wrapper.
+		def wrapper(socket: Socket):
+			return inner(socket)
+
+		self.reg.on("evt")(wrapper)
+		self._session()
+		await dispatch_mod._run_handlers(self.sio, "evt", "/s1", "sid1", ())
+		self.assertEqual(ran, ["ran"])
+
+	async def test_sync_handler_runs_in_thread(self):
+		seen = []
+
+		def handler(socket: Socket) -> None:
+			socket.join("room1")
+			seen.append((type(socket).__name__, threading.current_thread() is threading.main_thread()))
+
+		self.reg.on("evt")(handler)
+		self._session()
+		await dispatch_mod._run_handlers(self.sio, "evt", "/s1", "sid1", ())
+		self.assertEqual(seen, [("SyncSocket", False)])
+		self.assertIn("room1", self.sio.rooms_of("sid1"))
+
+	async def test_frappe_context_wrap(self):
 		entered = []
 
 		@contextmanager
@@ -365,10 +609,10 @@ class TestDispatch(unittest.TestCase):
 		self.reg.on("evt", frappe_context=True)(lambda s: None)
 		self._session()
 		with patch.object(dispatch_mod, "frappe_context", fake_ctx):
-			dispatch_mod._run_handlers(self.sio, "evt", "/s1", "sid1", ())
+			await dispatch_mod._run_handlers(self.sio, "evt", "/s1", "sid1", ())
 		self.assertEqual(entered, [("s1", "a@b.com")])
 
-	def test_handler_error_swallowed(self):
+	async def test_handler_error_swallowed(self):
 		ran = []
 
 		def boom(s: Socket) -> None:
@@ -378,44 +622,167 @@ class TestDispatch(unittest.TestCase):
 		self.reg.on("evt")(lambda s: ran.append("after"))
 		self._session()
 		# Must not raise; the second handler still runs.
-		dispatch_mod._run_handlers(self.sio, "evt", "/s1", "sid1", ())
+		await dispatch_mod._run_handlers(self.sio, "evt", "/s1", "sid1", ())
 		self.assertEqual(ran, ["after"])
 
-	def test_passes_event_args(self):
+	async def test_passes_event_args(self):
 		seen = []
 		self.reg.on("evt")(lambda s, a, b: seen.append((a, b)))
 		self._session()
-		dispatch_mod._run_handlers(self.sio, "evt", "/s1", "sid1", ("x", "y"))
+		await dispatch_mod._run_handlers(self.sio, "evt", "/s1", "sid1", ("x", "y"))
 		self.assertEqual(seen, [("x", "y")])
 
 
-class TestBridge(unittest.TestCase):
+class TestFrappeContext(unittest.IsolatedAsyncioTestCase):
+	def test_init_rebinds_a_fresh_local(self):
+		# frappe.local is a shared mutable dict behind a ContextVar; without force the
+		# worker thread would mutate the loop's copy (or skip init as already done).
+		frappe = MagicMock()
+		with patch.dict(sys.modules, {"frappe": frappe}), frappe_context("s1", "a@b.com"):
+			pass
+
+		frappe.init.assert_called_once_with("s1", force=True)
+		frappe.set_user.assert_called_once_with("a@b.com")
+		frappe.db.commit.assert_called_once()
+		frappe.destroy.assert_called_once()
+
+	async def test_two_concurrent_contexts_do_not_share_local(self):
+		# Two tasks each open a context. frappe.local is one mutable dict behind a
+		# ContextVar; init(force=True) must rebind a fresh one per call, otherwise the
+		# tasks overwrite each other's site/user (plan.md 4.4).
+		frappe = MagicMock()
+
+		async def open_context(site: str, user: str) -> None:
+			with frappe_context(site, user):
+				await asyncio.sleep(0)
+
+		with patch.dict(sys.modules, {"frappe": frappe}):
+			await asyncio.gather(open_context("s1", "a@b.com"), open_context("s2", "c@d.com"))
+
+		self.assertEqual([c.args[0] for c in frappe.init.call_args_list], ["s1", "s2"])
+		self.assertTrue(all(c.kwargs["force"] for c in frappe.init.call_args_list))
+		self.assertEqual([c.args[0] for c in frappe.set_user.call_args_list], ["a@b.com", "c@d.com"])
+
+
+class TestConfig(unittest.TestCase):
+	def _config(self, **conf: object) -> RealtimeConfig:
+		import frappe
+
+		base = {"socketio_port": 9000, "redis_queue": "redis://127.0.0.1:11311"}
+		base.update(conf)
+		with patch.object(frappe, "get_common_site_config", return_value=base):
+			return get_config(sites_path=".")
+
+	def test_worker_threads_are_unset_by_default(self):
+		# Nothing built in dispatches to a thread, so the loop's own executor stands.
+		self.assertIsNone(self._config().worker_threads)
+
+	def test_sites_path_is_absolute(self):
+		# serve() changes into sites/ after the config is built, so a relative path
+		# would then resolve one level too deep.
+		import frappe
+
+		with patch.object(frappe, "get_common_site_config", return_value={"socketio_port": 9000}):
+			config = get_config(sites_path="sites")
+
+		self.assertEqual(config.sites_path, os.path.abspath("sites"))
+
+	def test_worker_threads_override(self):
+		self.assertEqual(self._config(socketio_worker_threads="8").worker_threads, 8)
+
+
+class TestServerApp(unittest.IsolatedAsyncioTestCase):
+	"""RealtimeServer wiring; needs the real socketio/uvicorn deps."""
+
+	def setUp(self):
+		try:
+			from frappe.realtime import server as server_mod
+		except Exception as exc:  # pragma: no cover - depends on the environment
+			self.skipTest(f"realtime server dependencies unavailable: {exc}")
+		self.server_mod = server_mod
+
+	def test_handlers_are_loaded_before_events_are_wired(self):
+		# wire() snapshots the registry, so an embedder that only builds the server
+		# must still end up with every handler bound.
+		order = []
+		with (
+			patch.object(self.server_mod, "load_handlers", lambda *a, **k: order.append("load")),
+			patch.object(self.server_mod, "wire", lambda *a, **k: order.append("wire")),
+		):
+			self.server_mod.RealtimeServer(make_config())
+
+		self.assertEqual(order, ["load", "wire"])
+
+	def test_discovery_gets_the_sites_path_from_the_config(self):
+		# serve() moves into sites/ before it builds the server, so a cwd-relative path
+		# reads sites/sites/apps.txt there and the bench root's apps.txt when embedded.
+		# Neither exists, and get_all_apps raises rather than returning nothing.
+		seen = []
+		with patch.object(self.server_mod, "wire", lambda *a, **k: None):
+			with patch(
+				"frappe.realtime.registry.discover_app_handlers",
+				lambda sites_path=None: seen.append(sites_path),
+			):
+				self.server_mod.RealtimeServer(make_config(sites_path="/bench/sites"))
+
+		self.assertEqual(seen, ["/bench/sites"])
+
+	async def _startup(self, config: RealtimeConfig) -> MagicMock:
+		with (
+			patch.object(self.server_mod, "load_handlers", lambda *a, **k: None),
+			patch.object(self.server_mod, "wire", lambda *a, **k: None),
+		):
+			server = self.server_mod.RealtimeServer(config)
+		loop = asyncio.get_running_loop()
+		with (
+			patch.object(server.bridge, "start"),
+			patch.object(loop, "set_default_executor") as set_executor,
+		):
+			await server._on_startup()
+		return set_executor
+
+	async def test_the_loop_executor_is_left_alone_by_default(self):
+		# set_default_executor replaces it for the whole loop, and nothing built in
+		# dispatches to a thread.
+		(await self._startup(make_config())).assert_not_called()
+
+	async def test_worker_threads_installs_a_sized_executor(self):
+		set_executor = await self._startup(make_config(worker_threads=7))
+
+		set_executor.assert_called_once()
+		self.assertEqual(set_executor.call_args.args[0]._max_workers, 7)
+
+
+class TestBridge(unittest.IsolatedAsyncioTestCase):
 	def setUp(self):
 		self.sio = MagicMock()
+		self.sio.emit = AsyncMock()
 		self.bridge = bridge_mod.RedisBridge(self.sio, "redis://x")
 
-	def test_room_emit(self):
-		self.bridge._handle('{"namespace": "s1", "room": "user:a", "event": "msg", "message": {"k": 1}}')
+	async def test_room_emit(self):
+		await self.bridge._handle(
+			'{"namespace": "s1", "room": "user:a", "event": "msg", "message": {"k": 1}}'
+		)
 		self.sio.emit.assert_called_once_with("msg", {"k": 1}, room="user:a", namespace="/s1")
 
-	def test_no_room_broadcast(self):
+	async def test_no_room_broadcast(self):
 		self.sio.manager.rooms = {"/s1": {}, "/s2": {}}
-		self.bridge._handle('{"namespace": "s1", "event": "build", "message": {"k": 1}}')
+		await self.bridge._handle('{"namespace": "s1", "event": "build", "message": {"k": 1}}')
 		self.assertEqual(self.sio.emit.call_count, 2)
 		namespaces = {c.kwargs["namespace"] for c in self.sio.emit.call_args_list}
 		self.assertEqual(namespaces, {"/s1", "/s2"})
 
-	def test_malformed_message_skipped(self):
-		self.bridge._handle("not json")
-		self.bridge._handle('{"no_namespace": true}')
+	async def test_malformed_message_skipped(self):
+		await self.bridge._handle("not json")
+		await self.bridge._handle('{"no_namespace": true}')
 		self.sio.emit.assert_not_called()
 
 
-class TestCoreHandlers(unittest.TestCase):
+class TestCoreHandlers(unittest.IsolatedAsyncioTestCase):
 	def _socket(
 		self,
 		sio: FakeSio,
-		request: Callable[..., dict] | None = None,
+		request: Callable[..., Awaitable[dict]] | None = None,
 		data: dict | None = None,
 		**identity: object,
 	) -> Socket:
@@ -423,67 +790,67 @@ class TestCoreHandlers(unittest.TestCase):
 		sio.sessions["sid1"] = session
 		return Socket(sio, "sid1", "/s1", session)
 
-	def test_ping_pong(self):
+	async def test_ping_pong(self):
 		sio = FakeSio()
 		s = self._socket(sio)
-		handlers_mod.ping(s)
+		await handlers_mod.ping(s)
 		self.assertEqual(sio.emits[-1]["event"], "pong")
 
-	def test_on_connect_joins_rooms(self):
+	async def test_on_connect_joins_rooms(self):
 		sio = FakeSio()
 		s = self._socket(sio, user="a@b.com")
-		handlers_mod.on_connect(s)
+		await handlers_mod.on_connect(s)
 		rooms = sio.rooms_of("sid1")
 		self.assertIn("user:a@b.com", rooms)
 		self.assertIn("website", rooms)
 		self.assertIn("all", rooms)  # System User
 
-	def test_on_connect_website_user_skips_site_room(self):
+	async def test_on_connect_website_user_skips_site_room(self):
 		sio = FakeSio()
 		s = self._socket(sio, user_type="Website User")
-		handlers_mod.on_connect(s)
+		await handlers_mod.on_connect(s)
 		self.assertNotIn("all", sio.rooms_of("sid1"))
 
-	def test_doctype_subscribe_permission_gated(self):
+	async def test_doctype_subscribe_permission_gated(self):
 		sio = FakeSio()
-		allow = self._socket(sio, request=lambda path, method="GET", params=None, body=None: {"message": 1})
-		handlers_mod.doctype_subscribe(allow, "ToDo")
+		allow = self._socket(sio, request=make_request(1))
+		await handlers_mod.doctype_subscribe(allow, "ToDo")
 		self.assertIn("doctype:ToDo", sio.rooms_of("sid1"))
 
 		sio2 = FakeSio()
-		deny = self._socket(sio2, request=lambda path, method="GET", params=None, body=None: {"message": 0})
-		handlers_mod.doctype_subscribe(deny, "ToDo")
+		deny = self._socket(sio2, request=make_request(0))
+		await handlers_mod.doctype_subscribe(deny, "ToDo")
 		self.assertNotIn("doctype:ToDo", sio2.rooms_of("sid1"))
 
-	def test_doc_close_removes_tracked_pair(self):
+	async def test_doc_close_removes_tracked_pair(self):
 		# Regression for the Node bug: the pair must actually be dropped.
 		sio = FakeSio()
 		s = self._socket(sio, data={"subscribed_documents": [["ToDo", "n1"], ["ToDo", "n2"]]})
-		handlers_mod.doc_close(s, "ToDo", "n1")
+		await handlers_mod.doc_close(s, "ToDo", "n1")
 		self.assertEqual(sio.sessions["sid1"].data["subscribed_documents"], [["ToDo", "n2"]])
 
-	def test_doc_viewers_emitted_for_multiple_users(self):
+	async def test_doc_viewers_emitted_for_multiple_users(self):
 		sio = FakeSio()
 		session_a = make_session(user="a@b.com")
 		sio.sessions["sid1"] = session_a
 		sio.sessions["sid2"] = make_session(user="b@b.com")
 		room = handlers_mod.open_doc_room("ToDo", "n1")
-		sio.enter_room("sid1", room)
-		sio.enter_room("sid2", room)
+		await sio.enter_room("sid1", room)
+		await sio.enter_room("sid2", room)
 		s = Socket(sio, "sid1", "/s1", session_a)
-		handlers_mod.notify_doc_viewers(s, "ToDo", "n1")
+		await handlers_mod.notify_doc_viewers(s, "ToDo", "n1")
 		emit = sio.emits[-1]
 		self.assertEqual(emit["event"], "doc_viewers")
 		self.assertEqual(set(emit["data"]["users"]), {"a@b.com", "b@b.com"})
 
-	def test_doc_viewers_silent_for_lone_self(self):
+	async def test_doc_viewers_silent_for_lone_self(self):
 		sio = FakeSio()
 		session_a = make_session(user="a@b.com")
 		sio.sessions["sid1"] = session_a
 		room = handlers_mod.open_doc_room("ToDo", "n1")
-		sio.enter_room("sid1", room)
+		await sio.enter_room("sid1", room)
 		s = Socket(sio, "sid1", "/s1", session_a)
-		handlers_mod.notify_doc_viewers(s, "ToDo", "n1")
+		await handlers_mod.notify_doc_viewers(s, "ToDo", "n1")
 		self.assertEqual(sio.emits, [])
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,10 +96,10 @@ dependencies = [
     # Pin exact versions after a manual handshake check (polling + websocket upgrade).
     "python-socketio~=5.16.2",
     "python-engineio~=4.13.2",
-    "gevent~=25.9.1",
-    # gevent-websocket is effectively unmaintained but is the documented websocket
-    # path for python-socketio's gevent WSGIServer. Pinned deliberately.
-    "gevent-websocket~=0.10.1",
+    # ASGI server for the realtime process.
+    "uvicorn~=0.52.1",
+    # async HTTP client for the realtime connect/auth path.
+    "httpx~=0.28.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Previous realtime implementation has used gevent.
New implementation will use asyncio + uvicorn.

So, that we can run it as thread as well to save some more memory for small sites.

`no-docs`

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>