### PR TITLE
fix: consistent link style in toast message

### DIFF
--- a/frappe/public/css/espresso/components/toast.css
+++ b/frappe/public/css/espresso/components/toast.css
@@ -124,6 +124,15 @@
     overflow-wrap: break-word;
 }
 
+/* Links in the message or description have the same problem as 'close' class, 
+    it's styled directly by the global `a { color: var(--text-color) }`.
+    This out-specifies the global styles*/
+.es-toast a,
+.es-toast a:hover,
+.es-toast a:focus {
+    color: var(--ink-base);
+}
+
 /* extra html passed through the legacy body option */
 .es-toast__body {
     margin-top: var(--spacing);

--- a/frappe/public/css/espresso/components/toast.css
+++ b/frappe/public/css/espresso/components/toast.css
@@ -124,7 +124,7 @@
     overflow-wrap: break-word;
 }
 
-/* Links in the message or description have the same problem as 'close' class, 
+/* Links in the message or description have the same problem as 'close' class,
     it's styled directly by the global `a { color: var(--text-color) }`.
     This out-specifies the global styles*/
 .es-toast a,
@@ -132,6 +132,8 @@
 .es-toast a:focus {
     color: var(--ink-base);
 }
+
+
 
 /* extra html passed through the legacy body option */
 .es-toast__body {


### PR DESCRIPTION
This anchor tag had the same problem as the close class. It's styled by the global CSS after toast is styled to a dark grey. Specifying the styles for the tag in toast.css.

### Before
<img width="566" height="146" alt="image" src="https://github.com/user-attachments/assets/03231e68-69fd-48d2-a2a9-c798ed62b0f5" />


### After
<img width="545" height="186" alt="image" src="https://github.com/user-attachments/assets/4da9a1e1-681e-45da-bea6-72f1e0d20a90" />