### PR TITLE
fix: untranslated quill table picker labels

### DIFF
--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -275,6 +275,26 @@ frappe.ui.form.ControlTextEditor = class ControlTextEditor extends frappe.ui.for
 					sprite_icon("a-large-small", 'class="ql-label-icon"')
 				);
 			});
+
+		// table picker: menu items ride the same data-label channel; the
+		// visible label rides data-title instead, since selectItem copies the
+		// clicked item's data-label onto the label
+		const table_labels = {
+			"insert-table": __("Insert Table"),
+			"insert-row-above": __("Insert Row Above"),
+			"insert-row-below": __("Insert Row Below"),
+			"insert-column-right": __("Insert Column Right"),
+			"insert-column-left": __("Insert Column Left"),
+			"delete-row": __("Delete Row"),
+			"delete-column": __("Delete Column"),
+			"delete-table": __("Delete Table"),
+		};
+		toolbar.container.querySelectorAll(".ql-table .ql-picker-item").forEach((item) => {
+			item.setAttribute("data-label", table_labels[item.dataset.value]);
+		});
+		toolbar.container
+			.querySelector(".ql-table .ql-picker-label")
+			?.setAttribute("data-title", __("Table"));
 	}
 
 	add_toolbar_tooltips(toolbar) {

--- a/frappe/public/scss/common/quill.scss
+++ b/frappe/public/scss/common/quill.scss
@@ -609,40 +609,12 @@
 	width: 66px;
 
 	.ql-picker-label::before {
-		content: "Table";
+		content: attr(data-title);
 	}
 
 	.ql-picker-options {
-		[data-value="insert-table"]::before {
-			content: "Insert Table";
-		}
-
-		[data-value="insert-row-above"]::before {
-			content: "Insert Row Above";
-		}
-
-		[data-value="insert-row-below"]::before {
-			content: "Insert Row Below";
-		}
-
-		[data-value="insert-column-right"]::before {
-			content: "Insert Column Right";
-		}
-
-		[data-value="insert-column-left"]::before {
-			content: "Insert Column Left";
-		}
-
-		[data-value="delete-row"]::before {
-			content: "Delete Row";
-		}
-
-		[data-value="delete-column"]::before {
-			content: "Delete Column";
-		}
-
-		[data-value="delete-table"]::before {
-			content: "Delete Table";
+		.ql-picker-item[data-label]::before {
+			content: attr(data-label);
 		}
 	}
 }


### PR DESCRIPTION
Quill's table picker labels are hardcoded English CSS `content` rules, so they ignore the user's language and Custom Translations. Render them from `data-label`/`data-title` attributes set through `__()` instead.

Awesomplete status message fix split into a separate [PR](https://github.com/frappe/frappe/pull/41858): 

Ref: https://support.frappe.io/helpdesk/tickets/75845?view=VIEW-HD+Ticket-76199