### PR TITLE
fix: translated doctype search repeats rows across pages

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -149,10 +149,11 @@ def search_widget(
 
 	if query:  # Query = custom search query i.e. python function
 		meta = frappe.get_meta(doctype)
-		# For translated doctypes, pass empty txt and a large page_length so the custom query
-		# returns all records without SQL-level text filtering; Python-level filtering against
-		# translated values is applied below.
+		# For translated doctypes, pass empty txt, no offset and a large page_length so the custom
+		# query returns all records without SQL-level text filtering or paging; Python-level
+		# filtering against translated values and paging are applied below.
 		query_txt = "" if meta.translated_doctype else txt
+		query_start = 0 if meta.translated_doctype else start
 		query_page_length = PAGE_LENGTH_FOR_LINK_VALIDATION if meta.translated_doctype else page_length
 
 		if sbool(query_filters_as_dict) and isinstance(filters, list):
@@ -168,7 +169,7 @@ def search_widget(
 				doctype,
 				query_txt,
 				searchfield,
-				start,
+				query_start,
 				query_page_length,
 				filters,
 				as_dict=as_dict,
@@ -194,7 +195,7 @@ def search_widget(
 			if meta.translated_doctype:
 				values = filter_translated(values, txt, as_dict)
 				values = sorted(values, key=lambda x: relevance_sorter(x, txt, as_dict))
-				values = values[:page_length]
+				values = values[start : start + page_length]
 
 		return values
 
@@ -288,7 +289,8 @@ def search_widget(
 		filters=filters,
 		fields=formatted_fields,
 		or_filters=or_filters,
-		limit_start=start,
+		# translated doctypes are matched and paged in Python below, so the whole set is fetched
+		limit_start=0 if meta.translated_doctype else start,
 		limit_page_length=None if meta.translated_doctype else page_length,
 		order_by=order_by,
 		ignore_permissions=doctype == "DocType",
@@ -306,6 +308,9 @@ def search_widget(
 		# This will first bring elements on top in which query is a prefix of element
 		# Then it will bring the rest of the elements and sort them in lexicographical order
 		values = sorted(values, key=lambda x: relevance_sorter(x, txt, as_dict))
+
+		if meta.translated_doctype:
+			values = values[start : start + page_length]
 
 		# remove _relevance from results
 		if add_relevance:

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -164,6 +164,8 @@ def search_widget(
 
 		try:
 			is_whitelisted(frappe.get_attr(query))
+			# guarded by is_whitelisted above
+			# nosemgrep: frappe-semgrep-rules.rules.security.frappe-codeinjection-eval
 			values = frappe.call(
 				query,
 				doctype,

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -148,6 +148,46 @@ class TestSearch(IntegrationTestCase):
 				"Search results for 'nutzer' in German should include 'User' ('Nutzer')",
 			)
 
+	def test_translated_doctype_search_pagination(self):
+		doctype = "Test Translated Search Paging"
+		if frappe.db.exists("DocType", doctype):
+			frappe.delete_doc("DocType", doctype, force=True)
+		new_doctype(
+			name=doctype,
+			translated_doctype=1,
+			autoname="field:title",
+			sort_field="sequence",
+			sort_order="ASC",
+			fields=[
+				{"label": "Title", "fieldname": "title", "fieldtype": "Data"},
+				{"label": "Sequence", "fieldname": "sequence", "fieldtype": "Int"},
+			],
+		).insert()
+		self.addCleanup(lambda: frappe.delete_doc("DocType", doctype, force=True, ignore_missing=True))
+
+		# non matching records are stored first, so an offset applied before the translated
+		# filtering would eat into them instead of into the matches
+		titles = [f"Harbour Freight Terminal {i:02d}" for i in range(1, 7)]
+		titles += [f"Northwind Depot {i:02d}" for i in range(1, 10)]
+		for sequence, title in enumerate(titles, start=1):
+			frappe.get_doc({"doctype": doctype, "title": title, "sequence": sequence}).insert()
+
+		expected = [title for title in titles if "Depot" in title]
+
+		for query in (None, "frappe.tests.test_search.paginated_query"):
+			with self.subTest(query=query):
+				pages = [
+					[
+						result[0]
+						for result in search_widget(
+							doctype=doctype, txt="Depot", query=query, start=start, page_length=3
+						)
+					]
+					for start in (0, 3, 6, 9)
+				]
+
+				self.assertEqual(pages, [expected[0:3], expected[3:6], expected[6:9], []])
+
 	def test_validate_and_sanitize_search_inputs(self):
 		# should raise error if searchfield is injectable
 		self.assertRaises(
@@ -772,6 +812,27 @@ def query_by_title(
 	filters: str | list | dict[str, Any],
 ):
 	return frappe.get_list(doctype, filters={"title": ("like", f"%{txt}%")}, as_list=True)
+
+
+@whitelist_for_tests()
+@frappe.validate_and_sanitize_search_inputs
+def paginated_query(
+	doctype: str,
+	txt: str,
+	searchfield: str,
+	start: int,
+	page_len: int,
+	filters: str | list | dict[str, Any],
+):
+	return frappe.get_all(
+		doctype,
+		fields=["name"],
+		filters={"name": ["like", f"%{txt}%"]} if txt else None,
+		order_by="sequence asc",
+		limit_start=start,
+		limit_page_length=page_len,
+		as_list=True,
+	)
 
 
 def setup_test_link_field_order(TestCase):


### PR DESCRIPTION
## Bug

Search pagination was incorrect for doctypes with `translated_doctype` enabled. Since translated values are filtered in Python, applying `start` in SQL caused pages to repeat rows and miss matches.

The standard `get_list` path also returned all matching rows because `limit_page_length` is `None` for translated doctypes.

## Fix

Pagination for translated doctypes now happens entirely in Python:

- Query without SQL offset.
- Filter and sort translated results first.
- Apply `values[start : start + page_length]` afterwards.
- Keep `for_link_validation` behavior unchanged.

Flagged during review of #41760; that backport keeps the current ordering to match develop, so it should pick this up once this lands.