### PR TITLE
fix: untranslated awesomplete status messages

### DIFF
--- a/frappe/public/js/frappe/form/controls/autocomplete.js
+++ b/frappe/public/js/frappe/form/controls/autocomplete.js
@@ -1,4 +1,4 @@
-import Awesomplete from "awesomplete";
+import Awesomplete from "../../ui/awesomplete";
 
 frappe.ui.form.ControlAutocomplete = class ControlAutoComplete extends frappe.ui.form.ControlData {
 	static trigger_change_on_input_event = false;

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -4,7 +4,8 @@
 // link validation
 // custom queries
 // add_fetches
-import Awesomplete from "awesomplete";
+import Awesomplete from "../../ui/awesomplete";
+
 frappe.ui.form.recent_link_validations = {};
 
 frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlData {

--- a/frappe/public/js/frappe/ui/awesomplete.js
+++ b/frappe/public/js/frappe/ui/awesomplete.js
@@ -1,0 +1,36 @@
+import BaseAwesomplete from "awesomplete";
+
+export default class Awesomplete extends BaseAwesomplete {
+	constructor(input, options) {
+		super(input, options);
+		this.status.textContent = this.minChars
+			? __("Type {0} or more characters for results.", [this.minChars])
+			: __("Begin typing for results.");
+	}
+
+	evaluate() {
+		super.evaluate();
+		this.status.textContent = this.opened
+			? __("{0} results found", [this.ul.children.length])
+			: __("No results found");
+	}
+
+	goto(index) {
+		super.goto(index);
+		const items = this.ul.children;
+		if (index > -1 && items.length) {
+			this.status.textContent = __("{0}, list item {1} of {2}", [
+				items[index].textContent,
+				index + 1,
+				items.length,
+			]);
+		}
+	}
+}
+
+// replace the global set by the library, so consumers outside this bundle
+// (awesome bar, tag editor, field select) get this subclass without
+// bundling their own copy of the library
+if (typeof window !== "undefined") {
+	window.Awesomplete = Awesomplete;
+}


### PR DESCRIPTION
Awesomplete hardcodes its aria status messages in English ("Begin typing for results.", "N results found", …), so they ignore the user's language and Custom Translations. Route them through `__()` via a subclass; the subclass also replaces the library's global so the awesome bar, tag editor and field select pick it up without bundling extra copies.

Split out of #41854

Ref: https://support.frappe.io/helpdesk/tickets/75845?view=VIEW-HD+Ticket-76199