### PR TITLE
fix(notification-log): record the source document a notification came from

### DIFF
--- a/frappe/core/doctype/comment/comment.py
+++ b/frappe/core/doctype/comment/comment.py
@@ -58,7 +58,13 @@ class Comment(Document):
 	no_feed_on_delete = True
 
 	def after_insert(self):
-		notify_mentions(self.reference_doctype, self.reference_name, self.content)
+		notify_mentions(
+			self.reference_doctype,
+			self.reference_name,
+			self.content,
+			source_doctype=self.doctype,
+			source_name=self.name,
+		)
 		self.notify_change("add")
 
 	def validate(self):

--- a/frappe/desk/doctype/notification_log/notification_log.json
+++ b/frappe/desk/doctype/notification_log/notification_log.json
@@ -12,6 +12,8 @@
   "reference_section",
   "document_type",
   "document_name",
+  "source_doctype",
+  "source_name",
   "app",
   "column_break_ref",
   "link",
@@ -69,6 +71,21 @@
    "fieldname": "document_name",
    "fieldtype": "Data",
    "label": "Document Name",
+   "search_index": 1
+  },
+  {
+   "fieldname": "source_doctype",
+   "fieldtype": "Link",
+   "label": "Source Document Type",
+   "options": "DocType",
+   "read_only": 1
+  },
+  {
+   "fieldname": "source_name",
+   "fieldtype": "Dynamic Link",
+   "label": "Source Document Name",
+   "options": "source_doctype",
+   "read_only": 1,
    "search_index": 1
   },
   {

--- a/frappe/desk/doctype/notification_log/notification_log.json
+++ b/frappe/desk/doctype/notification_log/notification_log.json
@@ -85,8 +85,7 @@
    "fieldtype": "Dynamic Link",
    "label": "Source Document Name",
    "options": "source_doctype",
-   "read_only": 1,
-   "search_index": 1
+   "read_only": 1
   },
   {
    "description": "App that produced this notification; used to scope app-specific panels. Derived from the reference document when not set explicitly.",

--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -33,6 +33,8 @@ class NotificationLog(Document):
 		from_user: DF.Link | None
 		link: DF.SmallText | None
 		read: DF.Check
+		source_doctype: DF.Link | None
+		source_name: DF.DynamicLink | None
 		subject: DF.Text | None
 		title: DF.SmallText | None
 		type: DF.Link | None

--- a/frappe/desk/doctype/notification_log/test_notification_log.py
+++ b/frappe/desk/doctype/notification_log/test_notification_log.py
@@ -55,13 +55,9 @@ class TestNotificationLog(IntegrationTestCase):
 		install_notification_types()
 		todo = get_todo()
 		recipient = make_recipient("notify_mention_source@example.com")
-		frappe.db.set_value(
-			"User", recipient, {"allowed_in_mentions": 1, "user_type": "System User"}
-		)
+		frappe.db.set_value("User", recipient, {"allowed_in_mentions": 1, "user_type": "System User"})
 
-		comment = todo.add_comment(
-			"Comment", f'<span class="mention" data-id="{recipient}">@mention</span>'
-		)
+		comment = todo.add_comment("Comment", f'<span class="mention" data-id="{recipient}">@mention</span>')
 
 		log = frappe.db.get_value(
 			"Notification Log",

--- a/frappe/desk/doctype/notification_log/test_notification_log.py
+++ b/frappe/desk/doctype/notification_log/test_notification_log.py
@@ -49,6 +49,30 @@ class TestNotificationLog(IntegrationTestCase):
 		)
 		self.assertTrue(frappe.db.exists("Notification Log", {"for_user": user, "subject": "Self alert"}))
 
+	def test_mention_records_the_comment_it_was_written_in(self):
+		"""The notification is about the document, but a reader needs the comment
+		to land on the mention itself."""
+		install_notification_types()
+		todo = get_todo()
+		recipient = make_recipient("notify_mention_source@example.com")
+		frappe.db.set_value(
+			"User", recipient, {"allowed_in_mentions": 1, "user_type": "System User"}
+		)
+
+		comment = todo.add_comment(
+			"Comment", f'<span class="mention" data-id="{recipient}">@mention</span>'
+		)
+
+		log = frappe.db.get_value(
+			"Notification Log",
+			{"for_user": recipient, "type": "Mention", "document_name": todo.name},
+			["document_type", "source_doctype", "source_name"],
+			as_dict=True,
+		)
+		self.assertEqual(log.document_type, "ToDo")
+		self.assertEqual(log.source_doctype, "Comment")
+		self.assertEqual(log.source_name, comment.name)
+
 	def test_get_email_header_unknown_type_falls_back(self):
 		"""A custom type with no header_map entry must not KeyError."""
 		doc = frappe._dict(type="Some Custom Type", document_name="X", email_header=None)

--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -400,7 +400,12 @@ def get_dynamic_link_filters(doctype, links, fieldname):
 	return {doctype_fieldname: doctype_value}
 
 
-def notify_mentions(ref_doctype, ref_name, content):
+def notify_mentions(ref_doctype, ref_name, content, source_doctype=None, source_name=None):
+	"""Notify users mentioned in `content`.
+	`source_doctype` / `source_name` identify the record the mention was
+	written in (e.g. a Comment) when that is not the reference document
+	itself.
+	"""
 	if ref_doctype and ref_name and content:
 		mentions = extract_mentions(content)
 
@@ -427,6 +432,8 @@ def notify_mentions(ref_doctype, ref_name, content):
 			"type": "Mention",
 			"document_type": ref_doctype,
 			"document_name": ref_name,
+			"source_doctype": source_doctype,
+			"source_name": source_name,
 			"subject": notification_message,
 			"from_user": frappe.session.user,
 			"email_content": content,

--- a/frappe/public/js/frappe/form/controls/quill-mention/blots/mention.js
+++ b/frappe/public/js/frappe/form/controls/quill-mention/blots/mention.js
@@ -26,11 +26,19 @@ class MentionBlot extends Embed {
 	}
 
 	static value(domNode) {
+		// mentions written by other editors (e.g. tiptap editor)
+		// stores in label with format
+		// '<p><span data-id="abc@g.com" data-label="RKL" class="mention" data-type="mention">@RKL</span> sdf</p>'
+		const denotationChar = domNode.dataset.denotationChar || "@";
+		const value =
+			domNode.dataset.value ||
+			domNode.dataset.label ||
+			domNode.textContent.replace(denotationChar, "").trim();
 		return {
 			id: domNode.dataset.id,
-			value: domNode.dataset.value,
+			value: value,
 			link: domNode.dataset.link || null,
-			denotationChar: domNode.dataset.denotationChar,
+			denotationChar: denotationChar,
 			isGroup: domNode.dataset.isGroup,
 		};
 	}

--- a/frappe/public/js/frappe/ui/notifications/notifications.js
+++ b/frappe/public/js/frappe/ui/notifications/notifications.js
@@ -421,7 +421,16 @@ class NotificationsView extends BaseNotificationsView {
 		const link_docname = notification_doc.document_name
 			? notification_doc.document_name
 			: notification_doc.name;
-		return frappe.utils.get_form_link(link_doctype, link_docname);
+		const form_link = frappe.utils.get_form_link(link_doctype, link_docname);
+		// the timeline renders each entry with `id="<doctype>-<name>"`, so the
+		// source record anchors the link to the exact spot in the document
+		if (notification_doc.source_doctype && notification_doc.source_name) {
+			const anchor = `${frappe.scrub(notification_doc.source_doctype)}-${
+				notification_doc.source_name
+			}`;
+			return `${form_link}#${anchor}`;
+		}
+		return form_link;
 	}
 
 	update_count_badge(count) {

--- a/ui/src/components/Notifications/types.ts
+++ b/ui/src/components/Notifications/types.ts
@@ -19,6 +19,9 @@ export interface NotificationLog {
   from_user_image?: string;
   document_type?: string;
   document_name?: string;
+  /** record the notification came from, when that is not the document itself (e.g. a Comment) */
+  source_doctype?: string;
+  source_name?: string;
   link?: string;
   creation: string;
   // app-specific Custom Fields flow through untyped (the feed is fetched with `["*"]`)


### PR DESCRIPTION
**Issue**

When someone is mentioned in a comment, the Notification Log row records only the document the comment belongs to. The comment itself is not recorded anywhere, so nothing can point the reader at the mention.

Today, mentioning a user in a comment on ticket `INCD-00004` produces:

```
type           Mention
document_type  HD Ticket
document_name  INCD-00004
```

Clicking that lands you on the document. If it has fifty comments, you have to find the one that mentions you. Apps that need the precision work around it: CRM built its own `CRM Notification` doctype storing both pointers, Helpdesk suppressed core's mentions and wrote its own notification, both to keep the comment reference.


**Example**
<img width="910" height="655" alt="image" src="https://github.com/user-attachments/assets/7e4a8246-85d6-4a4a-b0f7-c85a24f3d36d" />
The user was mentioned in "some" comment inside the HD Ticket. There is no way to know the reference of the comment, making it difficult to find the actual comment the user was referred to.


**Solution**

Add `source_doctype` / `source_name` to Notification Log: the record the notification came from, when that is not the reference document itself. `document_type` / `document_name` keep meaning "where to navigate", so existing consumers are unaffected, and the fields are optional, so every other producer stays as it is.

The same mention now produces:

```
type           Mention
document_type  HD Ticket      <- where to go
document_name  INCD-00004
source_doctype Comment        <- what happened, and where inside the document
source_name    tf8uk80fo6
```

`Comment.after_insert` passes itself to `notify_mentions`, and Desk's notification panel appends the timeline anchor, so a mention opens the document scrolled to the comment:

```
/app/hd-ticket/INCD-00004#comment-tf8uk80fo6
```

Apps with their own frontends can build their own route from the same two facts, which a stored `link` URL cannot do since it can only hold one destination.

**Also fixes**

Desk's Quill editor rendered mentions written by other editors as `undefinedundefined`. Its `MentionBlot` reads `data-value` and `data-denotation-char`, which tiptap (used by the portals and frappe-ui) does not write — it puts the label in `data-label` and the text in the node. The blot now falls back to `data-label`, then the node's own text, and defaults the denotation char to `@`. Quill-authored mentions are unaffected, and this fixes already-stored content, not just new mentions.
