### PR TITLE
fix(todo): consider ownership of a document in perm. hooks

### DIFF
--- a/frappe/desk/doctype/todo/test_todo.py
+++ b/frappe/desk/doctype/todo/test_todo.py
@@ -108,6 +108,28 @@ class TestToDo(IntegrationTestCase):
 		clear_permissions_cache("ToDo")
 		frappe.db.rollback()
 
+	def test_owner_only_access(self):
+		# owner is test4, but assigned_by and allocated_to belong to someone else
+		frappe.set_user("test4@example.com")
+		todo = frappe.get_doc(
+			doctype="ToDo", description="Owner only todo", assigned_by="testperm@example.com"
+		).insert()
+
+		self.assertEqual(todo.owner, "test4@example.com")
+		self.assertNotEqual(todo.assigned_by, "test4@example.com")
+		self.assertFalse(todo.allocated_to)
+
+		# direct document access should be granted on ownership alone
+		self.assertTrue(todo.has_permission("read"))
+		self.assertTrue(todo.has_permission("write"))
+
+		# list view / report filtering should also surface owned todos
+		todo_names = DatabaseQuery("ToDo").execute(filters={"name": todo.name}, pluck="name")
+		self.assertIn(todo.name, todo_names)
+
+		frappe.set_user("Administrator")
+		frappe.db.rollback()
+
 	def test_fetch_if_empty(self):
 		frappe.db.delete("ToDo")
 

--- a/frappe/desk/doctype/todo/todo.py
+++ b/frappe/desk/doctype/todo/todo.py
@@ -158,7 +158,7 @@ def get_permission_query_conditions(user):
 	if any(check in todo_roles for check in frappe.get_roles(user)):
 		return None
 	else:
-		return """(`tabToDo`.allocated_to = {user} or `tabToDo`.assigned_by = {user})""".format(
+		return """(`tabToDo`.allocated_to = {user} or `tabToDo`.assigned_by = {user} or `tabToDo`.owner = {user})""".format(
 			user=frappe.db.escape(user)
 		)
 
@@ -171,7 +171,7 @@ def has_permission(doc, ptype="read", user=None):
 	if any(check in todo_roles for check in frappe.get_roles(user)):
 		return True
 	else:
-		return doc.allocated_to == user or doc.assigned_by == user
+		return doc.allocated_to == user or doc.assigned_by == user or doc.owner == user
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Consider ownership of a `ToDo` document in perm. hooks.
related to #41853 