### PR TITLE
feat(communication): fire doc event when a communication is relinked

### DIFF
--- a/frappe/core/doctype/communication/test_communication.py
+++ b/frappe/core/doctype/communication/test_communication.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 import json
+import textwrap
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
@@ -318,6 +319,58 @@ class TestCommunication(IntegrationTestCase):
 
 		self.assertIsNone(frappe.db.get_value("Communication", comm.name, "reference_name"))
 		self.assertEqual(comment_count("Note", old_note.name), 0)
+
+	def test_relink_runs_server_script(self):
+		"""relink() bypasses Document.save(), so it must announce the change itself for
+		anything to be able to react to a communication being relinked"""
+		frappe.delete_doc_if_exists("Note", "test relink server script - old")
+		frappe.delete_doc_if_exists("Note", "test relink server script - new")
+
+		old_note = frappe.get_doc(
+			{"doctype": "Note", "title": "test relink server script - old", "content": "old"}
+		).insert(ignore_permissions=True)
+		new_note = frappe.get_doc(
+			{"doctype": "Note", "title": "test relink server script - new", "content": "new"}
+		).insert(ignore_permissions=True)
+
+		comm = frappe.get_doc(
+			{
+				"doctype": "Communication",
+				"communication_type": "Communication",
+				"content": "Test relink server script",
+				"reference_doctype": "Note",
+				"reference_name": old_note.name,
+			}
+		).insert(ignore_permissions=True)
+
+		# the doc handed to the script must already carry the new reference and status
+		script_body = textwrap.dedent(
+			"""
+			if doc.status == "Linked":
+				frappe.db.set_value("Note", doc.reference_name, "content", "relinked")
+			"""
+		)
+
+		self.enterContext(self.enable_safe_exec())
+		frappe.get_doc("User", "Administrator").add_roles("Script Manager")
+		script = frappe.get_doc(
+			{
+				"doctype": "Server Script",
+				"name": "test_relink_marks_note",
+				"script_type": "DocType Event",
+				"reference_doctype": "Communication",
+				"doctype_event": "After Communication Relink",
+				"script": script_body,
+			}
+		).insert(ignore_permissions=True)
+		self.addCleanup(frappe.client_cache.delete_value, "server_script_map")
+		self.addCleanup(script.delete, ignore_permissions=True)
+		frappe.client_cache.delete_value("server_script_map")
+
+		relink(comm.name, reference_doctype="Note", reference_name=new_note.name)
+
+		self.assertEqual(frappe.db.get_value("Note", new_note.name, "content"), "relinked")
+		self.assertEqual(frappe.db.get_value("Note", old_note.name, "content"), "old")
 
 	def test_save_updates_comment_count(self):
 		"""changing reference_doctype/reference_name via Document.save() (not just relink())

--- a/frappe/core/doctype/server_script/server_script.json
+++ b/frappe/core/doctype/server_script/server_script.json
@@ -57,7 +57,7 @@
    "fieldname": "doctype_event",
    "fieldtype": "Select",
    "label": "DocType Event",
-   "options": "Before Insert\nBefore Validate\nBefore Save\nAfter Insert\nAfter Save\nBefore Rename\nAfter Rename\nBefore Submit\nAfter Submit\nBefore Cancel\nAfter Cancel\nBefore Discard\nAfter Discard\nBefore Delete\nAfter Delete\nBefore Save (Submitted Document)\nAfter Save (Submitted Document)\nBefore Print\nOn Payment Authorization\nOn Payment Paid\nOn Payment Failed\nOn Payment Charge Processed\nOn Payment Mandate Charge Processed\nOn Payment Mandate Acquisition Processed"
+   "options": "Before Insert\nBefore Validate\nBefore Save\nAfter Insert\nAfter Save\nBefore Rename\nAfter Rename\nBefore Submit\nAfter Submit\nBefore Cancel\nAfter Cancel\nBefore Discard\nAfter Discard\nBefore Delete\nAfter Delete\nBefore Save (Submitted Document)\nAfter Save (Submitted Document)\nBefore Print\nAfter Communication Relink\nOn Payment Authorization\nOn Payment Paid\nOn Payment Failed\nOn Payment Charge Processed\nOn Payment Mandate Charge Processed\nOn Payment Mandate Acquisition Processed"
   },
   {
    "depends_on": "eval:doc.script_type==='API'",
@@ -151,7 +151,7 @@
    "link_fieldname": "server_script"
   }
  ],
- "modified": "2025-09-02 11:11:07.528661",
+ "modified": "2026-08-14 09:00:00.000000",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Server Script",

--- a/frappe/core/doctype/server_script/server_script_utils.py
+++ b/frappe/core/doctype/server_script/server_script_utils.py
@@ -22,6 +22,7 @@ EVENT_MAP = {
 	"before_update_after_submit": "Before Save (Submitted Document)",
 	"on_update_after_submit": "After Save (Submitted Document)",
 	"before_print": "Before Print",
+	"on_communication_relinked": "After Communication Relink",
 	"on_payment_paid": "On Payment Paid",
 	"on_payment_failed": "On Payment Failed",
 	"on_payment_authorized": "On Payment Authorization",

--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -86,7 +86,11 @@ def relink(name: str, reference_doctype: str | None = None, reference_name: str 
 
 	comm.reference_doctype = reference_doctype
 	comm.reference_name = reference_name
+	comm.status = "Linked"
 	relink_comment_cache(comm, old_reference_doctype, old_reference_name)
+
+	# the update above bypasses Document.save(), so no document event fires on its own
+	comm.run_method("on_communication_relinked")
 
 
 @frappe.whitelist()


### PR DESCRIPTION
relink() updates tabCommunication with a raw SQL UPDATE, so no document event fires, modified is not touched and no Version is written. Anything that wants to react to an email being linked to a document is therefore never called, while the same action through link_communication_to_document() does go through doc.save() and does fire events.

Keep the fast path as is and announce the change explicitly instead, via run_method(), which reaches doc_events hooks, Notifications, Webhooks and Server Scripts in one call. #4513 had to hand-replicate one such side effect (the comment cache); side effects in user space cannot be patched that way, hence an event.

Also sets status on the in-memory doc, which the SQL already writes to the row, so handlers do not see a stale value.

Closes #41876
Merge into: `develop`

## What existing problem does this solve?

`frappe.email.relink()` updates `tabCommunication` with a raw SQL `UPDATE`. As a result relinking a communication is invisible to the rest of the system: no document event fires, `modified` / `modified_by` are untouched, and no Version row is written. Anything that wants to react to an email being linked to a document is never called.

The same action through a different code path does fire events; `frappe.email.inbox.link_communication_to_document()` (used by "Create Issue from email") assigns the fields and calls `doc.save()`. So whether an integration sees the link depends on which path the user happened to take, for an action that is identical from their point of view.

Measured on frappe 16.29.0, after relinking through the Relink dialog:

- `modified` and `modified_by` unchanged from before the relink
- no Version row for the `reference_name` change
- a Server Script on Communication / After Save never ran, no Error Log entry

The same communication linked via "Create Issue from email" on the same instance did bump `modified` and did write a Version with `reference_doctype: "" -> "Issue"` and `reference_name: "" -> "ISS-…"`.

Reported in #41876.

## Details of the change

The raw `UPDATE` is deliberate; it keeps relinking cheap and free of validation side effects; so this keeps it and announces the change explicitly instead:

```python
comm.status = "Linked"
relink_comment_cache(comm, old_reference_doctype, old_reference_name)

# the update above bypasses Document.save(), so no document event fires on its own
comm.run_method("on_communication_relinked")
```

`run_method()` is the existing central trigger, so one call reaches `doc_events` hooks, Notifications, Webhooks and Server Scripts. `run_webhooks()` returns early on an unsupported event and Notifications filter on their own `event` field, so nothing unrelated fires.

`comm.status = "Linked"` is set on the in-memory doc because the SQL already writes that column to the row; without it handlers would read a stale status.

To make the event reachable from user space, `on_communication_relinked` is added to `EVENT_MAP` as "After Communication Relink" and to the `doctype_event` Select on Server Script.

Why an event rather than replicating side effects: #4513 was the same underlying pattern, and #40871 fixed it by keeping the raw `UPDATE` and hand-replicating that one side effect via `relink_comment_cache()`. That works for side effects inside the framework, but Server Scripts and `doc_events` in third-party apps cannot be enumerated by maintainers, so they will always be missed. One event closes the category without giving up the fast path.

## Tests

`test_relink_runs_server_script` registers a Server Script on "After Communication Relink" and asserts it ran with the new reference and status already applied, covering `run_method()`, `EVENT_MAP` and the Select option end to end.

closes #41876
