### PR TITLE
fix: report view status column corrupts link title fetch on doctypes without an indicator

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1073,13 +1073,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 		);
 
 		// add status field derived from docstatus, if status is not a standard field
-		let has_status_values = false;
-
-		if (this.data) {
-			has_status_values = frappe.get_indicator(this.data[0], this.doctype);
-		}
-
-		if (!frappe.meta.has_field(this.doctype, "status") && has_status_values) {
+		if (!frappe.meta.has_field(this.doctype, "status") && frappe.has_indicator(this.doctype)) {
 			doctype_fields = [
 				{
 					label: __("Status"),
@@ -1192,8 +1186,8 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			} else {
 				// if status is not in fields append status column derived from docstatus
 				if (
-					!this.fields.includes(["status", this.doctype]) &&
-					!frappe.meta.has_field(this.doctype, "status")
+					!frappe.meta.has_field(this.doctype, "status") &&
+					frappe.has_indicator(this.doctype)
 				) {
 					column = this.build_column(["docstatus", this.doctype]);
 				}


### PR DESCRIPTION
Report view builds a Status column from `docstatus` even for doctypes with no indicator, then removes it mid-`this.columns.map()` when no indicator value turns up. 
That leaves one render pass where rows still carry the Status cell but the columns don't, shifting every cell after it onto the wrong column; the formatter then harvested a Date value under a Link docfield and fetched a title for `Employee 2026-08-12`, popping a "not found" modal on load. 

Now the column is only built when `frappe.has_indicator()` is true, so there is nothing to remove mid-render. The column picker made the same decision from `this.data[0]` and threw on an empty report; same check there.

---

Ref: https://support.frappe.io/helpdesk/tickets/76161?view=VIEW-HD+Ticket-1242