### PR TITLE
fix(auth): enforce IP restrictions for header-based authentication

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -644,6 +644,7 @@ def validate_auth():
 	Authenticate and sets user for the request.
 	"""
 	authorization_header = frappe.get_request_header("Authorization", "").split(" ")
+	user_before_auth = frappe.session.user
 
 	if len(authorization_header) == 2:
 		validate_oauth(authorization_header)
@@ -655,6 +656,13 @@ def validate_auth():
 	# should terminate here.
 	if len(authorization_header) == 2 and frappe.session.user in ("", "Guest"):
 		raise frappe.AuthenticationError
+
+	# `restrict_ip` is enforced for interactive logins in `LoginManager.post_login` and for
+	# cookie-based requests in `Session.resume`. A request authenticated here takes neither
+	# path, so the allowlist has to be enforced explicitly - without this, API keys, tokens
+	# and bearer tokens bypass the user's IP restrictions entirely.
+	if frappe.session.user != user_before_auth and frappe.session.user not in ("", "Guest"):
+		validate_ip_address(frappe.session.user)
 
 
 def validate_oauth(authorization_header):

--- a/frappe/tests/test_auth.py
+++ b/frappe/tests/test_auth.py
@@ -8,7 +8,8 @@ from werkzeug.test import EnvironBuilder
 from werkzeug.wrappers import Request
 
 import frappe
-from frappe.auth import LoginAttemptTracker
+from frappe.auth import LoginAttemptTracker, validate_auth
+from frappe.core.doctype.user.user import generate_keys
 from frappe.frappeclient import AuthError, FrappeClient
 from frappe.sessions import Session, get_expired_sessions, get_expiry_in_seconds
 from frappe.tests import IntegrationTestCase, UnitTestCase
@@ -212,6 +213,75 @@ class TestAllowedReferrer(UnitTestCase):
 		# Clean up
 		frappe.cache.delete_value("allowed_referrers")
 		frappe.local.request = None
+
+
+class TestIPRestrictionForAPIAuth(IntegrationTestCase):
+	"""Header-authenticated requests must honour the user's `restrict_ip` allowlist.
+
+	`validate_ip_address` runs in `LoginManager.post_login` for interactive logins and in
+	`Session.resume` for cookie-based requests. A request authenticated purely from an
+	`Authorization` header takes neither path, so `validate_auth` has to enforce it.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.user_email = "test_api_ip_restriction@test.com"
+		if not frappe.db.exists("User", cls.user_email):
+			frappe.get_doc(doctype="User", email=cls.user_email, first_name="API IP Restricted").insert(
+				ignore_permissions=True
+			)
+
+		cls.api_secret = generate_keys(cls.user_email)["api_secret"]
+		cls.api_key = frappe.db.get_value("User", cls.user_email, "api_key")
+		frappe.db.commit()
+
+	def setUp(self):
+		self._request = getattr(frappe.local, "request", None)
+		self._request_ip = getattr(frappe.local, "request_ip", None)
+		self._login_manager = getattr(frappe.local, "login_manager", None)
+		self.addCleanup(self._restore)
+
+	def _restore(self):
+		frappe.local.request = self._request
+		frappe.local.request_ip = self._request_ip
+		frappe.local.login_manager = self._login_manager
+		frappe.set_user("Administrator")
+
+	def _authenticated_request_from(self, request_ip):
+		"""Simulate an unauthenticated request carrying an API key/secret token."""
+		env = EnvironBuilder(
+			headers={"Authorization": f"token {self.api_key}:{self.api_secret}"}
+		).get_environ()
+		frappe.local.request = Request(env)
+		frappe.local.request_ip = request_ip
+		frappe.local.login_manager = frappe._dict(user="Guest")
+		frappe.set_user("Guest")
+
+	def _set_restrict_ip(self, value):
+		frappe.db.set_value("User", self.user_email, "restrict_ip", value)
+		frappe.clear_cache(user=self.user_email)
+
+	def test_api_auth_blocked_from_disallowed_ip(self):
+		self._set_restrict_ip("192.168.255.254")
+		self._authenticated_request_from("10.0.0.1")
+
+		with self.assertRaises(frappe.AuthenticationError):
+			validate_auth()
+
+	def test_api_auth_allowed_from_allowed_ip(self):
+		self._set_restrict_ip("10.0.0.1")
+		self._authenticated_request_from("10.0.0.1")
+
+		validate_auth()
+		self.assertEqual(frappe.session.user, self.user_email)
+
+	def test_api_auth_unaffected_without_ip_restriction(self):
+		self._set_restrict_ip("")
+		self._authenticated_request_from("10.0.0.1")
+
+		validate_auth()
+		self.assertEqual(frappe.session.user, self.user_email)
 
 
 class TestLoginAttemptTracker(IntegrationTestCase):


### PR DESCRIPTION
Enforce the allowlist at the end of `validate_auth()`, which covers all three paths. The check only runs when authentication actually happened in this function, so cookie-based requests are not validated twice.

closes Ticket 75325

Raising PR on behalf of @krupalvora 
