### PR TITLE
fix: avoid duplicate DROP INDEX for accent/case-colliding fields during schema sync

### DIFF
--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -403,7 +403,7 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 
 		indexes = self.sql(
 			f"""SHOW INDEX FROM `{table_name}`
-				WHERE Column_name = "{fieldname}"
+				WHERE Column_name = BINARY "{fieldname}"
 					AND Seq_in_index = 1
 					AND Non_unique={int(not unique)}
 					AND Index_type != 'FULLTEXT'

--- a/frappe/database/mariadb/mysqlclient.py
+++ b/frappe/database/mariadb/mysqlclient.py
@@ -430,7 +430,7 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 
 		indexes = self.sql(
 			f"""SHOW INDEX FROM `{table_name}`
-				WHERE Column_name = "{fieldname}"
+				WHERE Column_name = BINARY "{fieldname}"
 					AND Seq_in_index = 1
 					AND Non_unique={int(not unique)}
 					AND Index_type != 'FULLTEXT'

--- a/frappe/database/mariadb/schema.py
+++ b/frappe/database/mariadb/schema.py
@@ -143,6 +143,9 @@ class MariaDBTable(DBTable):
 				if index_record := frappe.db.get_column_index(self.table_name, col.fieldname, unique=False):
 					drop_index_query.append(f"DROP INDEX `{index_record.Key_name}`")
 
+		# drop each index only once
+		drop_index_query = list(dict.fromkeys(drop_index_query))
+
 		for col in self.change_nullability:
 			if col.not_nullable:
 				try:

--- a/frappe/tests/test_db_update.py
+++ b/frappe/tests/test_db_update.py
@@ -336,6 +336,36 @@ class TestDBUpdate(IntegrationTestCase):
 			doctype.delete(force=True)
 			frappe.db.commit()  # nosemgrep
 
+	@run_only_if(db_type_is.MARIADB)
+	def test_drop_index_for_accent_colliding_fields(self):
+		# removing two fields whose names collide under the collation must not fail schema sync
+		doctype = new_doctype(
+			fields=[
+				{"fieldname": "some_fieldname", "fieldtype": "Data"},
+				{"fieldname": "patrimonio", "fieldtype": "Data", "unique": 1},
+				{"fieldname": "patrimônio", "fieldtype": "Data", "unique": 1},
+			]
+		).insert()
+		try:
+			self.assertTrue(self.get_unique_index(doctype.name, "patrimonio"))
+			self.assertTrue(self.get_unique_index(doctype.name, "patrimônio"))
+
+			doctype.fields = [f for f in doctype.fields if f.fieldname not in ("patrimonio", "patrimônio")]
+			doctype.save()
+
+			self.assertFalse(self.get_unique_index(doctype.name, "patrimonio"))
+			self.assertFalse(self.get_unique_index(doctype.name, "patrimônio"))
+		finally:
+			# DDL in this test auto-commits, so the cleanup delete must be committed explicitly
+			doctype.delete()
+			frappe.db.commit()  # nosemgrep
+
+	def get_unique_index(self, doctype: str, column: str):
+		# binary match so colliding names are compared exactly
+		return frappe.db.sql(
+			f"show index from `tab{doctype}` where column_name = binary %s and Non_unique = 0", column
+		)
+
 	def test_uuid_varchar_migration(self):
 		doctype = new_doctype().insert()
 		doctype.autoname = "UUID"


### PR DESCRIPTION
### Issue
Upgrading a site failed during `migrate` when a table had two columns whose names differ only by an accent (e.g. `patrimonio` and `patrimônio`) — leftovers from renamed fields. MariaDB's collation treats them as equal, so schema sync emitted `DROP INDEX` twice for the same index and the migration crashed with `(1091, "Can't DROP INDEX ...")`.

### Fix
- Drop each index only once.
- Look up a column's index with an exact (binary) match, so each column resolves to its own index.

https://support.frappe.io/helpdesk/tickets/75465
