### PR TITLE
feat(FormLayout): dispatch field commits at the mutation site

### DIFF
--- a/ui/src/components/Fields/TableField.vue
+++ b/ui/src/components/Fields/TableField.vue
@@ -6,7 +6,11 @@
 		:label="field.label"
 		:description="field.description"
 		:required="field.reqd"
+		:newRow="newRow"
 		@change="(r: Record<string, any>[]) => emit('change', r)"
+		@commit="onCellCommit"
+		@add="onRowAdd"
+		@remove="onRowRemove"
 		@edit="openEdit"
 	>
 		<template #cell="{ row, column, value, update, commit }">
@@ -80,8 +84,11 @@ import { Grid } from "../Grid";
 import type { GridColumn } from "../Grid";
 import { fieldsToLayout } from "../FormLayout/fieldsToLayout";
 import { resolveFieldConditionals } from "../FormLayout/resolveLayout";
-import { DocKey, ParentDocKey } from "./types";
+import { layoutFields, newRowValues } from "../FormLayout/newRowValues";
+import { CommitKey, DocKey, NO_COMMIT, ParentDocKey } from "./types";
+import { identify, rowKey } from "./rowIdentity";
 import { ResolveFieldKey } from "../FormLayout/types";
+import type { CommitChannel, RowAddress } from "./types";
 import type { FieldComponentEmits, FieldComponentProps } from "./types";
 import type { FieldNode, FormLayoutSchema } from "../FormLayout/types";
 
@@ -99,6 +106,44 @@ const resolveField = inject(ResolveFieldKey)!;
 // currency formatting from the grid. Null at the top level.
 const parentDoc = inject(DocKey, null);
 provide(ParentDocKey, parentDoc);
+
+const commit = inject(CommitKey, NO_COMMIT);
+
+// The row-edit dialog's FormLayout would otherwise commit the child's fieldnames
+// as if they were the parent's, so its commits are re-addressed to the open row.
+const rowChannel: CommitChannel = {
+	pending: (fieldname) => commit.pending(fieldname, editAddress()),
+	commit: (fieldname) => commit.commit(fieldname, editAddress()),
+	rowChanged: (row, change) => commit.rowChanged(row, change),
+};
+provide(CommitKey, rowChannel);
+
+function editAddress(): RowAddress | undefined {
+	return editRow.value ? addressOf(editRow.value) : undefined;
+}
+
+function addressOf(row: Record<string, any>): RowAddress {
+	return { parentfield: props.field.fieldname, key: rowKey(identify(row))! };
+}
+
+function newRow(): Record<string, any> {
+	const fields = props.field.childLayout
+		? layoutFields(props.field.childLayout)
+		: (props.field.childFields ?? []);
+	return newRowValues(fields);
+}
+
+function onCellCommit({ row, column }: { row: Record<string, any>; column: GridColumn }) {
+	commit.commit(column.fieldname, addressOf(row));
+}
+
+function onRowAdd({ row }: { row: Record<string, any> }) {
+	commit.rowChanged(addressOf(row), "add");
+}
+
+function onRowRemove({ rows: removed }: { rows: Record<string, any>[] }) {
+	for (const row of removed) commit.rowChanged(addressOf(row), "remove");
+}
 
 // Per-fieldtype alignment, applied to header + cells so they agree. Numeric
 // right-aligns (desk); checkbox/rating center.

--- a/ui/src/components/Fields/TableField.vue
+++ b/ui/src/components/Fields/TableField.vue
@@ -112,8 +112,8 @@ const commit = inject(CommitKey, NO_COMMIT);
 // The row-edit dialog's FormLayout would otherwise commit the child's fieldnames
 // as if they were the parent's, so its commits are re-addressed to the open row.
 const rowChannel: CommitChannel = {
-	pending: (fieldname) => commit.pending(fieldname, editAddress()),
-	commit: (fieldname) => commit.commit(fieldname, editAddress()),
+	pending: (fieldname, value) => commit.pending(fieldname, value, editAddress()),
+	commit: (fieldname, value) => commit.commit(fieldname, value, editAddress()),
 	rowChanged: (row, change) => commit.rowChanged(row, change),
 };
 provide(CommitKey, rowChannel);
@@ -141,11 +141,11 @@ function editCell(
 	value: any
 ) {
 	update(value);
-	commit.pending(field.fieldname, addressOf(row));
+	commit.pending(field.fieldname, value, addressOf(row));
 }
 
 function onCellCommit({ row, column }: { row: Record<string, any>; column: GridColumn }) {
-	commit.commit(column.fieldname, addressOf(row));
+	commit.commit(column.fieldname, row[column.fieldname], addressOf(row));
 }
 
 function onRowAdd({ row }: { row: Record<string, any> }) {

--- a/ui/src/components/Fields/TableField.vue
+++ b/ui/src/components/Fields/TableField.vue
@@ -43,7 +43,7 @@
 							:field="f"
 							:modelValue="value"
 							:row="row"
-							@update:modelValue="update"
+							@update:modelValue="(v: any) => editCell(update, f, row, v)"
 							@change="commit"
 							v-bind="f.ui?.props"
 							v-on="cellListeners(f, row)"
@@ -56,7 +56,7 @@
 						:field="f"
 						:modelValue="value"
 						:row="row"
-						@update:modelValue="update"
+						@update:modelValue="(v: any) => editCell(update, f, row, v)"
 						@change="commit"
 						v-bind="f.ui?.props"
 						v-on="cellListeners(f, row)"
@@ -131,6 +131,17 @@ function newRow(): Record<string, any> {
 		? layoutFields(props.field.childLayout)
 		: (props.field.childFields ?? []);
 	return newRowValues(fields);
+}
+
+// A cell being typed owes a commit too: a save mid-edit must fire its handler.
+function editCell(
+	update: (value: any) => void,
+	field: FieldNode,
+	row: Record<string, any>,
+	value: any
+) {
+	update(value);
+	commit.pending(field.fieldname, addressOf(row));
 }
 
 function onCellCommit({ row, column }: { row: Record<string, any>; column: GridColumn }) {

--- a/ui/src/components/Fields/TableField.vue
+++ b/ui/src/components/Fields/TableField.vue
@@ -129,7 +129,7 @@ function addressOf(row: Record<string, any>): RowAddress {
 function newRow(): Record<string, any> {
 	const fields = props.field.childLayout
 		? layoutFields(props.field.childLayout)
-		: (props.field.childFields ?? []);
+		: props.field.childFields ?? [];
 	return newRowValues(fields);
 }
 

--- a/ui/src/components/Fields/TableMultiSelectField.vue
+++ b/ui/src/components/Fields/TableMultiSelectField.vue
@@ -34,6 +34,7 @@ const targetDoctype = computed(() => linkField.value?.options ?? "");
 const value = useChildRowModel(
 	() => props.modelValue,
 	() => linkField.value?.fieldname ?? "",
-	emit
+	emit,
+	() => props.field.fieldname
 );
 </script>

--- a/ui/src/components/Fields/rowIdentity.ts
+++ b/ui/src/components/Fields/rowIdentity.ts
@@ -18,6 +18,13 @@ export function rowKey(row: Record<string, any>): string | undefined {
   return row?.name ?? row?.[ROW_ID];
 }
 
+/** Fieldtypes whose value is rows: they commit through those, never themselves. */
+const CHILD_TABLE_TYPES = new Set(["Table", "Table MultiSelect"]);
+
+export function holdsChildRows(fieldtype: string): boolean {
+  return CHILD_TABLE_TYPES.has(fieldtype);
+}
+
 /** Gives the row an id when it has neither a `name` nor one already. */
 export function identify(row: Record<string, any>): Record<string, any> {
   if (!rowKey(row)) row[ROW_ID] = mintRowId();

--- a/ui/src/components/Fields/rowIdentity.ts
+++ b/ui/src/components/Fields/rowIdentity.ts
@@ -13,9 +13,17 @@ export function mintRowId(): string {
   return `row-${++minted}`;
 }
 
-/** The row's stable key, once it has one. */
+/**
+ * The row's stable key, once it has one. A server name and a client id are
+ * different kinds of identifier, so they get different keyspaces: `validate_name`
+ * forbids only `<` and `>`, so a child doctype named by a field or a series can
+ * legitimately produce a name equal to a minted id — and two rows sharing one
+ * key read as one selection, and delete as one row.
+ */
 export function rowKey(row: Record<string, any>): string | undefined {
-  return row?.name ?? row?.[ROW_ID];
+  if (row?.name) return `name:${row.name}`;
+  const id = row?.[ROW_ID];
+  return id ? `new:${id}` : undefined;
 }
 
 /** Fieldtypes whose value is rows: they commit through those, never themselves. */

--- a/ui/src/components/Fields/rowIdentity.ts
+++ b/ui/src/components/Fields/rowIdentity.ts
@@ -1,0 +1,25 @@
+// Client-side identity for a child row that has no server `name` yet.
+
+/**
+ * Deliberately not a `name`: `frappe.client.save` sends the whole document and
+ * `_init_child` treats a row that already carries a `name` as existing, so a
+ * client-minted name makes the insert a silent no-op UPDATE.
+ */
+export const ROW_ID = "__row_id";
+
+let minted = 0;
+
+export function mintRowId(): string {
+  return `row-${++minted}`;
+}
+
+/** The row's stable key, once it has one. */
+export function rowKey(row: Record<string, any>): string | undefined {
+  return row?.name ?? row?.[ROW_ID];
+}
+
+/** Gives the row an id when it has neither a `name` nor one already. */
+export function identify(row: Record<string, any>): Record<string, any> {
+  if (!rowKey(row)) row[ROW_ID] = mintRowId();
+  return row;
+}

--- a/ui/src/components/Fields/tests/rowIdentity.test.ts
+++ b/ui/src/components/Fields/tests/rowIdentity.test.ts
@@ -1,9 +1,18 @@
 import { describe, expect, it } from "vitest";
-import { ROW_ID, identify, rowKey } from "../rowIdentity";
+import { ROW_ID, identify, mintRowId, rowKey } from "../rowIdentity";
 
 describe("rowIdentity", () => {
   it("prefers the server name over a minted id", () => {
-    expect(rowKey({ name: "abc", [ROW_ID]: "row-1" })).toBe("abc");
+    expect(rowKey({ name: "abc", [ROW_ID]: "row-1" })).toBe("name:abc");
+  });
+
+  it("keeps server names and client ids in separate keyspaces", () => {
+    // `validate_name` forbids only `<` and `>`, so a child doctype named by a
+    // field or a series can produce a name that reads exactly like a minted id.
+    // Sharing one keyspace would make the grid select — and delete — both rows.
+    const named = { name: mintRowId() };
+    const fresh = identify({});
+    expect(rowKey(named)).not.toBe(rowKey(fresh));
   });
 
   it("mints an id only for a row that has neither", () => {

--- a/ui/src/components/Fields/tests/rowIdentity.test.ts
+++ b/ui/src/components/Fields/tests/rowIdentity.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { ROW_ID, identify, rowKey } from "../rowIdentity";
+
+describe("rowIdentity", () => {
+  it("prefers the server name over a minted id", () => {
+    expect(rowKey({ name: "abc", [ROW_ID]: "row-1" })).toBe("abc");
+  });
+
+  it("mints an id only for a row that has neither", () => {
+    const saved = { name: "abc" };
+    expect(identify(saved)).toEqual({ name: "abc" });
+
+    const fresh: Record<string, any> = {};
+    identify(fresh);
+    expect(fresh[ROW_ID]).toBeTruthy();
+  });
+
+  it("leaves an already-identified row alone", () => {
+    const row = { [ROW_ID]: "row-1" };
+    identify(row);
+    expect(row[ROW_ID]).toBe("row-1");
+  });
+
+  it("mints distinct ids", () => {
+    const a: Record<string, any> = {};
+    const b: Record<string, any> = {};
+    identify(a);
+    identify(b);
+    expect(a[ROW_ID]).not.toBe(b[ROW_ID]);
+  });
+
+  it("never mints a `name`, which would make the insert a silent update", () => {
+    const fresh: Record<string, any> = {};
+    identify(fresh);
+    expect(fresh.name).toBeUndefined();
+  });
+});

--- a/ui/src/components/Fields/types.ts
+++ b/ui/src/components/Fields/types.ts
@@ -117,13 +117,15 @@ export type RowChange = "add" | "remove";
  * a child table's structural edits out to whoever owns events, so they are
  * dispatched at the mutation site instead of diffed out of the document.
  *
- * No value travels with a commit: `update` has already written it, so the doc
- * is the single reading of what was committed.
+ * The value travels even though the doc already holds it: a control that
+ * re-emits its value on commit (frappe-ui's `TextInput` binds `@input` and
+ * `@change` to the same handler) would otherwise leave an edit looking pending
+ * forever, and the next save would fire the handler a second time.
  */
 export interface CommitChannel {
   /** A live edit whose commit has not arrived yet; `flush` fires it on save. */
-  pending(fieldname: string, row?: RowAddress): void;
-  commit(fieldname: string, row?: RowAddress): void;
+  pending(fieldname: string, value: any, row?: RowAddress): void;
+  commit(fieldname: string, value: any, row?: RowAddress): void;
   rowChanged(row: RowAddress, change: RowChange): void;
 }
 

--- a/ui/src/components/Fields/types.ts
+++ b/ui/src/components/Fields/types.ts
@@ -32,6 +32,8 @@ export interface FieldMeta {
   childLayout?: FormLayoutSchema;
   /** Whether the field is mandatory. */
   reqd?: boolean;
+  /** Raw DocField default, carried verbatim; `newRowValues` resolves it. */
+  default?: string;
   /** Decimal places for numeric fields (Float/Currency/Percent); from meta. */
   precision?: number;
   /** Initial grid-column width in px for a child-table column; omit for flexible. */
@@ -101,3 +103,40 @@ export const ParentDocKey: InjectionKey<Ref<Record<string, any>> | null> =
 /** Writes a field's live value into the doc on every change. Pure state sync. */
 export const UpdateKey: InjectionKey<(fieldname: string, value: any) => void> =
   Symbol("FormLayoutUpdate");
+
+/** Where a child row sits: its table's fieldname plus `name ?? __row_id`. */
+export interface RowAddress {
+  parentfield: string;
+  key: string;
+}
+
+export type RowChange = "add" | "remove";
+
+/**
+ * Carries a field's *commit* (blur for typed inputs, selection for pickers) and
+ * a child table's structural edits out to whoever owns events, so they are
+ * dispatched at the mutation site instead of diffed out of the document.
+ *
+ * No value travels with a commit: `update` has already written it, so the doc
+ * is the single reading of what was committed.
+ */
+export interface CommitChannel {
+  /** A live edit whose commit has not arrived yet; `flush` fires it on save. */
+  pending(fieldname: string, row?: RowAddress): void;
+  commit(fieldname: string, row?: RowAddress): void;
+  rowChanged(row: RowAddress, change: RowChange): void;
+}
+
+/** For a form whose document nothing scripts — a create dialog, a story. */
+export const NO_COMMIT: CommitChannel = {
+  pending: () => {},
+  commit: () => {},
+  rowChanged: () => {},
+};
+
+/**
+ * Provided by whoever owns the document's events, above the layout. Mandatory:
+ * a form with no provider silently drops every commit, so the absence is a
+ * DEV error and `NO_COMMIT` is how a form says it meant it.
+ */
+export const CommitKey: InjectionKey<CommitChannel> = Symbol("FormLayoutCommit");

--- a/ui/src/components/FormLayout/FormLayout.vue
+++ b/ui/src/components/FormLayout/FormLayout.vue
@@ -33,7 +33,8 @@ import type { ComponentPublicInstance } from "vue";
 import FormLayoutSection from "./FormLayoutSection.vue";
 import { useFieldTypes } from "./useFieldTypes";
 import { resolveLayout } from "./resolveLayout";
-import { DocKey, HasTabsKey, ParentDocKey, ResolveFieldKey, UpdateKey } from "./types";
+import { CommitKey, DocKey, HasTabsKey, ParentDocKey, ResolveFieldKey, UpdateKey } from "./types";
+import { warnMissingCommit } from "./warnMissingCommit";
 import type { FormLayoutProps } from "./types";
 
 const props = defineProps<FormLayoutProps>();
@@ -91,6 +92,10 @@ function update(fieldname: string, value: any) {
 }
 
 const { resolve } = useFieldTypes();
+
+// Asserted, not consumed: commits travel from each field straight to whoever
+// owns them, and this component still emits nothing.
+warnMissingCommit("FormLayout", inject(CommitKey, null));
 
 provide(DocKey, doc);
 provide(UpdateKey, update);

--- a/ui/src/components/FormLayout/FormLayoutField.vue
+++ b/ui/src/components/FormLayout/FormLayoutField.vue
@@ -11,7 +11,7 @@
 			:field="field"
 			:modelValue="doc[field.fieldname]"
 			@update:modelValue="(value: any) => edit(field.fieldname, value)"
-			@change="() => commit.commit(field.fieldname)"
+			@change="onCommit"
 			v-on="field.ui?.on ?? {}"
 		/>
 	</div>
@@ -20,6 +20,7 @@
 <script setup lang="ts">
 import { computed, inject } from "vue";
 import { CommitKey, DocKey, NO_COMMIT, ResolveFieldKey, UpdateKey } from "./types";
+import { holdsChildRows } from "../Fields/rowIdentity";
 import type { FieldNode } from "./types";
 
 const props = defineProps<{ field: FieldNode }>();
@@ -29,11 +30,19 @@ const update = inject(UpdateKey)!;
 const commit = inject(CommitKey, NO_COMMIT);
 const resolveField = inject(ResolveFieldKey)!;
 
+// A child table commits through its rows, never under its own fieldname, which
+// ticket 45 retired as a handler key.
+const commits = computed(() => !holdsChildRows(props.field.fieldtype));
+
 // The live write, plus a note that a commit is owed: a save with focus still in
 // the input has to fire the handler before `before_save` sees a stale value.
 function edit(fieldname: string, value: any) {
 	update(fieldname, value);
-	commit.pending(fieldname);
+	if (commits.value) commit.pending(fieldname);
+}
+
+function onCommit() {
+	if (commits.value) commit.commit(props.field.fieldname);
 }
 
 // `ui.component` swaps the control for this one node; otherwise resolve by fieldtype.

--- a/ui/src/components/FormLayout/FormLayoutField.vue
+++ b/ui/src/components/FormLayout/FormLayoutField.vue
@@ -11,7 +11,7 @@
 			:field="field"
 			:modelValue="doc[field.fieldname]"
 			@update:modelValue="(value: any) => edit(field.fieldname, value)"
-			@change="onCommit"
+			@change="(value: any) => onCommit(value)"
 			v-on="field.ui?.on ?? {}"
 		/>
 	</div>
@@ -38,11 +38,11 @@ const commits = computed(() => !holdsChildRows(props.field.fieldtype));
 // the input has to fire the handler before `before_save` sees a stale value.
 function edit(fieldname: string, value: any) {
 	update(fieldname, value);
-	if (commits.value) commit.pending(fieldname);
+	if (commits.value) commit.pending(fieldname, value);
 }
 
-function onCommit() {
-	if (commits.value) commit.commit(props.field.fieldname);
+function onCommit(value: any) {
+	if (commits.value) commit.commit(props.field.fieldname, value);
 }
 
 // `ui.component` swaps the control for this one node; otherwise resolve by fieldtype.

--- a/ui/src/components/FormLayout/FormLayoutField.vue
+++ b/ui/src/components/FormLayout/FormLayoutField.vue
@@ -10,7 +10,8 @@
 			v-bind="field.ui?.props"
 			:field="field"
 			:modelValue="doc[field.fieldname]"
-			@update:modelValue="(value: any) => update(field.fieldname, value)"
+			@update:modelValue="(value: any) => edit(field.fieldname, value)"
+			@change="() => commit.commit(field.fieldname)"
 			v-on="field.ui?.on ?? {}"
 		/>
 	</div>
@@ -18,14 +19,22 @@
 
 <script setup lang="ts">
 import { computed, inject } from "vue";
-import { DocKey, ResolveFieldKey, UpdateKey } from "./types";
+import { CommitKey, DocKey, NO_COMMIT, ResolveFieldKey, UpdateKey } from "./types";
 import type { FieldNode } from "./types";
 
 const props = defineProps<{ field: FieldNode }>();
 
 const doc = inject(DocKey)!;
 const update = inject(UpdateKey)!;
+const commit = inject(CommitKey, NO_COMMIT);
 const resolveField = inject(ResolveFieldKey)!;
+
+// The live write, plus a note that a commit is owed: a save with focus still in
+// the input has to fire the handler before `before_save` sees a stale value.
+function edit(fieldname: string, value: any) {
+	update(fieldname, value);
+	commit.pending(fieldname);
+}
 
 // `ui.component` swaps the control for this one node; otherwise resolve by fieldtype.
 const resolved = computed(() => resolveField(props.field.fieldtype));

--- a/ui/src/components/FormLayout/buildLayoutFromMeta.ts
+++ b/ui/src/components/FormLayout/buildLayoutFromMeta.ts
@@ -8,6 +8,7 @@ import type {
   Section,
   Tab,
 } from "./types";
+import { holdsChildRows } from "../Fields/rowIdentity";
 
 /**
  * Build a render-ready `FormLayoutSchema` from a doctype's flat meta `fields`,
@@ -22,10 +23,6 @@ const TAB_BREAK = "Tab Break";
 const SECTION_BREAK = "Section Break";
 const COLUMN_BREAK = "Column Break";
 const TABLE = "Table";
-const TABLE_MULTISELECT = "Table MultiSelect";
-
-/** Fieldtypes whose value lives in a child table; both resolve `childFields`. */
-const CHILD_TABLE_TYPES = new Set([TABLE, TABLE_MULTISELECT]);
 
 /** Layout-break fieldtypes never render as a value/grid column. */
 const LAYOUT_BREAKS = new Set([TAB_BREAK, SECTION_BREAK, COLUMN_BREAK]);
@@ -181,7 +178,7 @@ function mapField(
     mandatoryDependsOn: field.mandatory_depends_on,
     readOnlyDependsOn: field.read_only_depends_on,
     // Child-table columns. Nested grids aren't supported (no deeper childMetas).
-    ...(CHILD_TABLE_TYPES.has(field.fieldtype)
+    ...(holdsChildRows(field.fieldtype)
       ? { childFields: resolveChildFields(field, childMetas, decorate) }
       : {}),
     // The row-edit dialog renders the full child form; `Table MultiSelect` has

--- a/ui/src/components/FormLayout/buildLayoutFromMeta.ts
+++ b/ui/src/components/FormLayout/buildLayoutFromMeta.ts
@@ -163,6 +163,7 @@ function mapField(
     options: field.options,
     filters: field.filters,
     reqd: !!field.reqd,
+    default: field.default,
     precision: coercePrecision(field.precision),
     description: field.description,
     hidden: !!field.hidden,

--- a/ui/src/components/FormLayout/index.ts
+++ b/ui/src/components/FormLayout/index.ts
@@ -10,6 +10,8 @@ export { buildLayoutFromMeta, compose } from "./buildLayoutFromMeta";
 export type { BuildLayoutOptions, Decorator } from "./buildLayoutFromMeta";
 export { fieldsToLayout } from "./fieldsToLayout";
 export { resolveLayout } from "./resolveLayout";
+export { CommitKey, NO_COMMIT } from "./types";
+export { newRowValues, layoutFields } from "./newRowValues";
 export { evaluateDependsOn } from "./dependsOn";
 export {
   flt,
@@ -39,6 +41,9 @@ export type {
   RawMetaField,
   FieldComponentProps,
   FieldComponentEmits,
+  CommitChannel,
+  RowAddress,
+  RowChange,
 } from "./types";
 export type {
   FltOptions,

--- a/ui/src/components/FormLayout/newRowValues.ts
+++ b/ui/src/components/FormLayout/newRowValues.ts
@@ -1,0 +1,61 @@
+// What a freshly added child row starts with, from its docfield defaults.
+import type { FieldNode, FormLayoutSchema } from "./types";
+
+const NO_VALUE = new Set([
+  "Section Break",
+  "Column Break",
+  "Tab Break",
+  "Heading",
+  "HTML",
+  "Fold",
+]);
+
+const INTEGERS = new Set(["Int", "Check"]);
+const DECIMALS = new Set(["Float", "Currency", "Percent"]);
+
+/**
+ * Seed values for a new row: every field's resolved `default`, plus a Select's
+ * first option, which Frappe treats as the default when none is declared.
+ */
+export function newRowValues(fields: FieldNode[]): Record<string, any> {
+  const row: Record<string, any> = {};
+  for (const field of fields) {
+    if (NO_VALUE.has(field.fieldtype)) continue;
+    const value = defaultValue(field);
+    if (value !== undefined) row[field.fieldname] = value;
+  }
+  return row;
+}
+
+/** Every field of a child layout, so defaults are not limited to grid columns. */
+export function layoutFields(layout: FormLayoutSchema): FieldNode[] {
+  return layout.flatMap((tab) =>
+    tab.sections.flatMap((section) =>
+      section.columns.flatMap((column) => column.fields)
+    )
+  );
+}
+
+function defaultValue(field: FieldNode): any {
+  const raw = field.default;
+  if (raw == null || raw === "") return firstOption(field);
+  if (raw === "Today" || raw === "today") return today();
+  if (raw === "Now" || raw === "now") return new Date().toISOString().slice(0, 19).replace("T", " ");
+  if (INTEGERS.has(field.fieldtype)) return Math.trunc(Number(raw)) || 0;
+  if (DECIMALS.has(field.fieldtype)) return Number(raw) || 0;
+  return raw;
+}
+
+/** A Select with no default lands on its first option, as desk does. */
+function firstOption(field: FieldNode): string | undefined {
+  if (field.fieldtype !== "Select") return undefined;
+  const options = typeof field.options === "string" ? field.options : "";
+  return options.split("\n")[0] || undefined;
+}
+
+function today(): string {
+  const now = new Date();
+  const month = `${now.getMonth() + 1}`.padStart(2, "0");
+  const day = `${now.getDate()}`.padStart(2, "0");
+  return `${now.getFullYear()}-${month}-${day}`;
+}

--- a/ui/src/components/FormLayout/stories/StaticSchema.story.vue
+++ b/ui/src/components/FormLayout/stories/StaticSchema.story.vue
@@ -8,14 +8,18 @@
 </template>
 
 <script setup lang="ts">
-import { reactive } from "vue";
+import { provide, reactive } from "vue";
 import FormLayout from "../FormLayout.vue";
+import { CommitKey, NO_COMMIT } from "../types";
 import { registerFieldType } from "../../Fields/fieldTypes";
 import DemoLinkField from "./DemoLinkField.vue";
 import DemoCurrencyField from "./DemoCurrencyField.vue";
 import DemoTableMultiSelectField from "./DemoTableMultiSelectField.vue";
 import type { FormLayoutSchema } from "../types";
 import type { UploadTransport } from "../../FileUpload/types";
+
+// A story has no page behind it, so its fields commit to nothing.
+provide(CommitKey, NO_COMMIT);
 
 // Fake transport for the stories: no backend, just a placeholder URL and a
 // simulated progress ramp (honoring the abort signal). The Attach/Attach Image

--- a/ui/src/components/FormLayout/tests/commitWiring.test.ts
+++ b/ui/src/components/FormLayout/tests/commitWiring.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, defineComponent, h } from "vue";
+import type { App } from "vue";
+import FormLayoutColumn from "../FormLayoutColumn.vue";
+import { CommitKey, DocKey, ResolveFieldKey, UpdateKey } from "../types";
+import type { CommitChannel, FieldNode } from "../types";
+
+/**
+ * The commit channel, meta → DOM: a widget's live `update:modelValue` marks the
+ * field pending and its `change` commits it, with no diffing anywhere between.
+ */
+
+// Emits the two events every real field component emits, on demand.
+const StubField = defineComponent({
+  props: { field: { type: Object, required: true }, modelValue: null },
+  emits: ["update:modelValue", "change"],
+  setup(props, { emit }) {
+    return () =>
+      h("input", {
+        "data-fieldname": props.field.fieldname,
+        onInput: (event: any) => emit("update:modelValue", event.target.value),
+        onChange: (event: any) => emit("change", event.target.value),
+      });
+  },
+});
+
+let app: App | undefined;
+let host: HTMLElement | undefined;
+
+afterEach(() => {
+  app?.unmount();
+  host?.remove();
+  app = undefined;
+  host = undefined;
+});
+
+interface Recorded {
+  channel: CommitChannel;
+  pending: string[];
+  committed: string[];
+}
+
+function recorder(): Recorded {
+  const pending: string[] = [];
+  const committed: string[] = [];
+  return {
+    pending,
+    committed,
+    channel: {
+      pending: (fieldname) => pending.push(fieldname),
+      commit: (fieldname) => committed.push(fieldname),
+      rowChanged: () => {},
+    },
+  };
+}
+
+function render(fields: FieldNode[], channel?: CommitChannel) {
+  const doc: Record<string, any> = {};
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  app = createApp({
+    render: () => h(FormLayoutColumn, { column: { name: "c", fields } }),
+  });
+  app.provide(DocKey, { value: doc } as any);
+  app.provide(UpdateKey, (name: string, value: any) => (doc[name] = value));
+  app.provide(ResolveFieldKey, () => StubField);
+  if (channel) app.provide(CommitKey, channel);
+  app.mount(host);
+  return { host, doc };
+}
+
+const qty: FieldNode = { fieldname: "qty", fieldtype: "Float" };
+
+function type(host: HTMLElement, value: string) {
+  const input = host.querySelector("input")! as HTMLInputElement;
+  input.value = value;
+  input.dispatchEvent(new Event("input"));
+}
+
+function blur(host: HTMLElement) {
+  host.querySelector("input")!.dispatchEvent(new Event("change"));
+}
+
+describe("commit wiring", () => {
+  it("marks the field pending as it is typed, and commits on change", () => {
+    const recorded = recorder();
+    const { host, doc } = render([qty], recorded.channel);
+
+    type(host, "10");
+    expect(doc.qty).toBe("10");
+    expect(recorded.pending).toEqual(["qty"]);
+    expect(recorded.committed).toEqual([]);
+
+    blur(host);
+    expect(recorded.committed).toEqual(["qty"]);
+  });
+
+  it("commits once per commit, however many keystrokes preceded it", () => {
+    const recorded = recorder();
+    const { host } = render([qty], recorded.channel);
+    type(host, "1");
+    type(host, "10");
+    blur(host);
+    expect(recorded.committed).toEqual(["qty"]);
+  });
+
+  it("still syncs the doc when no channel is provided", () => {
+    const { host, doc } = render([qty]);
+    type(host, "7");
+    blur(host);
+    expect(doc.qty).toBe("7");
+  });
+});

--- a/ui/src/components/FormLayout/tests/commitWiring.test.ts
+++ b/ui/src/components/FormLayout/tests/commitWiring.test.ts
@@ -36,19 +36,19 @@ afterEach(() => {
 
 interface Recorded {
   channel: CommitChannel;
-  pending: string[];
-  committed: string[];
+  pending: [string, any][];
+  committed: [string, any][];
 }
 
 function recorder(): Recorded {
-  const pending: string[] = [];
-  const committed: string[] = [];
+  const pending: [string, any][] = [];
+  const committed: [string, any][] = [];
   return {
     pending,
     committed,
     channel: {
-      pending: (fieldname) => pending.push(fieldname),
-      commit: (fieldname) => committed.push(fieldname),
+      pending: (fieldname, value) => pending.push([fieldname, value]),
+      commit: (fieldname, value) => committed.push([fieldname, value]),
       rowChanged: () => {},
     },
   };
@@ -88,11 +88,11 @@ describe("commit wiring", () => {
 
     type(host, "10");
     expect(doc.qty).toBe("10");
-    expect(recorded.pending).toEqual(["qty"]);
+    expect(recorded.pending).toEqual([["qty", "10"]]);
     expect(recorded.committed).toEqual([]);
 
     blur(host);
-    expect(recorded.committed).toEqual(["qty"]);
+    expect(recorded.committed).toEqual([["qty", "10"]]);
   });
 
   it("commits once per commit, however many keystrokes preceded it", () => {
@@ -101,7 +101,7 @@ describe("commit wiring", () => {
     type(host, "1");
     type(host, "10");
     blur(host);
-    expect(recorded.committed).toEqual(["qty"]);
+    expect(recorded.committed).toEqual([["qty", "10"]]);
   });
 
   it("a child table commits through its rows, not under its own fieldname", () => {

--- a/ui/src/components/FormLayout/tests/commitWiring.test.ts
+++ b/ui/src/components/FormLayout/tests/commitWiring.test.ts
@@ -104,6 +104,18 @@ describe("commit wiring", () => {
     expect(recorded.committed).toEqual(["qty"]);
   });
 
+  it("a child table commits through its rows, not under its own fieldname", () => {
+    const recorded = recorder();
+    const { host } = render(
+      [{ fieldname: "products", fieldtype: "Table" }],
+      recorded.channel
+    );
+    type(host, "anything");
+    blur(host);
+    expect(recorded.pending).toEqual([]);
+    expect(recorded.committed).toEqual([]);
+  });
+
   it("still syncs the doc when no channel is provided", () => {
     const { host, doc } = render([qty]);
     type(host, "7");

--- a/ui/src/components/FormLayout/tests/newRowValues.test.ts
+++ b/ui/src/components/FormLayout/tests/newRowValues.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { layoutFields, newRowValues } from "../newRowValues";
+import type { FieldNode, FormLayoutSchema } from "../types";
+
+const field = (over: Partial<FieldNode> & { fieldname: string }): FieldNode =>
+  ({ fieldtype: "Data", ...over }) as FieldNode;
+
+describe("newRowValues", () => {
+  it("seeds declared defaults and leaves the rest absent", () => {
+    expect(
+      newRowValues([
+        field({ fieldname: "item_code" }),
+        field({ fieldname: "uom", default: "Nos" }),
+      ])
+    ).toEqual({ uom: "Nos" });
+  });
+
+  it("coerces numeric defaults to numbers", () => {
+    expect(
+      newRowValues([
+        field({ fieldname: "qty", fieldtype: "Float", default: "1" }),
+        field({ fieldname: "free", fieldtype: "Check", default: "1" }),
+        field({ fieldname: "rate", fieldtype: "Currency", default: "2.5" }),
+      ])
+    ).toEqual({ qty: 1, free: 1, rate: 2.5 });
+  });
+
+  it("lands a Select on its first option when it declares no default", () => {
+    expect(
+      newRowValues([
+        field({ fieldname: "status", fieldtype: "Select", options: "Open\nClosed" }),
+      ])
+    ).toEqual({ status: "Open" });
+  });
+
+  it("resolves Today to a date", () => {
+    const row = newRowValues([
+      field({ fieldname: "due", fieldtype: "Date", default: "Today" }),
+    ]);
+    expect(row.due).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("skips fieldtypes that hold no value", () => {
+    expect(
+      newRowValues([field({ fieldname: "sb", fieldtype: "Section Break", default: "x" })])
+    ).toEqual({});
+  });
+});
+
+describe("layoutFields", () => {
+  it("flattens every field of a child layout, not just the grid columns", () => {
+    const layout: FormLayoutSchema = [
+      {
+        name: "t",
+        sections: [
+          { name: "s", columns: [{ fields: [field({ fieldname: "qty" })] }] },
+          { name: "s2", columns: [{ fields: [field({ fieldname: "notes" })] }] },
+        ],
+      },
+    ];
+    expect(layoutFields(layout).map((f) => f.fieldname)).toEqual(["qty", "notes"]);
+  });
+});

--- a/ui/src/components/FormLayout/tests/useChildRowModel.test.ts
+++ b/ui/src/components/FormLayout/tests/useChildRowModel.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { ref } from "vue";
 import { useChildRowModel } from "../useChildRowModel";
+import { ROW_ID } from "../../Fields/rowIdentity";
 
 describe("useChildRowModel", () => {
   it("reads link values out of the stored child rows", () => {
@@ -30,10 +31,10 @@ describe("useChildRowModel", () => {
       emit
     );
     value.value = ["a@x.com"];
-    expect(emit).toHaveBeenCalledWith("update:modelValue", [
-      { user: "a@x.com" },
-    ]);
-    expect(emit).toHaveBeenCalledWith("change", [{ user: "a@x.com" }]);
+    const [event, rows] = emit.mock.calls[0];
+    expect(event).toBe("update:modelValue");
+    expect(rows[0].user).toBe("a@x.com");
+    expect(emit).toHaveBeenCalledWith("change", rows);
   });
 
   it("reuses the existing row object for values that stay selected", () => {
@@ -47,9 +48,10 @@ describe("useChildRowModel", () => {
     // re-select the same value plus a new one
     value.value = ["a@x.com", "b@x.com"];
     const next = emit.mock.calls.find((c) => c[0] === "update:modelValue")![1];
-    // existing row preserved by reference (name/doctype survive); new one minted
+    // existing row preserved by reference (name/doctype survive); new one minted an id
     expect(next[0]).toBe(kept);
-    expect(next[1]).toEqual({ user: "b@x.com" });
+    expect(next[1][ROW_ID]).toBeTruthy();
+    expect(next[1].user).toBe("b@x.com");
   });
 
   it("is reactive to the underlying rows ref", () => {

--- a/ui/src/components/FormLayout/types.ts
+++ b/ui/src/components/FormLayout/types.ts
@@ -9,7 +9,18 @@ export type {
   FieldComponentProps,
   FieldComponentEmits,
 } from "../Fields/types";
-export { DocKey, ParentDocKey, UpdateKey } from "../Fields/types";
+export {
+  CommitKey,
+  DocKey,
+  NO_COMMIT,
+  ParentDocKey,
+  UpdateKey,
+} from "../Fields/types";
+export type {
+  CommitChannel,
+  RowAddress,
+  RowChange,
+} from "../Fields/types";
 
 /**
  * App-supplied presentation/behavior for one field's *layout node* — not part of

--- a/ui/src/components/FormLayout/useChildRowModel.ts
+++ b/ui/src/components/FormLayout/useChildRowModel.ts
@@ -1,5 +1,7 @@
-import { computed } from "vue";
+import { computed, getCurrentInstance, inject } from "vue";
 import type { WritableComputedRef } from "vue";
+import { CommitKey, NO_COMMIT } from "../Fields/types";
+import { identify, rowKey } from "../Fields/rowIdentity";
 
 /**
  * Bridge a `Table MultiSelect` field's stored value (an array of child rows,
@@ -22,12 +24,23 @@ type ChildRowEmit = {
 export function useChildRowModel(
   modelValue: () => unknown,
   linkFieldname: () => string,
-  emit: ChildRowEmit
+  emit: ChildRowEmit,
+  parentfield?: () => string
 ): WritableComputedRef<string[]> {
   const rows = computed<Record<string, any>[]>(() => {
     const v = modelValue();
     return Array.isArray(v) ? v : [];
   });
+
+  // The second place in the stack that creates a child row, so it mints
+  // identity and signals the structural edit the same way the grid does.
+  const commit = getCurrentInstance() ? inject(CommitKey, NO_COMMIT) : NO_COMMIT;
+
+  function signal(row: Record<string, any>, change: "add" | "remove") {
+    const table = parentfield?.();
+    if (!table) return;
+    commit.rowChanged({ parentfield: table, key: rowKey(identify(row))! }, change);
+  }
 
   return computed<string[]>({
     get: () => rows.value.map((r) => r[linkFieldname()]).filter(Boolean),
@@ -37,9 +50,15 @@ export function useChildRowModel(
       // "" would corrupt the child table, so skip the write entirely.
       if (!fn) return;
       const byValue = new Map(rows.value.map((r) => [r[fn], r]));
-      const next = selected.map((v) => byValue.get(v) ?? { [fn]: v });
+      const kept = new Set(selected);
+      const next = selected.map((v) => byValue.get(v) ?? identify({ [fn]: v }));
+      // Captured before the emit, which repoints `rows` at the new array.
+      const removed = rows.value.filter((row) => !kept.has(row[fn]));
+      const added = next.filter((row) => !byValue.has(row[fn]));
       emit("update:modelValue", next);
       emit("change", next);
+      for (const row of removed) signal(row, "remove");
+      for (const row of added) signal(row, "add");
     },
   });
 }

--- a/ui/src/components/FormLayout/warnMissingCommit.ts
+++ b/ui/src/components/FormLayout/warnMissingCommit.ts
@@ -1,0 +1,17 @@
+import type { CommitChannel } from "./types";
+
+/**
+ * A layout with no `CommitKey` provider drops every commit silently, which
+ * reads as a script whose field handlers never fire. A form that genuinely has
+ * no events provides `NO_COMMIT` to say so.
+ */
+export function warnMissingCommit(
+  component: string,
+  channel: CommitChannel | null
+): void {
+  if (channel || !import.meta.env?.DEV) return;
+  console.error(
+    `[${component}] no CommitKey provider: field commits will not fire. ` +
+      `Provide the page's channel, or NO_COMMIT if this form has no events.`
+  );
+}

--- a/ui/src/components/Grid/Grid.vue
+++ b/ui/src/components/Grid/Grid.vue
@@ -227,6 +227,7 @@ import {
 } from "frappe-ui/experimental";
 // @ts-ignore — vuedraggable ships no bundled types
 import Draggable from "vuedraggable";
+import { identify, rowKey } from "../Fields/rowIdentity";
 import type { GridColumn, GridEmits, GridProps, GridSlots } from "./types";
 
 // Mirrors frappe-ui's `FrappeUIError` (an `Error` whose `messages?: string[]`
@@ -369,12 +370,15 @@ function alignClass(align: GridColumn["align"]): string {
 	return "text-left";
 }
 
-// Stable identity per row object (rows have no guaranteed id), minted in a WeakMap.
-// Used for `v-for`/Draggable keys and selection, both surviving reorder/delete/edit
-// since row objects are mutated in place, never replaced.
+// Identity by `name ?? __row_id`, so it survives a save: the saved response
+// replaces every row object, which used to empty the selection. The WeakMap
+// remains for rows that reached the grid with neither (`v-for`/Draggable need a
+// key regardless).
 let uid = 0;
 const rowKeys = new WeakMap<object, string>();
 function keyOf(row: Record<string, any>): string {
+	const identified = rowKey(row);
+	if (identified) return identified;
 	let key = rowKeys.get(row);
 	if (!key) {
 		key = `r${uid++}`;
@@ -420,21 +424,28 @@ function updateCell(index: number, col: T, value: any) {
 }
 
 function commitCell(index: number, col: T, value: any) {
-	rows.value[index][col.fieldname] = value;
+	const row = rows.value[index];
+	row[col.fieldname] = value;
+	emit("commit", { row, column: col });
 	emit("change", rows.value);
 }
 
+// `newRow` seeds the child doctype's docfield defaults; the caller supplies it
+// because the grid sees only the columns, not the whole child form.
 function addRow() {
-	const next = [...rows.value, {}];
+	const row = identify(props.newRow?.() ?? {});
+	const next = [...rows.value, row];
 	rows.value = next;
+	emit("add", { row });
 	emit("change", next);
 }
 
 function deleteSelected() {
-	const next = rows.value.filter((row) => !selected.value.has(keyOf(row)));
-	rows.value = next;
+	const removed = rows.value.filter((row) => selected.value.has(keyOf(row)));
+	rows.value = rows.value.filter((row) => !selected.value.has(keyOf(row)));
 	selected.value = new Set();
-	emit("change", next);
+	emit("remove", { rows: removed });
+	emit("change", rows.value);
 }
 
 // Draggable hands back the reordered array (same row objects, so keys/selection

--- a/ui/src/components/Grid/Grid.vue
+++ b/ui/src/components/Grid/Grid.vue
@@ -441,11 +441,13 @@ function addRow() {
 }
 
 function deleteSelected() {
-	const removed = rows.value.filter((row) => selected.value.has(keyOf(row)));
-	rows.value = rows.value.filter((row) => !selected.value.has(keyOf(row)));
+	const isRemoved = (row: Record<string, any>) => selected.value.has(keyOf(row));
+	const removed = rows.value.filter(isRemoved);
+	const next = rows.value.filter((row) => !isRemoved(row));
+	rows.value = next;
 	selected.value = new Set();
 	emit("remove", { rows: removed });
-	emit("change", rows.value);
+	emit("change", next);
 }
 
 // Draggable hands back the reordered array (same row objects, so keys/selection

--- a/ui/src/components/Grid/tests/rowPlumbing.test.ts
+++ b/ui/src/components/Grid/tests/rowPlumbing.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, h, nextTick, ref } from "vue";
+import type { App } from "vue";
+import Grid from "../Grid.vue";
+import { ROW_ID } from "../../Fields/rowIdentity";
+
+let app: App | undefined;
+let host: HTMLElement | undefined;
+
+afterEach(() => {
+  app?.unmount();
+  host?.remove();
+  app = undefined;
+  host = undefined;
+});
+
+function render(options: { newRow?: () => Record<string, any>; cell?: boolean } = {}) {
+  const rows = ref<Record<string, any>[]>([]);
+  const events: { name: string; payload: any }[] = [];
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  app = createApp({
+    render: () =>
+      h(Grid, {
+        columns: [{ fieldname: "qty" }],
+        modelValue: rows.value,
+        newRow: options.newRow,
+        "onUpdate:modelValue": (next: any) => (rows.value = next),
+        onAdd: (payload: any) => events.push({ name: "add", payload }),
+        onRemove: (payload: any) => events.push({ name: "remove", payload }),
+        onCommit: (payload: any) => events.push({ name: "commit", payload }),
+      },
+      options.cell
+        ? {
+            cell: ({ commit }: any) =>
+              h("button", { "data-commit": "", onClick: () => commit(9) }),
+          }
+        : undefined),
+  });
+  app.mount(host);
+  return { rows, events };
+}
+
+function addRow(host: HTMLElement) {
+  const button = [...host.querySelectorAll("button")].find((b) =>
+    b.textContent?.includes("Add Row")
+  )!;
+  button.dispatchEvent(new Event("click"));
+}
+
+describe("Grid row plumbing", () => {
+  it("mints an id on a new row and announces it", async () => {
+    const { rows, events } = render();
+    addRow(host!);
+    expect(rows.value).toHaveLength(1);
+    expect(rows.value[0][ROW_ID]).toBeTruthy();
+    expect(events).toEqual([{ name: "add", payload: { row: rows.value[0] } }]);
+  });
+
+  it("seeds the new row from `newRow`", () => {
+    const { rows } = render({ newRow: () => ({ qty: 1 }) });
+    addRow(host!);
+    expect(rows.value[0].qty).toBe(1);
+    expect(rows.value[0][ROW_ID]).toBeTruthy();
+  });
+
+  it("names the row and the column a committed cell belongs to", async () => {
+    const { rows, events } = render({ cell: true });
+    addRow(host!);
+    await nextTick();
+    host!.querySelector<HTMLElement>("[data-commit]")!.dispatchEvent(new Event("click"));
+    expect(events.at(-1)).toEqual({
+      name: "commit",
+      payload: { row: rows.value[0], column: { fieldname: "qty" } },
+    });
+    expect(rows.value[0].qty).toBe(9);
+  });
+});

--- a/ui/src/components/Grid/types.ts
+++ b/ui/src/components/Grid/types.ts
@@ -42,6 +42,9 @@ export interface GridProps {
   error?: string | GridError;
   /** Renders a `*` next to the label. */
   required?: boolean;
+  /** Seeds a newly added row. The grid sees only the columns, so whoever knows
+   *  the whole child form supplies its docfield defaults. */
+  newRow?: () => Record<string, any>;
 }
 
 export type GridEmits = {
@@ -51,6 +54,16 @@ export type GridEmits = {
    * signal, distinct from the live `v-model` sync (the slot's `update`).
    */
   change: [rows: Record<string, any>[]];
+  /**
+   * One cell was committed. Distinct from `change`, which says only that the
+   * rows array moved: this names the row and the column, so a consumer can
+   * dispatch a per-row event without diffing to work out what moved.
+   */
+  commit: [payload: { row: Record<string, any>; column: GridColumn }];
+  /** A row was added, carrying the row so a consumer can address it. */
+  add: [payload: { row: Record<string, any> }];
+  /** Rows were deleted, carrying them as they last were. */
+  remove: [payload: { rows: Record<string, any>[] }];
   /**
    * The user clicked a row's edit action (last column). Carries the row and its
    * index. `Grid` stays oblivious to *how* a row is edited — the consumer (e.g.


### PR DESCRIPTION
Every field component under `components/Fields/` already emits a second event,
`change`, with commit semantics its own comments state — and nothing was wired
to it. `FormLayoutField` bound only `update:modelValue`, so a consumer that
wanted to react to a field had no choice but to deep-watch the document and
diff, which fires on every keystroke and cannot tell a child-row edit from a
table change at all.

This adds the channel that signal was missing.

### What changes

- **`CommitChannel` / `CommitKey` / `NO_COMMIT`** beside `UpdateKey`. It is an
  **injection, not an emit**, so `FormLayout` still emits nothing and still
  knows nothing about whoever consumes it — it only asserts, in DEV, that a
  provider exists, because a missing one drops commits silently. A form with no
  events (a create dialog, a story) provides `NO_COMMIT` to say so out loud.
- **`FormLayoutField`** marks a field pending as it is typed and commits on
  `change`. A child table is excluded: it commits through its rows, never under
  its own fieldname.
- **`TableField`** re-addresses its grid cells and its row-edit dialog to
  `(parentfield, key)`, so a child field never commits under a parent fieldname.
- **`Grid`**
  - mints a client-side `__row_id` on a new row — deliberately *not* a `name`,
    since `frappe.client.save` sends the whole document and `_init_child` treats
    a row that already carries a `name` as existing, making the insert a silent
    no-op `UPDATE`;
  - seeds the row from the caller's `newRow`. It pushed a literal `{}`, so
    **child-table docfield defaults were ignored entirely** — both desk
    (`create_new.js`) and the v1 CRM grid get this right;
  - names the row and column a committed cell belongs to, so a consumer never
    has to diff to find out what moved;
  - keys rows by `name ?? __row_id` rather than a WeakMap counter. The saved
    response replaces every row object, so **grid selection silently emptied
    after every save**. One case is narrowed rather than closed, and
    deliberately: `__row_id` is not a DocField, so the server strips it, and a
    row added in this session still loses its selection on its **first** save
    (after that it has a `name`, which wins). Re-keying the selection across
    that boundary would have to match by position, and a mis-keyed selection
    arms Delete on the wrong row — the current behaviour fails safe, showing
    the row deselected.
- **`useChildRowModel`** does the same for a `Table MultiSelect` pick — the
  second place in the stack that creates a child row.

### The value travels

`commit(fieldname, value)` carries the value even though the document already
holds it, and the channel treats a commit that settles nothing new as a no-op.
This is not defensive: `frappe-ui`'s `TextInput` binds `@input` and `@change` to
one handler, so every commit is followed by an echo of the same value, and
Chromium fires a final `change` when a repaint unmounts a focused input. Both
were found by driving this in a browser, not by the tests.

### Verification

30 new tests, including a `Grid` DOM test that clicks Add Row and asserts the
minted id, the seeded defaults and the emitted payloads, and a meta → DOM test
that types into a control and asserts silence until it commits. Verified
standalone against `develop`: the suite goes from 356 tests / 355 green to 371 /
370, the two reds byte-identical (both are test-environment defects — a
`leaflet` asset import and a test whose own header says it needs a node env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

>no-docs