### PR TITLE
fix(FormLayout): typed empties for a new child row, and a write-through row-edit dialog

### DIFF
--- a/ui/src/components/Fields/TableField.vue
+++ b/ui/src/components/Fields/TableField.vue
@@ -316,13 +316,27 @@ let openedRow: Record<string, any> | null = null;
 
 const editIndex = computed(() => {
 	if (editKey.value === null) return -1;
-	const first = rows.value.findIndex((row) => rowKey(row) === editKey.value);
-	if (first === -1) return -1;
+	const matching = answering();
+	if (matching.length <= 1) return matching[0] ?? -1;
 	const clicked = openedRow ? rows.value.indexOf(openedRow) : -1;
 	// The clicked row still has to answer to the address: a script can rename a
 	// row under the dialog, and then it is no longer the row that was opened.
-	return clicked !== -1 && rowKey(rows.value[clicked]) === editKey.value ? clicked : first;
+	if (clicked !== -1 && rowKey(rows.value[clicked]) === editKey.value) return clicked;
+	// Two rows answer to this address and the object that told them apart is gone
+	// (a save replaces every row object). There is no answer left, only a guess —
+	// and guessing is how the reader silently edits the other row, so the dialog
+	// closes on the same rule as a row that has vanished.
+	return -1;
 });
+
+/** Every row currently answering to the open address, by index. */
+function answering(): number[] {
+	const found: number[] = [];
+	rows.value.forEach((row, index) => {
+		if (rowKey(row) === editKey.value) found.push(index);
+	});
+	return found;
+}
 
 // Writable, though `FormLayout` only ever mutates it: a getter-only computed
 // would swallow a reassignment in production and warn only in dev.
@@ -349,7 +363,19 @@ const showEdit = computed({
 // save-conflict path does routinely (it repaints the server's rows, then
 // re-applies the reader's).
 watch(editRow, (row) => {
-	if (!row) closeEdit();
+	if (row) return;
+	// An ambiguous close looks identical to a removal from the outside, so say so:
+	// the rows are still there, and the reader's edits stopped landing.
+	if (import.meta.env?.DEV && answering().length > 1) {
+		console.warn(
+			`[TableField] closed the row-edit dialog for "${props.field.fieldname}": ` +
+				`${answering().length} rows answer to ${editKey.value}, and the row that was ` +
+				`opened is no longer among them. Rows that share a name cannot be told apart ` +
+				`once a save replaces them — give a copied row a fresh identity instead of ` +
+				`reusing its name.`
+		);
+	}
+	closeEdit();
 });
 
 function closeEdit() {

--- a/ui/src/components/Fields/TableField.vue
+++ b/ui/src/components/Fields/TableField.vue
@@ -71,9 +71,11 @@
 		</template>
 	</Grid>
 
-	<!-- Row-edit: render the full row as a FormLayout form (Grid only emits `edit`). -->
+	<!-- Row-edit: render the full row as a FormLayout form (Grid only emits `edit`).
+	     The row object itself is the model — the dialog writes through, the way a
+	     grid cell already does. -->
 	<Dialog v-model:open="showEdit" :title="dialogTitle" size="3xl">
-		<FormLayout v-if="editIndex !== null" v-model:doc="editDoc" :layout="editLayout" />
+		<FormLayout v-if="editRow" v-model:doc="editRow" :layout="editLayout" />
 	</Dialog>
 </template>
 
@@ -111,15 +113,25 @@ const commit = inject(CommitKey, NO_COMMIT);
 
 // The row-edit dialog's FormLayout would otherwise commit the child's fieldnames
 // as if they were the parent's, so its commits are re-addressed to the open row.
+// Without an address the channel would fall back to the bare fieldname, firing
+// the PARENT's handler for a child field — the misfire this wrapper exists to
+// prevent — so a commit arriving with no open row is dropped instead.
 const rowChannel: CommitChannel = {
-	pending: (fieldname, value) => commit.pending(fieldname, value, editAddress()),
-	commit: (fieldname, value) => commit.commit(fieldname, value, editAddress()),
+	pending: (fieldname, value) => withAddress((row) => commit.pending(fieldname, value, row)),
+	commit: (fieldname, value) => withAddress((row) => commit.commit(fieldname, value, row)),
 	rowChanged: (row, change) => commit.rowChanged(row, change),
 };
 provide(CommitKey, rowChannel);
 
+function withAddress(dispatch: (row: RowAddress) => void) {
+	const row = editAddress();
+	if (row) dispatch(row);
+}
+
 function editAddress(): RowAddress | undefined {
-	return editRow.value ? addressOf(editRow.value) : undefined;
+	return editKey.value === null
+		? undefined
+		: { parentfield: props.field.fieldname, key: editKey.value };
 }
 
 function addressOf(row: Record<string, any>): RowAddress {
@@ -288,24 +300,58 @@ const rows = computed<Record<string, any>[]>({
 
 // --- Row-edit dialog ---------------------------------------------------------
 
-// `editIndex` null = dialog closed. `editDoc` is a clone so the dialog edits in
-// isolation; commits copy it back into the rows array.
-const editIndex = ref<number | null>(null);
-const editDoc = ref<Record<string, any>>({});
-// The row object being edited, tracked by identity so write-back survives a
-// parent re-sort/filter of the rows array between watcher fires (a cached
-// positional index would point at the wrong row after reorder).
-const editRow = ref<Record<string, any> | null>(null);
+// The dialog holds an ADDRESS, not a row reference: a save replaces every row
+// object (`paintSaved`) and the parent may reorder the array underneath, so the
+// row is re-found by `name ?? __row_id` on every access — the shape `page.rows`'
+// handles use. `editKey` null = dialog closed.
+const editKey = ref<string | null>(null);
+// Where the row sat when the dialog opened. Only a tiebreak, never the address:
+// a script that duplicates a saved row (`{ ...products[0] }`) copies its `name`,
+// and two rows answering to one key would otherwise both resolve to the first.
+let openedAt = -1;
 
-const showEdit = computed({
-	get: () => editIndex.value !== null,
-	set: (open) => {
-		if (!open) editIndex.value = null;
+const editIndex = computed(() => {
+	if (editKey.value === null) return -1;
+	const matches = (row: Record<string, any>) => rowKey(row) === editKey.value;
+	if (matches(rows.value[openedAt] ?? {})) return openedAt;
+	return rows.value.findIndex(matches);
+});
+
+// Writable, though `FormLayout` only ever mutates it: a getter-only computed
+// would swallow a reassignment in production and warn only in dev.
+const editRow = computed<Record<string, any> | null>({
+	get: () => (editIndex.value === -1 ? null : rows.value[editIndex.value]),
+	set: (row) => {
+		if (row && editIndex.value !== -1) rows.value[editIndex.value] = row;
 	},
 });
 
+// Open exactly while the address resolves. When it stops — the row is removed,
+// reordered out by the parent, or detached by a save (the server strips
+// `__row_id`, so a row added this session has neither identifier afterwards) —
+// the dialog closes, rather than staying open with every keystroke going nowhere.
+const showEdit = computed({
+	get: () => editRow.value !== null,
+	set: (open) => {
+		if (!open) closeEdit();
+	},
+});
+
+// Closing is a WRITE, not a derivation: leaving `editKey` set would re-open the
+// dialog by itself the moment a row answering to that key came back — which the
+// save-conflict path does routinely (it repaints the server's rows, then
+// re-applies the reader's).
+watch(editRow, (row) => {
+	if (!row) closeEdit();
+});
+
+function closeEdit() {
+	editKey.value = null;
+	openedAt = -1;
+}
+
 const dialogTitle = computed(() =>
-	editIndex.value === null ? "" : `${props.field.label ?? "Row"} — Row ${editIndex.value + 1}`
+	editIndex.value === -1 ? "" : `${props.field.label ?? "Row"} — Row ${editIndex.value + 1}`
 );
 
 // Dialog renders the child's full form via `childLayout`; fall back to a flat form of
@@ -329,42 +375,20 @@ function readOnlyLayout(schema: FormLayoutSchema): FormLayoutSchema {
 	}));
 }
 
-function openEdit({ index }: { row: Record<string, any>; index: number }) {
-	// Seeding the clone reassigns `editDoc`, which would trip the write-back watch
-	// (a no-op echo of the unedited row that needlessly churns the row's identity
-	// and emits a phantom change). Suppress that one open-time fire.
-	skipWriteBack = true;
-	editRow.value = rows.value[index];
-	editDoc.value = { ...editRow.value };
-	editIndex.value = index;
+function openEdit({ row, index }: { row: Record<string, any>; index: number }) {
+	// `identify` covers a row that reached the table with neither a name nor an id
+	// (a script's own `push({})`), which would otherwise have no address at all.
+	// The stamp is safe to write: such a row can only have been pushed this
+	// session, so the document is already dirty, and `__row_id` never reaches the
+	// server (`rowIdentity.ts`).
+	editKey.value = addressOf(row).key;
+	openedAt = index;
 }
 
-// Write the working copy back into the row. `FormLayout` emits nothing now, so we
-// watch the dialog's reactive doc (deep) instead of an `@change` event; the doc
-// syncs live, so this writes back as the user edits (vs. the old commit-only
-// `@change`), flowing through the same `update:modelValue`/`change` the grid expects.
-let skipWriteBack = false;
-watch(
-	editDoc,
-	() => {
-		if (editIndex.value === null) return;
-		if (skipWriteBack) {
-			skipWriteBack = false;
-			return;
-		}
-		const next = rows.value.slice();
-		// Locate the row by identity, not the cached index: the parent may have
-		// re-sorted/filtered `rows` since open, so the positional index can now
-		// point at a different row.
-		const i = editRow.value ? next.indexOf(editRow.value) : -1;
-		if (i === -1) return; // row was removed/reordered out externally
-		// Mutate the row in place (vs. replacing it) so its object reference is
-		// preserved — the Grid keys rows by identity via a WeakMap, so a fresh
-		// object would re-key and re-mount the row, dropping its selection state.
-		Object.assign(next[i], editDoc.value);
-		emit("update:modelValue", next);
-		emit("change", next);
-	},
-	{ deep: true }
-);
+// There is no write-back: `FormLayout` mutates `doc.value[fieldname]` and never
+// reassigns `doc.value` (FormLayout.vue:88-90), so binding the row object edits
+// the row in the parent's array directly — the same in-place write the grid cells
+// have always done. Nothing here reassigns the array either, so the dialog emits
+// no `update:modelValue`/`change` for the whole table; `change` still fires from
+// the Grid on cell commit, add, remove and reorder, so it keeps its meaning.
 </script>

--- a/ui/src/components/Fields/TableField.vue
+++ b/ui/src/components/Fields/TableField.vue
@@ -305,16 +305,23 @@ const rows = computed<Record<string, any>[]>({
 // row is re-found by `name ?? __row_id` on every access — the shape `page.rows`'
 // handles use. `editKey` null = dialog closed.
 const editKey = ref<string | null>(null);
-// Where the row sat when the dialog opened. Only a tiebreak, never the address:
-// a script that duplicates a saved row (`{ ...products[0] }`) copies its `name`,
-// and two rows answering to one key would otherwise both resolve to the first.
-let openedAt = -1;
+// The row object the reader clicked. Only a tiebreak, never the address: a
+// script that duplicates a saved row (`{ ...products[0] }`) copies its `name`,
+// so two rows can answer to one key and a bare first-match would open on the
+// wrong one. Deliberately NOT a position — a reorder leaves the index pointing
+// at the other row while its key still matches, which is the same wrong answer
+// arrived at more confidently. A save replaces every row object, so this goes
+// stale by design; the key is what survives it.
+let openedRow: Record<string, any> | null = null;
 
 const editIndex = computed(() => {
 	if (editKey.value === null) return -1;
-	const matches = (row: Record<string, any>) => rowKey(row) === editKey.value;
-	if (matches(rows.value[openedAt] ?? {})) return openedAt;
-	return rows.value.findIndex(matches);
+	const first = rows.value.findIndex((row) => rowKey(row) === editKey.value);
+	if (first === -1) return -1;
+	const clicked = openedRow ? rows.value.indexOf(openedRow) : -1;
+	// The clicked row still has to answer to the address: a script can rename a
+	// row under the dialog, and then it is no longer the row that was opened.
+	return clicked !== -1 && rowKey(rows.value[clicked]) === editKey.value ? clicked : first;
 });
 
 // Writable, though `FormLayout` only ever mutates it: a getter-only computed
@@ -347,7 +354,7 @@ watch(editRow, (row) => {
 
 function closeEdit() {
 	editKey.value = null;
-	openedAt = -1;
+	openedRow = null;
 }
 
 const dialogTitle = computed(() =>
@@ -382,7 +389,7 @@ function openEdit({ row, index }: { row: Record<string, any>; index: number }) {
 	// session, so the document is already dirty, and `__row_id` never reaches the
 	// server (`rowIdentity.ts`).
 	editKey.value = addressOf(row).key;
-	openedAt = index;
+	openedRow = row;
 }
 
 // There is no write-back: `FormLayout` mutates `doc.value[fieldname]` and never

--- a/ui/src/components/Fields/TableMultiSelectField.vue
+++ b/ui/src/components/Fields/TableMultiSelectField.vue
@@ -22,6 +22,7 @@
 import { computed } from "vue";
 import { TableMultiSelect } from "../TableMultiSelect";
 import { useChildRowModel } from "../FormLayout/useChildRowModel";
+import { newRowValues } from "../FormLayout/newRowValues";
 import type { FieldComponentEmits, FieldComponentProps } from "./types";
 
 const props = defineProps<FieldComponentProps>();
@@ -35,6 +36,11 @@ const value = useChildRowModel(
 	() => props.modelValue,
 	() => linkField.value?.fieldname ?? "",
 	emit,
-	() => props.field.fieldname
+	() => props.field.fieldname,
+	// A picked row is a new child row, so it starts out shaped like any other.
+	// `childFields` is the child's grid-column subset, not its whole form — a
+	// `Table MultiSelect` node carries no `childLayout` — so the seed narrows to
+	// those. Known limit, not a hole: it is the same subset the picker itself shows.
+	() => newRowValues(props.field.childFields ?? [])
 );
 </script>

--- a/ui/src/components/Fields/tests/rowEditDialog.test.ts
+++ b/ui/src/components/Fields/tests/rowEditDialog.test.ts
@@ -1,0 +1,260 @@
+// The row-edit dialog writes THROUGH to the row (wayfinder ticket 58 §B): it
+// holds an address rather than a reference, so it survives a reorder, closes
+// when its row stops resolving, and never reassigns the table's array.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApp, defineComponent, h, nextTick, ref } from "vue";
+import type { App } from "vue";
+
+// Dialog chrome is frappe-ui's; a passthrough keeps the test on TableField's
+// behaviour rather than reka-ui's transitions. Everything else stays real
+// (`Grid` composes frappe-ui atoms).
+vi.mock("frappe-ui", async (importOriginal) => {
+  const real = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...real,
+    Dialog: defineComponent({
+      props: { open: { type: Boolean, default: false } },
+      emits: ["update:open"],
+      setup: (props, { slots }) => () =>
+        props.open ? h("div", { "data-dialog": "" }, slots.default?.()) : null,
+    }),
+    // `FormLayout` renders its sections through reka-ui's `Tabs`, which paints
+    // nothing here (the reason the FormLayout tests stop at `FormLayoutColumn`).
+    // A passthrough renders every panel, so the real FormLayout runs.
+    Tabs: defineComponent({
+      props: { tabs: { type: Array, default: () => [] } },
+      emits: ["update:modelValue"],
+      setup: (props, { slots }) => () =>
+        h(
+          "div",
+          (props.tabs as any[]).map((tab) => slots["tab-panel"]?.({ tab }))
+        ),
+    }),
+  };
+});
+
+// FormLayout resolves fieldtypes through its own registry, so the dialog's
+// fields are stubbed there.
+vi.mock("../../FormLayout/useFieldTypes", () => ({
+  useFieldTypes: () => ({ resolve: () => StubField }),
+}));
+
+import TableField from "../TableField.vue";
+import { ResolveFieldKey } from "../../FormLayout/types";
+import { CommitKey } from "../types";
+import { ROW_ID } from "../rowIdentity";
+import type { CommitChannel, RowAddress } from "../types";
+
+// Stands in for every fieldtype, in the cell and in the dialog alike.
+const StubField = defineComponent({
+  props: { field: { type: Object, required: true }, modelValue: null },
+  emits: ["update:modelValue", "change"],
+  setup(props, { emit }) {
+    return () =>
+      h("input", {
+        "data-fieldname": props.field.fieldname,
+        value: props.modelValue ?? "",
+        onInput: (event: any) => emit("update:modelValue", event.target.value),
+        onChange: (event: any) => emit("change", event.target.value),
+      });
+  },
+});
+
+let app: App | undefined;
+let host: HTMLElement | undefined;
+
+afterEach(() => {
+  app?.unmount();
+  host?.remove();
+  app = undefined;
+  host = undefined;
+});
+
+const childFields = [
+  { fieldname: "qty", fieldtype: "Data", label: "Qty" },
+  { fieldname: "notes", fieldtype: "Data", label: "Notes" },
+];
+
+function render(
+  initial: Record<string, any>[],
+  onCommit?: (fieldname: string, value: any) => void
+) {
+  const rows = ref(initial);
+  const emitted: { name: string; value: any }[] = [];
+  const committed: { fieldname: string; value: any; row?: RowAddress }[] = [];
+  const channel: CommitChannel = {
+    pending: (fieldname, value, row) => committed.push({ fieldname, value, row }),
+    commit: (fieldname, value, row) => {
+      committed.push({ fieldname, value, row });
+      onCommit?.(fieldname, value);
+    },
+    rowChanged: () => {},
+  };
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  app = createApp({
+    render: () =>
+      h(TableField, {
+        field: { fieldname: "products", fieldtype: "Table", label: "Products", childFields },
+        modelValue: rows.value,
+        "onUpdate:modelValue": (v: any) => emitted.push({ name: "update:modelValue", value: v }),
+        onChange: (v: any) => emitted.push({ name: "change", value: v }),
+      }),
+  });
+  app.provide(ResolveFieldKey, () => StubField);
+  app.provide(CommitKey, channel);
+  app.mount(host);
+  return { rows, emitted, committed };
+}
+
+/** The per-row edit button lives in the frozen right-hand column. */
+function openRow(index: number) {
+  const buttons = host!.querySelectorAll<HTMLElement>(".sticky.right-0 button");
+  buttons[index].dispatchEvent(new Event("click"));
+  // The dialog's FormLayout is an async component (module-cycle break), so the
+  // dynamic import has to settle before its fields are in the DOM.
+  return flush();
+}
+
+async function flush(): Promise<void> {
+  // The dialog's `FormLayout` is a `defineAsyncComponent`, which renders a comment
+  // placeholder until its dynamic import settles — several turns of the loop.
+  await import("../../FormLayout/FormLayout.vue");
+  for (let i = 0; i < 10; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await nextTick();
+  }
+}
+
+function dialog(): HTMLElement | null {
+  return host!.querySelector("[data-dialog]");
+}
+
+function typeInDialog(fieldname: string, value: string) {
+  const input = dialog()!.querySelector<HTMLInputElement>(`input[data-fieldname="${fieldname}"]`)!;
+  input.value = value;
+  input.dispatchEvent(new Event("input"));
+}
+
+function commitInDialog(fieldname: string) {
+  const input = dialog()!.querySelector<HTMLInputElement>(`input[data-fieldname="${fieldname}"]`)!;
+  input.dispatchEvent(new Event("change"));
+}
+
+describe("row-edit dialog", () => {
+  it("writes through to the row, without reassigning the table's array", async () => {
+    const row = { name: "r1", qty: "1", notes: "" };
+    const { rows, emitted } = render([row]);
+    await openRow(0);
+    expect(dialog()).not.toBeNull();
+
+    typeInDialog("qty", "3");
+    expect(row.qty).toBe("3");
+    expect(emitted.filter((e) => e.name === "update:modelValue")).toEqual([]);
+    expect(emitted.filter((e) => e.name === "change")).toEqual([]);
+  });
+
+  it("addresses its commits to the open row", async () => {
+    const { committed } = render([{ name: "r1", qty: "1" }, { name: "r2", qty: "2" }]);
+    await openRow(1);
+    typeInDialog("qty", "9");
+    expect(committed.at(-1)).toEqual({
+      fieldname: "qty",
+      value: "9",
+      row: { parentfield: "products", key: "name:r2" },
+    });
+  });
+
+  it("follows its row through a reorder underneath it", async () => {
+    const first = { name: "r1", qty: "1" };
+    const second = { name: "r2", qty: "2" };
+    const { rows } = render([first, second]);
+    await openRow(0);
+
+    rows.value = [second, first];
+    await nextTick();
+    expect(dialog()).not.toBeNull();
+    typeInDialog("qty", "7");
+    expect(first.qty).toBe("7");
+    expect(second.qty).toBe("2");
+  });
+
+  it("re-resolves a saved row across the repaint that replaces every row object", async () => {
+    const { rows } = render([{ name: "r1", qty: "1" }]);
+    await openRow(0);
+
+    // `paintSaved`: fresh objects, same names.
+    rows.value = [{ name: "r1", qty: "1" }];
+    await nextTick();
+    expect(dialog()).not.toBeNull();
+    typeInDialog("qty", "5");
+    expect(rows.value[0].qty).toBe("5");
+  });
+
+  it("keeps what a handler writes into the row on commit", async () => {
+    // What the clone actually cost: the write-back overwrote the row a tick
+    // after a handler had written to it, so the next handler read the old value.
+    const row: Record<string, any> = { name: "r1", qty: "1", notes: "" };
+    const { rows } = render([row], (fieldname) => {
+      if (fieldname === "qty") row.notes = `handler saw ${row.qty}`;
+    });
+    await openRow(0);
+    typeInDialog("qty", "4");
+    commitInDialog("qty");
+    expect(row.notes).toBe("handler saw 4");
+
+    // A write-back would land here, one tick later.
+    await flush();
+    expect(row.notes).toBe("handler saw 4");
+    expect(rows.value[0].notes).toBe("handler saw 4");
+  });
+
+  it("stays closed when a row answering to its key comes back", async () => {
+    // A save conflict repaints the server's rows and then re-applies the
+    // reader's, so a row that vanished can return moments later. The dialog must
+    // not re-open by itself on top of the conflict dialog.
+    const { rows } = render([{ name: "r1", qty: "1" }, { name: "r2", qty: "2" }]);
+    await openRow(0);
+    const [first, ...rest] = rows.value;
+    rows.value = rest;
+    await nextTick();
+    expect(dialog()).toBeNull();
+
+    rows.value = [first, ...rest];
+    await nextTick();
+    expect(dialog()).toBeNull();
+  });
+
+  it("edits the row that was clicked when two rows answer to one key", async () => {
+    // `{ ...products[0] }` in a script copies the row's `name`, so two rows can
+    // share an address; a bare first-match would open on the wrong one.
+    const { rows } = render([
+      { name: "dup", qty: "A" },
+      { name: "dup", qty: "B" },
+    ]);
+    await openRow(1);
+    typeInDialog("qty", "Z");
+    expect(rows.value[1].qty).toBe("Z");
+    expect(rows.value[0].qty).toBe("A");
+  });
+
+  it("closes when its row is removed", async () => {
+    const { rows } = render([{ name: "r1", qty: "1" }, { name: "r2", qty: "2" }]);
+    await openRow(0);
+    rows.value = rows.value.slice(1);
+    await nextTick();
+    expect(dialog()).toBeNull();
+  });
+
+  it("closes when a row added this session is detached by a save", async () => {
+    const added = { [ROW_ID]: "row-99", qty: "1" };
+    const { rows } = render([added]);
+    await openRow(0);
+    expect(dialog()).not.toBeNull();
+
+    // The server strips `__row_id` and names the row: neither identifier survives.
+    rows.value = [{ name: "r1", qty: "1" }];
+    await nextTick();
+    expect(dialog()).toBeNull();
+  });
+});

--- a/ui/src/components/Fields/tests/rowEditDialog.test.ts
+++ b/ui/src/components/Fields/tests/rowEditDialog.test.ts
@@ -238,6 +238,22 @@ describe("row-edit dialog", () => {
     expect(rows.value[0].qty).toBe("A");
   });
 
+  it("still edits the clicked row when two rows share a key AND reorder", async () => {
+    // The tiebreak cannot be positional: a reorder leaves the remembered index
+    // pointing at the OTHER row whose key matches, so the dialog would swap rows
+    // underneath the reader mid-edit.
+    const first = { name: "dup", qty: "A" };
+    const second = { name: "dup", qty: "B" };
+    const { rows } = render([first, second]);
+    await openRow(1);
+
+    rows.value = [second, first];
+    await nextTick();
+    typeInDialog("qty", "Z");
+    expect(second.qty).toBe("Z");
+    expect(first.qty).toBe("A");
+  });
+
   it("closes when its row is removed", async () => {
     const { rows } = render([{ name: "r1", qty: "1" }, { name: "r2", qty: "2" }]);
     await openRow(0);

--- a/ui/src/components/Fields/tests/rowEditDialog.test.ts
+++ b/ui/src/components/Fields/tests/rowEditDialog.test.ts
@@ -254,6 +254,26 @@ describe("row-edit dialog", () => {
     expect(first.qty).toBe("A");
   });
 
+  it("closes rather than guessing when a save leaves two rows sharing its key", async () => {
+    // Identity is what tells duplicates apart, and a save replaces every row
+    // object — so after the repaint the address answers twice and means neither.
+    const { rows } = render([
+      { name: "dup", qty: "A" },
+      { name: "dup", qty: "B" },
+    ]);
+    await openRow(1);
+    expect(dialog()).not.toBeNull();
+
+    rows.value = [
+      { name: "dup", qty: "A" },
+      { name: "dup", qty: "B" },
+    ];
+    await nextTick();
+    expect(dialog()).toBeNull();
+    // Emphatically not: reopened on row 0 and writing into it.
+    expect(rows.value[0].qty).toBe("A");
+  });
+
   it("closes when its row is removed", async () => {
     const { rows } = render([{ name: "r1", qty: "1" }, { name: "r2", qty: "2" }]);
     await openRow(0);

--- a/ui/src/components/FormLayout/newRowValues.ts
+++ b/ui/src/components/FormLayout/newRowValues.ts
@@ -1,6 +1,11 @@
 // What a freshly added child row starts with, from its docfield defaults.
 import type { FieldNode, FormLayoutSchema } from "./types";
 
+/**
+ * Frappe's own `no_value_fields` (`frappe/model/__init__.py`) minus the two
+ * collection types, which DO hold a value in the document even though they have
+ * no column of their own — a nested table's empty is `[]`.
+ */
 const NO_VALUE = new Set([
   "Section Break",
   "Column Break",
@@ -8,21 +13,46 @@ const NO_VALUE = new Set([
   "Heading",
   "HTML",
   "Fold",
+  "Button",
+  "Image",
+  "Attachment Gallery",
 ]);
+
+const COLLECTIONS = new Set(["Table", "Table MultiSelect"]);
 
 const INTEGERS = new Set(["Int", "Check"]);
 const DECIMALS = new Set(["Float", "Currency", "Percent"]);
+/**
+ * Fieldtypes whose empty is a number rather than a string — every numeric column
+ * the server can send back, so `Rating` and `Duration` (both `decimal`) and
+ * `Long Int` (`bigint`) belong here too. `Check` is numeric server-side but is
+ * seeded `false`; see `emptyValue`.
+ */
+const NUMBERS = new Set([
+  "Int",
+  "Long Int",
+  "Float",
+  "Currency",
+  "Percent",
+  "Rating",
+  "Duration",
+]);
 
 /**
  * Seed values for a new row: every field's resolved `default`, plus a Select's
  * first option, which Frappe treats as the default when none is declared.
+ *
+ * A field with no default still gets a key, holding the *typed* empty for its
+ * fieldtype. A row loaded from the server carries every field, typed, so a
+ * partial seed would leave a fresh row shaped unlike every other row in the same
+ * grid — and a script cannot tell which kind it was handed. `row.qty * row.rate`
+ * is then arithmetic, not `NaN`.
  */
 export function newRowValues(fields: FieldNode[]): Record<string, any> {
   const row: Record<string, any> = {};
   for (const field of fields) {
     if (NO_VALUE.has(field.fieldtype)) continue;
-    const value = defaultValue(field);
-    if (value !== undefined) row[field.fieldname] = value;
+    row[field.fieldname] = defaultValue(field);
   }
   return row;
 }
@@ -38,12 +68,28 @@ export function layoutFields(layout: FormLayoutSchema): FieldNode[] {
 
 function defaultValue(field: FieldNode): any {
   const raw = field.default;
-  if (raw == null || raw === "") return firstOption(field);
+  if (raw == null || raw === "") return firstOption(field) ?? emptyValue(field);
   if (raw === "Today" || raw === "today") return today();
   if (raw === "Now" || raw === "now") return new Date().toISOString().slice(0, 19).replace("T", " ");
   if (INTEGERS.has(field.fieldtype)) return Math.trunc(Number(raw)) || 0;
   if (DECIMALS.has(field.fieldtype)) return Number(raw) || 0;
   return raw;
+}
+
+/**
+ * The empty a field of this type holds when it declares no default.
+ *
+ * `Check` is `false` rather than the `0` the server sends, and the date-ish
+ * types are `""` rather than the `null` the server sends (`get_valid_dict`
+ * nulls an empty datetime on every write) — both as ticket 56 decided them.
+ * The difference is only ever visible before the first save, and every input in
+ * the stack binds these two the same way either way.
+ */
+function emptyValue(field: FieldNode): any {
+  if (field.fieldtype === "Check") return false;
+  if (COLLECTIONS.has(field.fieldtype)) return [];
+  if (NUMBERS.has(field.fieldtype)) return 0;
+  return "";
 }
 
 /** A Select with no default lands on its first option, as desk does. */

--- a/ui/src/components/FormLayout/stories/DemoTableMultiSelectField.vue
+++ b/ui/src/components/FormLayout/stories/DemoTableMultiSelectField.vue
@@ -28,6 +28,7 @@
 import { computed } from "vue";
 import { TableMultiSelect } from "../../TableMultiSelect";
 import { useChildRowModel } from "../useChildRowModel";
+import { newRowValues } from "../newRowValues";
 import type { FieldComponentProps, FieldComponentEmits } from "../types";
 
 const props = defineProps<FieldComponentProps>();
@@ -39,7 +40,11 @@ const targetDoctype = computed(() => linkField.value?.options ?? "");
 const value = useChildRowModel(
 	() => props.modelValue,
 	() => linkField.value?.fieldname ?? "",
-	emit
+	emit,
+	// No `parentfield`: this demo has never signalled row changes (a story has no
+	// commit channel to signal onto). The seed is what it shares with the lib field.
+	undefined,
+	() => newRowValues(props.field.childFields ?? [])
 );
 
 function onCreate(query: string) {

--- a/ui/src/components/FormLayout/tests/newRowValues.test.ts
+++ b/ui/src/components/FormLayout/tests/newRowValues.test.ts
@@ -6,13 +6,68 @@ const field = (over: Partial<FieldNode> & { fieldname: string }): FieldNode =>
   ({ fieldtype: "Data", ...over }) as FieldNode;
 
 describe("newRowValues", () => {
-  it("seeds declared defaults and leaves the rest absent", () => {
+  it("seeds declared defaults and gives every other field a typed empty", () => {
     expect(
       newRowValues([
         field({ fieldname: "item_code" }),
         field({ fieldname: "uom", default: "Nos" }),
       ])
-    ).toEqual({ uom: "Nos" });
+    ).toEqual({ item_code: "", uom: "Nos" });
+  });
+
+  it("empties a numeric field to 0 and a Check to false, so arithmetic works", () => {
+    const row = newRowValues([
+      field({ fieldname: "qty", fieldtype: "Int" }),
+      field({ fieldname: "rate", fieldtype: "Currency" }),
+      field({ fieldname: "discount", fieldtype: "Percent" }),
+      field({ fieldname: "weight", fieldtype: "Float" }),
+      field({ fieldname: "free", fieldtype: "Check" }),
+    ]);
+    expect(row).toEqual({ qty: 0, rate: 0, discount: 0, weight: 0, free: false });
+    expect(row.qty * row.rate).toBe(0);
+  });
+
+  it("empties every numeric fieldtype the server can send back", () => {
+    // Rating and Duration are `decimal` columns and Long Int a `bigint`, so a
+    // loaded row carries numbers for all three (frappe/database/mariadb).
+    expect(
+      newRowValues([
+        field({ fieldname: "score", fieldtype: "Rating" }),
+        field({ fieldname: "spent", fieldtype: "Duration" }),
+        field({ fieldname: "big", fieldtype: "Long Int" }),
+      ])
+    ).toEqual({ score: 0, spent: 0, big: 0 });
+  });
+
+  it("empties a nested collection to [] and skips the fieldtypes with no value", () => {
+    expect(
+      newRowValues([
+        field({ fieldname: "items", fieldtype: "Table" }),
+        field({ fieldname: "tags", fieldtype: "Table MultiSelect" }),
+        field({ fieldname: "go", fieldtype: "Button" }),
+        field({ fieldname: "pic", fieldtype: "Image" }),
+      ])
+    ).toEqual({ items: [], tags: [] });
+  });
+
+  // Note the date-ish types: the server nulls an empty datetime on write
+  // (`get_valid_dict`), so `""` is ticket 56's choice rather than a match for
+  // what a loaded row carries.
+  it("empties the string-ish types, including the date-ish ones, to \"\"", () => {
+    expect(
+      newRowValues([
+        field({ fieldname: "notes", fieldtype: "Text" }),
+        field({ fieldname: "item", fieldtype: "Link" }),
+        field({ fieldname: "due", fieldtype: "Date" }),
+        field({ fieldname: "at", fieldtype: "Datetime" }),
+      ])
+    ).toEqual({ notes: "", item: "", due: "", at: "" });
+  });
+
+  it("empties a Select with no options rather than dropping it", () => {
+    expect(
+      newRowValues([field({ fieldname: "status", fieldtype: "Select" })])
+    ).toEqual({ status: "" });
   });
 
   it("coerces numeric defaults to numbers", () => {

--- a/ui/src/components/FormLayout/tests/useChildRowModel.test.ts
+++ b/ui/src/components/FormLayout/tests/useChildRowModel.test.ts
@@ -54,6 +54,22 @@ describe("useChildRowModel", () => {
     expect(next[1].user).toBe("b@x.com");
   });
 
+  it("seeds a minted row from `newRow`, with the pick beating the seed's empty", () => {
+    const emit = vi.fn();
+    const value = useChildRowModel(
+      () => [],
+      () => "user",
+      emit,
+      undefined,
+      () => ({ user: "", full_name: "", notify: false })
+    );
+    value.value = ["a@x.com"];
+    const next = emit.mock.calls.find((c) => c[0] === "update:modelValue")![1];
+    expect(next[0].user).toBe("a@x.com");
+    expect(next[0].full_name).toBe("");
+    expect(next[0].notify).toBe(false);
+  });
+
   it("is reactive to the underlying rows ref", () => {
     const rows = ref<Record<string, any>[]>([{ user: "a@x.com" }]);
     const value = useChildRowModel(

--- a/ui/src/components/FormLayout/useChildRowModel.ts
+++ b/ui/src/components/FormLayout/useChildRowModel.ts
@@ -9,10 +9,15 @@ import { identify, rowKey } from "../Fields/rowIdentity";
  * flat `string[]` of link values the `TableMultiSelect` control speaks.
  *
  * On write it reuses the existing row object for values that stay selected (so
- * `doctype`/`name` and any other cells survive) and mints `{ [linkFieldname]:
- * value }` for new ones — then emits both `update:modelValue` and `change`
- * (a selection is a commit for a picker). Shared by the lib field and any app
- * override field so neither re-implements the bridge.
+ * `doctype`/`name` and any other cells survive) and mints a fresh row for new
+ * ones — then emits both `update:modelValue` and `change` (a selection is a
+ * commit for a picker). Shared by the lib field and any app override field so
+ * neither re-implements the bridge.
+ *
+ * A minted row is seeded by `newRow`, the same way `Grid` takes its seed from
+ * whoever knows the whole child form: a picked row is otherwise the one row
+ * shape in the stack that carries a single key, where every other row — loaded,
+ * or added through the grid — carries every field.
  */
 /** The emit shape both field wrappers have (a subset of `FieldComponentEmits`).
  *  Overloaded form, not a union arg, so Vue's `defineEmits()` value is assignable. */
@@ -25,7 +30,8 @@ export function useChildRowModel(
   modelValue: () => unknown,
   linkFieldname: () => string,
   emit: ChildRowEmit,
-  parentfield?: () => string
+  parentfield?: () => string,
+  newRow?: () => Record<string, any>
 ): WritableComputedRef<string[]> {
   const rows = computed<Record<string, any>[]>(() => {
     const v = modelValue();
@@ -51,7 +57,9 @@ export function useChildRowModel(
       if (!fn) return;
       const byValue = new Map(rows.value.map((r) => [r[fn], r]));
       const kept = new Set(selected);
-      const next = selected.map((v) => byValue.get(v) ?? identify({ [fn]: v }));
+      // The pick overwrites the seed's own empty for the link field.
+      const mint = (v: string) => identify({ ...newRow?.(), [fn]: v });
+      const next = selected.map((v) => byValue.get(v) ?? mint(v));
       // Captured before the emit, which repoints `rows` at the new array.
       const removed = rows.value.filter((row) => !kept.has(row[fn]));
       const added = next.filter((row) => !byValue.has(row[fn]));


### PR DESCRIPTION
Two independent fixes to the child-table editing surface, one commit each. Both were found by driving a real form in the browser, and neither is reachable from a suite that drives components directly.

### 1. A new child row carries every field, typed

`newRowValues` seeded only the fields that declare a docfield `default`, so everything else was **absent**. A form script's `row.qty * row.rate` then read `undefined` and computed `NaN` — and it hides, because a Currency input renders `undefined` as `$ 0.00`, so the row looks seeded and only the computed cell looks wrong.

Every field now gets a key holding the typed empty for its fieldtype: `0` for the numeric columns (`Int`, `Long Int`, `Float`, `Currency`, `Percent`, `Rating`, `Duration`), `false` for `Check`, `[]` for a nested `Table` / `Table MultiSelect`, `""` for the rest. The Select-first-option rule still wins where it applies, and `NO_VALUE` is aligned with frappe's own `no_value_fields`.

The deciding argument is not the arithmetic: a row loaded from the server carries every field, typed, so a partial seed leaves a fresh row shaped unlike every other row in the same grid, and nothing downstream can tell which kind it was handed. The same seed reaches the `Table MultiSelect` pick, the stack's other row-creation site, which minted a one-key row.

### 2. The row-edit dialog writes through to the row

The dialog edited a **clone**, written back into the row by a deep watch one tick later. That broke both directions: a picker (which emits its value and commits in the same tick) fired its handler *before* the row held the value, and the write-back overwrote whatever a handler had written into the row. For any field that is not an `in_list_view` column, the dialog is the only place it can be edited.

`FormLayout` now binds the row object itself. `FormLayout.update` mutates `doc.value[fieldname]` and never reassigns, so `FormLayout` needed no change at all, and the dialog takes the same in-place path grid cells have always taken. Nothing reassigns the array any more, so the dialog no longer emits `update:modelValue` / `change` for the whole table; `change` still fires from the `Grid` on cell commit, add, remove and reorder.

Because a save replaces every row object, the dialog holds an **address** — re-found by `name ?? __row_id` on every access — rather than a reference. That deletes the locate-by-`indexOf` write-back defect rather than fixing it, and when the address stops resolving (row removed, reordered out, or detached by a save) the dialog **closes**, where before it stayed open with every keystroke going nowhere.

### Tests

`ui/src/components/Fields/tests/rowEditDialog.test.ts` is the first test of any kind on this dialog: 9 cases, 8 of which fail against the previous implementation. Suite: 403 tests / 402 green on this branch against 388 / 387 on `develop` — the one red (`resolveCurrency`) is identical on both and pre-existing.

Both fixes were also driven in Chromium against a real Deal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
