### PR TITLE
feat: `after_app_build` hook to hook into another app's build process

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -102,7 +102,13 @@ def build(
 		run_after_build_hook(apps)
 
 
-def run_after_build_hook(built_apps):
+def run_after_build_hook(built_apps: list[str]):
+	"""Run build hooks after assets are built.
+
+	- `after_build`: self-referential - runs only for apps that were just built, called with no arguments.
+	- `after_app_build`: cross-app - runs for every app on the bench, called with the list of built apps,
+	  so an app can react to another app's build (e.g. compile frontends it owns for that app).
+	"""
 	from importlib import import_module
 
 	def _get_method(fn):
@@ -110,12 +116,10 @@ def run_after_build_hook(built_apps):
 		methodname = fn.split(".")[-1]
 		return getattr(import_module(modulename), methodname)
 
-	# after_build: self-referential hook, runs only for built apps, no args
 	for app in built_apps:
 		for fn in frappe.get_hooks("after_build", app_name=app):
 			_get_method(fn)()
 
-	# after_app_build: cross-app hook, runs for ALL apps, receives the list of built apps
 	for app in frappe.get_all_apps():
 		for fn in frappe.get_hooks("after_app_build", app_name=app):
 			_get_method(fn)(built_apps)

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -102,15 +102,23 @@ def build(
 		run_after_build_hook(apps)
 
 
-def run_after_build_hook(apps):
+def run_after_build_hook(built_apps):
 	from importlib import import_module
 
-	for app in apps:
+	def _get_method(fn):
+		modulename = ".".join(fn.split(".")[:-1])
+		methodname = fn.split(".")[-1]
+		return getattr(import_module(modulename), methodname)
+
+	# after_build: self-referential hook, runs only for built apps, no args
+	for app in built_apps:
 		for fn in frappe.get_hooks("after_build", app_name=app):
-			modulename = ".".join(fn.split(".")[:-1])
-			methodname = fn.split(".")[-1]
-			method = getattr(import_module(modulename), methodname)
-			method()
+			_get_method(fn)()
+
+	# after_app_build: cross-app hook, runs for ALL apps, receives the list of built apps
+	for app in frappe.get_all_apps():
+		for fn in frappe.get_hooks("after_app_build", app_name=app):
+			_get_method(fn)(built_apps)
 
 
 @click.command("watch")

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -555,6 +555,11 @@ use_json_request_body = True
 
 # after_build = "{app_name}.build.after_build"
 
+# To hook into the build process of other apps
+# The list of apps being built is passed as an argument
+
+# after_app_build = "{app_name}.build.after_app_build"
+
 # Desk Notifications
 # ------------------
 # See frappe.core.notifications.get_notification_config


### PR DESCRIPTION
To hook into another app's build process. Needed for studio to build an app's studio frontends when the app is installed/built
https://github.com/frappe/studio/pull/174/

Docs: https://docs.frappe.io/framework/user/en/python-api/hooks#after_app_build