### PR TITLE
fix(FormLayout): identify tabs by name, not by position

### DIFF
--- a/ui/src/components/FormLayout/FormLayout.vue
+++ b/ui/src/components/FormLayout/FormLayout.vue
@@ -4,7 +4,8 @@
 		:class="{ 'border border-outline-gray-1 border-outline-elevation-2 rounded-lg': hasTabs }"
 	>
 		<Tabs
-			v-model="tabIndex"
+			:model-value="activeIndex"
+			@update:model-value="select"
 			as="div"
 			:tabs="visibleTabs"
 			:class="[
@@ -28,11 +29,12 @@
 
 <script setup lang="ts">
 import { Tabs } from "frappe-ui";
-import { computed, inject, provide, ref, watch } from "vue";
+import { computed, inject, provide } from "vue";
 import type { ComponentPublicInstance } from "vue";
 import FormLayoutSection from "./FormLayoutSection.vue";
 import { useFieldTypes } from "./useFieldTypes";
 import { resolveLayout } from "./resolveLayout";
+import { identifyTabs } from "./tabIdentity";
 import { CommitKey, DocKey, HasTabsKey, ParentDocKey, ResolveFieldKey, UpdateKey } from "./types";
 import { warnMissingCommit } from "./warnMissingCommit";
 import type { FormLayoutProps } from "./types";
@@ -44,7 +46,12 @@ const props = defineProps<FormLayoutProps>();
 // per-field actions/side-effects are baked into the layout via `field.ui.on`.
 const doc = defineModel<Record<string, any>>("doc", { required: true });
 
-const tabIndex = ref(0);
+// The tab the reader last *chose*, by identity — an intent, not a position, and
+// the only piece of strip state there is. It falls back to an internal ref, so a
+// host that doesn't care (the dialogs, the stories) binds nothing; a host that
+// wants the reader's place to outlive this component being rebuilt — as the
+// Record page does on every save — holds the ref itself.
+const desired = defineModel<string>("tab", { default: "" });
 
 // Enclosing doc when this form is a child-row dialog, so `eval:parent.x` resolves
 // against the parent. Absent at top level → `parent` falls back to `doc`.
@@ -56,7 +63,12 @@ const resolvedLayout = computed(() =>
 );
 
 const visibleTabs = computed(() => {
-	const tabs = resolvedLayout.value.filter((tab) => !tab.hidden);
+	// Identity is resolved over the *whole* layout and before the label fallback
+	// below, both deliberately. Resolving it over the visible subset would make
+	// the positional fallback shift when a `depends_on` neighbour hides — the
+	// very bug identity exists to kill — and resolving it after the fallback
+	// would collapse every unlabelled tab onto "details".
+	const tabs = identifyTabs(resolvedLayout.value).filter((tab) => !tab.hidden);
 	// With multiple tabs the strip is always shown, so an unlabelled tab would
 	// render a blank button — fall back to "Details" so every tab reads clearly.
 	const multipleTabs = tabs.length > 1;
@@ -67,12 +79,28 @@ const visibleTabs = computed(() => {
 	}));
 });
 
-// A `depends_on` tab can disappear while the user is on it, leaving `tabIndex`
-// pointing past the end so `Tabs` renders nothing (blank form). Clamp it back
-// into range when the visible set shrinks.
-watch(visibleTabs, (tabs) => {
-	if (tabIndex.value >= tabs.length) tabIndex.value = Math.max(0, tabs.length - 1);
-});
+// Which tab is *shown* is derived, never stored: it is `desired` looked up in the
+// tabs visible right now, falling back to the first. So a `depends_on` tab that
+// disappears cannot strand the reader on a blank form — no clamp is needed —
+// and one that comes back brings the reader with it, because a miss leaves
+// `desired` alone. Nothing writes state in response to visibility changing.
+const active = computed(
+	() => visibleTabs.value.find((tab) => tab.identity === desired.value) ?? visibleTabs.value[0]
+);
+
+// frappe-ui's `Tabs` addresses its tabs by index. That index is a wire format
+// living inside these two — it is never state, and because it is always derived
+// from the list we just rendered, it can never point at a tab that isn't there.
+const activeIndex = computed(() => Math.max(0, visibleTabs.value.indexOf(active.value)));
+
+function select(index: string | number) {
+	// An index naming no tab leaves the intent alone rather than blanking it:
+	// `desired` is the reader's, and on the Record page it belongs to a host that
+	// outlives this component. Writing `""` here would snap them to the first tab
+	// and throw away the memory that makes a returning tab free.
+	const chosen = visibleTabs.value[Number(index)];
+	if (chosen) desired.value = chosen.identity;
+}
 
 const hasTabs = computed(
 	() =>

--- a/ui/src/components/FormLayout/tabIdentity.ts
+++ b/ui/src/components/FormLayout/tabIdentity.ts
@@ -1,0 +1,45 @@
+import type { Tab } from "./types";
+
+/**
+ * A tab is addressed by a stable *identity* — never by its position. Identity is
+ * what the strip remembers, so the reader keeps their place when a `depends_on`
+ * tab appears or disappears beside them, and when the whole form is torn down and
+ * rebuilt on save.
+ *
+ * `FormLayout` resolves identity itself and guarantees it is unique within the
+ * strip, rather than trusting the tabs it is handed: `name` is optional and no
+ * writer enforces uniqueness, and a component with several unrelated hosts cannot
+ * check an invariant none of them promises.
+ */
+
+/** `name` if the author wrote one, else the label slugified, else the position. */
+function baseIdentity(tab: Pick<Tab, "name" | "label">, index: number): string {
+  return tab.name || slug(tab.label ?? "") || `tab-${index + 1}`;
+}
+
+function slug(label: string): string {
+  return label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Stamp each tab with its `identity`, suffixing collisions deterministically
+ * (`details`, `details-2`, `details-3`) so the same strip always resolves the
+ * same way. `identity` is deliberately *not* `name`: `name` stays "what the
+ * author wrote", `identity` is "what the strip addresses".
+ */
+export function identifyTabs<T extends Pick<Tab, "name" | "label">>(
+  tabs: T[]
+): (T & { identity: string })[] {
+  const taken = new Set<string>();
+  return tabs.map((tab, index) => {
+    const base = baseIdentity(tab, index);
+    let identity = base;
+    for (let suffix = 2; taken.has(identity); suffix++)
+      identity = `${base}-${suffix}`;
+    taken.add(identity);
+    return { ...tab, identity };
+  });
+}

--- a/ui/src/components/FormLayout/tests/tabIdentity.test.ts
+++ b/ui/src/components/FormLayout/tests/tabIdentity.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { identifyTabs } from "../tabIdentity";
+
+const identities = (tabs: { name?: string; label?: string }[]) =>
+  identifyTabs(tabs).map((tab) => tab.identity);
+
+describe("identifyTabs", () => {
+  it("prefers the author's name", () => {
+    expect(identities([{ name: "products", label: "Products" }])).toEqual([
+      "products",
+    ]);
+  });
+
+  it("falls back to the label, slugified", () => {
+    expect(identities([{ label: "Product Details" }])).toEqual([
+      "product-details",
+    ]);
+  });
+
+  it("falls back to the position when there is neither", () => {
+    expect(identities([{}, { label: "" }])).toEqual(["tab-1", "tab-2"]);
+  });
+
+  it("suffixes collisions deterministically", () => {
+    const tabs = [
+      { name: "details" },
+      { label: "Details" },
+      { name: "details" },
+    ];
+    expect(identities(tabs)).toEqual(["details", "details-2", "details-3"]);
+  });
+
+  it("does not hand out a suffix that is already someone's name", () => {
+    // Two tabs would both like `details-2`: the author wrote one and the
+    // de-duplicator wants the other. Every identity must still be distinct.
+    const tabs = [{ name: "details" }, { name: "details-2" }, { name: "details" }];
+    expect(new Set(identities(tabs)).size).toBe(3);
+    expect(identities(tabs)).toEqual(["details", "details-2", "details-3"]);
+  });
+
+  it("numbers the positional fallback over the list it is given", () => {
+    // `FormLayout` hands it the *whole* layout, hidden tabs included, so this
+    // numbering does not shift when a `depends_on` neighbour disappears.
+    expect(identities([{}, { label: "Named" }, {}])).toEqual([
+      "tab-1",
+      "named",
+      "tab-3",
+    ]);
+  });
+
+  it("keeps name meaning what the author wrote", () => {
+    const [tab] = identifyTabs([{ label: "Product Details" }]);
+    expect(tab.name).toBeUndefined();
+    expect(tab.identity).toBe("product-details");
+  });
+});

--- a/ui/src/components/FormLayout/tests/tabStrip.test.ts
+++ b/ui/src/components/FormLayout/tests/tabStrip.test.ts
@@ -1,0 +1,277 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApp, defineComponent, h, nextTick, ref } from "vue";
+import type { App, Ref } from "vue";
+import FormLayout from "../FormLayout.vue";
+import type { FormLayoutSchema } from "../types";
+
+/**
+ * The tab strip's promise, at the DOM: *the reader keeps their place*.
+ *
+ * Two failures are asserted against, and a fix for one that isn't a fix for the
+ * other is not a fix — an index survives neither, and an identity held inside
+ * the component survives only the second:
+ *
+ *  1. the form is destroyed and rebuilt (what a save does to it), and
+ *  2. a `depends_on` tab appears or disappears beside the reader.
+ *
+ * frappe-ui's `Tabs` is stubbed because reka-ui paints nothing under happy-dom.
+ * The stub is deliberately faithful about the one thing under test: it speaks
+ * only `modelValue` *indices*, exactly as the real wrapper does, so these tests
+ * exercise the identity/index translation rather than assuming it away.
+ */
+vi.mock("frappe-ui", async (importOriginal) => ({
+  ...((await importOriginal()) as object),
+  Tabs: defineComponent({
+    props: { tabs: { type: Array, required: true }, modelValue: Number },
+    emits: ["update:modelValue"],
+    setup(props, { emit, slots }) {
+      return () =>
+        h("div", { "data-active-index": String(props.modelValue) }, [
+          ...(props.tabs as any[]).map((tab, index) =>
+            h("button", {
+              "data-tab": tab.identity,
+              onClick: () => emit("update:modelValue", index),
+            })
+          ),
+          slots["tab-panel"]?.({
+            tab: (props.tabs as any[])[props.modelValue ?? 0],
+          }),
+        ]);
+    },
+  }),
+}));
+
+let app: App | undefined;
+let host: HTMLElement | undefined;
+
+afterEach(() => {
+  app?.unmount();
+  host?.remove();
+  app = undefined;
+  host = undefined;
+});
+
+/** Three tabs, the middle one conditional on `doc.extra`. */
+const LAYOUT: FormLayoutSchema = [
+  { name: "organization", label: "Organization", sections: [] },
+  {
+    name: "products",
+    label: "Products",
+    dependsOn: "eval:doc.extra",
+    sections: [],
+  },
+  { name: "contacts", label: "Contacts", sections: [] },
+];
+
+/**
+ * Mount the form under a host that owns the `tab` model, as `RecordTabs` does —
+ * the arrangement the whole design rests on, since the form itself does not
+ * survive a save.
+ */
+function mount(doc: Ref<Record<string, any>>, tab: Ref<string>) {
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  const shown = ref(true);
+  app = createApp(
+    defineComponent({
+      setup() {
+        return () =>
+          shown.value
+            ? h(FormLayout, {
+                layout: LAYOUT,
+                doc: doc.value,
+                "onUpdate:doc": (value: any) => (doc.value = value),
+                tab: tab.value,
+                "onUpdate:tab": (identity: string) => (tab.value = identity),
+              })
+            : h("div");
+      },
+    })
+  );
+  app.mount(host);
+
+  const triggers = () => [...host!.querySelectorAll("[data-tab]")];
+  return {
+    identities: () => triggers().map((el) => el.getAttribute("data-tab")),
+    activeIdentity: () => {
+      const index = Number(
+        host!
+          .querySelector("[data-active-index]")!
+          .getAttribute("data-active-index")
+      );
+      return triggers()[index]?.getAttribute("data-tab");
+    },
+    click: async (identity: string) => {
+      host!.querySelector<HTMLElement>(`[data-tab="${identity}"]`)!.click();
+      await nextTick();
+    },
+    /** What a save does: the panel is torn down and built again from scratch. */
+    remount: async () => {
+      shown.value = false;
+      await nextTick();
+      shown.value = true;
+      await nextTick();
+    },
+  };
+}
+
+describe("the reader keeps their place", () => {
+  it("starts on the first visible tab", () => {
+    const strip = mount(ref({ extra: 1 }), ref(""));
+    expect(strip.activeIdentity()).toBe("organization");
+  });
+
+  it("survives the form being destroyed and rebuilt", async () => {
+    const strip = mount(ref({ extra: 1 }), ref(""));
+
+    await strip.click("contacts");
+    expect(strip.activeIdentity()).toBe("contacts");
+
+    await strip.remount();
+    expect(strip.activeIdentity()).toBe("contacts");
+  });
+
+  it("does not move the reader when a tab appears beside them", async () => {
+    const doc = ref<Record<string, any>>({ extra: 0 });
+    const strip = mount(doc, ref(""));
+
+    await strip.click("contacts");
+    doc.value.extra = 1;
+    await nextTick();
+
+    expect(strip.identities()).toEqual(["organization", "products", "contacts"]);
+    expect(strip.activeIdentity()).toBe("contacts");
+  });
+
+  it("falls back to the first tab when the reader's tab disappears", async () => {
+    const doc = ref<Record<string, any>>({ extra: 1 });
+    const strip = mount(doc, ref(""));
+
+    await strip.click("products");
+    doc.value.extra = 0;
+    await nextTick();
+
+    expect(strip.identities()).toEqual(["organization", "contacts"]);
+    expect(strip.activeIdentity()).toBe("organization");
+  });
+
+  it("returns the reader to their tab when it comes back", async () => {
+    const doc = ref<Record<string, any>>({ extra: 1 });
+    const strip = mount(doc, ref(""));
+
+    await strip.click("products");
+    doc.value.extra = 0;
+    await nextTick();
+    doc.value.extra = 1;
+    await nextTick();
+
+    // The miss never overwrote the intent, so remembering it costs nothing.
+    expect(strip.activeIdentity()).toBe("products");
+  });
+
+  it("addresses by identity, not position, when the set shifts under it", async () => {
+    // The old index bug in one assertion: `contacts` is index 2, then index 1.
+    const doc = ref<Record<string, any>>({ extra: 1 });
+    const strip = mount(doc, ref(""));
+
+    await strip.click("contacts");
+    doc.value.extra = 0;
+    await nextTick();
+
+    expect(strip.activeIdentity()).toBe("contacts");
+  });
+
+  it("keeps unlabelled, unnamed tabs apart when one of them hides", async () => {
+    // The weakest layout there is: nothing to key on but position, and the
+    // strip relabels every one of them "Details" for the reader. Identity is
+    // resolved over the whole layout and before that relabelling, so hiding the
+    // second tab must not renumber the third onto the second's identity.
+    host = document.createElement("div");
+    document.body.appendChild(host);
+    const doc = ref<Record<string, any>>({ extra: 1 });
+    app = createApp(
+      defineComponent({
+        setup() {
+          return () =>
+            h(FormLayout, {
+              layout: [
+                { sections: [] },
+                { dependsOn: "eval:doc.extra", sections: [] },
+                { sections: [] },
+              ] as FormLayoutSchema,
+              doc: doc.value,
+              "onUpdate:doc": (value: any) => (doc.value = value),
+            });
+        },
+      })
+    );
+    app.mount(host);
+
+    const identities = () =>
+      [...host!.querySelectorAll("[data-tab]")].map((el) =>
+        el.getAttribute("data-tab")
+      );
+    const activeIdentity = () =>
+      identities()[
+        Number(
+          host!
+            .querySelector("[data-active-index]")!
+            .getAttribute("data-active-index")
+        )
+      ];
+
+    expect(identities()).toEqual(["tab-1", "tab-2", "tab-3"]);
+    host.querySelector<HTMLElement>('[data-tab="tab-3"]')!.click();
+    await nextTick();
+    expect(activeIdentity()).toBe("tab-3");
+
+    doc.value.extra = 0;
+    await nextTick();
+    expect(identities()).toEqual(["tab-1", "tab-3"]);
+    expect(activeIdentity()).toBe("tab-3");
+  });
+
+  it("leaves the intent alone when handed an index naming no tab", async () => {
+    // The wrapper cannot reach this today — every index it is given was just
+    // derived from the list it rendered — but the model may be a host's, and
+    // blanking someone else's state on a stray emit is not this component's to
+    // do. Asserted because it is exactly what the first draft got wrong.
+    const tab = ref("");
+    const strip = mount(ref({ extra: 1 }), tab);
+
+    await strip.click("contacts");
+    expect(tab.value).toBe("contacts");
+
+    const wrapper = host!.querySelector("[data-active-index]")!;
+    // @ts-expect-error reaching the stub's emit through the rendered vnode
+    wrapper.__vnode.component.emit("update:modelValue", 99);
+    await nextTick();
+
+    expect(tab.value).toBe("contacts");
+  });
+
+  it("works standalone, with no host holding the model", async () => {
+    host = document.createElement("div");
+    document.body.appendChild(host);
+    app = createApp(
+      defineComponent({
+        setup() {
+          const doc = ref({ extra: 1 });
+          return () =>
+            h(FormLayout, {
+              layout: LAYOUT,
+              doc: doc.value,
+              "onUpdate:doc": (value: any) => (doc.value = value),
+            });
+        },
+      })
+    );
+    app.mount(host);
+
+    host.querySelector<HTMLElement>('[data-tab="contacts"]')!.click();
+    await nextTick();
+    expect(
+      host.querySelector("[data-active-index]")!.getAttribute("data-active-index")
+    ).toBe("2");
+  });
+});


### PR DESCRIPTION
Fixes two bugs in `FormLayout`'s tab strip that are really one mistake: the
selected tab was identified by its **index** in the visible list, which is not a
tab — it is a slot two different tabs can occupy.

**What went wrong**

- A `depends_on` tab appearing or disappearing changed which tab an index
  *referred to*, so the reader was silently slid onto a neighbour. The clamp
  watcher only clamped downward; it never preserved which tab you were on, and
  when a tab vanished it dumped you on the **last** one.
- Rebuilding the component started the count again from zero. In Frappe CRM's
  new record page that happens on **every save**, so saving returned the reader
  to the first tab.

**What this does**

Each visible tab resolves an `identity` — the author's `name`, else its label
slugified, else its position — de-duplicated in the component rather than
trusted from outside, since `name` is optional and nothing enforces uniqueness.
`identity` is deliberately not `name`: `name` keeps meaning "what the author
wrote".

What is *held* is the identity the reader chose; which tab is *shown* is derived
from it against the tabs visible right now. Two things follow:

- The clamp watcher is **deleted, not ported**. Its guarantee — never leave the
  reader on a blank form — is structural once the active tab is derived from the
  visible set, and the watcher was itself the cause of the dumped-on-the-last-tab
  behaviour. Nothing writes state in response to visibility changing.
- A tab that disappears and comes back brings the reader with it, for free,
  because a miss never overwrites the intent.

The choice is exposed as `v-model:tab`, falling back to an internal ref — so a
host that outlives the form can hold it (which is what the CRM record page
needs), and every existing caller is untouched by construction.

frappe-ui's `Tabs` still addresses by index. That index is now a wire format
inside two computeds, always derived from the list just rendered, and never
state again — which also makes reka-ui's unmatched-value behaviour unreachable
rather than merely handled.

**Tests**

`tabIdentity.test.ts` covers identity resolution and collision suffixing;
`tabStrip.test.ts` drives the real component at the DOM through both failures —
destroy-and-rebuild, and a `depends_on` tab toggling beside the reader — with a
stub that speaks only indices, so the translation is exercised rather than
assumed. Also verified live on a real CRM Deal: before the change the reader is
moved in both cases; after it, they stay.

No story changes: the stories bind no `tab` model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
