### PR TITLE
fix(ui): name the Page Script save event by its current spelling

### DIFF
--- a/ui/src/components/FormLayout/FormLayoutField.vue
+++ b/ui/src/components/FormLayout/FormLayoutField.vue
@@ -35,7 +35,7 @@ const resolveField = inject(ResolveFieldKey)!;
 const commits = computed(() => !holdsChildRows(props.field.fieldtype));
 
 // The live write, plus a note that a commit is owed: a save with focus still in
-// the input has to fire the handler before `before_save` sees a stale value.
+// the input has to fire the handler before `beforeSave` sees a stale value.
 function edit(fieldname: string, value: any) {
 	update(fieldname, value);
 	if (commits.value) commit.pending(fieldname, value);


### PR DESCRIPTION
`FormLayoutField`'s commit-channel note cites `before_save`, a Page Script handler key that was respelled to `beforeSave` — a hard break, so the old name now refers to nothing.

Comment only; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)