### PR TITLE
feat(form-layout): a per-render tab override, and announce the resolved tab

### DIFF
--- a/ui/src/components/FormLayout/FormLayout.vue
+++ b/ui/src/components/FormLayout/FormLayout.vue
@@ -29,22 +29,30 @@
 
 <script setup lang="ts">
 import { Tabs } from "frappe-ui";
-import { computed, inject, provide } from "vue";
+import { computed, inject, provide, watch } from "vue";
 import type { ComponentPublicInstance } from "vue";
 import FormLayoutSection from "./FormLayoutSection.vue";
 import { useFieldTypes } from "./useFieldTypes";
-import { resolveLayout } from "./resolveLayout";
-import { identifyTabs } from "./tabIdentity";
+import { applyTabOverride, resolveLayout } from "./resolveLayout";
+import { identifyTabs, tabStripLabel } from "./tabIdentity";
 import { CommitKey, DocKey, HasTabsKey, ParentDocKey, ResolveFieldKey, UpdateKey } from "./types";
 import { warnMissingCommit } from "./warnMissingCommit";
 import type { FormLayoutProps } from "./types";
 
 const props = defineProps<FormLayoutProps>();
 
-// `FormLayout` is render-only and emits nothing: its sole outward channel is
-// `v-model:doc`. A consumer that wants "react to any change" uses `watch(doc, …)`;
-// per-field actions/side-effects are baked into the layout via `field.ui.on`.
+// The document channel is `v-model:doc` alone: a consumer that wants "react to
+// any change" uses `watch(doc, …)`, and per-field actions/side-effects are baked
+// into the layout via `field.ui.on`. The strip has two channels of its own —
+// `v-model:tab` below, and `update:activeTab` at the foot of this block.
 const doc = defineModel<Record<string, any>>("doc", { required: true });
+
+// The identity of the tab actually **shown**, announced whenever it changes and
+// once on mount. `tab` above is the reader's *intent* and only the reader writes
+// it; this is the resolution, which a `depends_on` moves without touching the
+// intent — so a host that has to know where the reader ended up cannot get it
+// from the model, and re-deriving it host-side would put one rule in two repos.
+const emit = defineEmits<{ "update:activeTab": [identity: string] }>();
 
 // The tab the reader last *chose*, by identity — an intent, not a position, and
 // the only piece of strip state there is. It falls back to an internal ref, so a
@@ -63,18 +71,21 @@ const resolvedLayout = computed(() =>
 );
 
 const visibleTabs = computed(() => {
-	// Identity is resolved over the *whole* layout and before the label fallback
-	// below, both deliberately. Resolving it over the visible subset would make
-	// the positional fallback shift when a `depends_on` neighbour hides — the
-	// very bug identity exists to kill — and resolving it after the fallback
-	// would collapse every unlabelled tab onto "details".
-	const tabs = identifyTabs(resolvedLayout.value).filter((tab) => !tab.hidden);
-	// With multiple tabs the strip is always shown, so an unlabelled tab would
-	// render a blank button — fall back to "Details" so every tab reads clearly.
+	// Identity is resolved over the *whole* layout, before the override and before
+	// the label fallback, all three deliberately. Resolving it over the visible
+	// subset would make the positional fallback shift when a `depends_on`
+	// neighbour hides — the very bug identity exists to kill — resolving it after
+	// the fallback would collapse every unlabelled tab onto "details", and
+	// resolving it after a relabel would move the address a script wrote.
+	// The override lands after `resolveLayout` baked the `depends_on`, which is
+	// what lets it lift one.
+	const tabs = identifyTabs(resolvedLayout.value)
+		.map((tab) => ({ ...tab, ...applyTabOverride(tab) }))
+		.filter((tab) => !tab.hidden);
 	const multipleTabs = tabs.length > 1;
 	return tabs.map((tab) => ({
 		...tab,
-		label: tab.label || (multipleTabs ? "Details" : ""),
+		label: tabStripLabel(tab.label, multipleTabs),
 		sections: tab.sections.filter((section) => !section.hidden),
 	}));
 });
@@ -86,6 +97,15 @@ const visibleTabs = computed(() => {
 // `desired` alone. Nothing writes state in response to visibility changing.
 const active = computed(
 	() => visibleTabs.value.find((tab) => tab.identity === desired.value) ?? visibleTabs.value[0]
+);
+
+// Announced, never stored: the resolution leaves the component but does not come
+// back, so `desired` stays the reader's alone and a tab that returns still brings
+// them with it.
+watch(
+	() => active.value?.identity ?? "",
+	(identity) => emit("update:activeTab", identity),
+	{ immediate: true }
 );
 
 // frappe-ui's `Tabs` addresses its tabs by index. That index is a wire format
@@ -122,7 +142,7 @@ function update(fieldname: string, value: any) {
 const { resolve } = useFieldTypes();
 
 // Asserted, not consumed: commits travel from each field straight to whoever
-// owns them, and this component still emits nothing.
+// owns them, on their own channel rather than through this component.
 warnMissingCommit("FormLayout", inject(CommitKey, null));
 
 provide(DocKey, doc);

--- a/ui/src/components/FormLayout/index.ts
+++ b/ui/src/components/FormLayout/index.ts
@@ -37,6 +37,7 @@ export type {
   FieldMeta,
   FieldNode,
   FieldOverride,
+  TabOverride,
   FieldUI,
   RawMetaField,
   FieldComponentProps,

--- a/ui/src/components/FormLayout/resolveLayout.ts
+++ b/ui/src/components/FormLayout/resolveLayout.ts
@@ -172,12 +172,43 @@ export function resolveLayout(
   });
 
   const resolveTab = (t: Tab): Tab => ({
-    ...t,
-    hidden:
-      t.hidden ||
-      (!!t.dependsOn && !evaluateDependsOn(t.dependsOn, doc, parent)),
+    ...resolveTabConditionals(t, doc, parent),
     sections: t.sections.map(resolveSection),
   });
 
   return schema.map(resolveTab);
+}
+
+/**
+ * Bake one tab's conditional visibility against `doc`, returning a **fresh**
+ * `Tab` with `hidden` resolved: static `hidden` OR `depends_on` false. Pure.
+ *
+ * Exported because the Record page's `page.formTabs` answers "is this one tab on
+ * screen" without resolving the whole form, and the two must not drift.
+ */
+export function resolveTabConditionals(
+  t: Tab,
+  doc: Record<string, any>,
+  parent: Record<string, any> = doc
+): Tab {
+  return {
+    ...t,
+    hidden:
+      t.hidden ||
+      (!!t.dependsOn && !evaluateDependsOn(t.dependsOn, doc, parent)),
+  };
+}
+
+/**
+ * A tab's visibility and label as the strip shows them: the values resolved
+ * above, with a per-render `override` as the last word — the only thing here
+ * that can lift a `depends_on`, mirroring `FieldOverride`.
+ *
+ * Applied by `FormLayout` rather than by `resolveLayout`: see `TabOverride`.
+ */
+export function applyTabOverride(t: Tab): { hidden: boolean; label: string } {
+  return {
+    hidden: t.override?.hidden ?? !!t.hidden,
+    label: t.override?.label ?? t.label ?? "",
+  };
 }

--- a/ui/src/components/FormLayout/tabIdentity.ts
+++ b/ui/src/components/FormLayout/tabIdentity.ts
@@ -17,6 +17,16 @@ function baseIdentity(tab: Pick<Tab, "name" | "label">, index: number): string {
   return tab.name || slug(tab.label ?? "") || `tab-${index + 1}`;
 }
 
+/**
+ * What the strip actually shows for a tab. With more than one tab the strip is
+ * always on screen, so an unlabelled tab would render a blank button — it reads
+ * "Details" instead. Exported because anything that *reports* a tab's label has
+ * to agree with the button the reader is looking at.
+ */
+export function tabStripLabel(label: string, multipleTabs: boolean): string {
+  return label || (multipleTabs ? "Details" : "");
+}
+
 function slug(label: string): string {
   return label
     .toLowerCase()

--- a/ui/src/components/FormLayout/tests/tabStrip.test.ts
+++ b/ui/src/components/FormLayout/tests/tabStrip.test.ts
@@ -30,6 +30,7 @@ vi.mock("frappe-ui", async (importOriginal) => ({
           ...(props.tabs as any[]).map((tab, index) =>
             h("button", {
               "data-tab": tab.identity,
+              "data-label": tab.label,
               onClick: () => emit("update:modelValue", index),
             })
           ),
@@ -68,21 +69,28 @@ const LAYOUT: FormLayoutSchema = [
  * the arrangement the whole design rests on, since the form itself does not
  * survive a save.
  */
-function mount(doc: Ref<Record<string, any>>, tab: Ref<string>) {
+function mount(
+  doc: Ref<Record<string, any>>,
+  tab: Ref<string>,
+  layout: Ref<FormLayoutSchema> = ref(LAYOUT)
+) {
   host = document.createElement("div");
   document.body.appendChild(host);
   const shown = ref(true);
+  const announced: string[] = [];
   app = createApp(
     defineComponent({
       setup() {
         return () =>
           shown.value
             ? h(FormLayout, {
-                layout: LAYOUT,
+                layout: layout.value,
                 doc: doc.value,
                 "onUpdate:doc": (value: any) => (doc.value = value),
                 tab: tab.value,
                 "onUpdate:tab": (identity: string) => (tab.value = identity),
+                "onUpdate:activeTab": (identity: string) =>
+                  announced.push(identity),
               })
             : h("div");
       },
@@ -92,6 +100,9 @@ function mount(doc: Ref<Record<string, any>>, tab: Ref<string>) {
 
   const triggers = () => [...host!.querySelectorAll("[data-tab]")];
   return {
+    labels: () => triggers().map((el) => el.getAttribute("data-label")),
+    /** Every `update:activeTab` since mount, in order. */
+    announced: () => announced,
     identities: () => triggers().map((el) => el.getAttribute("data-tab")),
     activeIdentity: () => {
       const index = Number(
@@ -250,6 +261,36 @@ describe("the reader keeps their place", () => {
     expect(tab.value).toBe("contacts");
   });
 
+  it("announces the resolved identity, on mount and on every move", async () => {
+    const doc = ref<Record<string, any>>({ extra: 1 });
+    const strip = mount(doc, ref(""));
+
+    // On mount, so a host that has just been rebuilt is told where the reader
+    // landed without having to re-derive the resolution itself.
+    expect(strip.announced()).toEqual(["organization"]);
+
+    await strip.click("products");
+    doc.value.extra = 0;
+    await nextTick();
+
+    // The `depends_on` miss moved the reader without touching their intent —
+    // the case the model alone cannot report.
+    expect(strip.announced()).toEqual([
+      "organization",
+      "products",
+      "organization",
+    ]);
+  });
+
+  it("announces the same identity after a rebuild, so nothing reads as a move", async () => {
+    const strip = mount(ref({ extra: 1 }), ref(""));
+
+    await strip.click("contacts");
+    await strip.remount();
+
+    expect(strip.announced()).toEqual(["organization", "contacts", "contacts"]);
+  });
+
   it("works standalone, with no host holding the model", async () => {
     host = document.createElement("div");
     document.body.appendChild(host);
@@ -273,5 +314,78 @@ describe("the reader keeps their place", () => {
     expect(
       host.querySelector("[data-active-index]")!.getAttribute("data-active-index")
     ).toBe("2");
+  });
+});
+
+/**
+ * The per-render override: plain data on the tab, applied where the strip is
+ * drawn. `FormLayout` knows nothing about who wrote it — on the Record page it
+ * is a Page Script's `page.formTabs`, which is what makes these two rules load
+ * bearing rather than incidental.
+ */
+describe("a per-render tab override", () => {
+  const overridden = (override: Record<string, any>) =>
+    ref(
+      LAYOUT.map((tab) =>
+        tab.name === "products" ? { ...tab, override } : tab
+      ) as FormLayoutSchema
+    );
+
+  it("hides a tab the layout shows", async () => {
+    const strip = mount(ref({ extra: 1 }), ref(""), overridden({ hidden: true }));
+
+    expect(strip.identities()).toEqual(["organization", "contacts"]);
+  });
+
+  it("shows a tab its `depends_on` hides", async () => {
+    // The whole reason the override is applied here and not folded in as a
+    // static `hidden` at build time: `resolveLayout` ORs that with the
+    // expression, so a `show()` written that way would be silently inert.
+    const strip = mount(
+      ref({ extra: 0 }),
+      ref(""),
+      overridden({ hidden: false })
+    );
+
+    expect(strip.identities()).toEqual([
+      "organization",
+      "products",
+      "contacts",
+    ]);
+  });
+
+  it("relabels a tab without moving its identity", async () => {
+    // An unnamed tab's identity is its label slugified, so a relabelling that
+    // ran before identity would rename the very address the override was
+    // written against.
+    const layout = ref([
+      { label: "Organization", sections: [] },
+      { label: "Products", sections: [] },
+    ] as FormLayoutSchema);
+    const strip = mount(ref({}), ref(""), layout);
+    expect(strip.identities()).toEqual(["organization", "products"]);
+
+    layout.value = [
+      layout.value[0],
+      { ...layout.value[1], override: { label: "Items" } },
+    ];
+    await nextTick();
+
+    expect(strip.identities()).toEqual(["organization", "products"]);
+    expect(strip.labels()).toEqual(["Organization", "Items"]);
+  });
+
+  it("brings the reader back when the tab they were on is shown again", async () => {
+    const layout = overridden({ hidden: false });
+    const strip = mount(ref({ extra: 0 }), ref(""), layout);
+
+    await strip.click("products");
+    layout.value = LAYOUT;
+    await nextTick();
+    expect(strip.activeIdentity()).toBe("organization");
+
+    layout.value = overridden({ hidden: false }).value;
+    await nextTick();
+    expect(strip.activeIdentity()).toBe("products");
   });
 });

--- a/ui/src/components/FormLayout/types.ts
+++ b/ui/src/components/FormLayout/types.ts
@@ -136,12 +136,31 @@ export interface Section {
   columns: Column[];
 }
 
+/**
+ * The two tab properties an app can override *per render*, applied by
+ * `applyTabOverride` after `resolveLayout` has baked the `depends_on` — so an
+ * override wins over a conditional expression, exactly as `FieldOverride` does.
+ *
+ * Applied where the strip is drawn rather than in `resolveLayout`, because it
+ * addresses the strip: `PanelLayout` renders the same layout as one flat list
+ * with no strip at all, where hiding a tab would silently drop its rows.
+ *
+ * Plain data, deliberately: it keeps `FormLayout` an independent component that
+ * takes a schema and knows nothing about whoever wrote the override.
+ */
+export interface TabOverride {
+  hidden?: boolean;
+  label?: string;
+}
+
 export interface Tab {
   name?: string;
   label?: string;
   hidden?: boolean;
   /** Conditional visibility; `resolveLayout` bakes it into `hidden`. */
   dependsOn?: string;
+  /** Per-render override; the last word on visibility and label. */
+  override?: TabOverride;
   sections: Section[];
 }
 


### PR DESCRIPTION
`FormLayout`'s tab strip grows two channels. Neither is specific to the caller that
needed them — the component still takes plain data and knows nothing about who wrote
the override.

### `Tab.override` — a per-render override, `hidden` and `label`

Mirrors `FieldOverride`, and is applied **after** `resolveLayout` has baked the
`depends_on`, so it is the only thing here that can lift one. Folding it in earlier as
a static `hidden` would leave a `show()` silently inert, because `resolveLayout` ORs
that with the expression.

It is applied by `FormLayout` rather than inside `resolveLayout` because it addresses
the **strip**: `PanelLayout` renders the same schema as one flat list with no strip at
all, where hiding a "tab" would silently drop its rows from the side panel.

Identity is resolved before the override, from the authored label, so relabelling a
tab leaves the address it is known by exactly where it was.

### `update:activeTab` — the identity of the tab actually shown

`v-model:tab` is the reader's *intent* and only the reader writes it. A `depends_on`
that hides the tab under them moves the **resolution** without touching that intent —
which is what makes a returning tab bring the reader back with it — so a host cannot
learn where they ended up from the model. This announces it, on mount and on every
change, and is never written back.

The alternative was for the host to re-derive `find(desired) ?? first(visible)` itself,
which puts one resolution rule in two repositories to drift.

### Also

`tabStripLabel` is exported: the strip relabels an unlabelled tab "Details", and
anything that *reports* a tab's label has to agree with the button the reader sees.

Six new cases in `tabStrip.test.ts` cover both channels, including `show()` lifting a
`depends_on` and a relabel leaving the identity alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

>no-docs