### PR TITLE
feat(awesomebar): let apps add search results via hook

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -117,6 +117,7 @@ def get_bootinfo():
 	bootinfo.error_report_email = frappe.conf.error_report_email
 	bootinfo.calendars = sorted(frappe.get_hooks("calendars"))
 	bootinfo.treeviews = frappe.get_hooks("treeviews") or []
+	bootinfo.has_awesomebar_search = bool(hooks.awesomebar_search)
 	bootinfo.lang_dict = get_lang_dict()
 	bootinfo.success_action = get_success_action()
 	bootinfo.update(get_email_accounts(user=frappe.session.user))

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -527,7 +527,7 @@ def awesomebar_search(txt: str) -> list[dict]:
 	Each hooked method receives `txt` and should return a list of dicts with:
 	- `label` (or `value`): title shown in the dropdown
 	- `description`: optional snippet under the title
-	- `route`: desk route list, or a URL string (`https://…` opens in a new tab)
+	- `route`: desk route list, or a URL string (`http://` / `https://` opens in a new tab)
 	- `index`: optional ranking score (higher ranks first; built-in Search is 100)
 	- `route_options`: optional dict passed to `frappe.route_options` on select
 	"""

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -527,7 +527,8 @@ def awesomebar_search(txt: str) -> list[dict]:
 	Each hooked method receives `txt` and should return a list of dicts with:
 	- `label` (or `value`): title shown in the dropdown
 	- `description`: optional snippet under the title
-	- `route`: desk route list, or a URL string (`http://` / `https://` opens in a new tab)
+	- `route`: desk route list (`["List", "ToDo"]`), in-app path (`/desk/docs/some/page`),
+	  or URL string (`http://` / `https://` opens in a new tab)
 	- `index`: optional ranking score (higher ranks first; built-in Search is 100)
 	- `route_options`: optional dict passed to `frappe.route_options` on select
 	"""
@@ -566,7 +567,9 @@ def _normalize_awesomebar_result(item) -> dict | None:
 	else:
 		return None
 
-	if not route or (":" in route[0] and not route[0].startswith(("http://", "https://"))):
+	if not route or route[0].startswith("//"):
+		return None
+	if ":" in route[0] and not route[0].startswith(("http://", "https://")):
 		return None
 
 	result = {

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -521,6 +521,70 @@ def get_user_groups():
 
 
 @frappe.whitelist()
+def awesomebar_search(txt: str) -> list[dict]:
+	"""Collect extra Awesome Bar results from the `awesomebar_search` hook.
+
+	Each hooked method receives `txt` and should return a list of dicts with:
+	- `label` (or `value`): title shown in the dropdown
+	- `description`: optional snippet under the title
+	- `route`: desk route list, or a URL string (`https://…` opens in a new tab)
+	- `index`: optional ranking score (higher ranks first; built-in Search is 100)
+	- `route_options`: optional dict passed to `frappe.route_options` on select
+	"""
+	txt = cstr(txt).strip()
+	if not txt:
+		return []
+
+	results = []
+	for method in frappe.get_hooks("awesomebar_search"):
+		try:
+			items = frappe.get_attr(method)(txt) or []
+		except Exception:
+			frappe.logger("awesomebar").error(f"awesomebar_search hook failed: {method}", exc_info=True)
+			continue
+		if not isinstance(items, list | tuple):
+			continue
+		for item in items[:20]:
+			if normalized := _normalize_awesomebar_result(item):
+				results.append(normalized)
+	return results
+
+
+def _normalize_awesomebar_result(item) -> dict | None:
+	if not isinstance(item, dict):
+		return None
+
+	label = cstr(item.get("label") or item.get("value"))
+	if not label:
+		return None
+
+	route = item.get("route")
+	if isinstance(route, str):
+		route = [route]
+	elif route:
+		route = [cstr(part) for part in route]
+	else:
+		return None
+
+	if not route or (":" in route[0] and not route[0].startswith(("http://", "https://"))):
+		return None
+
+	result = {
+		"label": label,
+		"value": cstr(item.get("value") or label),
+		"index": cint(item.get("index")),
+		"route": route,
+	}
+	if description := item.get("description"):
+		result["description"] = cstr(description)
+	if result_type := item.get("type"):
+		result["type"] = cstr(result_type)
+	if (route_options := item.get("route_options")) and isinstance(route_options, dict):
+		result["route_options"] = route_options
+	return result
+
+
+@frappe.whitelist()
 def get_link_title(doctype: str, docname: str | int):
 	meta = frappe.get_meta(doctype)
 

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -240,12 +240,12 @@ frappe.search.AwesomeBar = class AwesomeBar {
 				item.onclick(item.match);
 			} else {
 				let event = o.originalEvent;
-				if (event.ctrlKey || event.metaKey) {
-					frappe.open_in_new_tab = true;
-				}
 				if (is_external_url(item.route)) {
 					window.open(Array.isArray(item.route) ? item.route[0] : item.route, "_blank");
 					return;
+				}
+				if (event.ctrlKey || event.metaKey) {
+					frappe.open_in_new_tab = true;
 				}
 				frappe.set_route(item.route);
 			}

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -365,7 +365,9 @@ frappe.search.AwesomeBar = class AwesomeBar {
 				this.search_modal
 					.find(".cool-awesomebar-modal-footer")
 					.toggleClass("hide", cint(this.options?.length) == 0);
-				this.awesomplete.options_with_desc = this.create_options_with_descriptions(this.options);
+				this.awesomplete.options_with_desc = this.create_options_with_descriptions(
+					this.options
+				);
 				this.awesomplete.list = this.options;
 			},
 		});
@@ -530,7 +532,9 @@ function first_route(route) {
 
 function is_external_url(route) {
 	const first = first_route(route);
-	return typeof first === "string" && (first.startsWith("https://") || first.startsWith("http://"));
+	return (
+		typeof first === "string" && (first.startsWith("https://") || first.startsWith("http://"))
+	);
 }
 
 function is_in_app_path(route) {

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -238,12 +238,10 @@ frappe.search.AwesomeBar = class AwesomeBar {
 
 			if (item.onclick) {
 				item.onclick(item.match);
+			} else if (is_external_url(item.route)) {
+				window.open(Array.isArray(item.route) ? item.route[0] : item.route, "_blank");
 			} else {
 				let event = o.originalEvent;
-				if (is_external_url(item.route)) {
-					window.open(Array.isArray(item.route) ? item.route[0] : item.route, "_blank");
-					return;
-				}
 				if (event.ctrlKey || event.metaKey) {
 					frappe.open_in_new_tab = true;
 				}

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -172,6 +172,7 @@ frappe.search.AwesomeBar = class AwesomeBar {
 				var txt = value.trim().replace(/\s\s+/g, " ");
 				var last_space = txt.lastIndexOf(" ");
 				me.global_results = [];
+				me._hook_search_seq = (me._hook_search_seq || 0) + 1;
 
 				me.options = [];
 
@@ -182,6 +183,9 @@ frappe.search.AwesomeBar = class AwesomeBar {
 					me.add_defaults(txt);
 					me.options = me.options.concat(me.build_options(txt));
 					me.options = me.options.concat(me.global_results);
+					if (frappe.boot.has_awesomebar_search) {
+						me.fetch_hook_results(txt, me._hook_search_seq);
+					}
 				} else {
 					me.options = me.options.concat(
 						me.deduplicate(frappe.search.utils.get_recent_pages(txt || ""))
@@ -342,6 +346,24 @@ frappe.search.AwesomeBar = class AwesomeBar {
 
 	set_global_results(global_results, txt) {
 		this.global_results = this.global_results.concat(global_results);
+	}
+
+	fetch_hook_results(txt, seq) {
+		frappe.call({
+			method: "frappe.desk.search.awesomebar_search",
+			args: { txt },
+			callback: (r) => {
+				if (seq !== this._hook_search_seq || !r.message?.length) return;
+				this.options = this.deduplicate(this.options.concat(r.message));
+				this.options.sort((a, b) => b.index - a.index);
+				$(this.awesomplete.ul).toggleClass("p-0 m-0", cint(this.options?.length) == 0);
+				this.search_modal
+					.find(".cool-awesomebar-modal-footer")
+					.toggleClass("hide", cint(this.options?.length) == 0);
+				this.awesomplete.options_with_desc = this.create_options_with_descriptions(this.options);
+				this.awesomplete.list = this.options;
+			},
+		});
 	}
 
 	make_global_search(txt) {

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -137,8 +137,8 @@ frappe.search.AwesomeBar = class AwesomeBar {
 			item: function (item, term) {
 				const d = this.get_item(item.value);
 				let target = "#";
-				if (is_external_url(d.route)) {
-					target = Array.isArray(d.route) ? d.route[0] : d.route;
+				if (is_external_url(d.route) || is_in_app_path(d.route)) {
+					target = first_route(d.route);
 				} else if (d.route) {
 					target = frappe.router.make_url(
 						frappe.router.convert_from_standard_route(
@@ -239,7 +239,9 @@ frappe.search.AwesomeBar = class AwesomeBar {
 			if (item.onclick) {
 				item.onclick(item.match);
 			} else if (is_external_url(item.route)) {
-				window.open(Array.isArray(item.route) ? item.route[0] : item.route, "_blank");
+				window.open(first_route(item.route), "_blank");
+			} else if (is_in_app_path(item.route)) {
+				navigate_in_app_path(first_route(item.route), o.originalEvent);
 			} else {
 				let event = o.originalEvent;
 				if (event.ctrlKey || event.metaKey) {
@@ -522,7 +524,39 @@ frappe.search.AwesomeBar = class AwesomeBar {
 	}
 };
 
+function first_route(route) {
+	return Array.isArray(route) ? route[0] : route;
+}
+
 function is_external_url(route) {
-	const first = Array.isArray(route) ? route[0] : route;
+	const first = first_route(route);
 	return typeof first === "string" && (first.startsWith("https://") || first.startsWith("http://"));
+}
+
+function is_in_app_path(route) {
+	const first = first_route(route);
+	return typeof first === "string" && first.startsWith("/") && !first.startsWith("//");
+}
+
+function is_desk_path(path) {
+	const pathname = path.split(/[?#]/)[0];
+	return (
+		pathname === "/desk" ||
+		pathname.startsWith("/desk/") ||
+		pathname === "/app" ||
+		pathname.startsWith("/app/")
+	);
+}
+
+function navigate_in_app_path(path, event) {
+	if (is_desk_path(path)) {
+		if (event.ctrlKey || event.metaKey) {
+			frappe.open_in_new_tab = true;
+		}
+		frappe.set_route(path);
+	} else if (event.ctrlKey || event.metaKey) {
+		window.open(path, "_blank");
+	} else {
+		window.location.href = path;
+	}
 }

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -26,6 +26,9 @@ frappe.search.AwesomeBar = class AwesomeBar {
 			const input = search_modal.find("#navbar-search").get(0);
 			setTimeout(() => input.focus(), 10);
 		});
+		search_modal.on("hide.bs.modal", () => {
+			this._hook_search_seq = (this._hook_search_seq || 0) + 1;
+		});
 
 		let search_modal_body = `<div class="align-baseline flex p-2 relative navbar-modal-wrapper">
 			<input
@@ -134,7 +137,9 @@ frappe.search.AwesomeBar = class AwesomeBar {
 			item: function (item, term) {
 				const d = this.get_item(item.value);
 				let target = "#";
-				if (d.route) {
+				if (is_external_url(d.route)) {
+					target = Array.isArray(d.route) ? d.route[0] : d.route;
+				} else if (d.route) {
 					target = frappe.router.make_url(
 						frappe.router.convert_from_standard_route(
 							frappe.router.get_route_from_arguments(
@@ -238,8 +243,8 @@ frappe.search.AwesomeBar = class AwesomeBar {
 				if (event.ctrlKey || event.metaKey) {
 					frappe.open_in_new_tab = true;
 				}
-				if (item.route && item.route[0].startsWith("https://")) {
-					window.open(item.route[0], "_blank");
+				if (is_external_url(item.route)) {
+					window.open(Array.isArray(item.route) ? item.route[0] : item.route, "_blank");
 					return;
 				}
 				frappe.set_route(item.route);
@@ -518,3 +523,8 @@ frappe.search.AwesomeBar = class AwesomeBar {
 		});
 	}
 };
+
+function is_external_url(route) {
+	const first = Array.isArray(route) ? route[0] : route;
+	return typeof first === "string" && (first.startsWith("https://") || first.startsWith("http://"));
+}

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -5,10 +5,11 @@ import re
 from contextlib import contextmanager
 from functools import partial
 from typing import Any
+from unittest.mock import patch
 
 import frappe
 from frappe.core.doctype.doctype.test_doctype import new_doctype
-from frappe.desk.search import get_names_for_mentions, search_link, search_widget
+from frappe.desk.search import awesomebar_search, get_names_for_mentions, search_link, search_widget
 from frappe.permissions import add_user_permission
 from frappe.tests import IntegrationTestCase
 from frappe.tests.utils import whitelist_for_tests
@@ -567,6 +568,72 @@ class TestSearch(IntegrationTestCase):
 				reference_doctype="Test Search Dangling Parent",
 				link_fieldname="nonexistent_field",
 			)
+
+	def test_awesomebar_search_hook(self):
+		real_get_hooks = frappe.get_hooks
+
+		def get_hooks(hook=None, *args, **kwargs):
+			if hook == "awesomebar_search":
+				return [
+					"frappe.tests.test_search._awesomebar_help",
+					"frappe.tests.test_search._awesomebar_broken",
+					"frappe.tests.test_search._awesomebar_bad_items",
+				]
+			return real_get_hooks(hook, *args, **kwargs)
+
+		with patch.object(frappe, "get_hooks", side_effect=get_hooks):
+			self.assertEqual(awesomebar_search(""), [])
+			self.assertEqual(awesomebar_search("   "), [])
+
+			results = awesomebar_search("help")
+			self.assertEqual(
+				results,
+				[
+					{
+						"label": "Open Help",
+						"value": "Open Help",
+						"index": 50,
+						"route": ["https://docs.example.com"],
+						"description": "Docs",
+					},
+					{
+						"label": "ToDo List",
+						"value": "ToDo List",
+						"index": 0,
+						"route": ["List", "ToDo"],
+					},
+				],
+			)
+
+			self.assertEqual(awesomebar_search("unrelated"), [])
+
+
+def _awesomebar_help(txt):
+	if "help" not in txt.lower():
+		return []
+	return [
+		{
+			"label": "Open Help",
+			"description": "Docs",
+			"route": "https://docs.example.com",
+			"index": 50,
+		}
+	]
+
+
+def _awesomebar_broken(txt):
+	raise RuntimeError("boom")
+
+
+def _awesomebar_bad_items(txt):
+	if "help" not in txt.lower():
+		return []
+	return [
+		"not a dict",
+		{},
+		{"label": "JS", "route": "javascript:alert(1)"},
+		{"label": "ToDo List", "route": ["List", "ToDo"]},
+	]
 
 
 @frappe.validate_and_sanitize_search_inputs

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -605,20 +605,42 @@ class TestSearch(IntegrationTestCase):
 				],
 			)
 
+			http_results = awesomebar_search("intranet")
+			self.assertEqual(
+				http_results,
+				[
+					{
+						"label": "Intranet",
+						"value": "Intranet",
+						"index": 40,
+						"route": ["http://docs.local"],
+					},
+				],
+			)
+
 			self.assertEqual(awesomebar_search("unrelated"), [])
 
 
 def _awesomebar_help(txt):
-	if "help" not in txt.lower():
-		return []
-	return [
-		{
-			"label": "Open Help",
-			"description": "Docs",
-			"route": "https://docs.example.com",
-			"index": 50,
-		}
-	]
+	query = txt.lower()
+	if "help" in query:
+		return [
+			{
+				"label": "Open Help",
+				"description": "Docs",
+				"route": "https://docs.example.com",
+				"index": 50,
+			}
+		]
+	if "intranet" in query:
+		return [
+			{
+				"label": "Intranet",
+				"route": "http://docs.local",
+				"index": 40,
+			}
+		]
+	return []
 
 
 def _awesomebar_broken(txt):

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -618,6 +618,19 @@ class TestSearch(IntegrationTestCase):
 				],
 			)
 
+			inapp_results = awesomebar_search("inapp")
+			self.assertEqual(
+				inapp_results,
+				[
+					{
+						"label": "Desk Docs",
+						"value": "Desk Docs",
+						"index": 30,
+						"route": ["/desk/docs/some/page"],
+					},
+				],
+			)
+
 			self.assertEqual(awesomebar_search("unrelated"), [])
 
 
@@ -640,6 +653,14 @@ def _awesomebar_help(txt):
 				"index": 40,
 			}
 		]
+	if "inapp" in query:
+		return [
+			{
+				"label": "Desk Docs",
+				"route": "/desk/docs/some/page",
+				"index": 30,
+			}
+		]
 	return []
 
 
@@ -654,6 +675,7 @@ def _awesomebar_bad_items(txt):
 		"not a dict",
 		{},
 		{"label": "JS", "route": "javascript:alert(1)"},
+		{"label": "Proto", "route": "//evil.com"},
 		{"label": "ToDo List", "route": ["List", "ToDo"]},
 	]
 

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -569,6 +569,7 @@ use_json_request_body = True
 # Awesome Bar
 # -----------
 # Extra search results: list of dicts with label, description, route, index.
+# route: ["List", "ToDo"], "/desk/docs/some/page", or "https://example.com"
 # awesomebar_search = ["{app_name}.search.awesomebar_results"]
 
 # Permissions

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -566,6 +566,11 @@ use_json_request_body = True
 
 # notification_config = "{app_name}.notifications.get_notification_config"
 
+# Awesome Bar
+# -----------
+# Extra search results: list of dicts with label, description, route, index.
+# awesomebar_search = ["{app_name}.search.awesomebar_results"]
+
 # Permissions
 # -----------
 # Permissions evaluated in scripted ways

--- a/hooks.md
+++ b/hooks.md
@@ -37,7 +37,7 @@ A disable or an enable is one transaction. If a hook fails, the site keeps the s
 #### Desktop
 
 1. `get_desktop_icons` - method to get list of desktop icons
-1. `awesomebar_search` - method(txt) returning extra Awesome Bar results (`label`, `description`, `route`, `index`)
+1. `awesomebar_search` - method(txt) returning extra Awesome Bar results (`label`, `description`, `route`, `index`). `route` may be a desk route list, an in-app path (`/desk/...`), or an `http(s)://` URL.
 
 #### Notifications
 

--- a/hooks.md
+++ b/hooks.md
@@ -37,6 +37,7 @@ A disable or an enable is one transaction. If a hook fails, the site keeps the s
 #### Desktop
 
 1. `get_desktop_icons` - method to get list of desktop icons
+1. `awesomebar_search` - method(txt) returning extra Awesome Bar results (`label`, `description`, `route`, `index`)
 
 #### Notifications
 


### PR DESCRIPTION
Immediate need: enable in-app docs search for https://github.com/alyf-de/compendium

Other use cases:

- app calls external search API (e.g. Google, Wolfram Alpha, industry specific databases)
- app enables embedding and semantic search for certain doctypes
-  ...