### PR TITLE
fix(role): open workspace by slug in Workspaces tab

### DIFF
--- a/frappe/core/doctype/role/role.js
+++ b/frappe/core/doctype/role/role.js
@@ -656,7 +656,7 @@ class WorkspacesTab extends RoleAccessTab {
 					fieldname: "title",
 					type: "link",
 					text: (row) => row.title || row.name,
-					route: (row) => [row.name],
+					route: (row) => [frappe.router.slug(row.name)],
 				},
 				{ label: __("Module"), fieldname: "module" },
 				this.remove_action_column(),


### PR DESCRIPTION
### Problem
On the Role form's **Workspaces** tab, clicking a workspace row routed with its raw name (`frappe.set_route("Accounting")`). The router looks workspaces up by **slug**, so the lookup misses and it falls back to a Page route — showing "Page … not found" with 404s.

### Fix
Route via `frappe.router.slug(row.name)`, matching how the sidebar opens a workspace.