### PR TITLE
feat: built-in MCP server

### DIFF
--- a/frappe/api/__init__.py
+++ b/frappe/api/__init__.py
@@ -88,6 +88,7 @@ def handle(request: Request):
 # Merge all API version routing rules
 from frappe.api.v1 import url_rules as v1_rules
 from frappe.api.v2 import url_rules as v2_rules
+from frappe.mcp import url_rules as mcp_rules
 
 API_URL_MAP = Map(
 	[
@@ -95,6 +96,7 @@ API_URL_MAP = Map(
 		Submount("/api", v1_rules),
 		Submount(f"/api/{ApiVersion.V1.value}", v1_rules),
 		Submount(f"/api/{ApiVersion.V2.value}", v2_rules),
+		Submount("/api", mcp_rules),
 	],
 	strict_slashes=False,  # Allows skipping trailing slashes
 	merge_slashes=False,

--- a/frappe/mcp/README.md
+++ b/frappe/mcp/README.md
@@ -11,23 +11,41 @@ claude mcp add --transport http frappe https://<site>/api/mcp
 
 ## Protocol
 
-The server implements the `2026-07-28` revision only. That revision has no
-`initialize` handshake and no protocol level session: every request carries its
-own protocol version, identity and capabilities. The endpoint is therefore a
-plain request/response HTTP workload, with no session store, no session
-affinity and no long-lived stream.
+The server speaks two revisions and lets the client choose. They differ in how
+a client announces the protocol version:
 
-| Area          | Support                                                    |
-| ------------- | ---------------------------------------------------------- |
-| Endpoint      | `POST /api/mcp`. `GET` and `DELETE` return `405`.           |
-| Response body | Always `application/json`. No SSE.                          |
-| Capabilities  | `tools` only.                                               |
-| RPC methods   | `server/discover`, `tools/list`, `tools/call`               |
-| Authorization | The site's OAuth 2.1 resource-server support, or a session. |
+| Revision     | Version announced by                                              |
+| ------------ | ----------------------------------------------------------------- |
+| `2026-07-28` | Every request, in transport headers and `params._meta`.           |
+| `2025-11-25` | Once, through the `initialize` handshake.                         |
 
-Both omissions are legal. A server chooses per request whether to answer with a
-single JSON object or a stream, and `subscriptions/listen` and MRTR are
-capability-gated.
+The newer revision has no handshake and no protocol level session, which makes
+the endpoint a plain request/response HTTP workload: no session store, no
+session affinity, no long-lived stream. Its transport headers let a proxy route
+and a gateway authorize a call without parsing the body, so the server requires
+them to agree with the body they describe.
+
+The older revision is what shipping clients speak today. A client on that
+revision cannot send the version header on its first request, because it does
+not yet know what the server supports, so the header is optional and the
+handshake carries the version instead.
+
+| Area          | Support                                                                        |
+| ------------- | ------------------------------------------------------------------------------ |
+| Endpoint      | `POST /api/mcp`. `GET` and `DELETE` return `405`.                              |
+| Response body | Always `application/json`. No SSE.                                             |
+| Capabilities  | `tools` only.                                                                  |
+| RPC methods   | `initialize`, `ping`, `server/discover`, `tools/list`, `tools/call`            |
+| Authorization | The site's OAuth 2.1 resource-server support, or a session.                    |
+
+Omitting SSE is legal: a server chooses per request whether to answer with a
+single JSON object or a stream. `subscriptions/listen` and MRTR are
+capability-gated, so omitting those is legal too.
+
+A request whose version header names a revision the server does not have gets
+`-32022` with the list it does have. An `initialize` asking for an unknown
+version gets the newest revision the server has, and the client decides whether
+it can continue.
 
 ## Tools
 

--- a/frappe/mcp/README.md
+++ b/frappe/mcp/README.md
@@ -1,0 +1,70 @@
+# MCP server
+
+Every Frappe site serves an MCP endpoint at `POST /api/mcp`. An agent points its
+MCP client at the site, authenticates with the OAuth flow the site already
+supports, and gets a small tool surface over the same semantics as the REST API
+v2.
+
+```sh
+claude mcp add --transport http frappe https://<site>/api/mcp
+```
+
+## Protocol
+
+The server implements the `2026-07-28` revision only. That revision has no
+`initialize` handshake and no protocol level session: every request carries its
+own protocol version, identity and capabilities. The endpoint is therefore a
+plain request/response HTTP workload, with no session store, no session
+affinity and no long-lived stream.
+
+| Area          | Support                                                    |
+| ------------- | ---------------------------------------------------------- |
+| Endpoint      | `POST /api/mcp`. `GET` and `DELETE` return `405`.           |
+| Response body | Always `application/json`. No SSE.                          |
+| Capabilities  | `tools` only.                                               |
+| RPC methods   | `server/discover`, `tools/list`, `tools/call`               |
+| Authorization | The site's OAuth 2.1 resource-server support, or a session. |
+
+Both omissions are legal. A server chooses per request whether to answer with a
+single JSON object or a stream, and `subscriptions/listen` and MRTR are
+capability-gated.
+
+## Tools
+
+Four tools, folded broad. Every tool in the list costs context in the model's
+prompt on every turn.
+
+| Tool             | Covers                                                                  |
+| ---------------- | ----------------------------------------------------------------------- |
+| `discover`       | Site summary, search, DocType schema, and the contract of one method.   |
+| `get_documents`  | Read one document, list documents, or count them.                       |
+| `write_document` | Create, update and delete.                                              |
+| `call_method`    | Every whitelisted method. The escape hatch.                             |
+
+`call_method` is why the tool list stays short. Reports, read-only SQL, file
+upload, the submit and cancel lifecycle actions and every app specific method
+all go through it.
+
+## Permissions
+
+The MCP layer adds no permission model of its own. Every tool runs as the
+authenticated user and relies on Frappe permissions, method whitelisting and
+OAuth scopes. An unauthenticated request gets `401` with the `WWW-Authenticate`
+challenge the rest of the site sends.
+
+A tool that fails answers with `isError: true` and the message as text, so the
+model can read what went wrong and correct itself. The call runs inside a
+savepoint, so a failed call leaves no partial write behind.
+
+## Operating
+
+The endpoint is on by default. It requires authentication, and it exposes
+nothing that an authenticated REST client cannot already reach. To turn it off,
+set `disable_mcp_server` in `site_config.json`; the endpoint then returns `404`.
+
+For an MCP client to complete the authorization flow, the site must publish
+OAuth resource metadata. Enable `show_protected_resource_metadata` in **OAuth
+Settings**.
+
+Each call reports `mcp_tool=<name>` to the monitor, so MCP traffic is visible
+alongside REST traffic.

--- a/frappe/mcp/__init__.py
+++ b/frappe/mcp/__init__.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+"""The MCP server built into every Frappe site.
+
+An agent points its MCP client at `https://<site>/api/mcp` and gets a small tool
+surface over the same semantics as the REST API v2. Authorization, CORS, rate
+limiting and the `WWW-Authenticate` challenge all come from the normal request
+pipeline, so this package only implements the protocol.
+
+Set `disable_mcp_server` in `site_config.json` to turn the endpoint off.
+"""
+
+from werkzeug.routing import Rule
+from werkzeug.wrappers import Response
+
+import frappe
+
+
+def handle() -> Response:
+	if frappe.conf.get("disable_mcp_server"):
+		raise frappe.DoesNotExistError
+
+	from frappe.mcp import transport
+
+	return transport.handle_request(frappe.local.request)
+
+
+url_rules = [
+	Rule("/mcp", methods=["POST", "GET", "DELETE"], endpoint=handle),
+]

--- a/frappe/mcp/instructions.py
+++ b/frappe/mcp/instructions.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+"""The primer returned in `DiscoverResult.instructions`.
+
+Adapted from the `frappectl guide` command. It tells an agent how the four tools
+relate to each other, and above all to orient with `discover` before it guesses a
+DocType name, a field name or a method path.
+"""
+
+import frappe
+
+INSTRUCTIONS = r"""This is the MCP server built into a Frappe site. Four tools cover the whole API.
+
+Every call runs as the authenticated user. Frappe permissions, method
+whitelisting and OAuth scopes decide what you can see and change. A denied call
+returns an error you can read, not a silent empty result.
+
+ORIENT YOURSELF (do this before you guess a DocType name, a field name or a method)
+  discover                                   # site summary and the modules present
+  discover {"query": "invoice"}              # search DocTypes and whitelisted methods
+  discover {"doctype": "Sales Invoice"}      # fields, permissions and methods
+  discover {"method": "frappe.client.get_count"}              # one RPC method
+  discover {"doctype": "User", "method": "add_comment"}       # one DocType method
+
+READ
+  get_documents {"doctype": "ToDo", "name": "abc123"}         # one document
+  get_documents {"doctype": "ToDo", "filters": {"status": "Open"},
+                 "fields": ["name", "description"],
+                 "order_by": "creation desc", "limit": 50}
+  get_documents {"doctype": "ToDo", "filters": {"status": "Open"}, "count_only": true}
+
+  Filters take a dict of equalities, or a list for other operators, such as
+  [["status", "in", ["Open", "Closed"]]]. The result reports `has_next_page`;
+  page with `start` and `limit`.
+
+WRITE
+  write_document {"action": "create", "doctype": "ToDo", "data": {"description": "Follow up"}}
+  write_document {"action": "update", "doctype": "ToDo", "name": "abc123", "data": {"status": "Closed"}}
+  write_document {"action": "delete", "doctype": "ToDo", "name": "abc123"}
+
+  Lifecycle actions are DocType methods, not write actions. Submit, cancel and
+  amend go through call_method.
+
+EVERYTHING ELSE
+  call_method is the escape hatch. It reaches every whitelisted method on the
+  site, so it also covers reports, read-only SQL, file upload and app specific
+  business logic.
+
+  call_method {"method": "frappe.desk.query_report.run",
+               "args": {"report_name": "Permitted Documents For User"}}
+  call_method {"doctype": "Sales Invoice", "name": "SINV-0001", "method": "submit"}
+  call_method {"method": "frappe.desk.doctype.system_console.system_console.execute_code",
+               "args": {"doc": {"doctype": "System Console", "type": "SQL",
+                                "console": "select count(*) from tabUser"}}}
+
+  Use discover to read a method's parameters before you call it.
+"""
+
+
+def render() -> str:
+	return f"Site: {frappe.local.site}\n\n{INSTRUCTIONS}"

--- a/frappe/mcp/protocol.py
+++ b/frappe/mcp/protocol.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+"""Constants and JSON-RPC envelope builders for the MCP endpoint.
+
+Only the `2026-07-28` revision is implemented. That revision has no `initialize`
+handshake and no protocol level session: every request carries its own protocol
+version, identity and capabilities.
+"""
+
+from typing import Any
+
+import frappe
+
+PROTOCOL_VERSION = "2026-07-28"
+SUPPORTED_VERSIONS = (PROTOCOL_VERSION,)
+
+SERVER_NAME = "frappe"
+
+# `_meta` keys reserved by the specification.
+META_PROTOCOL_VERSION = "io.modelcontextprotocol/protocolVersion"
+META_SERVER_INFO = "io.modelcontextprotocol/serverInfo"
+
+# Result cache lifetimes, in milliseconds.
+DISCOVER_TTL_MS = 60 * 60 * 1000
+TOOLS_TTL_MS = 5 * 60 * 1000
+
+# JSON-RPC 2.0 errors.
+PARSE_ERROR = -32700
+INVALID_REQUEST = -32600
+METHOD_NOT_FOUND = -32601
+INVALID_PARAMS = -32602
+INTERNAL_ERROR = -32603
+
+# MCP transport errors.
+HEADER_MISMATCH = -32020
+UNSUPPORTED_PROTOCOL_VERSION = -32022
+
+
+class McpError(Exception):
+	"""A protocol level error, returned as a JSON-RPC `error` object."""
+
+	def __init__(
+		self,
+		code: int,
+		message: str,
+		http_status_code: int = 400,
+		data: dict[str, Any] | None = None,
+	):
+		super().__init__(message)
+		self.code = code
+		self.message = message
+		self.http_status_code = http_status_code
+		self.data = data
+
+
+def server_info() -> dict[str, str]:
+	return {"name": SERVER_NAME, "version": frappe.__version__}
+
+
+def result_envelope(id: Any, result: dict[str, Any]) -> dict[str, Any]:
+	"""Wrap a result in a JSON-RPC response, with the fields every result carries."""
+	result = {"resultType": "complete", **result}
+	meta = dict(result.get("_meta") or {})
+	meta[META_SERVER_INFO] = server_info()
+	result["_meta"] = meta
+
+	return {"jsonrpc": "2.0", "id": id, "result": result}
+
+
+def error_envelope(id: Any, error: McpError) -> dict[str, Any]:
+	body: dict[str, Any] = {"code": error.code, "message": error.message}
+	if error.data is not None:
+		body["data"] = error.data
+
+	return {"jsonrpc": "2.0", "id": id, "error": body}

--- a/frappe/mcp/protocol.py
+++ b/frappe/mcp/protocol.py
@@ -2,17 +2,34 @@
 # License: MIT. See LICENSE
 """Constants and JSON-RPC envelope builders for the MCP endpoint.
 
-Only the `2026-07-28` revision is implemented. That revision has no `initialize`
-handshake and no protocol level session: every request carries its own protocol
-version, identity and capabilities.
+Two revisions are implemented, because they differ in how a client announces
+the protocol version:
+
+- `2026-07-28` removes the `initialize` handshake and the protocol level
+  session. Every request carries its own version, identity and capabilities, in
+  transport headers that a proxy can route on without parsing the body.
+- `2025-11-25` negotiates the version once, through `initialize`. The client
+  cannot send the version header on that first request, because it does not yet
+  know what the server supports.
+
+Shipping clients speak the second one, so the server answers both and lets the
+client choose.
 """
 
 from typing import Any
 
 import frappe
 
-PROTOCOL_VERSION = "2026-07-28"
-SUPPORTED_VERSIONS = (PROTOCOL_VERSION,)
+LATEST_VERSION = "2026-07-28"
+HANDSHAKE_VERSION = "2025-11-25"
+
+# Newest first: the version offered when a client asks for one we do not know.
+SUPPORTED_VERSIONS = (LATEST_VERSION, HANDSHAKE_VERSION)
+
+# Revisions that require the transport headers to agree with the body.
+STRICT_VERSIONS = (LATEST_VERSION,)
+
+PROTOCOL_VERSION = LATEST_VERSION
 
 SERVER_NAME = "frappe"
 
@@ -57,12 +74,17 @@ def server_info() -> dict[str, str]:
 	return {"name": SERVER_NAME, "version": frappe.__version__}
 
 
-def result_envelope(id: Any, result: dict[str, Any]) -> dict[str, Any]:
-	"""Wrap a result in a JSON-RPC response, with the fields every result carries."""
-	result = {"resultType": "complete", **result}
-	meta = dict(result.get("_meta") or {})
-	meta[META_SERVER_INFO] = server_info()
-	result["_meta"] = meta
+def result_envelope(id: Any, result: dict[str, Any], version: str = LATEST_VERSION) -> dict[str, Any]:
+	"""Wrap a result in a JSON-RPC response.
+
+	`resultType` and the `_meta` server info belong to the newer revision. An
+	older client would ignore them, but it never asked for them either.
+	"""
+	if version in STRICT_VERSIONS:
+		result = {"resultType": "complete", **result}
+		meta = dict(result.get("_meta") or {})
+		meta[META_SERVER_INFO] = server_info()
+		result["_meta"] = meta
 
 	return {"jsonrpc": "2.0", "id": id, "result": result}
 

--- a/frappe/mcp/server.py
+++ b/frappe/mcp/server.py
@@ -17,6 +17,33 @@ def dispatch(method: str, params: dict[str, Any]) -> dict[str, Any]:
 	return handler(params)
 
 
+def initialize(params: dict[str, Any]) -> dict[str, Any]:
+	"""Negotiate the protocol version, for a client on the handshake revision.
+
+	The client names the version it wants. Answer with that version when the
+	server speaks it, otherwise with the newest one the server has; the client
+	then decides whether it can continue.
+	"""
+	requested = params.get("protocolVersion")
+	negotiated = requested if requested in protocol.SUPPORTED_VERSIONS else protocol.LATEST_VERSION
+
+	return {
+		"protocolVersion": negotiated,
+		"capabilities": {"tools": {"listChanged": False}},
+		"serverInfo": protocol.server_info(),
+		"instructions": instructions.render(),
+	}
+
+
+def initialized(params: dict[str, Any]) -> dict[str, Any]:
+	"""Acknowledge the end of the handshake. Normally sent as a notification."""
+	return {}
+
+
+def ping(params: dict[str, Any]) -> dict[str, Any]:
+	return {}
+
+
 def discover(params: dict[str, Any]) -> dict[str, Any]:
 	return {
 		"supportedVersions": list(protocol.SUPPORTED_VERSIONS),
@@ -50,7 +77,14 @@ def call_tool(params: dict[str, Any]) -> dict[str, Any]:
 
 
 RPC_METHODS = {
+	"initialize": initialize,
+	"notifications/initialized": initialized,
+	"ping": ping,
 	"server/discover": discover,
 	"tools/list": list_tools,
 	"tools/call": call_tool,
 }
+
+# Methods a client sends before it knows the negotiated version, so they carry
+# no `MCP-Protocol-Version` header and no transport headers to validate.
+HANDSHAKE_METHODS = ("initialize", "notifications/initialized", "ping")

--- a/frappe/mcp/server.py
+++ b/frappe/mcp/server.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+"""Dispatch of the three RPC methods this server implements."""
+
+from typing import Any
+
+import frappe
+from frappe.mcp import instructions, protocol, tools
+from frappe.mcp.protocol import INVALID_PARAMS, METHOD_NOT_FOUND, McpError
+
+
+def dispatch(method: str, params: dict[str, Any]) -> dict[str, Any]:
+	handler = RPC_METHODS.get(method)
+	if not handler:
+		raise McpError(METHOD_NOT_FOUND, f"Unknown method {method}", http_status_code=404)
+
+	return handler(params)
+
+
+def discover(params: dict[str, Any]) -> dict[str, Any]:
+	return {
+		"supportedVersions": list(protocol.SUPPORTED_VERSIONS),
+		"capabilities": {"tools": {}},
+		"serverInfo": protocol.server_info(),
+		"instructions": instructions.render(),
+		"ttlMs": protocol.DISCOVER_TTL_MS,
+		"cacheScope": "public",
+	}
+
+
+def list_tools(params: dict[str, Any]) -> dict[str, Any]:
+	return {
+		"tools": tools.definitions(),
+		"ttlMs": protocol.TOOLS_TTL_MS,
+		# The visible surface follows the caller's permissions and OAuth scopes.
+		"cacheScope": "private",
+	}
+
+
+def call_tool(params: dict[str, Any]) -> dict[str, Any]:
+	name = params.get("name")
+	if not isinstance(name, str):
+		raise McpError(INVALID_PARAMS, "params.name is required")
+
+	arguments = params.get("arguments") or {}
+	if not isinstance(arguments, dict):
+		raise McpError(INVALID_PARAMS, "params.arguments must be an object")
+
+	return tools.call(name, arguments)
+
+
+RPC_METHODS = {
+	"server/discover": discover,
+	"tools/list": list_tools,
+	"tools/call": call_tool,
+}

--- a/frappe/mcp/tools/__init__.py
+++ b/frappe/mcp/tools/__init__.py
@@ -51,7 +51,9 @@ def form_dict(arguments: dict[str, Any]):
 
 
 def registry() -> list[Tool]:
-	return sorted([], key=lambda tool: tool.name)
+	from frappe.mcp.tools import discover
+
+	return sorted([discover.TOOL], key=lambda tool: tool.name)
 
 
 def definitions() -> list[dict[str, Any]]:

--- a/frappe/mcp/tools/__init__.py
+++ b/frappe/mcp/tools/__init__.py
@@ -51,9 +51,9 @@ def form_dict(arguments: dict[str, Any]):
 
 
 def registry() -> list[Tool]:
-	from frappe.mcp.tools import discover
+	from frappe.mcp.tools import discover, documents
 
-	return sorted([discover.TOOL], key=lambda tool: tool.name)
+	return sorted([discover.TOOL, documents.GET_DOCUMENTS], key=lambda tool: tool.name)
 
 
 def definitions() -> list[dict[str, Any]]:

--- a/frappe/mcp/tools/__init__.py
+++ b/frappe/mcp/tools/__init__.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+"""The tool registry and the shared plumbing every tool call goes through."""
+
+import json
+from collections.abc import Callable
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any
+
+import frappe
+from frappe.mcp.protocol import METHOD_NOT_FOUND, McpError
+from frappe.monitor import add_data_to_monitor
+from frappe.utils import strip_html
+
+SAVEPOINT = "mcp_tool_call"
+
+
+@dataclass(frozen=True)
+class Tool:
+	name: str
+	title: str
+	description: str
+	input_schema: dict[str, Any]
+	handler: Callable[[dict[str, Any]], dict[str, Any]]
+	annotations: dict[str, Any] = field(default_factory=dict)
+
+	def definition(self) -> dict[str, Any]:
+		return {
+			"name": self.name,
+			"title": self.title,
+			"description": self.description,
+			"inputSchema": self.input_schema,
+			"annotations": self.annotations,
+		}
+
+
+@contextmanager
+def form_dict(arguments: dict[str, Any]):
+	"""Present the tool arguments as `frappe.form_dict` for the duration of a call.
+
+	`make_form_dict` fills `form_dict` with the whole JSON-RPC envelope, but every
+	whitelisted method and every API v2 handler reads its arguments from there.
+	"""
+	original = frappe.local.form_dict
+	frappe.local.form_dict = frappe._dict(arguments or {})
+	try:
+		yield frappe.local.form_dict
+	finally:
+		frappe.local.form_dict = original
+
+
+def registry() -> list[Tool]:
+	return sorted([], key=lambda tool: tool.name)
+
+
+def definitions() -> list[dict[str, Any]]:
+	return [tool.definition() for tool in registry()]
+
+
+def call(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+	tool = next((tool for tool in registry() if tool.name == name), None)
+	if not tool:
+		raise McpError(METHOD_NOT_FOUND, f"Unknown tool {name}", http_status_code=404)
+
+	add_data_to_monitor(mcp_tool=name)
+
+	frappe.db.savepoint(SAVEPOINT)
+	try:
+		with form_dict(arguments):
+			structured = tool.handler(arguments)
+	except McpError:
+		frappe.db.rollback(save_point=SAVEPOINT)
+		raise
+	except Exception as e:
+		# A failed call must not leave a partial write for `sync_database` to commit.
+		frappe.db.rollback(save_point=SAVEPOINT)
+		return error_result(e)
+
+	return success_result(structured)
+
+
+def success_result(structured: dict[str, Any]) -> dict[str, Any]:
+	return {
+		"content": [{"type": "text", "text": json.dumps(structured, indent=2, default=str)}],
+		"structuredContent": structured,
+		"isError": False,
+	}
+
+
+def error_result(exception: Exception) -> dict[str, Any]:
+	"""Report a failed call as a readable result so that the model can self-correct."""
+	return {
+		"content": [{"type": "text", "text": _error_message(exception)}],
+		"isError": True,
+	}
+
+
+def _error_message(exception: Exception) -> str:
+	"""The exception message, without markup and without a traceback."""
+	message = str(exception).strip()
+	if not message:
+		message = " ".join(entry.get("message", "") for entry in frappe.local.message_log)
+
+	frappe.clear_messages()
+
+	message = strip_html(message).strip()
+	return message or type(exception).__name__

--- a/frappe/mcp/tools/__init__.py
+++ b/frappe/mcp/tools/__init__.py
@@ -51,9 +51,17 @@ def form_dict(arguments: dict[str, Any]):
 
 
 def registry() -> list[Tool]:
-	from frappe.mcp.tools import discover, documents
+	from frappe.mcp.tools import discover, documents, methods
 
-	return sorted([discover.TOOL, documents.GET_DOCUMENTS], key=lambda tool: tool.name)
+	return sorted(
+		[
+			discover.TOOL,
+			documents.GET_DOCUMENTS,
+			documents.WRITE_DOCUMENT,
+			methods.CALL_METHOD,
+		],
+		key=lambda tool: tool.name,
+	)
 
 
 def definitions() -> list[dict[str, Any]]:

--- a/frappe/mcp/tools/discover.py
+++ b/frappe/mcp/tools/discover.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+"""The `discover` tool: one lookup tool, the arguments select the subject."""
+
+from typing import Any
+
+import frappe
+from frappe.api import discovery
+from frappe.mcp.tools import Tool
+
+DESCRIPTION = """Look up what this Frappe site holds. Use it before you guess a DocType name, a field name or a method path.
+
+The arguments select the subject:
+- no arguments: a site summary with the modules present.
+- query: search DocType names and whitelisted methods.
+- doctype: the fields, permissions and methods of one DocType.
+- doctype and method: the contract of one DocType method.
+- method: the contract of one RPC method.
+
+Method discovery needs the System Manager role. Without it you still get the DocType schema."""
+
+INPUT_SCHEMA = {
+	"type": "object",
+	"properties": {
+		"query": {
+			"type": "string",
+			"description": "Free text. Matches DocType names and whitelisted methods.",
+		},
+		"doctype": {"type": "string", "description": "A DocType name, such as 'Sales Invoice'."},
+		"method": {
+			"type": "string",
+			"description": (
+				"A dotted RPC path, such as 'frappe.client.get_count'. "
+				"With 'doctype', a controller method name instead, such as 'submit'."
+			),
+		},
+	},
+	"additionalProperties": False,
+}
+
+# Fields that only shape the form. They carry no data and waste the model's context.
+LAYOUT_FIELDTYPES = {
+	"Section Break",
+	"Column Break",
+	"Tab Break",
+	"HTML",
+	"Heading",
+	"Image",
+	"Fold",
+}
+
+PERMISSION_TYPES = ("read", "write", "create", "delete", "submit", "cancel", "amend")
+
+METHODS_UNAVAILABLE = "Method discovery needs the System Manager role."
+
+SEARCH_LIMIT = 50
+
+
+def handle(arguments: dict[str, Any]) -> dict[str, Any]:
+	doctype = arguments.get("doctype")
+	method = arguments.get("method")
+	query = arguments.get("query")
+
+	if doctype and method:
+		return discovery.doctype_method(doctype, method)
+	if doctype:
+		return _doctype_schema(doctype)
+	if method:
+		return discovery.method(method)
+	if query:
+		return _search(query)
+
+	return _site_summary()
+
+
+def _site_summary() -> dict[str, Any]:
+	doctypes = frappe.get_all("DocType", fields=["module"], filters={"istable": 0})
+	modules = sorted({row.module for row in doctypes if row.module})
+
+	return {
+		"type": "site",
+		"site": frappe.local.site,
+		"user": frappe.session.user,
+		"roles": sorted(frappe.get_roles()),
+		"counts": {"doctypes": len(doctypes), "modules": len(modules)},
+		"modules": modules,
+		"next": ("Call discover again with 'query' to search, or with 'doctype' to read a schema."),
+	}
+
+
+def _search(query: str) -> dict[str, Any]:
+	result: dict[str, Any] = {
+		"type": "search",
+		"query": query,
+		"doctypes": frappe.get_all(
+			"DocType",
+			filters={"name": ("like", f"%{query}%"), "istable": 0},
+			fields=["name", "module", "issingle", "is_submittable"],
+			order_by="name",
+			limit=SEARCH_LIMIT,
+		),
+	}
+
+	try:
+		result["methods"] = discovery.search(query)["results"]
+	except frappe.PermissionError:
+		result["methods_unavailable"] = METHODS_UNAVAILABLE
+
+	return result
+
+
+def _doctype_schema(doctype: str) -> dict[str, Any]:
+	"""A compact schema. Raw meta is large and most of it does not help an agent."""
+	meta = frappe.get_meta(doctype)
+
+	schema: dict[str, Any] = {
+		"type": "doctype",
+		"doctype": meta.name,
+		"module": meta.module,
+		"is_submittable": bool(meta.is_submittable),
+		"is_single": bool(meta.issingle),
+		"is_child_table": bool(meta.istable),
+		"title_field": meta.title_field,
+		"fields": [_field(df) for df in meta.fields if df.fieldtype not in LAYOUT_FIELDTYPES],
+		"permissions": {
+			permission: frappe.has_permission(doctype, permission) for permission in PERMISSION_TYPES
+		},
+	}
+
+	try:
+		schema["methods"] = discovery.doctype_methods(doctype)["methods"]
+	except frappe.PermissionError:
+		schema["methods_unavailable"] = METHODS_UNAVAILABLE
+
+	return schema
+
+
+def _field(df) -> dict[str, Any]:
+	field = {
+		"fieldname": df.fieldname,
+		"fieldtype": df.fieldtype,
+		"label": df.label,
+		"options": df.options,
+		"reqd": bool(df.reqd) or None,
+		"read_only": bool(df.read_only) or None,
+	}
+	return {key: value for key, value in field.items() if value is not None}
+
+
+TOOL = Tool(
+	name="discover",
+	title="Discover the site",
+	description=DESCRIPTION,
+	input_schema=INPUT_SCHEMA,
+	annotations={"readOnlyHint": True},
+	handler=handle,
+)

--- a/frappe/mcp/tools/documents.py
+++ b/frappe/mcp/tools/documents.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+"""The document tools: `get_documents` reads, `write_document` changes.
+
+Both mirror the API v2 handlers in `frappe.api.v2`, so an MCP client and a REST
+client see the same semantics, the same permission checks and the same hooks.
+"""
+
+from typing import Any
+
+import frappe
+from frappe.api import v2
+from frappe.mcp.tools import Tool, form_dict
+
+GET_DESCRIPTION = """Read documents from this Frappe site.
+
+Give 'name' to read one whole document. Otherwise this lists documents, and you
+can narrow the list with 'filters', 'fields', 'order_by', 'start' and 'limit'.
+Set 'count_only' to count instead of listing.
+
+'filters' takes a dict of equalities, such as {"status": "Open"}, or a list for
+other operators, such as [["status", "in", ["Open", "Closed"]]].
+
+The result reports 'has_next_page'. Page through with 'start' and 'limit'.
+Call discover first if you do not know the DocType or its fields."""
+
+GET_INPUT_SCHEMA = {
+	"type": "object",
+	"properties": {
+		"doctype": {"type": "string", "description": "A DocType name, such as 'ToDo'."},
+		"name": {"type": "string", "description": "Read this one document, whole."},
+		"filters": {
+			"type": ["object", "array"],
+			"description": 'A dict of equalities, or a list such as [["status", "in", ["Open"]]].',
+		},
+		"fields": {
+			"type": "array",
+			"items": {"type": "string"},
+			"description": "Fields to return. Defaults to the name only.",
+		},
+		"order_by": {"type": "string", "description": "For example 'creation desc'."},
+		"start": {"type": "integer", "description": "Offset for paging. Defaults to 0."},
+		"limit": {"type": "integer", "description": "Page size. Defaults to 20."},
+		"count_only": {"type": "boolean", "description": "Count the matches instead of listing them."},
+	},
+	"required": ["doctype"],
+	"additionalProperties": False,
+}
+
+DEFAULT_LIMIT = 20
+
+
+def get_documents(arguments: dict[str, Any]) -> dict[str, Any]:
+	doctype = _required(arguments, "doctype")
+	name = arguments.get("name")
+
+	if name:
+		return {"document": v2.read_doc(doctype, name)}
+
+	filters = arguments.get("filters")
+
+	if arguments.get("count_only"):
+		with form_dict({"filters": filters}):
+			return {"doctype": doctype, "count": v2.count(doctype)}
+
+	start = arguments.get("start") or 0
+	limit = arguments.get("limit") or DEFAULT_LIMIT
+
+	list_arguments = {
+		"filters": filters,
+		"fields": arguments.get("fields"),
+		"order_by": arguments.get("order_by"),
+		"start": start,
+		"limit": limit,
+	}
+
+	with form_dict({key: value for key, value in list_arguments.items() if value is not None}):
+		documents = v2.document_list(doctype)
+
+	return {
+		"doctype": doctype,
+		"documents": documents,
+		"start": start,
+		"limit": limit,
+		# `document_list` reports this on the response, which MCP does not use.
+		"has_next_page": bool(frappe.response.pop("has_next_page", False)),
+	}
+
+
+def _required(arguments: dict[str, Any], key: str) -> Any:
+	value = arguments.get(key)
+	if not value:
+		frappe.throw(f"'{key}' is required", frappe.ValidationError)
+	return value
+
+
+GET_DOCUMENTS = Tool(
+	name="get_documents",
+	title="Read documents",
+	description=GET_DESCRIPTION,
+	input_schema=GET_INPUT_SCHEMA,
+	annotations={"readOnlyHint": True},
+	handler=get_documents,
+)

--- a/frappe/mcp/tools/documents.py
+++ b/frappe/mcp/tools/documents.py
@@ -9,6 +9,7 @@ client see the same semantics, the same permission checks and the same hooks.
 from typing import Any
 
 import frappe
+import frappe.client
 from frappe.api import v2
 from frappe.mcp.tools import Tool, form_dict
 
@@ -87,6 +88,55 @@ def get_documents(arguments: dict[str, Any]) -> dict[str, Any]:
 	}
 
 
+WRITE_DESCRIPTION = """Create, update or delete one document on this Frappe site.
+
+- create: give 'doctype' and 'data'.
+- update: give 'doctype', 'name' and the 'data' to change.
+- delete: give 'doctype' and 'name'.
+
+Document lifecycle actions are not write actions. Submit, cancel and amend are
+DocType methods, so run them through call_method.
+
+Call discover first to learn which fields a DocType has and which are required."""
+
+WRITE_INPUT_SCHEMA = {
+	"type": "object",
+	"properties": {
+		"action": {"type": "string", "enum": ["create", "update", "delete"]},
+		"doctype": {"type": "string", "description": "A DocType name, such as 'ToDo'."},
+		"name": {"type": "string", "description": "The document to update or delete."},
+		"data": {
+			"type": "object",
+			"description": "Field values. For create, everything the DocType requires.",
+		},
+	},
+	"required": ["action", "doctype"],
+	"additionalProperties": False,
+}
+
+
+def write_document(arguments: dict[str, Any]) -> dict[str, Any]:
+	action = _required(arguments, "action")
+	doctype = _required(arguments, "doctype")
+	data = arguments.get("data") or {}
+
+	if action == "create":
+		with form_dict(data):
+			return {"action": action, "document": v2.create_doc(doctype)}
+
+	name = _required(arguments, "name")
+
+	if action == "update":
+		with form_dict(data):
+			return {"action": action, "document": v2.update_doc(doctype, name)}
+
+	if action == "delete":
+		frappe.client.delete_doc(doctype, name)
+		return {"action": action, "doctype": doctype, "name": name}
+
+	frappe.throw(f"Unknown action {action}. Use create, update or delete.", frappe.ValidationError)
+
+
 def _required(arguments: dict[str, Any], key: str) -> Any:
 	value = arguments.get(key)
 	if not value:
@@ -101,4 +151,13 @@ GET_DOCUMENTS = Tool(
 	input_schema=GET_INPUT_SCHEMA,
 	annotations={"readOnlyHint": True},
 	handler=get_documents,
+)
+
+WRITE_DOCUMENT = Tool(
+	name="write_document",
+	title="Create, update or delete a document",
+	description=WRITE_DESCRIPTION,
+	input_schema=WRITE_INPUT_SCHEMA,
+	annotations={"destructiveHint": True, "idempotentHint": False},
+	handler=write_document,
 )

--- a/frappe/mcp/tools/methods.py
+++ b/frappe/mcp/tools/methods.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+"""The `call_method` tool: the escape hatch onto every whitelisted method."""
+
+from collections.abc import Callable
+from typing import Any
+
+import frappe
+from frappe import _, is_whitelisted
+from frappe.core.doctype.server_script.server_script_utils import get_server_script_map
+from frappe.handler import run_server_script
+from frappe.mcp.tools import Tool, form_dict
+
+DESCRIPTION = """Call a whitelisted method on this Frappe site. This is the escape hatch: whatever the other tools do not cover, this does.
+
+Two forms:
+- an RPC method: give the dotted 'method' path and its 'args'.
+- a DocType method: give 'doctype', 'name' and the 'method' name.
+
+It covers reports (frappe.desk.query_report.run), read-only SQL through the
+System Console, file upload, the submit and cancel lifecycle actions, and every
+method an installed app whitelists.
+
+Call discover with the same method first to read its parameters."""
+
+INPUT_SCHEMA = {
+	"type": "object",
+	"properties": {
+		"method": {
+			"type": "string",
+			"description": (
+				"A dotted RPC path, such as 'frappe.client.get_count'. "
+				"With 'doctype' and 'name', a controller method name instead, such as 'submit'."
+			),
+		},
+		"doctype": {"type": "string", "description": "The DocType, for a DocType method."},
+		"name": {"type": "string", "description": "The document to run the method on."},
+		"args": {"type": "object", "description": "Arguments for the method."},
+	},
+	"required": ["method"],
+	"additionalProperties": False,
+}
+
+
+def call_method(arguments: dict[str, Any]) -> dict[str, Any]:
+	method = arguments.get("method")
+	if not method:
+		frappe.throw("'method' is required", frappe.ValidationError)
+
+	doctype = arguments.get("doctype")
+	name = arguments.get("name")
+	args = arguments.get("args") or {}
+
+	if doctype and name:
+		return _run_document_method(doctype, name, method, args)
+
+	return {"method": method, "result": _run_rpc(method, doctype, args)}
+
+
+def _run_rpc(method: str, doctype: str | None, args: dict[str, Any]) -> Any:
+	"""Mirror `handle_rpc_call` from the API v2."""
+	from frappe.modules.utils import load_doctype_module
+
+	if doctype:
+		# Expand to run the actual method from the doctype controller.
+		module = load_doctype_module(doctype)
+		method = module.__name__ + "." + method
+
+	method = frappe.override_whitelisted_method(method)
+
+	if server_script := get_server_script_map().get("_api", {}).get(method):
+		with form_dict(args):
+			return run_server_script(server_script)
+
+	try:
+		fn = frappe.get_attr(method)
+	except frappe.AppNotInstalledError:
+		raise
+	except Exception as e:
+		frappe.throw(_("Failed to get method {0} with {1}").format(method, str(e)))
+
+	is_whitelisted(fn)
+	_check_http_method(fn)
+
+	with form_dict(args) as arguments:
+		return frappe.call(fn, **arguments)
+
+
+def _run_document_method(doctype: str, name: str, method: str, args: dict[str, Any]) -> dict[str, Any]:
+	"""Mirror `execute_doc_method` from the API v2."""
+	doc = frappe.get_doc(doctype, name)
+	doc.is_whitelisted(method)
+
+	method_obj = getattr(doc, method)
+	fn = getattr(method_obj, "__func__", method_obj)
+	doc.check_permission(_check_http_method(fn))
+
+	with form_dict(args) as arguments:
+		result = doc.run_method(method, **arguments)
+
+	doc.apply_fieldlevel_read_permissions()
+	return {"doctype": doctype, "name": name, "method": method, "result": result, "document": doc.as_dict()}
+
+
+def _check_http_method(fn: Callable) -> str:
+	"""Check the method against its allowed HTTP methods, and map that to a permission.
+
+	`is_valid_http_method` reads `frappe.request.method`, which is always POST on
+	this endpoint, so it would reject every GET-only method. Read the allow-list
+	directly instead, and map it the way `PERMISSION_MAP` in the API v2 does.
+	"""
+	allowed = set(frappe.allowed_http_methods_for_whitelisted_func.get(fn, ()))
+	if not allowed & {"GET", "POST"}:
+		frappe.throw_permission_error()
+
+	return "write" if "POST" in allowed else "read"
+
+
+CALL_METHOD = Tool(
+	name="call_method",
+	title="Call a whitelisted method",
+	description=DESCRIPTION,
+	input_schema=INPUT_SCHEMA,
+	annotations={"destructiveHint": True, "idempotentHint": False},
+	handler=call_method,
+)

--- a/frappe/mcp/transport.py
+++ b/frappe/mcp/transport.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+"""HTTP concerns of the MCP endpoint.
+
+Origin check, header validation, body parsing and the mapping from a protocol
+error to an HTTP status code. Everything else is in `server.py`.
+"""
+
+import base64
+import binascii
+import json
+from typing import Any
+
+from werkzeug.wrappers import Request, Response
+
+import frappe
+from frappe.mcp import protocol, server
+from frappe.mcp.protocol import (
+	HEADER_MISMATCH,
+	INVALID_REQUEST,
+	PARSE_ERROR,
+	SUPPORTED_VERSIONS,
+	UNSUPPORTED_PROTOCOL_VERSION,
+	McpError,
+)
+
+BASE64_SENTINEL_PREFIX = "=?base64?"
+BASE64_SENTINEL_SUFFIX = "?="
+
+
+def handle_request(request: Request) -> Response:
+	request_id = None
+	try:
+		if request.method != "POST":
+			# No GET SSE stream and no session to delete, so nothing else is answerable.
+			raise McpError(INVALID_REQUEST, "Only POST is supported on this endpoint", http_status_code=405)
+
+		_check_origin(request)
+		_check_authentication()
+
+		payload = _parse_body(request)
+		if payload.get("jsonrpc") != "2.0" or not isinstance(payload.get("method"), str):
+			raise McpError(INVALID_REQUEST, "Body is not a JSON-RPC 2.0 request")
+
+		if payload.get("id") is None:
+			# A notification. Nothing to answer, but the request was accepted.
+			return Response(status=202)
+
+		request_id = payload["id"]
+		_check_headers(request, payload)
+		_check_protocol_version(request)
+
+		result = server.dispatch(payload["method"], payload.get("params") or {})
+		return _json_response(protocol.result_envelope(request_id, result))
+	except McpError as e:
+		return _json_response(protocol.error_envelope(request_id, e), status=e.http_status_code)
+
+
+def _check_origin(request: Request) -> None:
+	"""Reject a cross origin browser request unless the site allows that origin.
+
+	Without this a page in the user's browser could reach a local MCP server
+	through DNS rebinding. Non browser clients send no `Origin` header.
+	"""
+	origin = request.headers.get("Origin")
+	if not origin:
+		return
+
+	allowed = getattr(frappe.local, "allow_cors", None) or frappe.conf.allow_cors
+	if allowed == "*":
+		return
+
+	if not isinstance(allowed, list):
+		allowed = [allowed] if allowed else []
+
+	if origin not in allowed:
+		raise McpError(INVALID_REQUEST, f"Origin {origin} is not allowed", http_status_code=403)
+
+
+def _check_authentication() -> None:
+	if frappe.session.user == "Guest":
+		# `process_response` adds the `WWW-Authenticate` challenge on a 401.
+		raise McpError(INVALID_REQUEST, "Authentication required", http_status_code=401)
+
+
+def _parse_body(request: Request) -> dict[str, Any]:
+	try:
+		payload = json.loads(request.get_data(as_text=True) or "")
+	except ValueError:
+		raise McpError(PARSE_ERROR, "Body is not valid JSON")
+
+	if not isinstance(payload, dict):
+		# Batching was removed from the protocol, so an array is not a valid body.
+		raise McpError(INVALID_REQUEST, "Body must be a single JSON-RPC request")
+
+	return payload
+
+
+def _check_headers(request: Request, payload: dict[str, Any]) -> None:
+	"""The transport headers must agree with the body they describe.
+
+	They let a proxy route and a gateway authorize a call without parsing the
+	body, so a disagreement between the two is a security relevant error.
+	"""
+	params = payload.get("params") or {}
+	meta = params.get("_meta") or {} if isinstance(params, dict) else {}
+
+	header_version = request.headers.get("MCP-Protocol-Version")
+	body_version = meta.get(protocol.META_PROTOCOL_VERSION)
+	if not header_version or header_version != body_version:
+		raise McpError(
+			HEADER_MISMATCH,
+			"MCP-Protocol-Version header must match params._meta protocol version",
+		)
+
+	header_method = request.headers.get("Mcp-Method")
+	if not header_method or header_method != payload["method"]:
+		raise McpError(HEADER_MISMATCH, "Mcp-Method header must match the request method")
+
+	if payload["method"] != "tools/call":
+		return
+
+	header_name = _decode_header_value(request.headers.get("Mcp-Name"))
+	if not header_name or header_name != params.get("name"):
+		raise McpError(HEADER_MISMATCH, "Mcp-Name header must match params.name")
+
+
+def _decode_header_value(value: str | None) -> str | None:
+	"""Decode the `=?base64?…?=` sentinel used for values outside US-ASCII."""
+	if not value or not value.startswith(BASE64_SENTINEL_PREFIX):
+		return value
+
+	if not value.endswith(BASE64_SENTINEL_SUFFIX):
+		return value
+
+	encoded = value[len(BASE64_SENTINEL_PREFIX) : -len(BASE64_SENTINEL_SUFFIX)]
+	try:
+		return base64.b64decode(encoded, validate=True).decode("utf-8")
+	except (binascii.Error, UnicodeDecodeError):
+		raise McpError(HEADER_MISMATCH, "Mcp-Name header is not valid base64")
+
+
+def _check_protocol_version(request: Request) -> None:
+	version = request.headers.get("MCP-Protocol-Version")
+	if version not in SUPPORTED_VERSIONS:
+		raise McpError(
+			UNSUPPORTED_PROTOCOL_VERSION,
+			f"Protocol version {version} is not supported",
+			data={"supported": list(SUPPORTED_VERSIONS), "requested": version},
+		)
+
+
+def _json_response(body: dict[str, Any], status: int = 200) -> Response:
+	return Response(
+		json.dumps(body, default=str),
+		status=status,
+		content_type="application/json",
+	)

--- a/frappe/mcp/transport.py
+++ b/frappe/mcp/transport.py
@@ -47,13 +47,42 @@ def handle_request(request: Request) -> Response:
 			return Response(status=202)
 
 		request_id = payload["id"]
-		_check_headers(request, payload)
-		_check_protocol_version(request)
+		version = _request_version(request, payload)
+		if version in protocol.STRICT_VERSIONS:
+			_check_headers(request, payload)
 
 		result = server.dispatch(payload["method"], payload.get("params") or {})
-		return _json_response(protocol.result_envelope(request_id, result))
+		return _json_response(protocol.result_envelope(request_id, result, version))
 	except McpError as e:
 		return _json_response(protocol.error_envelope(request_id, e), status=e.http_status_code)
+
+
+def _request_version(request: Request, payload: dict[str, Any]) -> str:
+	"""The revision this request speaks.
+
+	`initialize` is the one request that carries no version header: the client
+	sends it to find out what the server supports. Its own version lives in the
+	body and `server.initialize` negotiates against it, so the envelope for that
+	response follows the handshake revision.
+
+	Every later request carries the header. A request without one predates the
+	revision that introduced the header, so it is answered on those terms.
+	"""
+	if payload["method"] in server.HANDSHAKE_METHODS:
+		return protocol.HANDSHAKE_VERSION
+
+	version = request.headers.get("MCP-Protocol-Version")
+	if not version:
+		return protocol.HANDSHAKE_VERSION
+
+	if version not in SUPPORTED_VERSIONS:
+		raise McpError(
+			UNSUPPORTED_PROTOCOL_VERSION,
+			f"Protocol version {version} is not supported",
+			data={"supported": list(SUPPORTED_VERSIONS), "requested": version},
+		)
+
+	return version
 
 
 def _check_origin(request: Request) -> None:
@@ -138,16 +167,6 @@ def _decode_header_value(value: str | None) -> str | None:
 		return base64.b64decode(encoded, validate=True).decode("utf-8")
 	except (binascii.Error, UnicodeDecodeError):
 		raise McpError(HEADER_MISMATCH, "Mcp-Name header is not valid base64")
-
-
-def _check_protocol_version(request: Request) -> None:
-	version = request.headers.get("MCP-Protocol-Version")
-	if version not in SUPPORTED_VERSIONS:
-		raise McpError(
-			UNSUPPORTED_PROTOCOL_VERSION,
-			f"Protocol version {version} is not supported",
-			data={"supported": list(SUPPORTED_VERSIONS), "requested": version},
-		)
 
 
 def _json_response(body: dict[str, Any], status: int = 200) -> Response:

--- a/frappe/tests/test_mcp.py
+++ b/frappe/tests/test_mcp.py
@@ -8,10 +8,12 @@ from werkzeug.test import TestResponse
 
 import frappe
 from frappe.mcp.protocol import (
+	HANDSHAKE_VERSION,
 	HEADER_MISMATCH,
 	META_PROTOCOL_VERSION,
 	METHOD_NOT_FOUND,
 	PROTOCOL_VERSION,
+	SUPPORTED_VERSIONS,
 	UNSUPPORTED_PROTOCOL_VERSION,
 )
 from frappe.tests.test_api import FrappeAPITestCase, make_request
@@ -161,7 +163,7 @@ class TestMCP(FrappeAPITestCase):
 		self.assertEqual(response.status_code, 200)
 
 		result = response.json["result"]
-		self.assertEqual(result["supportedVersions"], [PROTOCOL_VERSION])
+		self.assertEqual(result["supportedVersions"], list(SUPPORTED_VERSIONS))
 		self.assertIn("tools", result["capabilities"])
 		self.assertEqual(result["serverInfo"]["name"], "frappe")
 		self.assertEqual(result["serverInfo"]["version"], frappe.__version__)
@@ -197,10 +199,73 @@ class TestMCP(FrappeAPITestCase):
 		self.assertEqual(response.status_code, 404)
 		self.assertEqual(response.json["error"]["code"], METHOD_NOT_FOUND)
 
-	def test_missing_protocol_version_header(self):
-		response = self.rpc("server/discover", headers={"MCP-Protocol-Version": None})
+	# Protocol revisions
+
+	def handshake_rpc(
+		self, method: str, params: dict | None = None, id: int | None = 1, headers: dict | None = None
+	):
+		"""A request as the handshake revision sends it: no transport headers."""
+		bare = {"MCP-Protocol-Version": None, "Mcp-Method": None, "Mcp-Name": None}
+		return self.rpc(method, params, id=id, headers={**bare, **(headers or {})})
+
+	def test_initialize_negotiates_the_requested_version(self):
+		response = self.handshake_rpc(
+			"initialize",
+			{
+				"protocolVersion": HANDSHAKE_VERSION,
+				"capabilities": {},
+				"clientInfo": {"name": "test-client", "version": "1"},
+			},
+			id=0,
+		)
+		self.assertEqual(response.status_code, 200)
+
+		result = response.json["result"]
+		self.assertEqual(result["protocolVersion"], HANDSHAKE_VERSION)
+		self.assertIn("tools", result["capabilities"])
+		self.assertEqual(result["serverInfo"]["name"], "frappe")
+		self.assertIn("discover", result["instructions"])
+
+		# The handshake revision has neither of these, so they are not sent.
+		self.assertNotIn("resultType", result)
+		self.assertNotIn("_meta", result)
+
+	def test_initialize_offers_the_newest_version_it_knows(self):
+		response = self.handshake_rpc("initialize", {"protocolVersion": "1999-01-01"}, id=0)
+		self.assertEqual(response.status_code, 200)
+		self.assertEqual(response.json["result"]["protocolVersion"], PROTOCOL_VERSION)
+
+	def test_handshake_revision_needs_no_transport_headers(self):
+		"""A client cannot send the version header until it knows the version."""
+		self.assertEqual(self.handshake_rpc("notifications/initialized", id=None).status_code, 202)
+		self.assertEqual(self.handshake_rpc("ping").status_code, 200)
+
+		response = self.handshake_rpc("tools/list", headers={"MCP-Protocol-Version": HANDSHAKE_VERSION})
+		self.assertEqual(response.status_code, 200)
+		self.assertEqual(
+			[tool["name"] for tool in response.json["result"]["tools"]],
+			["call_method", "discover", "get_documents", "write_document"],
+		)
+
+	def test_handshake_revision_can_call_a_tool(self):
+		response = self.rpc(
+			"tools/call",
+			{"name": "discover", "arguments": {"doctype": "ToDo"}},
+			headers={"MCP-Protocol-Version": HANDSHAKE_VERSION, "Mcp-Method": None, "Mcp-Name": None},
+		)
+		self.assertEqual(response.status_code, 200)
+		self.assertEqual(response.json["result"]["structuredContent"]["doctype"], "ToDo")
+
+	def test_unknown_version_header_is_rejected_after_the_handshake(self):
+		response = self.rpc("tools/list", headers={"MCP-Protocol-Version": "1999-01-01"})
 		self.assertEqual(response.status_code, 400)
-		self.assertEqual(response.json["error"]["code"], HEADER_MISMATCH)
+		self.assertEqual(response.json["error"]["code"], UNSUPPORTED_PROTOCOL_VERSION)
+
+	def test_missing_protocol_version_header(self):
+		"""Without a header the request predates the header, so it is answered as such."""
+		response = self.rpc("server/discover", headers={"MCP-Protocol-Version": None, "Mcp-Method": None})
+		self.assertEqual(response.status_code, 200)
+		self.assertNotIn("resultType", response.json["result"])
 
 	def test_mismatched_method_header(self):
 		response = self.rpc("server/discover", headers={"Mcp-Method": "tools/list"})
@@ -227,7 +292,7 @@ class TestMCP(FrappeAPITestCase):
 
 		error = response.json["error"]
 		self.assertEqual(error["code"], UNSUPPORTED_PROTOCOL_VERSION)
-		self.assertEqual(error["data"]["supported"], [PROTOCOL_VERSION])
+		self.assertEqual(error["data"]["supported"], list(SUPPORTED_VERSIONS))
 		self.assertEqual(error["data"]["requested"], "2000-01-01")
 
 	def test_origin_is_rejected_when_not_allowed(self):

--- a/frappe/tests/test_mcp.py
+++ b/frappe/tests/test_mcp.py
@@ -1,0 +1,429 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+
+import base64
+import json
+
+from werkzeug.test import TestResponse
+
+import frappe
+from frappe.mcp.protocol import (
+	HEADER_MISMATCH,
+	META_PROTOCOL_VERSION,
+	METHOD_NOT_FOUND,
+	PROTOCOL_VERSION,
+	UNSUPPORTED_PROTOCOL_VERSION,
+)
+from frappe.tests.test_api import FrappeAPITestCase, make_request
+from frappe.tests.utils import whitelist_for_tests
+
+MCP_PATH = "/api/mcp"
+
+
+@whitelist_for_tests(methods=["GET"])
+def read_only_method(value: str = "read"):
+	"""A GET-only whitelisted method, to prove the HTTP method mapping."""
+	return value
+
+
+@whitelist_for_tests(methods=["POST"])
+def write_then_fail(description: str):
+	"""Write a document and then fail, to prove the savepoint rolls the write back."""
+	frappe.get_doc({"doctype": "ToDo", "description": description}).insert()
+	frappe.throw("Deliberate failure")
+
+
+class TestMCP(FrappeAPITestCase):
+	TEST_USER = "mcp@example.com"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": cls.TEST_USER,
+				"first_name": "MCP",
+				"send_welcome_email": 0,
+				"roles": [],
+			}
+		).insert(ignore_permissions=True, ignore_if_duplicate=True)
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.db.rollback()
+		frappe.delete_doc_if_exists("User", cls.TEST_USER)
+		frappe.db.commit()
+
+	# Helpers
+
+	def sid_for(self, user: str) -> str:
+		from frappe.auth import CookieManager, LoginManager
+		from frappe.utils import set_request
+
+		original_request = getattr(frappe.local, "request", None)
+		set_request(path="/")
+		try:
+			frappe.local.cookie_manager = CookieManager()
+			frappe.local.login_manager = LoginManager()
+			frappe.local.login_manager.login_as(user)
+			return frappe.session.sid
+		finally:
+			frappe.local.request = original_request
+			frappe.set_user("Administrator")
+
+	def rpc(
+		self,
+		method: str,
+		params: dict | None = None,
+		id: int | None = 1,
+		headers: dict | None = None,
+		sid: str | None = "administrator",
+	) -> TestResponse:
+		params = {} if params is None else dict(params)
+		params.setdefault("_meta", {}).setdefault(META_PROTOCOL_VERSION, PROTOCOL_VERSION)
+
+		body = {"jsonrpc": "2.0", "method": method, "params": params}
+		if id is not None:
+			body["id"] = id
+
+		request_headers = {
+			"MCP-Protocol-Version": PROTOCOL_VERSION,
+			"Mcp-Method": method,
+			"Accept": "application/json, text/event-stream",
+		}
+		if method == "tools/call" and params.get("name"):
+			request_headers["Mcp-Name"] = params["name"]
+		request_headers.update(headers or {})
+		request_headers = {key: value for key, value in request_headers.items() if value is not None}
+
+		if sid == "administrator":
+			sid = self.sid
+		if sid:
+			self.TEST_CLIENT.set_cookie("sid", sid)
+		else:
+			self.TEST_CLIENT.delete_cookie("sid")
+
+		return make_request(
+			target=self.TEST_CLIENT.post,
+			args=(MCP_PATH,),
+			kwargs={"json": body, "headers": request_headers},
+		)
+
+	def call_tool(self, name: str, arguments: dict | None = None, **kwargs) -> TestResponse:
+		return self.rpc("tools/call", {"name": name, "arguments": arguments or {}}, **kwargs)
+
+	def assertToolError(self, response: TestResponse) -> str:
+		self.assertEqual(response.status_code, 200)
+		result = response.json["result"]
+		self.assertTrue(result["isError"], msg=json.dumps(result))
+
+		message = result["content"][0]["text"]
+		self.assertTrue(message)
+		self.assertNotIn("<", message, msg="the message must carry no markup")
+		self.assertNotIn("Traceback", message)
+		return message
+
+	def track(self, doctype: str, name: str) -> None:
+		"""Delete a document that a request committed, once this test is done."""
+
+		def cleanup():
+			# The request wrote on another connection. Refresh this one's snapshot.
+			frappe.db.rollback()
+			frappe.delete_doc_if_exists(doctype, name)
+			frappe.db.commit()
+
+		self.addCleanup(cleanup)
+
+	def create_todo(self, description: str) -> str:
+		"""Create through the tool, so that every write happens on the request's connection."""
+		result = self.assertToolSuccess(
+			self.call_tool(
+				"write_document",
+				{"action": "create", "doctype": "ToDo", "data": {"description": description}},
+			)
+		)
+		name = result["document"]["name"]
+		self.track("ToDo", name)
+		return name
+
+	def assertToolSuccess(self, response: TestResponse) -> dict:
+		self.assertEqual(response.status_code, 200)
+		result = response.json["result"]
+		self.assertFalse(result["isError"], msg=json.dumps(result))
+		return result["structuredContent"]
+
+	# server/discover
+
+	def test_discover_reports_the_server(self):
+		response = self.rpc("server/discover")
+		self.assertEqual(response.status_code, 200)
+
+		result = response.json["result"]
+		self.assertEqual(result["supportedVersions"], [PROTOCOL_VERSION])
+		self.assertIn("tools", result["capabilities"])
+		self.assertEqual(result["serverInfo"]["name"], "frappe")
+		self.assertEqual(result["serverInfo"]["version"], frappe.__version__)
+		self.assertIn("discover", result["instructions"])
+		self.assertEqual(result["resultType"], "complete")
+		self.assertEqual(result["cacheScope"], "public")
+		self.assertIn("ttlMs", result)
+
+	# Transport
+
+	def test_get_and_delete_are_not_allowed(self):
+		for method in (self.TEST_CLIENT.get, self.TEST_CLIENT.delete):
+			response = make_request(target=method, args=(MCP_PATH,))
+			self.assertEqual(response.status_code, 405)
+
+	def test_notification_is_accepted_without_a_body(self):
+		response = self.rpc("server/discover", id=None)
+		self.assertEqual(response.status_code, 202)
+		self.assertEqual(response.data, b"")
+
+	def test_guest_is_challenged(self):
+		with self.change_settings("OAuth Settings", commit=True, show_protected_resource_metadata=1):
+			response = self.rpc("server/discover", sid=None)
+
+		self.assertEqual(response.status_code, 401)
+		self.assertIn(
+			"/.well-known/oauth-protected-resource",
+			response.headers["WWW-Authenticate"],
+		)
+
+	def test_unknown_rpc_method(self):
+		response = self.rpc("tools/nope")
+		self.assertEqual(response.status_code, 404)
+		self.assertEqual(response.json["error"]["code"], METHOD_NOT_FOUND)
+
+	def test_missing_protocol_version_header(self):
+		response = self.rpc("server/discover", headers={"MCP-Protocol-Version": None})
+		self.assertEqual(response.status_code, 400)
+		self.assertEqual(response.json["error"]["code"], HEADER_MISMATCH)
+
+	def test_mismatched_method_header(self):
+		response = self.rpc("server/discover", headers={"Mcp-Method": "tools/list"})
+		self.assertEqual(response.status_code, 400)
+		self.assertEqual(response.json["error"]["code"], HEADER_MISMATCH)
+
+	def test_mismatched_name_header(self):
+		response = self.call_tool("discover", headers={"Mcp-Name": "get_documents"})
+		self.assertEqual(response.status_code, 400)
+		self.assertEqual(response.json["error"]["code"], HEADER_MISMATCH)
+
+	def test_base64_name_header(self):
+		encoded = base64.b64encode(b"discover").decode()
+		response = self.call_tool("discover", headers={"Mcp-Name": f"=?base64?{encoded}?="})
+		self.assertEqual(response.status_code, 200)
+
+	def test_unsupported_protocol_version(self):
+		response = self.rpc(
+			"server/discover",
+			params={"_meta": {META_PROTOCOL_VERSION: "2000-01-01"}},
+			headers={"MCP-Protocol-Version": "2000-01-01"},
+		)
+		self.assertEqual(response.status_code, 400)
+
+		error = response.json["error"]
+		self.assertEqual(error["code"], UNSUPPORTED_PROTOCOL_VERSION)
+		self.assertEqual(error["data"]["supported"], [PROTOCOL_VERSION])
+		self.assertEqual(error["data"]["requested"], "2000-01-01")
+
+	def test_origin_is_rejected_when_not_allowed(self):
+		from werkzeug.test import EnvironBuilder
+		from werkzeug.wrappers import Request
+
+		from frappe.mcp import transport
+		from frappe.mcp.protocol import McpError
+
+		def request_from(origin):
+			return Request(EnvironBuilder(headers={"Origin": origin}).get_environ())
+
+		frappe.local.allow_cors = "https://allowed.example.com"
+		try:
+			with self.assertRaises(McpError) as raised:
+				transport._check_origin(request_from("https://evil.example.com"))
+			self.assertEqual(raised.exception.http_status_code, 403)
+
+			transport._check_origin(request_from("https://allowed.example.com"))
+		finally:
+			del frappe.local.allow_cors
+
+	# tools/list
+
+	def test_tools_list_is_deterministic(self):
+		first = self.rpc("tools/list").json["result"]
+		second = self.rpc("tools/list").json["result"]
+
+		self.assertEqual(first["tools"], second["tools"])
+		self.assertEqual(first["cacheScope"], "private")
+		self.assertEqual(
+			[tool["name"] for tool in first["tools"]],
+			["call_method", "discover", "get_documents", "write_document"],
+		)
+		for tool in first["tools"]:
+			self.assertIn("inputSchema", tool)
+			self.assertIn("description", tool)
+
+	# discover
+
+	def test_discover_site_summary(self):
+		result = self.assertToolSuccess(self.call_tool("discover"))
+		self.assertEqual(result["type"], "site")
+		self.assertIn("Core", result["modules"])
+
+	def test_discover_doctype_schema(self):
+		result = self.assertToolSuccess(self.call_tool("discover", {"doctype": "ToDo"}))
+
+		self.assertEqual(result["doctype"], "ToDo")
+		self.assertFalse(result["is_submittable"])
+		self.assertTrue(result["permissions"]["read"])
+
+		fields = {field["fieldname"]: field for field in result["fields"]}
+		self.assertEqual(fields["description"]["fieldtype"], "Text Editor")
+		self.assertTrue(fields["description"]["reqd"])
+		self.assertNotIn("Section Break", {field["fieldtype"] for field in result["fields"]})
+
+	def test_discover_reports_missing_doctype(self):
+		message = self.assertToolError(self.call_tool("discover", {"doctype": "Not A DocType"}))
+		self.assertIn("Not A DocType", message)
+
+	def test_discover_without_system_manager(self):
+		result = self.assertToolSuccess(
+			self.call_tool("discover", {"doctype": "ToDo"}, sid=self.sid_for(self.TEST_USER))
+		)
+		self.assertIn("methods_unavailable", result)
+		self.assertIn("fields", result)
+
+	# get_documents
+
+	def test_get_documents_list(self):
+		name = self.create_todo("mcp list")
+
+		result = self.assertToolSuccess(
+			self.call_tool(
+				"get_documents",
+				{"doctype": "ToDo", "filters": {"name": name}, "fields": ["name", "description"]},
+			)
+		)
+		self.assertEqual(result["documents"][0]["name"], name)
+		self.assertFalse(result["has_next_page"])
+
+		result = self.assertToolSuccess(self.call_tool("get_documents", {"doctype": "ToDo", "name": name}))
+		self.assertEqual(result["document"]["description"], "mcp list")
+
+		result = self.assertToolSuccess(
+			self.call_tool("get_documents", {"doctype": "ToDo", "count_only": True})
+		)
+		self.assertGreaterEqual(result["count"], 1)
+
+	def test_get_documents_needs_permission(self):
+		message = self.assertToolError(
+			self.call_tool(
+				"get_documents",
+				{"doctype": "User", "name": "Administrator"},
+				sid=self.sid_for(self.TEST_USER),
+			)
+		)
+		self.assertIn("User", message)
+
+	# write_document
+
+	def test_write_document_lifecycle(self):
+		name = self.create_todo("mcp write")
+
+		result = self.assertToolSuccess(
+			self.call_tool(
+				"write_document",
+				{"action": "update", "doctype": "ToDo", "name": name, "data": {"status": "Closed"}},
+			)
+		)
+		self.assertEqual(result["document"]["status"], "Closed")
+
+		self.assertToolSuccess(
+			self.call_tool("write_document", {"action": "delete", "doctype": "ToDo", "name": name})
+		)
+		frappe.db.rollback()
+		self.assertFalse(frappe.db.exists("ToDo", name))
+
+	def test_write_document_denied_commits_nothing(self):
+		role_name = "MCP Denied Role"
+		message = self.assertToolError(
+			self.call_tool(
+				"write_document",
+				{"action": "create", "doctype": "Role", "data": {"role_name": role_name}},
+				sid=self.sid_for(self.TEST_USER),
+			)
+		)
+		self.assertIn("Role", message)
+
+		frappe.db.rollback()
+		self.assertFalse(frappe.db.exists("Role", role_name))
+
+	def test_failed_call_rolls_back_its_writes(self):
+		description = "mcp rolled back"
+		self.assertToolError(
+			self.call_tool(
+				"call_method",
+				{
+					"method": "frappe.tests.test_mcp.write_then_fail",
+					"args": {"description": description},
+				},
+			)
+		)
+		frappe.db.rollback()
+		self.assertFalse(frappe.db.exists("ToDo", {"description": description}))
+
+	# call_method
+
+	def test_call_method_rpc(self):
+		result = self.assertToolSuccess(self.call_tool("call_method", {"method": "frappe.ping"}))
+		self.assertEqual(result["result"], "pong")
+
+	def test_call_method_allows_a_get_only_method(self):
+		"""The endpoint is always POST, so the HTTP method must come from the allow-list."""
+		result = self.assertToolSuccess(
+			self.call_tool(
+				"call_method",
+				{"method": "frappe.tests.test_mcp.read_only_method", "args": {"value": "ok"}},
+			)
+		)
+		self.assertEqual(result["result"], "ok")
+
+	def test_call_method_on_a_document(self):
+		name = self.create_todo("mcp method")
+
+		result = self.assertToolSuccess(
+			self.call_tool(
+				"call_method",
+				{
+					"doctype": "ToDo",
+					"name": name,
+					"method": "add_comment",
+					"args": {"comment_type": "Comment", "text": "from mcp"},
+				},
+			)
+		)
+		self.assertEqual(result["document"]["name"], name)
+
+	def test_call_method_refuses_a_method_that_is_not_whitelisted(self):
+		message = self.assertToolError(
+			self.call_tool("call_method", {"method": "frappe.mcp.tools.methods.call_method"})
+		)
+		self.assertIn("whitelisted", message)
+
+	def test_call_method_needs_permission(self):
+		message = self.assertToolError(
+			self.call_tool(
+				"call_method",
+				{
+					"doctype": "User",
+					"name": "Administrator",
+					"method": "add_comment",
+					"args": {"comment_type": "Comment", "text": "from mcp"},
+				},
+				sid=self.sid_for(self.TEST_USER),
+			)
+		)
+		self.assertIn("User", message)


### PR DESCRIPTION
## Why

An agent that works with a Frappe site today must go through the REST API v2
with a separate client. That works, but every site owner must install and
configure the client first.

This adds a built-in MCP endpoint to every site. An agent points its client at
`https://<site>/api/mcp`, authenticates with the OAuth flow the site already
supports, and gets a small tool surface over the same API v2 semantics.

```sh
claude mcp add --transport http frappe https://<site>/api/mcp
```

## Protocol

`POST /api/mcp` serves two revisions and lets the client choose. They differ in
how a client announces the protocol version, which is the one thing a server
cannot be relaxed about.

| Revision     | Version announced by                                    |
| ------------ | ------------------------------------------------------- |
| `2026-07-28` | Every request, in transport headers and `params._meta`. |
| `2025-11-25` | Once, through the `initialize` handshake.               |

The newer revision removes the handshake and the protocol level session, so the
endpoint is a plain request/response HTTP workload that the synchronous WSGI
stack already serves well: no session store, no session affinity, no
long-lived stream, no asyncio. Its transport headers let a proxy route and a
gateway authorize a call without parsing the body, so the server requires them
to agree with the body they describe.

The older revision is what shipping clients speak today. A client on that
revision cannot send the version header on its first request, because it does
not yet know what the server supports, so the header is optional there and the
handshake carries the version instead.

The version header selects which set of rules applies:

| Request                                           | Revision  | Headers   | Result fields         |
| ------------------------------------------------- | --------- | --------- | --------------------- |
| `initialize`, `ping`, `notifications/initialized` | handshake | none      | plain                 |
| header `2025-11-25`, or no header                 | handshake | optional  | plain                 |
| header `2026-07-28`                               | strict    | enforced  | `resultType`, `_meta` |

An unknown header version returns `-32022` with the list the server does have.
An `initialize` asking for an unknown version is offered the newest revision the
server has, and the client decides whether it can continue.

Other decisions: the response body is always `application/json`, the only
capability is `tools`, and authorization is the existing OAuth 2.1
resource-server support with no new code. Omitting SSE is legal — a server
chooses per request whether to answer with one JSON object or a stream — and
`subscriptions/listen` and MRTR are capability-gated.

## Tools

Four tools, folded broad. Every tool in the list costs context in the model's
prompt on every turn.

| Tool             | Covers                                                            |
| ---------------- | ----------------------------------------------------------------- |
| `discover`       | Site summary, search, DocType schema, the contract of one method. |
| `get_documents`  | Read one document, list documents, or count them.                 |
| `write_document` | Create, update and delete.                                        |
| `call_method`    | Every whitelisted method. The escape hatch.                       |

Each tool mirrors the matching handler in `frappe/api/v2.py`, so an MCP client
and a REST client see the same semantics, the same permission checks and the
same hooks. `call_method` is why the list stays short: reports, read-only SQL,
file upload, the submit and cancel lifecycle actions and every app specific
method all go through it. That is also why an `mcp_tools` extension hook is not
needed yet.

Only one place needed a deliberate difference from the REST path.
`is_valid_http_method` reads `frappe.request.method`, which is always `POST` on
this endpoint, so it would reject every GET-only whitelisted method.
`call_method` reads `frappe.allowed_http_methods_for_whitelisted_func` directly
instead, and maps a GET-only method to the `read` permission, anything else to
`write`.

## Permissions

The MCP layer adds no permission model of its own. Every tool runs as the
authenticated user and relies on Frappe permissions, method whitelisting and
OAuth scopes. Auth, CORS, rate limit headers and the `WWW-Authenticate`
challenge all come from the existing request pipeline.

Protocol errors return a JSON-RPC `error`. A tool that fails returns
`isError: true` with the message as text, so the model can read what went wrong
and correct itself. Messages carry no markup and no traceback. Each call runs
inside a savepoint, so a failed call leaves no partial database write for
`sync_database` to commit.

Note the limit: the savepoint covers database writes only. A failed
`call_method` that touched the filesystem, a file upload for example, leaves
that file behind. This is inherent to Frappe savepoints, not new here, but it
is a real gap in the "no partial write" guarantee.

## Operating

The endpoint is on by default. It requires authentication, and it exposes
nothing that an authenticated REST client cannot already reach. Set
`disable_mcp_server` in `site_config.json` to turn it off; the endpoint then
returns `404`.

For an MCP client to complete the authorization flow, the site must publish
OAuth resource metadata. Enable `show_protected_resource_metadata` in **OAuth
Settings**.

Each call reports `mcp_tool=<name>` to the monitor, so MCP traffic is visible
alongside REST traffic.

## Verification

31 integration tests in `frappe/tests/test_mcp.py`, over the real WSGI stack:

- `initialize` negotiates the requested version, and offers the newest revision
  the server has when the client asks for one it does not know.
- The handshake revision works with no transport headers at all: `ping`,
  `notifications/initialized`, `tools/list` and `tools/call`.
- The strict revision still enforces its headers: a missing
  `MCP-Protocol-Version`, a mismatched `Mcp-Method`, a mismatched `Mcp-Name`,
  and a base64 `Mcp-Name` that does match.
- An unknown version returns `-32022` with the supported list.
- `server/discover` returns `supportedVersions`, `capabilities.tools`,
  `serverInfo` and `instructions`.
- `GET` and `DELETE` return `405`. A notification returns `202` with no body.
- A guest gets `401` with a `WWW-Authenticate` header naming the resource
  metadata URL.
- `tools/list` is deterministic across calls.
- Each tool: a success case, and a denied case that returns `isError: true` and
  commits nothing.
- A GET-only whitelisted method runs through `call_method`, proving the HTTP
  method fix.
- A method that writes and then fails leaves nothing behind, proving the
  savepoint.

`frappe/tests/test_api.py` still passes, so the addition to `API_URL_MAP` is
clean. `disable_mcp_server` returning `404` was checked by hand against a
running bench.

**End to end with a real client.** `claude mcp add --transport http` against a
running bench completes the OAuth flow and reports connected; `discover`
returns a DocType schema, `get_documents` reads a list and `write_document`
creates a ToDo. The full client byte sequence — `initialize`,
`notifications/initialized`, `tools/list`, `tools/call`, `ping` — was replayed
against the endpoint and verified.

Serving both revisions is what makes that possible: an earlier version of this
branch implemented `2026-07-28` alone, and no client could complete a handshake
with it.
