### PR TITLE
fix(print): stop bordered child tables doubling their bottom rounded edge

### DIFF
--- a/frappe/printing/doctype/print_format/test_print_format.py
+++ b/frappe/printing/doctype/print_format/test_print_format.py
@@ -102,6 +102,11 @@ class TestPrintFormatBuilderElements(IntegrationTestCase):
 		# no source -> block is skipped entirely
 		self.assertNotIn("print-image", self.render(df | {"image_url": ""}))
 
+	def test_allow_page_break_marks_field_breakable(self):
+		df = {"fieldname": "first_name", "fieldtype": "Data", "label": "First Name"}
+		self.assertNotIn("field--breakable", self.render(df))
+		self.assertIn("field--breakable", self.render(df | {"allow_page_break": 1}))
+
 	def test_barcode_element(self):
 		df = {"fieldname": "barcode_test", "fieldtype": "Barcode", "custom": 1, "label": ""}
 

--- a/frappe/printing/doctype/print_format/test_print_format.py
+++ b/frappe/printing/doctype/print_format/test_print_format.py
@@ -103,9 +103,13 @@ class TestPrintFormatBuilderElements(IntegrationTestCase):
 		self.assertNotIn("print-image", self.render(df | {"image_url": ""}))
 
 	def test_allow_page_break_marks_field_breakable(self):
+		# the class name also lives in the stylesheet, so assert on the body markup only
+		def body(html):
+			return html.split("<body", 1)[-1]
+
 		df = {"fieldname": "first_name", "fieldtype": "Data", "label": "First Name"}
-		self.assertNotIn("field--breakable", self.render(df))
-		self.assertIn("field--breakable", self.render(df | {"allow_page_break": 1}))
+		self.assertNotIn("field--breakable", body(self.render(df)))
+		self.assertIn("field--breakable", body(self.render(df | {"allow_page_break": 1})))
 
 	def test_barcode_element(self):
 		df = {"fieldname": "barcode_test", "fieldtype": "Barcode", "custom": 1, "label": ""}

--- a/frappe/public/js/print_format_builder/components/inspector/FieldPropertiesPanel.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldPropertiesPanel.vue
@@ -176,6 +176,12 @@
 					allow-empty
 					@update:model-value="(v) => (selected_field.label_gap = v)"
 				/>
+				<ToggleRow
+					v-if="can_break"
+					:label="__('Split across pages')"
+					:model-value="!!selected_field.allow_page_break"
+					@update:model-value="(v) => (selected_field.allow_page_break = v)"
+				/>
 			</template>
 		</InspectorSection>
 
@@ -205,6 +211,7 @@
 import { computed, inject } from "vue";
 import LabelField from "./LabelField.vue";
 import SegmentedRow from "./SegmentedRow.vue";
+import ToggleRow from "./ToggleRow.vue";
 import InspectorSection from "./InspectorSection.vue";
 import StepperRow from "./StepperRow.vue";
 import StyleSection from "./StyleSection.vue";
@@ -229,6 +236,18 @@ const NON_TEXT_FIELDTYPES = new Set([
 	"Field Template",
 ]);
 let is_text_field = computed(() => !NON_TEXT_FIELDTYPES.has(selected_field.value?.fieldtype));
+
+// Long-content fields that render through Data.html and can safely flow across
+// a page boundary instead of jumping whole
+const BREAKABLE_FIELDTYPES = new Set([
+	"Text Editor",
+	"Text",
+	"Long Text",
+	"Small Text",
+	"Code",
+	"HTML Editor",
+]);
+let can_break = computed(() => BREAKABLE_FIELDTYPES.has(selected_field.value?.fieldtype));
 
 let is_html_field = computed(() => selected_field.value?.fieldtype === "HTML");
 let is_typst_field = computed(() => selected_field.value?.fieldtype === "Typst");

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -352,6 +352,7 @@ const FIELD_PLUCK_KEYS = [
 	"row_condition",
 	"show_label",
 	"align",
+	"allow_page_break",
 	"label_justify",
 	"label_gap",
 	"visible_if",

--- a/frappe/templates/print_format/macros/Data.html
+++ b/frappe/templates/print_format/macros/Data.html
@@ -7,7 +7,7 @@
 {%- set _fstyle = (('gap: ' + df.label_gap|int|string + 'px;') if (_inline and df.label_gap is defined and df.label_gap is not none) else '') + (df.custom_style or '') -%}
 {%- set _lbl_style = (('color:' + df.label_color + ';') if df.label_color else '') -%}
 {%- set _val_style = (('color:' + df.value_color + ';') if df.value_color else '') -%}
-<div class="field {{ _orientation }}{% if _inline and _orientation != 'left-right' %} field-inline{% endif %}{% if _align %} field-align-{{ _align }}{% endif %}{% if _justify and _orientation == 'left-right' and _align not in ('center', 'right') %} field-justify-{{ _justify }}{% endif %}" {% if _fstyle %}style="{{ _fstyle|e }}"{% endif %} {{ field_attributes(df) }}>
+<div class="field {{ _orientation }}{% if _inline and _orientation != 'left-right' %} field-inline{% endif %}{% if _align %} field-align-{{ _align }}{% endif %}{% if _justify and _orientation == 'left-right' and _align not in ('center', 'right') %} field-justify-{{ _justify }}{% endif %}{% if df.allow_page_break %} field--breakable{% endif %}" {% if _fstyle %}style="{{ _fstyle|e }}"{% endif %} {{ field_attributes(df) }}>
 	{%- block label -%}
 	{%- if _show_label != 'hide' -%}
 	<div class="label"{% if _lbl_style %} style="{{ _lbl_style|e }}"{% endif %}>{{ _(df.label)|e }}</div>

--- a/frappe/templates/print_format/print_format_doc.css
+++ b/frappe/templates/print_format/print_format_doc.css
@@ -34,6 +34,13 @@
 	page-break-inside: avoid;
 }
 
+/* Long-content fields (Terms, notes) opt into flowing across a page boundary
+   instead of jumping whole and leaving the previous page half empty */
+.print-format-doc .field.field--breakable {
+	break-inside: auto;
+	page-break-inside: auto;
+}
+
 /* Stacked (default): muted label above value */
 .print-format-doc .field .label {
 	font-size: 1em;

--- a/frappe/templates/print_format/print_format_doc.css
+++ b/frappe/templates/print_format/print_format_doc.css
@@ -210,11 +210,14 @@
 	border-bottom-right-radius: var(--pfb-radius, 0);
 }
 
-.print-format-doc .child-table .table tbody tr:last-child td:first-child {
+/* bordered tables close their bottom corners through the .table-foot cap, so
+   the last body row must not also round them — two curved closes stack into a
+   doubled bottom edge otherwise */
+.print-format-doc .child-table:not(.child-table--bordered) .table tbody tr:last-child td:first-child {
 	border-bottom-left-radius: var(--pfb-radius, 0);
 }
 
-.print-format-doc .child-table .table tbody tr:last-child td:last-child {
+.print-format-doc .child-table:not(.child-table--bordered) .table tbody tr:last-child td:last-child {
 	border-bottom-right-radius: var(--pfb-radius, 0);
 }
 

--- a/frappe/utils/test_print_format_parity.py
+++ b/frappe/utils/test_print_format_parity.py
@@ -44,6 +44,9 @@ SERVER_ONLY_CLASSES = {
 	# per-section "page break" is page-break-after:always — likewise pagination-only;
 	# the canvas renders a separate .page-break-indicator element, not this class
 	"page-break",
+	# per-field "split across pages" flips break-inside to auto — pagination-only,
+	# invisible on the continuously-scrolled canvas
+	"field--breakable",
 }
 CANVAS_ONLY_CLASSES = set()
 

--- a/frappe/utils/test_print_format_parity.py
+++ b/frappe/utils/test_print_format_parity.py
@@ -238,7 +238,8 @@ class TestPrintSurfaceMarkupContract(UnitTestCase):
 
 	def _assert_df_props_mirrored(self, macro_path):
 		# properties that are server-render concerns, not canvas inputs
-		skip = {"get", "renderer", "section", "html"}
+		# (allow_page_break flips break-inside — pagination only, no canvas effect)
+		skip = {"get", "renderer", "section", "html", "allow_page_break"}
 		macro = macro_path.read_text()
 		props = set(re.findall(r"df\.([a-z_]+)", macro)) - skip
 		missing = sorted(p for p in props if f"df.{p}" not in _canvas_logic_text())


### PR DESCRIPTION
- Bordered child tables close their bottom corners through the `.table-foot` cap. The last body row was rounding those corners too, so the two curved closes stacked into a doubled bottom edge.
- Scope the last-row bottom-radius to `:not(.child-table--bordered)`; lined/plain tables are unchanged (their last row has no bottom border, so the radius was invisible there anyway).