### PR TITLE
fix(xlsxwriter): treat formula-like values as literal text in CSV/XLSX export

### DIFF
--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -1167,6 +1167,107 @@ class TestXlsxUtils(IntegrationTestCase):
 		self.assertIn("html data >", val)
 		self.assertEqual("abc", handle_html("abc"))
 
+	def test_formula_like_strings_are_not_written_as_formulas(self):
+		"""A leading =, +, -, @ etc must not cause the cell to be written as a real formula."""
+		from openpyxl import load_workbook
+
+		from frappe.utils.xlsxutils import make_xlsx
+
+		data = [
+			["notes", "amount", "phone"],
+			["=1+1", 1500.5, "+1-555-0100"],
+			["+91-1234567890", -5, "555-1234"],
+			["normal text", 10, "@handle-as-text"],
+		]
+		xlsx_file = make_xlsx(data, "Test Sheet")
+		wb = load_workbook(xlsx_file, data_only=False)
+		ws = wb.active
+
+		rows = list(ws.iter_rows(values_only=False))
+
+		# formula-trigger strings must be forced to string type, value unchanged
+		for coord, expected_value in (
+			((1, 0), "=1+1"),
+			((1, 2), "+1-555-0100"),
+			((2, 0), "+91-1234567890"),
+			((2, 2), "555-1234"),
+			((3, 2), "@handle-as-text"),
+		):
+			row_idx, col_idx = coord
+			cell = rows[row_idx][col_idx]
+			self.assertEqual(cell.data_type, "s")
+			self.assertEqual(cell.value, expected_value)
+
+		# real numeric values must keep their native type, not get stringified
+		self.assertEqual(rows[1][1].data_type, "n")
+		self.assertEqual(rows[1][1].value, 1500.5)
+		self.assertEqual(rows[2][1].data_type, "n")
+		self.assertEqual(rows[2][1].value, -5)
+
+
+class TestCsvUtils(IntegrationTestCase):
+	def test_escape_formula_injection_prefixes_trigger_chars(self):
+		from frappe.utils.csvutils import FORMULA_TRIGGER_CHARS, escape_formula_injection
+
+		for char in FORMULA_TRIGGER_CHARS:
+			value = f"{char}1+1"
+			self.assertEqual(escape_formula_injection(value), "'" + value)
+
+	def test_escape_formula_injection_leaves_normal_values_untouched(self):
+		from frappe.utils.csvutils import escape_formula_injection
+
+		self.assertEqual(escape_formula_injection("normal text"), "normal text")
+		self.assertEqual(escape_formula_injection("555-1234"), "555-1234")
+		self.assertEqual(escape_formula_injection(100), 100)
+		self.assertEqual(escape_formula_injection(None), None)
+
+	def test_unescape_reverses_escape(self):
+		from frappe.utils.csvutils import (
+			FORMULA_TRIGGER_CHARS,
+			escape_formula_injection,
+			unescape_formula_injection,
+		)
+
+		for char in FORMULA_TRIGGER_CHARS:
+			original = f"{char}1+1"
+			self.assertEqual(unescape_formula_injection(escape_formula_injection(original)), original)
+
+	def test_unescape_does_not_strip_literal_leading_quote(self):
+		"""A user-typed apostrophe not followed by a trigger char must survive untouched."""
+		from frappe.utils.csvutils import unescape_formula_injection
+
+		self.assertEqual(unescape_formula_injection("'hello"), "'hello")
+		self.assertEqual(unescape_formula_injection("'"), "'")
+
+	def test_to_csv_escapes_formula_like_values(self):
+		from frappe.utils.csvutils import to_csv
+
+		out = to_csv([["notes", "amount"], ["=1+1", "10"]])
+		self.assertIn("'=1+1", out)
+		self.assertNotIn('"=1+1"', out)
+
+	def test_export_reimport_round_trip_preserves_legit_data(self):
+		"""Export followed by reimport must not corrupt values that start with trigger chars."""
+		from frappe.utils.csvutils import read_csv_content, to_csv
+
+		rows = [
+			["name", "notes", "phone", "qty_text"],
+			["REC-001", "=1+1", "+1-555-0100", "-5"],
+			["REC-002", "normal text", "555-1234", "10"],
+		]
+
+		exported = to_csv(rows)
+		# a formula-like value must round-trip through escape_formula_injection
+		self.assertIn("'=1+1", exported)
+
+		reimported = read_csv_content(exported)
+		self.assertEqual(reimported, rows)
+
+		# a second export/import cycle must not accumulate extra quote markers
+		reexported = to_csv(reimported)
+		self.assertEqual(reexported, exported)
+		self.assertEqual(read_csv_content(reexported), rows)
+
 
 class TestLinkTitle(IntegrationTestCase):
 	def test_link_title_doctypes_in_boot_info(self):

--- a/frappe/utils/csvutils.py
+++ b/frappe/utils/csvutils.py
@@ -29,6 +29,10 @@ def unescape_formula_injection(value):
 	A leading single quote in front of a formula-trigger character is a display-only
 	marker, not part of the value, so re-importing our own export must not bake it in
 	permanently (e.g. phone numbers, negative quantities stored as text).
+
+	Trade-off: a value that genuinely starts with a quote, e.g. "'+S-001", loses that
+	quote too - CSV has no way to tell the two cases apart. Assumes the input came from
+	escape_formula_injection, not an arbitrary external CSV.
 	"""
 	if (
 		isinstance(value, str)

--- a/frappe/utils/csvutils.py
+++ b/frappe/utils/csvutils.py
@@ -12,6 +12,33 @@ from frappe import _, msgprint
 from frappe.core.doctype.file.file import FILE_ENCODING_OPTIONS
 from frappe.utils import cint, comma_or, cstr, flt
 
+# leading characters that spreadsheet applications treat as the start of a formula
+FORMULA_TRIGGER_CHARS = ("=", "+", "-", "@", "\t", "\r")
+
+
+def escape_formula_injection(value):
+	"""Prefix a leading single quote so spreadsheet apps render, but don't evaluate, formula-like strings."""
+	if isinstance(value, str) and value.startswith(FORMULA_TRIGGER_CHARS):
+		return "'" + value
+	return value
+
+
+def unescape_formula_injection(value):
+	"""Reverse escape_formula_injection on the way back in via CSV import.
+
+	A leading single quote in front of a formula-trigger character is a display-only
+	marker, not part of the value, so re-importing our own export must not bake it in
+	permanently (e.g. phone numbers, negative quantities stored as text).
+	"""
+	if (
+		isinstance(value, str)
+		and len(value) > 1
+		and value[0] == "'"
+		and value[1:].startswith(FORMULA_TRIGGER_CHARS)
+	):
+		return value[1:]
+	return value
+
 
 def read_csv_content_from_attached_file(doc):
 	fileid = frappe.get_all(
@@ -89,7 +116,7 @@ def read_csv_content(fcontent, use_sniffer: bool = False, delimiter: str | None 
 			r = []
 			for val in row:
 				# decode everything
-				val = val.strip()
+				val = unescape_formula_injection(val.strip())
 
 				if val == "":
 					# reason: in maraidb strict config, one cannot have blank strings for non string datatypes
@@ -137,7 +164,7 @@ class UnicodeWriter:
 		self.writer = csv.writer(self.queue, quoting=quoting)
 
 	def writerow(self, row):
-		self.writer.writerow(row)
+		self.writer.writerow([escape_formula_injection(v) for v in row])
 
 	def getvalue(self):
 		return self.queue.getvalue()

--- a/frappe/utils/xlsxutils.py
+++ b/frappe/utils/xlsxutils.py
@@ -17,6 +17,7 @@ import frappe
 from frappe import _
 from frappe.core.utils import html2text
 from frappe.utils import cint
+from frappe.utils.csvutils import FORMULA_TRIGGER_CHARS
 from frappe.utils.html_utils import unescape_html
 
 ILLEGAL_CHARACTERS_RE = re.compile(
@@ -584,11 +585,14 @@ def make_xlsx(
 	illegal_chars_sub = ILLEGAL_CHARACTERS_RE.sub
 
 	write = ws.write
+	write_string = ws.write_string
 	has_cell_formats = bool(cell_formats)
 	get_cell_format = cell_formats.get
 
 	for row_idx, row in enumerate(data):
 		for col_idx, value in enumerate(row):
+			is_formula_like = False
+
 			if isinstance(value, str):
 				if handle_html_content:
 					value = handle_html(value)
@@ -596,8 +600,15 @@ def make_xlsx(
 				if illegal_chars_search(value):
 					value = illegal_chars_sub("", value)
 
+				is_formula_like = value.startswith(FORMULA_TRIGGER_CHARS)
+
 			cell_format = get_cell_format((row_idx, col_idx)) if has_cell_formats else None
-			write(row_idx, col_idx, value, cell_format)
+
+			if is_formula_like:
+				# force literal text so the cell isn't parsed as a formula
+				write_string(row_idx, col_idx, value, cell_format)
+			else:
+				write(row_idx, col_idx, value, cell_format)
 
 	if not created_wb:
 		return


### PR DESCRIPTION
This PR ensures that formula-like values are treated as literal text in CSV/XLSX export. 

**Tradeoff**: **a hand-authored or third-party CSV, uploaded through Data Import, containing a field that genuinely starts with an apostrophe immediately followed by one of those six characters will have this character (') stripped.**

Taking such a call that this is a fair tradeoff given values having such shape most likely won't appear in practice.

closes Ticket 75546