### PR TITLE
chore: bump click to 8.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = ["version"]
 dependencies = [
     # core dependencies
     "Babel~=2.16.0",
-    "Click~=8.3.1",
+    "Click~=8.4.1",
     "filelock~=3.20.1",
     "filetype~=1.2.0",
     "GitPython~=3.1.45",


### PR DESCRIPTION
> According to https://raw.githubusercontent.com/pallets/click/refs/heads/main/CHANGES.md  , do changes between 8.3.1 and 8.4.1 break our usage?

Click 8.3.1 → 8.4.1 does not break Frappe’s CLI usage.

Frappe uses Click in the usual way: `@click.command` / `@click.option` / `@click.argument`, boolean flags, `echo` / `secho` / `style` / `prompt` / `confirm` / `progressbar` / `launch`, `CliRunner` in tests, and a thin `Group` subclass in `FrappeClickWrapper`. The 8.3.2–8.4.1 notes that change runtime behavior do not hit those paths.

### Changes that look risky, and why they do not apply

| Change | Why it is safe here |
|---|---|
| `Parameter` is now an ABC; `name` is `""` instead of `None` when `expose_value=False` | Frappe never instantiates `Parameter` and does not read `param.name` |
| `default_map` strings split for `nargs > 1` | No `default_map` |
| Feature-switch / `flag_value` arbitration (first-wins vs last-wins, `UNPROCESSED` auto-detect, `default=True` on boolean flags) | No `flag_value`. The only `default=True, is_flag=True` option is `--mute-emails`, which still returns `True` |
| `ParameterSource` became an `IntEnum` | Unused |
| `CliRunner(capture=...)` and the 8.3.3 `fileno()` revert | Tests use the default `capture="sys"` |
| Pager / editor `shlex.split`, `echo_via_pager`, `get_pager_file` | Unused (`browse` uses `click.launch`) |
| Fish / Zsh / Enum completion | Frappe does not use Click’s shell completion |
| Prompt text passed to `readline` / `input()` | UX fix for `prompt` / `confirm`; prompts are plain strings |

### The one place that touches a changed API

`FrappeClickWrapper.get_command` still raises `click.NoSuchOption` with a precomputed `possibilities` list:

```23:34:apps/frappe/frappe/utils/bench_helper.py
		def get_command(self, ctx, cmd_name):
			rv = super().get_command(ctx, cmd_name)
			if rv is not None:
				return rv
			# ...
			raise click.NoSuchOption(
				cmd_name, possibilities=possibilities, message=f"No such command: {cmd_name}."
			)
```

In 8.4.0, `NoSuchOption` runs `get_close_matches` on `possibilities` itself, and Click adds `NoSuchCommand` in `resolve_command`. That does not break this wrapper:

- `get_command` still returns `None` for unknown names, so the override still runs.
- Frappe never reaches the new `NoSuchCommand` path.
- Suggestions are filtered twice with the same cutoff, so they still appear. The only visible change is quoting (`Did you mean 'migrate'?`).