### PR TITLE
chore: drop bleach dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
     "Werkzeug==3.1.6",
     "Whoosh~=2.7.4",
     "beautifulsoup4~=4.13.5",
-    "bleach~=6.3.0",
     "bleach-allowlist~=1.0.3",
     "chardet~=5.2.0",
     "croniter~=6.0.0",


### PR DESCRIPTION
Frappe v16 [does not use it](https://github.com/frappe/frappe/pull/36569) and it is [no longer maintained](https://bleach.readthedocs.io/en/latest/changes.html#version-6-4-0-june-5th-2026), leading to unfixable security advisories.