### PR TITLE
fix(base_document): bypass forced sanitization for json fields

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -1410,7 +1410,7 @@ class BaseDocument:
 			if df and (
 				df.get("ignore_xss_filter")
 				or (df.get("fieldtype") in ("Data", "Small Text", "Text") and df.get("options") == "Email")
-				or df.get("fieldtype") in ("Attach", "Attach Image", "Barcode", "Code")
+				or df.get("fieldtype") in ("Attach", "Attach Image", "Barcode", "Code", "JSON")
 				# cancelled and submit but not update after submit should be ignored
 				or self.docstatus.is_cancelled()
 				or (self.docstatus.is_submitted() and not df.get("allow_on_submit"))

--- a/frappe/tests/test_base_document.py
+++ b/frappe/tests/test_base_document.py
@@ -28,6 +28,36 @@ class TestToDoExtension(BaseDocument):
 
 
 class TestBaseDocument(IntegrationTestCase):
+	def test_sanitize_content_skips_json_fieldtype(self):
+		"""JSON-fieldtype values must survive _sanitize_content untouched, even when
+		they contain HTML-like substrings, while ordinary text fields on the same
+		doctype are still sanitized."""
+		from frappe.core.doctype.doctype.test_doctype import new_doctype
+
+		if not frappe.db.exists("DocType", "Test JSON Sanitize"):
+			new_doctype(
+				"Test JSON Sanitize",
+				fields=[
+					{"label": "Config", "fieldname": "config", "fieldtype": "JSON"},
+					{"label": "Description", "fieldname": "description", "fieldtype": "Text"},
+				],
+			).insert()
+
+		payload = '{"label": "<b onclick=\\"alert(1)\\">hi</b>"}'
+		doc = frappe.get_doc(
+			{
+				"doctype": "Test JSON Sanitize",
+				"config": payload,
+				"description": '<b onclick="alert(1)">hi</b>',
+			}
+		).insert()
+
+		# JSON field: unchanged, still contains the raw onclick attribute
+		self.assertEqual(doc.config, payload)
+
+		# Text field: sanitized, onclick attribute stripped
+		self.assertNotIn("onclick", doc.description)
+
 	def test_docstatus(self):
 		doc = BaseDocument({"docstatus": 0, "doctype": "ToDo"})
 		self.assertTrue(doc.docstatus.is_draft())


### PR DESCRIPTION
Should ideally bypass such fields from sanitization to avoid data corruption.