### PR TITLE
fix(print): render the doc passed by the caller

### DIFF
--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -234,10 +234,13 @@ def get_html(
 	trigger_print=False,
 	settings=None,
 	no_letterhead=None,
+	doc=None,
 ):
 	from frappe.www.printview import validate_print
 
-	doc = frappe.get_doc(doctype, name)
+	# an unsaved document (e.g. a preview built in memory) can only be rendered
+	# from the doc the caller already holds — there is nothing to fetch by name
+	doc = doc or frappe.get_doc(doctype, name)
 	validate_print(doc)
 	generator = PrintFormatGenerator(
 		print_format, doc, letterhead, style=style, settings=settings, no_letterhead=no_letterhead

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -97,6 +97,7 @@ def get_context(context) -> PrintContext:
 		body = get_html(
 			doctype=frappe.form_dict.doctype,
 			name=frappe.form_dict.name,
+			doc=doc,
 			print_format=print_format,
 			letterhead=letterhead,
 			no_letterhead=frappe.form_dict.no_letterhead,


### PR DESCRIPTION
**Description:** `frappe.get_print()` accepts a `doc` argument so callers can render a document that is not in the database — an unsaved preview built in memory. That works for classic Jinja formats, but fails for any format that renders through the standalone renderer:

frappe.exceptions.DoesNotExistError: Salary Slip Preview for HR-EMP-00004 not found

Reproducible in HRMS: **Salary Structure → Actions → Preview Salary Slip**. It builds an unsaved Salary Slip, names it `Preview for <employee>`, and passes it to `get_print`. Since print-format-builder formats now resolve to the standalone
renderer, the preview is broken for every employee and every format.

**Before:**

[Screencast from 2026-08-14 01-18-50.webm](https://github.com/user-attachments/assets/34d702bf-8b1d-40e4-bd95-4766d52c94d2)


**After:**

[Screencast from 2026-08-14 01-18-04.webm](https://github.com/user-attachments/assets/023e5558-1c9e-4096-96da-3f215f95c264)
