### PR TITLE
fix(Web Form): encode redirect, raise rate limits, drop duplicate check

### DIFF
--- a/frappe/public/js/frappe/web_form/webform_script.js
+++ b/frappe/public/js/frappe/web_form/webform_script.js
@@ -16,7 +16,8 @@ frappe.ready(function () {
 			primary_action_label: __("Login"),
 			primary_action: () => {
 				window.location.replace(
-					"/login?redirect-to=" + window.location.pathname + window.location.search
+					"/login?redirect-to=" +
+						encodeURIComponent(window.location.pathname + window.location.search)
 				);
 			},
 		});

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -879,7 +879,7 @@ def accept(web_form: str, data: str | dict, web_form_request_key: str | None = N
 
 
 @frappe.whitelist(methods=["POST", "DELETE"], allow_guest=True)
-@rate_limit(key="web_form_name", limit=10, seconds=60)
+@rate_limit(key="web_form_name", limit=999, seconds=60)
 def delete(web_form_name: str, docname: str | int, web_form_request_key: str | None = None):
 	web_form: WebForm = frappe.get_lazy_doc("Web Form", web_form_name)
 	web_form.raise_if_unpublished()
@@ -916,7 +916,7 @@ def delete(web_form_name: str, docname: str | int, web_form_request_key: str | N
 
 
 @frappe.whitelist(methods=["POST", "DELETE"])
-@rate_limit(key="web_form_name", limit=10, seconds=60)
+@rate_limit(key="web_form_name", limit=999, seconds=60)
 def delete_multiple(web_form_name: str, docnames: str | list):
 	web_form = frappe.get_lazy_doc("Web Form", web_form_name)
 	web_form.raise_if_unpublished()

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -721,9 +721,6 @@ def get_context(context):
 
 
 def process_link_field(field, web_form_name, web_form_request_key=None, docname=None):
-	web_form = frappe.get_cached_doc("Web Form", web_form_name)
-	ensure_guest_key_link_doctype_allowed(web_form, field.options)
-
 	field.fieldtype = "Autocomplete"
 	field.options = get_link_options(
 		web_form_name,


### PR DESCRIPTION
Three small **Web Form** follow-ups from the v15 backport (#41938). They apply on develop without request-key access.

- Encode the login `redirect-to` target. Without encoding, a login-required form with two or more query parameters loses everything after the first `&`.
- Raise the `delete` and `delete_multiple` rate limits from 10 to 999 per minute. A limit of 10 rejects legitimate bulk delete. Leave `accept` and `get_web_form_list` at 10.
- Drop the extra `ensure_guest_key_link_doctype_allowed` call in `process_link_field`. `get_link_options` already runs that check on the same cached **Web Form**.
