### PR TITLE
fix: exclude dynamic routes from sitemap.xml

### DIFF
--- a/frappe/tests/test_sitemap.py
+++ b/frappe/tests/test_sitemap.py
@@ -1,6 +1,7 @@
 import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.utils import get_html_for_route
+from frappe.www.sitemap import get_public_pages_from_doctypes
 
 
 class TestSitemap(IntegrationTestCase):
@@ -8,3 +9,24 @@ class TestSitemap(IntegrationTestCase):
 		xml = get_html_for_route("sitemap.xml")
 		self.assertTrue("/about</loc>" in xml)
 		self.assertTrue("/contact</loc>" in xml)
+
+	def test_dynamic_routes_excluded(self):
+		web_page = frappe.get_doc(
+			{
+				"doctype": "Web Page",
+				"title": "Test Dynamic Sitemap Page",
+				"route": "test-dynamic-sitemap/<name>",
+				"dynamic_route": 1,
+				"published": 1,
+				"content_type": "Rich Text",
+				"main_section": "test",
+			}
+		).insert()
+
+		try:
+			get_public_pages_from_doctypes.clear_cache()
+			xml = get_html_for_route("sitemap.xml")
+			self.assertNotIn("test-dynamic-sitemap", xml)
+		finally:
+			web_page.delete()
+			get_public_pages_from_doctypes.clear_cache()

--- a/frappe/www/sitemap.py
+++ b/frappe/www/sitemap.py
@@ -68,6 +68,9 @@ def get_public_pages_from_doctypes():
 				raise e
 
 		for r in res:
+			if not r.route or is_dynamic_route(r.route):
+				continue
+
 			if robot_parser_instance and not robot_parser_instance.can_fetch("*", f"/{r.route}"):
 				continue
 
@@ -78,3 +81,8 @@ def get_public_pages_from_doctypes():
 			}
 
 	return routes
+
+
+def is_dynamic_route(route: str) -> bool:
+	"""Check if route has dynamic segments like /project/<name> or /blog/:name."""
+	return "<" in route or any(part.startswith(":") for part in route.split("/"))


### PR DESCRIPTION
Published pages with dynamic routes (e.g. `/project/<name>` from Web Pages, `/blog/:name` from Builder Pages) were included in `sitemap.xml` as literal URLs like `https://site/project/%3Cname%3E`, which are invalid links.

This skips routes with dynamic segments while generating the sitemap, and adds a test for it.

Note: the ideal fix would be to expand dynamic routes into the real static URLs they resolve to and include those in the sitemap. But there's no straightforward way to figure out the possible values for a dynamic segment right now, so this PR just removes the broken part... no URL is better than a broken URL in the sitemap.
