### PR TITLE
fix(navbar): Onclick link for routes expanded

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -563,10 +563,22 @@ frappe.ui.Sidebar = class Sidebar {
 						frappe.ui.toolbar.clear_cache();
 					},
 				},
-				...frappe.boot.navbar_settings.settings_dropdown.map((item) => ({
-					...item,
-					label: item.item_label,
-				})),
+				...frappe.boot.navbar_settings.settings_dropdown
+					.filter((item) => !item.hidden)
+					.map((item) => {
+						const mapped = {
+							name: item.name,
+							label: item.item_label,
+							icon: item.icon,
+							condition: item.condition,
+						};
+						if (item.item_type === "Route") {
+							mapped.url = item.route;
+						} else if (item.item_type === "Action") {
+							mapped.onClick = () => frappe.utils.eval(item.action);
+						}
+						return mapped;
+					}),
 				{ is_divider: true },
 				{
 					name: "logout",


### PR DESCRIPTION
closes: #41758 

The route, actions were not expanded and thats why issue occurred without any trace in console.