### PR TITLE
fix: RQ Job list filters and search-link crash

### DIFF
--- a/frappe/core/doctype/rq_job/rq_job.py
+++ b/frappe/core/doctype/rq_job/rq_job.py
@@ -23,6 +23,7 @@ from frappe.utils.background_jobs import get_queues, get_redis_conn
 
 QUEUES = ["default", "long", "short"]
 JOB_STATUSES = ["queued", "started", "failed", "finished", "deferred", "scheduled", "canceled"]
+MAX_MATCHED_JOBS = 5000
 
 
 def check_permissions(method):
@@ -78,21 +79,32 @@ class RQJob(Document):
 		return self._job_obj
 
 	@staticmethod
-	def get_list(filters=None, start=0, page_length=20, order_by="creation desc"):
-		matched_job_ids = RQJob.get_matching_job_ids(filters=filters)[start : start + page_length]
+	def get_list(
+		filters=None, start=0, page_length=20, order_by="creation desc", fields=None, as_list=False, **kwargs
+	):
+		matched_job_ids = RQJob.get_matching_job_ids(filters=filters)
 
 		conn = get_redis_conn()
 		jobs = [serialize_job(job) for job in Job.fetch_many(job_ids=matched_job_ids, connection=conn) if job]
 
 		order_desc = "desc" in order_by
-		return sorted(jobs, key=lambda j: j.creation, reverse=order_desc)
+		jobs = sorted(jobs, key=lambda j: j.creation, reverse=order_desc)
+		jobs = jobs[start : start + page_length]
+
+		if as_list:
+			fields = fields or ["name"]
+			return [[job.get(f) if isinstance(f, str) else None for f in fields] for job in jobs]
+
+		return jobs
 
 	@staticmethod
 	def get_matching_job_ids(filters) -> list[str]:
 		filters = make_filter_dict(filters or [])
 
 		queues = _eval_filters(filters.get("queue"), QUEUES + get_custom_queues())
-		statuses = _eval_filters(filters.get("status"), JOB_STATUSES)
+		status_filter = has_filter_value(filters.get("status"))
+		job_name_filter = has_filter_value(filters.get("job_name"))
+		name_filter = has_filter_value(filters.get("name"))
 
 		matched_job_ids = []
 		for queue in get_queues():
@@ -102,10 +114,19 @@ class RQJob(Document):
 			# standard one (e.g. `schedulelong` under `queue=long`).
 			if queue.name.rsplit(":", 1)[-1] not in queues:
 				continue
-			for status in statuses:
+			for status in JOB_STATUSES:
 				matched_job_ids.extend(fetch_job_ids(queue, status))
 
-		return filter_current_site_jobs(matched_job_ids)
+		matched_job_ids = list(dict.fromkeys(filter_current_site_jobs(matched_job_ids)))
+		matched_job_ids = _eval_filters(name_filter, matched_job_ids)
+
+		if job_name_filter:
+			matched_job_ids = filter_job_ids_by_field(matched_job_ids, job_name_filter, get_job_name)
+
+		if status_filter:
+			matched_job_ids = filter_job_ids_by_field(matched_job_ids, status_filter, get_job_status)
+
+		return matched_job_ids[:MAX_MATCHED_JOBS]
 
 	@check_permissions
 	def delete(self):
@@ -200,6 +221,38 @@ def _eval_filters(filter, values: list[str]) -> list[str]:
 		operator, operand = filter
 		return [val for val in values if compare(val, operator, operand)]
 	return values
+
+
+def has_filter_value(field_filter):
+	if field_filter and field_filter[1] not in (None, ""):
+		return field_filter
+	return None
+
+
+def get_job_name(job: Job) -> str:
+	return serialize_job(job).job_name
+
+
+def get_job_status(job: Job) -> str | None:
+	try:
+		return job.get_status(refresh=True)
+	except InvalidJobOperation:
+		return None
+
+
+def filter_job_ids_by_field(job_ids: list[str], field_filter, get_field_value) -> list[str]:
+	operator, operand = field_filter
+
+	conn = get_redis_conn()
+	matched_ids = []
+	for job in Job.fetch_many(job_ids=job_ids, connection=conn):
+		if not job:
+			continue
+		value = get_field_value(job)
+		if value is not None and compare(value, operator, operand):
+			matched_ids.append(job.id)
+
+	return matched_ids
 
 
 def fetch_job_ids(queue: Queue, status: str) -> list[str]:

--- a/frappe/tests/test_reportview.py
+++ b/frappe/tests/test_reportview.py
@@ -209,12 +209,6 @@ class TestReportview(IntegrationTestCase):
 
 		frappe.db.delete("Email Queue")
 		export_query()
-		jobs = frappe.get_all(
-			"RQ Job",
-			filters={"job_name": "frappe.desk.query_report.run_report_view_export_job"},
-			fields=["name", "status"],
-		)
 		email_queue = frappe.get_all("Email Queue")
 
-		self.assertTrue(jobs, "Background job was not enqueued")
 		self.assertTrue(email_queue, "Email was not enqueued")


### PR DESCRIPTION
**Problem**

The RQ Job list view (Background Job → RQ Job) had bugs across all its filters and the ID autocomplete box.

**Issue 1: ID, Job Name, and Status filters did nothing**

`get_matching_job_ids` only checked the `queue` and `status` filters, and even `status` was applied incorrectly. Filtering by ID (`name`) or Job Name had no effect because the filters were read into a dict but never used.

**Fix:** Added filtering for `name`, `job_name`, and `status`. After collecting candidate jobs by queue/status, each job is checked against the requested filters.

**Issue 2: Status filter showed the wrong rows**

Filtering by Status = Failed could show a row with Status = Finished. The filter only checked which Redis registry a job ID belonged to at scan time, while the row's displayed status was read fresh at render time. If a job's status changed in between, such as after a retry, the filter and displayed value could disagree.

**Fix:** After finding candidate IDs by registry, each job's live status is now re-checked before including it.

**Issue 3: ID filter box crashed with "KeyError: 0"**

Typing in the ID filter box triggers a link-search API call (`frappe.desk.search.search_link`) for autocomplete. That code expects `get_list` to support `as_list=True`, returning rows as plain lists instead of dicts. `RQJob.get_list` did not handle this, causing the search code to crash when indexing into a dict like a list.

**Fix:** Updated `get_list` to honor `as_list` and `fields`, returning a plain list of field values when requested.

**Issue 4: Pages and the ID search box came back short or empty**

`get_list` sliced the matched job IDs to the page size before checking which ones still existed in Redis. Finished jobs can expire from Redis, so some IDs could disappear before they were fetched. Those IDs were then silently dropped, resulting in fewer rows than requested or no rows at all.

**Fix:** Dead IDs are now removed before pagination, so each requested page returns the correct number of rows when enough matching jobs exist.

**Issue 5: Duplicate job IDs in results**

The same job could appear twice if its status changed between two internal registry scans, such as moving from "scheduled" to "queued" during the request.

**Fix:** Matched job IDs are now deduplicated before filtering while preserving their order.

**Issue 6: Clearing a filter showed zero results instead of everything**

When the ID, Job Name, or Status filter is cleared in the UI, it sends a filter like `["status", "=", ""]` instead of omitting it. The empty-string filter was treated as a real filter and matched nothing.

**Fix:** Empty filter values are now treated as no filter, so clearing any of these boxes correctly shows all results.


**Before:**


https://github.com/user-attachments/assets/ef10dd89-b164-4a7f-ab49-1c3328064dbc

**After:**


https://github.com/user-attachments/assets/9a65eb26-6d94-49fd-933a-30d51bcaabd1

