### PR TITLE
fix: enter key does not work on warning dialogs

### DIFF
--- a/cypress/integration/list_view.js
+++ b/cypress/integration/list_view.js
@@ -240,7 +240,7 @@ context("List View", () => {
 			cy.get("body").type("{ctrl}{shift}d");
 			cy.get_open_dialog().should("contain", "Permanently delete");
 
-			cy.get("body").type("{enter}");
+			cy.get_open_dialog().type("{enter}");
 			cy.get(".modal:visible").should("not.exist");
 
 			cy.call("frappe.client.get_list", {

--- a/cypress/integration/list_view.js
+++ b/cypress/integration/list_view.js
@@ -226,6 +226,7 @@ context("List View", () => {
 	);
 
 	it("deletes the open document on Enter after Shift+Ctrl+D", () => {
+		cy.go_to_list("ToDo");
 		cy.call("frappe.client.insert", {
 			doc: {
 				doctype: "ToDo",

--- a/cypress/integration/list_view.js
+++ b/cypress/integration/list_view.js
@@ -224,4 +224,30 @@ context("List View", () => {
 				});
 		}
 	);
+
+	it("deletes the open document on Enter after Shift+Ctrl+D", () => {
+		cy.call("frappe.client.insert", {
+			doc: {
+				doctype: "ToDo",
+				description: "cypress: delete on enter",
+			},
+		}).then((res) => {
+			const docname = res.body.message.name;
+			cy.visit(`/app/todo/${docname}`);
+			cy.title().should("contain", docname);
+
+			cy.get("body").type("{ctrl}{shift}d");
+			cy.get_open_dialog().should("contain", "Permanently delete");
+
+			cy.get("body").trigger("keydown", { key: "Enter", keyCode: 13, which: 13 });
+			cy.get(".modal:visible").should("not.exist");
+
+			cy.call("frappe.client.get_list", {
+				doctype: "ToDo",
+				filters: { name: docname },
+			}).then((list_res) => {
+				expect(list_res.body.message).to.have.length(0);
+			});
+		});
+	});
 });

--- a/cypress/integration/list_view.js
+++ b/cypress/integration/list_view.js
@@ -233,7 +233,7 @@ context("List View", () => {
 				description: "cypress: delete on enter",
 			},
 		}).then((res) => {
-			const docname = res.body.message.name;
+			const docname = res.message.name;
 			cy.visit(`/app/todo/${docname}`);
 			cy.title().should("contain", docname);
 
@@ -247,7 +247,7 @@ context("List View", () => {
 				doctype: "ToDo",
 				filters: { name: docname },
 			}).then((list_res) => {
-				expect(list_res.body.message).to.have.length(0);
+				expect(list_res.message).to.have.length(0);
 			});
 		});
 	});

--- a/cypress/integration/list_view.js
+++ b/cypress/integration/list_view.js
@@ -240,7 +240,7 @@ context("List View", () => {
 			cy.get("body").type("{ctrl}{shift}d");
 			cy.get_open_dialog().should("contain", "Permanently delete");
 
-			cy.get("body").trigger("keydown", { key: "Enter", keyCode: 13, which: 13 });
+			cy.get("body").type("{enter}");
 			cy.get(".modal:visible").should("not.exist");
 
 			cy.call("frappe.client.get_list", {

--- a/frappe/public/js/frappe/ui/messages.js
+++ b/frappe/public/js/frappe/ui/messages.js
@@ -92,6 +92,8 @@ frappe.warn = function (
 	// btn-primary → btn-danger class swap
 	d.get_primary_btn().attr("data-theme", "red");
 
+	d.confirm_dialog = true;
+
 	d.show();
 	return d;
 };


### PR DESCRIPTION
**What was wrong**

Before, pressing Cmd+Shift+D then Enter would delete the open document right away.

Now, Cmd+Shift+D still opens the delete confirm dialog, but Enter does nothing. You need to press Tab and then Enter, or click the Delete button by mouse.

**Why this happened**

Delete used to open its confirm dialog through `frappe.confirm`. That function turns on a flag (`confirm_dialog`) on the dialog. A global key handler checks this flag and clicks the primary button when you press Enter.

In #41444, delete was changed to use `frappe.warn` instead, so the Delete button could show in red. But `frappe.warn` never turns on that same flag. So the Enter key handler never runs for the delete dialog anymore.

**Fix**

Turn on the same `confirm_dialog` flag inside `frappe.warn`, the same way `frappe.confirm` already does. This brings back Enter-to-delete without changing how the dialog looks.
