### PR TITLE
chore: resolve sitemap backport conflict markers

### DIFF
--- a/frappe/tests/test_sitemap.py
+++ b/frappe/tests/test_sitemap.py
@@ -13,9 +13,7 @@ class TestSitemap(FrappeTestCase):
 		xml = get_html_for_route("sitemap.xml")
 		self.assertTrue("/about</loc>" in xml)
 		self.assertTrue("/contact</loc>" in xml)
-<<<<<<< HEAD
 		self.assertTrue(blogs[0].route in xml)
-=======
 
 	def test_dynamic_routes_excluded(self):
 		web_page = frappe.get_doc(
@@ -37,4 +35,3 @@ class TestSitemap(FrappeTestCase):
 		finally:
 			web_page.delete()
 			get_public_pages_from_doctypes.clear_cache()
->>>>>>> 07314557d0 (fix: exclude dynamic routes from sitemap.xml)


### PR DESCRIPTION
## Summary
- PR #41986 (backport of #41985) landed on `version-15-hotfix` with unresolved conflict markers in `frappe/tests/test_sitemap.py`.
- Keep the version-15 blog-route assertion and the new `test_dynamic_routes_excluded` test; drop the markers.
- `frappe/www/sitemap.py` was already applied correctly by the backport.

## Test plan
- [x] `python -m compileall` succeeds on `frappe/tests/test_sitemap.py`
- [x] Sitemap tests pass (`test_sitemap` and `test_dynamic_routes_excluded`)
- [ ] Cypress / compileall CI on this PR is green