### PR TITLE
fix: reject non-string Attachment Gallery filter fields and operators

### DIFF
--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -211,9 +211,12 @@ def get_filtered_attachments(dt: str, dn: str | int, filters: str):
 	frappe.get_doc(dt, dn).check_permission("read")
 	filters = frappe.parse_json(filters)
 	if not isinstance(filters, list) or any(
-		not isinstance(filter_row, list) or len(filter_row) != 4 for filter_row in filters
+		not isinstance(filter_row, list)
+		or len(filter_row) != 4
+		or not all(isinstance(value, str) for value in filter_row[:3])
+		for filter_row in filters
 	):
-		frappe.throw(_("Filters must be a list of four-value filter rows."))
+		frappe.throw(_("Filters must be four-value rows with string doctypes, fields, and operators."))
 	if any(filter_row[0] != "File" for filter_row in filters):
 		frappe.throw(_("Attachment Gallery filters must target File."))
 

--- a/frappe/desk/form/test_load.py
+++ b/frappe/desk/form/test_load.py
@@ -57,6 +57,23 @@ class TestLoad(IntegrationTestCase):
 
 		self.assertEqual([attachment.name for attachment in attachments], [matching_file.name])
 
+	def test_get_filtered_attachments_rejects_structured_field_and_operator(self):
+		todo = frappe.get_doc({"doctype": "ToDo", "description": "Attachment filter type test"}).insert()
+
+		with self.assertRaises(frappe.ValidationError):
+			get_filtered_attachments(
+				todo.doctype,
+				todo.name,
+				json.dumps([["File", ["file_name", "like", "x"], "=", "x"]]),
+			)
+
+		with self.assertRaises(frappe.ValidationError):
+			get_filtered_attachments(
+				todo.doctype,
+				todo.name,
+				json.dumps([["File", "file_name", ["like", "x"], "x"]]),
+			)
+
 	def test_get_document_email(self):
 		with patch(
 			"frappe.email.doctype.email_account.email_account.get_automatic_email_link",


### PR DESCRIPTION
This is already part of existing Attachment Gallery backports, so separate ones needed.