### PR TITLE
fix(cache): Remove locals when permission error occurs

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1594,18 +1594,9 @@ frappe.ui.form.Form = class FrappeForm {
 
 		if (!this.doc.__islocal) {
 			frappe.model.remove_from_locals(this.doctype, this.docname);
-			return frappe.model.with_doc(
-				this.doctype,
-				this.docname,
-				() => {
-					this.refresh();
-				},
-				(r, permission_denied) => {
-					if (permission_denied) {
-						frappe.show_not_permitted(__(this.doctype) + " " + __(cstr(this.docname)));
-					}
-				}
-			);
+			return frappe.model.with_doc(this.doctype, this.docname, () => {
+				this.refresh();
+			});
 		}
 	}
 

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1594,9 +1594,18 @@ frappe.ui.form.Form = class FrappeForm {
 
 		if (!this.doc.__islocal) {
 			frappe.model.remove_from_locals(this.doctype, this.docname);
-			return frappe.model.with_doc(this.doctype, this.docname, () => {
-				this.refresh();
-			});
+			return frappe.model.with_doc(
+				this.doctype,
+				this.docname,
+				() => {
+					this.refresh();
+				},
+				(r, permission_denied) => {
+					if (permission_denied) {
+						frappe.show_not_permitted(__(this.doctype) + " " + __(cstr(this.docname)));
+					}
+				}
+			);
 		}
 	}
 

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -290,17 +290,19 @@ $.extend(frappe.model, {
 		}
 	},
 
-	with_doc: function (doctype, name, callback) {
-		return new Promise((resolve) => {
+	with_doc: function (doctype, name, callback, error_callback) {
+		return new Promise((resolve, reject) => {
 			if (!name) name = doctype; // single type
-			if (
+			const use_cache =
+				!error_callback &&
 				locals[doctype] &&
 				locals[doctype][name] &&
-				frappe.model.get_docinfo(doctype, name)
-			) {
+				frappe.model.get_docinfo(doctype, name);
+			if (use_cache) {
 				callback && callback(name);
 				resolve(frappe.get_doc(doctype, name));
 			} else {
+				let permission_denied = false;
 				return frappe.call({
 					method: "frappe.desk.form.load.getdoc",
 					type: "GET",
@@ -311,6 +313,18 @@ $.extend(frappe.model, {
 					callback: function (r) {
 						callback && callback(name, r);
 						resolve(frappe.get_doc(doctype, name));
+					},
+					error_handlers: {
+						PermissionError: () => {
+							permission_denied = true;
+						},
+					},
+					error: function (r) {
+						if (permission_denied) {
+							frappe.model.remove_from_locals(doctype, name);
+						}
+						error_callback && error_callback(r, permission_denied);
+						reject(r);
 					},
 				});
 			}

--- a/frappe/public/js/frappe/views/formview.js
+++ b/frappe/public/js/frappe/views/formview.js
@@ -99,19 +99,28 @@ frappe.views.FormFactory = class FormFactory extends frappe.views.Factory {
 	}
 
 	fetch_and_render(doctype, name, doctype_layout) {
-		frappe.model.with_doc(doctype, name, (name, r) => {
-			if (r && r["403"]) return; // not permitted
+		return frappe.model.with_doc(
+			doctype,
+			name,
+			(name, r) => {
+				if (r && r["403"]) return; // not permitted
 
-			if (!(locals[doctype] && locals[doctype][name])) {
-				if (name && name.substr(0, 3) === "new") {
-					this.render_new_doc(doctype, name, doctype_layout);
-				} else {
-					frappe.show_not_found();
+				if (!(locals[doctype] && locals[doctype][name])) {
+					if (name && name.substr(0, 3) === "new") {
+						this.render_new_doc(doctype, name, doctype_layout);
+					} else {
+						frappe.show_not_found();
+					}
+					return;
 				}
-				return;
+				this.render(doctype_layout, name);
+			},
+			(r, permission_denied) => {
+				if (permission_denied) {
+					frappe.show_not_permitted(__(doctype) + " " + __(cstr(name)));
+				}
 			}
-			this.render(doctype_layout, name);
-		});
+		);
 	}
 
 	render_new_doc(doctype, name, doctype_layout) {

--- a/frappe/public/js/frappe/views/formview.js
+++ b/frappe/public/js/frappe/views/formview.js
@@ -115,11 +115,9 @@ frappe.views.FormFactory = class FormFactory extends frappe.views.Factory {
 				}
 				this.render(doctype_layout, name);
 			},
-			(r, permission_denied) => {
-				if (permission_denied) {
-					frappe.show_not_permitted(__(doctype) + " " + __(cstr(name)));
-				}
-			}
+			// Passing any error_callback here (even a no-op) makes with_doc() skip its
+			// cache and recheck with the server.
+			() => {}
 		);
 	}
 


### PR DESCRIPTION
closes: #41974 

This fixes the issue in that specific flow alone and can benefit other places as cache gets evicted. with_doc is invoked in 16 other places and they don't have error callback included for now. 