### PR TITLE
fix(webform): allow guest access for table multiselect fields

### DIFF
--- a/frappe/public/js/frappe/form/controls/table_multiselect.js
+++ b/frappe/public/js/frappe/form/controls/table_multiselect.js
@@ -93,6 +93,65 @@ frappe.ui.form.ControlTableMultiSelect = class ControlTableMultiSelect extends (
 	_get_rows() {
 		return this.get_model_value() || this.rows;
 	}
+	on_input(e) {
+		// Web Forms can be public (login_required=0), where the visitor is a Guest.
+		// The inherited ControlLink.on_input() always searches via
+		// frappe.desk.search.search_link, which is whitelisted for logged-in users
+		// only, so it throws "Not permitted" for anonymous visitors. Route through a
+		// Guest-safe endpoint instead when rendered inside a web form; Desk behaviour
+		// (frappe.web_form is undefined there) is unchanged.
+		if (!frappe.web_form) {
+			return super.on_input(e);
+		}
+
+		const term = e ? e.target.value : this.$input.val();
+		const doctype = this.get_options();
+		if (!doctype) return;
+
+		const cache = this.$input.cache;
+		if (!cache[doctype]) {
+			cache[doctype] = {};
+		}
+
+		if (cache[doctype][term] != null) {
+			this.awesomplete.list = cache[doctype][term];
+		}
+
+		frappe.call({
+			type: "POST",
+			method: "frappe.website.doctype.web_form.web_form.search_multiselect_link_options",
+			no_spinner: true,
+			args: {
+				web_form_name: frappe.web_form.name,
+				doctype: doctype,
+				txt: term,
+				web_form_request_key: frappe.web_form.web_form_request_key,
+			},
+			callback: (r) => {
+				if (!window.Cypress && !this.$input.is(":focus")) return;
+
+				const message = r.message || [];
+				cache[doctype][term] = message;
+				this.awesomplete.list = message;
+				message.forEach((item) => {
+					frappe.utils.add_link_title(doctype, item.value, item.label);
+				});
+			},
+		});
+	}
+	validate_multiselect_link_for_webform(value) {
+		if (!value) return value;
+
+		const link_field = this.get_link_field();
+		return frappe
+			.xcall("frappe.website.doctype.web_form.web_form.validate_multiselect_link", {
+				web_form_name: frappe.web_form.name,
+				doctype: link_field.options,
+				docname: value,
+				web_form_request_key: frappe.web_form.web_form_request_key,
+			})
+			.then((validated_value) => validated_value || null);
+	}
 	_update_rows(rows) {
 		this.rows = rows;
 
@@ -157,7 +216,11 @@ frappe.ui.form.ControlTableMultiSelect = class ControlTableMultiSelect extends (
 		}
 
 		if (!this.df.ignore_link_validation) {
-			const validated_value = await this.validate_link_and_fetch(link_value);
+			// frappe.client.validate_link_and_fetch (used by validate_link_and_fetch below)
+			// is also login-only, so it throws for Guests on a public web form.
+			const validated_value = frappe.web_form
+				? await this.validate_multiselect_link_for_webform(link_value)
+				: await this.validate_link_and_fetch(link_value);
 			if (frappe.utils.is_empty(validated_value)) {
 				return all_rows_except_last;
 			}

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -1129,7 +1129,7 @@ def has_link_option(fields, doctype):
 	for f in fields:
 		if f.options == doctype:
 			return True
-		if f.fieldtype == "Table" and f.options:
+		if f.fieldtype in ("Table", "Table MultiSelect") and f.options:
 			child_doctype = f.options
 			if not isinstance(child_doctype, str) or not child_doctype.strip():
 				continue
@@ -1197,6 +1197,115 @@ def get_link_options(
 
 		# Use the actual names as options without labels
 		return "\n".join([str(doc.value) for doc in link_options])
+
+
+def _validate_multiselect_link_access(
+	web_form_name: str, doctype: str, web_form_request_key: str | None = None
+) -> "WebForm":
+	"""Shared Guest-access gate for Table MultiSelect search/validation below.
+
+	Mirrors get_link_options()'s security checks (Guest Key gating via
+	key_required/web_form_request_key, ensure_guest_key_link_doctype_allowed,
+	and the has_link_option() doctype allow-list), so a Table MultiSelect field
+	gets the same access posture as a plain Link field on the same web form.
+	"""
+	web_form: WebForm = frappe.get_cached_doc("Web Form", web_form_name)
+
+	if web_form.login_required and frappe.session.user == "Guest":
+		frappe.throw(_("You must be logged in to use this form."), frappe.PermissionError)
+	if getattr(web_form, "key_required", False):
+		get_web_form_request(
+			web_form.name,
+			web_form_request_key,
+			required=True,
+			allow_used=True,
+		)
+
+	ensure_guest_key_link_doctype_allowed(web_form, doctype)
+
+	if not web_form.published or not has_link_option(web_form.web_form_fields, doctype):
+		frappe.throw(
+			_("You don't have permission to access the {0} DocType.").format(doctype),
+			frappe.PermissionError,
+		)
+
+	return web_form
+
+
+@frappe.whitelist(allow_guest=True)
+def search_multiselect_link_options(
+	web_form_name: str,
+	doctype: str,
+	txt: str = "",
+	page_length: int = 10,
+	allow_read_on_all_link_options: bool = False,
+	web_form_request_key: str | None = None,
+):
+	"""Guest-safe live search for Table MultiSelect fields on Web Forms.
+
+	frappe.ui.form.ControlTableMultiSelect searches via frappe.desk.search.search_link,
+	which is whitelisted for logged-in users only, so this field type is unusable for
+	anonymous visitors on a public (login_required=0) web form. Unlike plain Link
+	fields, which get_link_options() above fully preloads into a static Autocomplete,
+	Table MultiSelect needs incremental search-as-you-type to support picking several
+	values, so this keeps a live search but gates it the same way.
+	"""
+	web_form = _validate_multiselect_link_access(web_form_name, doctype, web_form_request_key)
+
+	filters = {}
+	if web_form.login_required and not cint(allow_read_on_all_link_options):
+		filters = {"owner": frappe.session.user}
+
+	meta = frappe.get_meta(doctype)
+	show_title_field = meta.title_field and meta.show_title_field_in_link
+
+	fields = ["name as value"]
+	if show_title_field:
+		fields.append(f"{meta.title_field} as label")
+
+	or_filters = []
+	txt = (txt or "").strip()
+	if txt:
+		or_filters.append(["name", "like", f"%{txt}%"])
+		if meta.title_field:
+			or_filters.append([meta.title_field, "like", f"%{txt}%"])
+
+	results = frappe.get_all(
+		doctype,
+		filters=filters,
+		or_filters=or_filters,
+		fields=fields,
+		page_length=cint(page_length) or 10,
+	)
+
+	if show_title_field and meta.translated_doctype:
+		return [{"value": r.value, "label": _(r.label)} for r in results]
+	if meta.translated_doctype:
+		return [{"value": r.value, "label": _(r.value)} for r in results]
+
+	return [{"value": r.value, "label": r.get("label")} for r in results]
+
+
+@frappe.whitelist(allow_guest=True)
+def validate_multiselect_link(
+	web_form_name: str,
+	doctype: str,
+	docname: str,
+	web_form_request_key: str | None = None,
+):
+	"""Guest-safe existence check for a value picked in a Table MultiSelect field.
+
+	ControlTableMultiSelect.validate() calls frappe.client.validate_link_and_fetch
+	after a value is chosen, which is also whitelisted for logged-in users only -
+	so even after search_multiselect_link_options() above fixes the search, picking
+	a value would still throw for anonymous visitors without this.
+	"""
+	_validate_multiselect_link_access(web_form_name, doctype, web_form_request_key)
+
+	if not frappe.db.exists(doctype, docname):
+		return None
+
+	return docname
 
 
 @redis_cache(ttl=60 * 60)


### PR DESCRIPTION
## Summary
Table MultiSelect fields on public (`login_required=0`) Web Forms throw `"Not permitted"` for anonymous visitors, because `ControlTableMultiSelect` (inherited from `ControlLink`) always:
- searches via `frappe.desk.search.search_link` while typing, and
- validates the picked value via `frappe.client.validate_link_and_fetch`

Both of those are `@frappe.whitelist()` **without** `allow_guest=True`, so they're login-only. Plain `Link` fields on a Web Form don't hit this because `get_form_data()` already special-cases them - `process_link_field()` converts them to `Autocomplete` and preloads their options server-side via `get_link_options()`. `Table MultiSelect` never got the equivalent treatment.

## Changes
- `frappe/website/doctype/web_form/web_form.py`:
  - Extend `has_link_option()` to also recognise `Table MultiSelect` fields (previously only `Table`), since both represent a child-table doctype via `f.options`.
  - Add `search_multiselect_link_options()` and `validate_multiselect_link()`, both `allow_guest=True`, gated through a shared `_validate_multiselect_link_access()` helper that mirrors `get_link_options()`'s existing security posture: Guest Key checks (`key_required` / `web_form_request_key`), `ensure_guest_key_link_doctype_allowed()`, and the `has_link_option()` doctype allow-list - so a request can't be used as an open search oracle for arbitrary doctypes, and gets the same access rules a Link field on the same web form would.
  - Unlike `get_link_options()` (which fully preloads all options since `Autocomplete` is single-value), `Table MultiSelect` keeps live, incremental search-as-you-type, since it needs to support picking several values from what can be a large list.
- `frappe/public/js/frappe/form/controls/table_multiselect.js`:
  - Add `on_input()` override: falls through to `super.on_input()` (unchanged Desk behaviour) when `frappe.web_form` is not set; otherwise calls the new `search_multiselect_link_options` endpoint.
  - Add `validate_multiselect_link_for_webform()` and branch the tail of `validate()` on `frappe.web_form` to call it instead of `validate_link_and_fetch()` when inside a web form.

Desk usage of Table MultiSelect (`frappe.web_form` undefined) is untouched - only the Web Form code path changes.

## Test plan
- [x] `ruff check` / `ruff format --diff` clean on the changed Python file.
- [x] Full repo `pre-commit run` (ruff import-sort/lint/format, prettier, eslint) passes on both changed files.
- [x] Verified locally against a running bench, as an actual anonymous (Guest) HTTP client with no session cookie, using a test Web Form with a Table MultiSelect field:
  - Baseline: `frappe.desk.search.search_link` as Guest -> `403 PermissionError` (reproduces the bug).
  - `search_multiselect_link_options` as Guest -> `200`, returns matching results for the search text.
  - `validate_multiselect_link` as Guest -> `200`, confirms the picked value exists.
  - Security check: calling `search_multiselect_link_options` for a doctype **not** referenced by that web form's Table MultiSelect field -> `403`, confirming the allow-list guard holds.
- [ ] Browser verification of the full search + validate + submit flow as an anonymous visitor (not yet done in a real browser session, only via direct API calls above).