### PR TITLE
fix(permissions): grant select on link targets to roles that need them

### DIFF
--- a/frappe/core/doctype/domain/domain.json
+++ b/frappe/core/doctype/domain/domain.json
@@ -19,7 +19,7 @@
   }
  ],
  "links": [],
- "modified": "2024-03-23 16:03:22.994251",
+ "modified": "2026-08-21 23:24:23.806039",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Domain",
@@ -46,9 +46,14 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Workspace Manager",
+   "select": 1
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "search_fields": "domain",
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/frappe/core/doctype/role/role.json
+++ b/frappe/core/doctype/role/role.json
@@ -146,7 +146,7 @@
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-06-15 12:00:00.000000",
+ "modified": "2026-08-21 23:24:24.285309",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Role",
@@ -163,6 +163,10 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Desk User",
+   "select": 1
   }
  ],
  "quick_entry": 1,

--- a/frappe/desk/doctype/dashboard_chart_source/dashboard_chart_source.json
+++ b/frappe/desk/doctype/dashboard_chart_source/dashboard_chart_source.json
@@ -35,7 +35,7 @@
   }
  ],
  "links": [],
- "modified": "2024-03-23 16:02:16.623353",
+ "modified": "2026-08-21 23:24:23.680622",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Dashboard Chart Source",
@@ -61,8 +61,13 @@
    "role": "Administrator",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Dashboard Manager",
+   "select": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/email/doctype/email_account/email_account.json
+++ b/frappe/email/doctype/email_account/email_account.json
@@ -768,7 +768,7 @@
  "index_web_pages_for_search": 1,
  "links": [],
  "make_attachments_public": 1,
- "modified": "2026-02-11 16:18:15.572240",
+ "modified": "2026-08-21 23:24:23.931446",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Account",
@@ -785,6 +785,10 @@
   {
    "read": 1,
    "role": "Inbox User"
+  },
+  {
+   "role": "Report Manager",
+   "select": 1
   }
  ],
  "row_format": "Dynamic",

--- a/frappe/geo/doctype/currency/currency.json
+++ b/frappe/geo/doctype/currency/currency.json
@@ -82,7 +82,7 @@
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-23 16:01:31.809369",
+ "modified": "2026-08-21 23:24:23.461092",
  "modified_by": "Administrator",
  "module": "Geo",
  "name": "Currency",
@@ -117,8 +117,13 @@
   {
    "read": 1,
    "role": "Purchase User"
+  },
+  {
+   "role": "Desk User",
+   "select": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/website/doctype/help_category/help_category.json
+++ b/frappe/website/doctype/help_category/help_category.json
@@ -46,7 +46,7 @@
  ],
  "icon": "icon-list",
  "links": [],
- "modified": "2024-03-23 16:03:27.650255",
+ "modified": "2026-08-21 23:24:24.171939",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Help Category",
@@ -63,8 +63,17 @@
    "role": "Website Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Knowledge Base Contributor",
+   "select": 1
+  },
+  {
+   "role": "Knowledge Base Editor",
+   "select": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/website/doctype/web_template/web_template.json
+++ b/frappe/website/doctype/web_template/web_template.json
@@ -54,7 +54,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-23 16:04:02.852688",
+ "modified": "2026-08-21 23:24:24.408508",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Web Template",
@@ -72,8 +72,13 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Website Manager",
+   "select": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],


### PR DESCRIPTION
## The problem

A role holds `write` on a DocType but has neither `read` nor `select` on a DocType the form links to.

Saving still works — `_validate_links` does not check permissions. The link picker does not: `frappe.desk.search.search_widget` goes through `frappe.get_list`, which enforces `select`/`read` on the target. The user gets an empty dropdown, and on a mandatory field the document cannot be completed at all.

Sweeping every DocType in this repo, including the Link fields of child tables, turns up 20 such gaps in frappe's own roles:

| Role | Cannot select | Where |
| --- | --- | --- |
| Knowledge Base Contributor, Knowledge Base Editor | `Help Category` | `Help Article.category` — **mandatory**, so the document cannot be saved |
| Workspace Manager | `Role` | `Workspace › Has Role.role`, `Workspace Customization › Has Role.role`, `Custom HTML Block › Has Role.role` |
| Website Manager | `Role` | `Portal Settings.default_role`, `Portal Settings › Portal Menu Item.role` |
| Dashboard Manager | `Role` | `Dashboard Chart › Has Role.role` |
| Report Manager | `Role` | `Report › Has Role.role` |
| Website Manager | `Web Template` | `Web Page › Web Page Block.web_template`, `Website Settings.footer_template`, `Website Settings.navbar_template` |
| Dashboard Manager | `Currency` | `Dashboard Chart.currency`, `Number Card.currency` |
| Dashboard Manager | `Dashboard Chart Source` | `Dashboard Chart.source` |
| Workspace Manager | `Domain` | `Workspace.restrict_to_domain`, `Workspace › Workspace Shortcut.restrict_to_domain` |
| Report Manager | `Email Account` | `Auto Email Report.sender` |

The `Has Role` cluster is the most visible one: a Workspace Manager can create a workspace but cannot restrict it to a role, because `Role` grants read to `System Manager` alone.

## How the gaps were found

For every DocType, for every role holding `write`, for every `Link` field on the DocType **and on its child tables**, resolve the target and check whether the role can select it. The framework rules are encoded rather than assumed:

- `select` is implied by `read` (`frappe/permissions.py:216`)
- only `permlevel: 0` rows gate doctype-level access (`permissions.py:320`)
- `All` and `Desk User` are automatic roles, so a grant to either satisfies every desk role
- `DocType` link searches run with `ignore_permissions=True` (`desk/search.py:289`), so they are excluded
- child-table, Single and virtual targets are excluded — they inherit or bypass permissions
- hidden, read-only and `fetch_from` fields are excluded — no picker, no breakage

## The change

Eight `select`-only rows, following the pattern already used for `Inbox User` on `Email Account`:

```json
{
 "role": "Workspace Manager",
 "select": 1
}
```

`Currency` and `Role` get a `Desk User` row rather than a list of named roles:

- **Currency** is a universal concept. Any desk user may have to reference one, and it carries nothing confidential.
- **Role** is referenced through the `Has Role` child table, a generic pattern any app can reuse, and through settings fields of the form `role_allowed_to_…`. Naming individual roles there does not scale — downstream apps would each need their own row in frappe core.

Everything else gets the specific role that showed the gap. `Email Account` in particular stays narrow at `Report Manager`, since account names are mailbox addresses.

`select` exposes names in a picker and nothing else. User Permissions still filter the result set, and `read` on the document itself is unaffected.

## Applying it

The rows were added through the ORM in developer mode rather than by hand-editing JSON, so frappe exported the files itself. Worth knowing for anyone doing the same: `DocPerm` defaults `read`, `write`, `create`, `delete`, `report`, `export`, `share`, `print` and `email` to `1`, so every Check field has to be zeroed explicitly or the role silently gets full access. An audit of the added lines confirms nothing beyond `role` and `select` was granted.

Five files also pick up `"row_format": "Dynamic"` and a trailing newline from frappe's own `as_json` export.

## Related

[frappe/erpnext#58334](https://github.com/frappe/erpnext/pull/58334) does the same sweep on erpnext and closes 313 gaps there. It leaves 45 gaps pointing at this repo, of which the `Currency` (20) and `Role` (17) rows here close 37. The remaining 8 are erpnext-side field bugs — `Sales Order.auto_repeat` is missing the `read_only` flag that its twelve sibling DocTypes carry, `BOM Update Log.error_log` likewise — plus four `Email Account` picks that need a decision in erpnext rather than a broad grant here.
