### PR TITLE
fix(ui): correct collapse indicator direction in RTL

### DIFF
--- a/cypress/integration/form_section_collapse_indicator.js
+++ b/cypress/integration/form_section_collapse_indicator.js
@@ -1,0 +1,77 @@
+import child_table_with_collapsible_section from "../fixtures/child_table_with_collapsible_section";
+import doctype_with_collapsible_child_section from "../fixtures/doctype_with_collapsible_child_section";
+
+const parent_doctype_name = doctype_with_collapsible_child_section.name;
+
+context("Form Section Collapse Indicator", () => {
+	const open_section = () => {
+		cy.fill_field("title", "Test Document");
+
+		cy.get('.frappe-control[data-fieldname="items"]').as("table");
+		cy.get("@table").findByRole("button", { name: "Add row" }).click();
+		cy.get("@table").find('[data-idx="1"]').find(".btn-open-row").click();
+		cy.get(".grid-row-open")
+			.find('.form-section[data-fieldname="details_section"]')
+			.as("section");
+	};
+
+	before(() => {
+		cy.login();
+		cy.visit("/desk/website");
+		return cy.insert_doc("DocType", child_table_with_collapsible_section, true).then(() => {
+			return cy.insert_doc("DocType", doctype_with_collapsible_child_section, true);
+		});
+	});
+
+	after(() => {
+		cy.window()
+			.its("frappe.user.name")
+			.then((user) => cy.set_value("User", user, { language: "en" }));
+	});
+
+	beforeEach(() => {
+		cy.login();
+		cy.visit("/desk/website");
+		cy.new_form(parent_doctype_name);
+		open_section();
+	});
+
+	const expect_indicator = (icon) => {
+		cy.get("@section")
+			.find(".collapse-indicator use")
+			.should("have.attr", "href", `#icon-${icon}`);
+	};
+
+	it("uses the correct collapse indicator in LTR", () => {
+		cy.get("@section").find(".section-body").should("have.class", "hide");
+		expect_indicator("chevron-right");
+
+		cy.get("@section").find(".section-head").click();
+		cy.get("@section").find(".section-body").should("not.have.class", "hide");
+		expect_indicator("chevron-down");
+
+		cy.get("@section").find(".section-head").click();
+		cy.get("@section").find(".section-body").should("have.class", "hide");
+		expect_indicator("chevron-right");
+	});
+
+	it("uses the correct collapse indicator in RTL", () => {
+		cy.window()
+			.its("frappe.user.name")
+			.then((user) => cy.set_value("User", user, { language: "ar" }))
+			.then(() => cy.new_form(parent_doctype_name))
+			.then(open_section);
+
+		cy.get("html").should("have.attr", "dir", "rtl");
+		cy.get("@section").find(".section-body").should("have.class", "hide");
+		expect_indicator("chevron-left");
+
+		cy.get("@section").find(".section-head").click();
+		cy.get("@section").find(".section-body").should("not.have.class", "hide");
+		expect_indicator("chevron-down");
+
+		cy.get("@section").find(".section-head").click();
+		cy.get("@section").find(".section-body").should("have.class", "hide");
+		expect_indicator("chevron-left");
+	});
+});

--- a/frappe/public/js/frappe/form/section.js
+++ b/frappe/public/js/frappe/form/section.js
@@ -136,7 +136,11 @@ export default class Section {
 	}
 
 	set_icon(hide) {
-		let indicator_icon = hide ? "chevron-right" : "chevron-down";
+		let indicator_icon = hide
+			? frappe.utils.is_rtl()
+				? "chevron-left"
+				: "chevron-right"
+			: "chevron-down";
 		this.indicator && this.indicator.html(frappe.utils.icon(indicator_icon, "sm", "mb-1"));
 	}
 


### PR DESCRIPTION
# fix(ui): correct collapse indicator direction in RTL

## Target branches

- `develop`: this PR applies the RTL-aware collapse indicator fix.
- `version-16`: open a separate backport PR. Version 16 uses `es-line-down` for expanded sections, so the backport should preserve that existing icon while applying the same RTL-aware collapsed direction.

## Description

Fix the collapse indicator direction for collapsible form sections in RTL interfaces.

### Problem

Collapsible form sections always displayed `chevron-right` when collapsed. This is correct for LTR interfaces but incorrect for RTL languages such as Arabic, where the collapsed indicator should point toward the left.

### Expected behavior

| Interface direction | Collapsed | Expanded |
| --- | --- | --- |
| LTR | `chevron-right` | `chevron-down` |
| RTL | `chevron-left` | `chevron-down` |

### Implementation

Reused Frappe's existing `frappe.utils.is_rtl()` helper in `Section#set_icon()` to select the appropriate collapsed icon.

Expanded sections continue to use `chevron-down` in both directions. Existing LTR behavior remains unchanged, and no broad CSS selectors or new RTL mechanisms were introduced.

For the version 16 backport, the existing expanded icon remains `es-line-down`.

### Tests

Added Cypress coverage for:

- LTR collapsed sections
- LTR expanded sections
- RTL collapsed sections
- RTL expanded sections
- Clicking the section header and verifying expand/collapse behavior
- Confirming RTL forms render with `dir="rtl"`

Available validation:

- `node --check` passed for the changed JavaScript files.
- `git diff --check` passed.

The full Cypress suite should be run before merging.

The version 16 backport should run the equivalent existing form-section collapse tests on the `version-16` branch.

### Screenshots/GIFs

Before:

```text
> إعدادات المكتب  
```

<img width="1298" height="841" alt="image" src="https://github.com/user-attachments/assets/a360585b-8c50-4da1-8ac2-0cb107fa098d" />




After:

```text
<  إعدادات المكتب
```

<img width="1407" height="758" alt="image" src="https://github.com/user-attachments/assets/e0e8a6cb-e742-4602-9558-b7077c033800" />

