### PR TITLE
fix(routing): open dashboard and report links in new tab on ctrl/cmd+…

### DIFF
--- a/cypress/integration/dashboard_links.js
+++ b/cypress/integration/dashboard_links.js
@@ -89,4 +89,66 @@ context("Dashboard links", () => {
 			'.frappe-control[data-fieldname="child_table"] .rows .data-row .col[data-fieldname="doctype_to_link"]'
 		).should("contain.text", "Test Linking");
 	});
+
+	it("Ctrl/Cmd+click on a document count link opens the list in a new tab", () => {
+		const user_route = `/desk/user/${cy.config("testUser")}`;
+		cy.visit(user_route);
+		cy.select_form_tab("Connections");
+
+		cy.window().then((win) => cy.stub(win, "open").as("windowOpen"));
+
+		// plain click: current behaviour is unaffected, navigates in the same tab
+		cy.get('.document-link[data-doctype="Contact"]').contains("Contact").click();
+		cy.location("pathname").should("eq", "/desk/contact");
+		cy.get("@windowOpen").should("not.have.been.called");
+
+		// back to the form and repeat with Ctrl/Cmd held: must open in a new tab
+		// and leave the current tab on the form (this is the fix for #17870)
+		// cy.visit does a full page load, so the stub needs to be re-attached
+		// to the fresh window.
+		cy.visit(user_route);
+		cy.select_form_tab("Connections");
+		cy.window().then((win) => cy.stub(win, "open").as("windowOpen"));
+		cy.get('.document-link[data-doctype="Contact"]')
+			.contains("Contact")
+			.click({ metaKey: true, ctrlKey: true });
+
+		cy.get("@windowOpen")
+			.should("have.been.calledOnce")
+			.its("firstCall.args.0")
+			.should("include", "/desk/contact");
+		cy.location("pathname").should("eq", user_route);
+	});
+
+	it("Ctrl/Cmd+click on a report link opens the report in a new tab", () => {
+		const user_route = `/desk/user/${cy.config("testUser")}`;
+		cy.visit(user_route);
+		cy.select_form_tab("Connections");
+
+		cy.window()
+			.its("cur_frm")
+			.then((cur_frm) => {
+				cur_frm.dashboard.data.reports = [
+					{
+						label: "Reports",
+						items: ["Website Analytics"],
+					},
+				];
+				cur_frm.dashboard.render_report_links();
+			});
+
+		cy.window().then((win) => cy.stub(win, "open").as("windowOpen"));
+
+		cy.get('.document-link[data-report="Website Analytics"]')
+			.contains("Website Analytics")
+			.click({ metaKey: true, ctrlKey: true });
+
+		cy.get("@windowOpen")
+			.should("have.been.calledOnce")
+			.its("firstCall.args.0")
+			.should("include", "query-report")
+			.and("include", "Website");
+		// current tab must stay on the form, not navigate to the report
+		cy.location("pathname").should("eq", user_route);
+	});
 });

--- a/cypress/integration/dashboard_links.js
+++ b/cypress/integration/dashboard_links.js
@@ -99,7 +99,7 @@ context("Dashboard links", () => {
 
 		// plain click: current behaviour is unaffected, navigates in the same tab
 		cy.get('.document-link[data-doctype="Contact"]').contains("Contact").click();
-		cy.location("pathname").should("eq", "/desk/contact");
+		cy.location("pathname").should("eq", "/desk/contact/view/list");
 		cy.get("@windowOpen").should("not.have.been.called");
 
 		// back to the form and repeat with Ctrl/Cmd held: must open in a new tab
@@ -127,14 +127,14 @@ context("Dashboard links", () => {
 
 		cy.window()
 			.its("cur_frm")
-			.then((cur_frm) => {
-				cur_frm.dashboard.data.reports = [
+			.then((frm) => {
+				frm.dashboard.data.reports = [
 					{
 						label: "Reports",
 						items: ["Website Analytics"],
 					},
 				];
-				cur_frm.dashboard.render_report_links();
+				frm.dashboard.render_report_links();
 			});
 
 		cy.window().then((win) => cy.stub(win, "open").as("windowOpen"));

--- a/cypress/integration/report_link_onclick_new_tab.js
+++ b/cypress/integration/report_link_onclick_new_tab.js
@@ -1,0 +1,50 @@
+context("Report cell link_onclick opens in new tab (#17870)", () => {
+	// frappe.form.formatters.Link renders `<a onclick="...">` for any report
+	// or list column that sets `column.link_onclick` (e.g. ERPNext's
+	// financial statement account-name drilldown links). This is the single
+	// shared renderer every such link goes through, in any app, so testing
+	// it here covers all of them without needing a real report/app.
+	const render_link_onclick_cell = (win) => {
+		const docfield = {
+			options: "ToDo",
+			link_onclick: "frappe.set_route('List', 'ToDo', 'Report')",
+		};
+		const html = win.frappe.form.formatters.Link("Test Cell", docfield, {}, {});
+		return win.$(html).appendTo(win.document.body);
+	};
+
+	before(() => {
+		cy.login();
+	});
+
+	it("plain click still navigates in the same tab", () => {
+		cy.visit("/desk/todo");
+
+		cy.window().then((win) => {
+			cy.stub(win, "open").as("windowOpen");
+			cy.wrap(render_link_onclick_cell(win)).as("cell");
+		});
+
+		cy.get("@cell").click();
+		cy.location("pathname").should("eq", "/desk/todo/view/report");
+		cy.get("@windowOpen").should("not.have.been.called");
+	});
+
+	it("Ctrl/Cmd+click opens the link in a new tab instead", () => {
+		cy.visit("/desk/todo");
+
+		cy.window().then((win) => {
+			cy.stub(win, "open").as("windowOpen");
+			cy.wrap(render_link_onclick_cell(win)).as("cell");
+		});
+
+		cy.get("@cell").click({ metaKey: true, ctrlKey: true });
+
+		cy.get("@windowOpen")
+			.should("have.been.calledOnce")
+			.its("firstCall.args.0")
+			.should("include", "/desk/todo/view/report");
+		// current tab must stay on the list, not follow the link
+		cy.location("pathname").should("eq", "/desk/todo");
+	});
+});

--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -331,13 +331,13 @@ frappe.ui.form.Dashboard = class FormDashboard {
 		this.render_report_links();
 
 		// bind links
-		transactions_area_body.find(".badge-link").on("click", function () {
-			me.open_document_list($(this).closest(".document-link"));
+		transactions_area_body.find(".badge-link").on("click", function (e) {
+			me.open_document_list($(this).closest(".document-link"), false, e);
 		});
 
 		// bind open notifications
-		transactions_area_body.find(".open-notification").on("click", function () {
-			me.open_document_list($(this).parent(), true);
+		transactions_area_body.find(".open-notification").on("click", function (e) {
+			me.open_document_list($(this).parent(), true, e);
 		});
 
 		// bind new
@@ -356,12 +356,12 @@ frappe.ui.form.Dashboard = class FormDashboard {
 			$(frappe.render_template("report_links", this.data)).appendTo(parent);
 			// bind reports
 			parent.find(".report-link").on("click", (e) => {
-				this.open_report($(e.target).parent());
+				this.open_report($(e.target).parent(), e);
 			});
 		}
 	}
 
-	open_report($link) {
+	open_report($link, event) {
 		let report = $link.attr("data-report");
 
 		let fieldname = this.data.non_standard_fieldnames
@@ -370,10 +370,11 @@ frappe.ui.form.Dashboard = class FormDashboard {
 
 		frappe.provide("frappe.route_options");
 		frappe.route_options[fieldname] = this.frm.doc.name;
+		this.set_open_in_new_tab(event);
 		frappe.set_route("query-report", report);
 	}
 
-	open_document_list($link, show_open) {
+	open_document_list($link, show_open, event) {
 		// show document list with filters
 		let doctype = $link.attr("data-doctype"),
 			names = $link.attr("data-names") || [];
@@ -399,7 +400,18 @@ frappe.ui.form.Dashboard = class FormDashboard {
 			}
 		}
 
+		this.set_open_in_new_tab(event);
 		frappe.set_route("List", doctype, "List");
+	}
+
+	set_open_in_new_tab(event) {
+		// Cmd/Ctrl+click on a dashboard link (transaction count, report link, etc.)
+		// should open the route in a new tab instead of navigating away from the
+		// current form. Mirrors the same modifier-key check used elsewhere for
+		// JS-driven navigation (e.g. quick_list_widget.js, awesome_bar.js).
+		if (event && (event.ctrlKey || event.metaKey)) {
+			frappe.open_in_new_tab = true;
+		}
 	}
 
 	get_document_filter(doctype, fieldname) {

--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -197,8 +197,20 @@ frappe.form.formatters = {
 			return value.substring(1, value.length - 1);
 		}
 		if (docfield && docfield.link_onclick) {
+			// Cmd/Ctrl+click should open the destination in a new tab instead of
+			// navigating away from the current page. `link_onclick` is arbitrary,
+			// report-authored code that (by convention) ends in frappe.set_route(),
+			// so instead of parsing a URL out of it, flip the same
+			// frappe.open_in_new_tab flag set_route() already honours, before that
+			// code runs. `event` here is the implicit Event object HTML provides
+			// to inline onclick="..." handlers. This fixes every report/list cell
+			// that sets `link_onclick`, in any app, with no changes on their end.
+			const onclick =
+				"if(event.ctrlKey||event.metaKey){frappe.open_in_new_tab=true;}" +
+				docfield.link_onclick.replace(/"/g, "&quot;") +
+				"; return false;";
 			return repl('<a onclick="%(onclick)s" href="#">%(value)s</a>', {
-				onclick: docfield.link_onclick.replace(/"/g, "&quot;") + "; return false;",
+				onclick: onclick,
 				value: value,
 			});
 		} else if (docfield && doctype) {


### PR DESCRIPTION
…click

Form Dashboard links (transaction counts, report shortcuts) and report/list cells that set  (e.g. drilldown links in financial reports) always navigated in the current tab, ignoring Ctrl/Cmd — both render as JS-driven <a> tags with no real href for the browser to act on.

- dashboard.js: pass the click event through to open_document_list()/ open_report() and set frappe.open_in_new_tab when held.
- formatters.js: same check in the one shared Link cell renderer every link_onclick column goes through, in any app — fixes financial reports and similar report links with no changes needed on their end.

Both reuse the frappe.open_in_new_tab flag frappe.set_route() already honours; plain clicks are unaffected.

Fixes #17870 