### PR TITLE
fix: link to the docs from the timeout error popups

### DIFF
--- a/cypress/integration/timeout_doc_links.js
+++ b/cypress/integration/timeout_doc_links.js
@@ -12,7 +12,12 @@ context("Timeout error popups", () => {
 
 		cy.window()
 			.its("frappe")
-			.then((frappe) => frappe.call("frappe.client.get_count", { doctype: "ToDo" }));
+			.then((frappe) => {
+				// the request is expected to fail, so the returned jqXHR must not be
+				// returned to cypress: it would reject and fail the test before the
+				// popup is asserted
+				frappe.call("frappe.client.get_count", { doctype: "ToDo" });
+			});
 		cy.wait("@timed_out");
 
 		cy.get(".modal-title").should("contain", "Request Timed Out");
@@ -34,7 +39,12 @@ context("Timeout error popups", () => {
 
 		cy.window()
 			.its("frappe")
-			.then((frappe) => frappe.call("frappe.client.get_count", { doctype: "ToDo" }));
+			.then((frappe) => {
+				// the request is expected to fail, so the returned jqXHR must not be
+				// returned to cypress: it would reject and fail the test before the
+				// popup is asserted
+				frappe.call("frappe.client.get_count", { doctype: "ToDo" });
+			});
 		cy.wait("@query_timed_out");
 
 		cy.get(".modal-title").should("contain", "Request Timeout");

--- a/cypress/integration/timeout_doc_links.js
+++ b/cypress/integration/timeout_doc_links.js
@@ -21,6 +21,7 @@ context("Timeout error popups", () => {
 		cy.wait("@timed_out");
 
 		cy.get(".modal-title").should("contain", "Request Timed Out");
+		cy.get(".msgprint").should("contain", "HTTP timeout of the bench");
 		cy.get(".msgprint")
 			.find("a")
 			.should("have.attr", "href")
@@ -49,6 +50,7 @@ context("Timeout error popups", () => {
 
 		cy.get(".modal-title").should("contain", "Request Timeout");
 		cy.get(".msgprint").should("contain", "Server was too busy");
+		cy.get(".msgprint").should("contain", "waited too long for a row lock");
 		cy.get(".msgprint")
 			.find("a")
 			.should("have.attr", "href")

--- a/cypress/integration/timeout_doc_links.js
+++ b/cypress/integration/timeout_doc_links.js
@@ -1,0 +1,47 @@
+context("Timeout error popups", () => {
+	before(() => {
+		cy.login();
+	});
+
+	it("links to the documentation on a gateway timeout", () => {
+		cy.visit("/app/todo");
+		cy.intercept("POST", "/api/method/frappe.client.get_count", {
+			statusCode: 504,
+			body: {},
+		}).as("timed_out");
+
+		cy.window()
+			.its("frappe")
+			.then((frappe) => frappe.call("frappe.client.get_count", { doctype: "ToDo" }));
+		cy.wait("@timed_out");
+
+		cy.get(".modal-title").should("contain", "Request Timed Out");
+		cy.get(".msgprint")
+			.find("a")
+			.should("have.attr", "href")
+			.and(
+				"include",
+				"docs.frappe.io/cloud/private-benches/common-issues/request-timed-out"
+			);
+	});
+
+	it("links to the documentation when a query times out", () => {
+		cy.visit("/app/todo");
+		cy.intercept("POST", "/api/method/frappe.client.get_count", {
+			statusCode: 500,
+			body: { exception: "frappe.exceptions.QueryTimeoutError: Query timed out" },
+		}).as("query_timed_out");
+
+		cy.window()
+			.its("frappe")
+			.then((frappe) => frappe.call("frappe.client.get_count", { doctype: "ToDo" }));
+		cy.wait("@query_timed_out");
+
+		cy.get(".modal-title").should("contain", "Request Timeout");
+		cy.get(".msgprint").should("contain", "Server was too busy");
+		cy.get(".msgprint")
+			.find("a")
+			.should("have.attr", "href")
+			.and("include", "request-timeout-server-was-too-busy-to-process-this-request");
+	});
+});

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -241,8 +241,12 @@ frappe.request.call = function (opts) {
 				title: __("Request Timed Out"),
 				indicator: "red",
 				message:
-					__("The server took too long to respond and stopped this request.") +
-					"<br>" +
+					__(
+						"The server did not respond in the permitted time. The server stopped this request."
+					) +
+					`<p class="text-muted small">${__(
+						"This happens when one action takes longer than the HTTP timeout of the bench."
+					)}</p>` +
 					`<a href="https://docs.frappe.io/cloud/private-benches/common-issues/request-timed-out" target="_blank" rel="noopener noreferrer">${__(
 						"Read the documentation to know more"
 					)}</a>`,
@@ -263,7 +267,9 @@ frappe.request.call = function (opts) {
 				indicator: "red",
 				message:
 					__("Server was too busy to process this request. Please try again.") +
-					"<br>" +
+					`<p class="text-muted small">${__(
+						"A database query waited too long for a row lock from a different transaction."
+					)}</p>` +
 					`<a href="https://docs.frappe.io/cloud/site/common-issues/request-timeout-server-was-too-busy-to-process-this-request" target="_blank" rel="noopener noreferrer">${__(
 						"Read the documentation to know more"
 					)}</a>`,

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -237,7 +237,16 @@ frappe.request.call = function (opts) {
 			}
 		},
 		504: function (xhr) {
-			frappe.msgprint(__("Request Timed Out"));
+			frappe.msgprint({
+				title: __("Request Timed Out"),
+				indicator: "red",
+				message:
+					__("The server took too long to respond and stopped this request.") +
+					"<br>" +
+					`<a href="https://docs.frappe.io/cloud/private-benches/common-issues/request-timed-out" target="_blank" rel="noopener noreferrer">${__(
+						"Read the documentation to know more"
+					)}</a>`,
+			});
 			opts.error_callback && opts.error_callback();
 		},
 		502: function (xhr) {
@@ -252,7 +261,12 @@ frappe.request.call = function (opts) {
 			frappe.msgprint({
 				title: __("Request Timeout"),
 				indicator: "red",
-				message: __("Server was too busy to process this request. Please try again."),
+				message:
+					__("Server was too busy to process this request. Please try again.") +
+					"<br>" +
+					`<a href="https://docs.frappe.io/cloud/site/common-issues/request-timeout-server-was-too-busy-to-process-this-request" target="_blank" rel="noopener noreferrer">${__(
+						"Read the documentation to know more"
+					)}</a>`,
 			});
 		},
 		QueryDeadlockError: function () {

--- a/frappe/tests/test_doc_links.py
+++ b/frappe/tests/test_doc_links.py
@@ -1,0 +1,38 @@
+import re
+import unittest
+from pathlib import Path
+
+import requests
+
+import frappe
+
+# Files that embed documentation URLs in user-facing error messages. A dead link here
+# is worse than no link: the user hits an error, clicks for help, and gets a 404.
+SOURCES_WITH_DOC_LINKS = ("public/js/frappe/request.js",)
+
+DOC_LINK_PATTERN = re.compile(r"https://docs\.frappe\.io/[^\s\"'`<>)]+")
+
+
+class TestDocumentationLinks(unittest.TestCase):
+	def test_doc_links_in_error_messages_resolve(self):
+		app_path = Path(frappe.get_app_path("frappe"))
+
+		urls = set()
+		for source in SOURCES_WITH_DOC_LINKS:
+			urls.update(DOC_LINK_PATTERN.findall((app_path / source).read_text()))
+
+		self.assertTrue(urls, "no documentation links found, has the pattern or path drifted?")
+
+		for url in sorted(urls):
+			with self.subTest(url=url):
+				try:
+					# redirects are fine, docs pages get reorganised; a 404 is not
+					response = requests.get(url, timeout=30, allow_redirects=True)
+				except requests.RequestException as e:
+					raise unittest.SkipTest(f"could not reach {url}: {e}")
+
+				self.assertLess(
+					response.status_code,
+					400,
+					f"{url} is dead (HTTP {response.status_code}), update or remove the link",
+				)


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

The `Request Timed Out` (HTTP 504) and `Request Timeout / Server was too busy to process this request` (`QueryTimeoutError`) popups in `frappe/public/js/frappe/request.js` name the error but do not say what happened or what to do about it. Both now carry a one line explanation of the cause and a link to the documentation page that covers the fix.

The two errors have different causes, so they link to different pages:

| Popup | Cause | Links to |
| --- | --- | --- |
| `Request Timed Out` (504) | HTTP timeout: the request ran past the gateway timeout | [request-timed-out](https://docs.frappe.io/cloud/private-benches/common-issues/request-timed-out) — raise the HTTP timeout, move the work to a background job |
| `Request Timeout` (`QueryTimeoutError`) | Database query timeout, usually lock contention | [request-timeout-server-was-too-busy…](https://docs.frappe.io/cloud/site/common-issues/request-timeout-server-was-too-busy-to-process-this-request) — watch the processlist, check the slow query log |

I read both pages to confirm the mapping. The first is about the HTTP timeout and the 2 minute default; the second is about SQL queries timing out on row locks (MariaDB 1205), which is exactly what raises `QueryTimeoutError`.

The 504 popup also gets a message body. It previously passed the error name as the body text, and that string is now the dialog title, so the body would otherwise have been empty.

Both messages follow the existing pattern in `frappe/utils/safe_exec.py`: the message and the call to action are separate translatable strings, the markup stays outside `__()`, and the link carries `rel="noopener noreferrer"`. The call to action reuses the existing `Read the documentation to know more` string, so it ships already translated. The wording of `Server was too busy to process this request. Please try again.` is deliberately left alone: it is translated in 39 locales and it is the title of the docs page users search for.

> Screenshots/GIFs

<img width="575" alt="Request Timed Out popup" src="https://raw.githubusercontent.com/balamurali27/frappe/pr-42043-screenshots/screenshots/504-request-timed-out.png">

<img width="575" alt="Request Timeout popup" src="https://raw.githubusercontent.com/balamurali27/frappe/pr-42043-screenshots/screenshots/query-timeout-error.png">

## Tests

- `frappe/tests/test_doc_links.py` requests every `docs.frappe.io` URL found in `request.js` and fails on 4xx/5xx, following redirects. A renamed docs page then breaks the build instead of sending users to a 404. It raises `SkipTest` when the network is unreachable, so it does not false-fail without egress. Verified it fails as intended by pointing it at a mutated URL: `AssertionError: 404 not less than 400`.
- `cypress/integration/timeout_doc_links.js` stubs both failures with `cy.intercept` and asserts each popup shows the right title, the right explanation, and the right `href`. Passing locally against a dev bench, and the screenshots above are from that run.

## Notes for maintainers

**These pages live under `docs.frappe.io/cloud`.** A self hosted user who hits a 504 is now pointed at a page written for Frappe Cloud private benches. The remediation itself is generic (bench HTTP timeout, background jobs, slow query log), but if you would rather these links were gated on Frappe Cloud, or pointed at a framework page instead, say so and I will change it.

**One docs page goes stale when this merges.** [request-timed-out](https://docs.frappe.io/cloud/private-benches/common-issues/request-timed-out) currently describes the dialog as title `Message`, body `Request Timed Out`, which matches today's `frappe.msgprint(__("Request Timed Out"))`. After this change the title is `Request Timed Out` and the body explains the cause. Worth a small docs update.

**`QueryDeadlockError`, the 502 handler, and the 417 transaction conflict popup are still bare.** I stopped at the two popups that have a matching docs page. Happy to extend it if you want them covered too.
