### PR TITLE
fix: scope child item selection to filtered parents

### DIFF
--- a/cypress/integration/multi_select_dialog.js
+++ b/cypress/integration/multi_select_dialog.js
@@ -104,4 +104,16 @@ context("MultiSelectDialog", () => {
 				}
 			});
 	});
+
+	it("scopes child rows to filtered parents", () => {
+		// search term that matches no parent Contact (child selection already enabled)
+		cy.get_open_dialog()
+			.get(`.frappe-control[data-fieldname="search_term"]`)
+			.find('input[data-fieldname="search_term"]')
+			.clear()
+			.type("NoSuchContactXYZ", { delay: 200 });
+
+		// no matching parent => child table must be empty, not every parent's rows
+		cy.get_open_dialog().get(".datatable .dt-scrollable .dt-row").should("not.exist");
+	});
 });

--- a/frappe/public/js/frappe/form/multi_select_dialog.js
+++ b/frappe/public/js/frappe/form/multi_select_dialog.js
@@ -661,9 +661,8 @@ frappe.ui.form.MultiSelectDialog = class MultiSelectDialog {
 
 	async add_parent_filters(filters) {
 		const parent_names = await this.get_filtered_parents_for_child_search();
-		if (parent_names.length) {
-			filters.push(["parent", "in", parent_names]);
-		}
+		// empty list must match nothing, else child search leaks every parent's rows
+		filters.push(["parent", "in", parent_names]);
 	}
 
 	add_custom_child_filters(filters) {


### PR DESCRIPTION
https://support.frappe.io/helpdesk/tickets/76751?view=VIEW-HD+Ticket-70177

Scope the child item selection table to the filtered parents so it no longer leaks every parent's rows when the setter filter matches nothing.

<img width="890" height="512" alt="Screenshot 2026-08-24 at 4 11 09 PM" src="https://github.com/user-attachments/assets/72f8c332-d082-4995-8755-dd72ca079522" />
<img width="876" height="772" alt="Screenshot 2026-08-24 at 4 11 15 PM" src="https://github.com/user-attachments/assets/b714eb73-cfa1-445d-85ae-03b6de8217a2" />
<img width="455" height="554" alt="Screenshot 2026-08-24 at 4 11 24 PM" src="https://github.com/user-attachments/assets/3eb05e4f-566c-4386-8466-917dc0c57549" />
