### PR TITLE
fix: don't import `frappe.boot` from the query layer (breaks backgrou…

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -32,6 +32,7 @@ from frappe.model.base_document import get_controller
 from frappe.utils import add_user_info, get_system_timezone
 from frappe.utils.caching import redis_cache
 from frappe.utils.change_log import get_versions
+from frappe.utils.data import get_additional_filters_from_hooks
 from frappe.website.doctype.web_page_view.web_page_view import is_tracking_enabled
 
 
@@ -512,16 +513,6 @@ def get_link_preview_doctypes():
 			link_preview_doctypes.append(custom.doc_type)
 
 	return filter_out_disabled_doctypes(link_preview_doctypes)
-
-
-def get_additional_filters_from_hooks():
-	filter_config = frappe._dict()
-	filter_hooks = frappe.get_hooks("filters_config")
-	for hook in filter_hooks:
-		filter_config.update(frappe.get_attr(hook)())
-
-	return filter_config
-
 
 def add_layouts(bootinfo):
 	bootinfo.doctype_layouts = frappe.get_all(

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -10,7 +10,6 @@ from pypika.terms import AggregateFunction, ArithmeticExpression, Star, Term, Va
 
 import frappe
 from frappe import _
-from frappe.boot import get_additional_filters_from_hooks
 from frappe.database.operator_map import NESTED_SET_OPERATORS, OPERATOR_MAP
 from frappe.database.utils import (
 	DefaultOrderBy,
@@ -25,6 +24,7 @@ from frappe.model.base_document import DOCTYPES_FOR_DOCTYPE
 from frappe.model.document import Document
 from frappe.query_builder import Criterion, Field, Order, functions
 from frappe.query_builder.custom import Month, MonthName, Quarter, Year
+from frappe.utils.data import get_additional_filters_from_hooks
 
 CORE_DOCTYPES = DOCTYPES_FOR_DOCTYPE | frozenset(
 	(

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -36,7 +36,11 @@ from frappe.utils import (
 	get_time,
 	get_timespan_date_range,
 )
-from frappe.utils.data import convert_type_for_between_filters, sbool
+from frappe.utils.data import (
+	convert_type_for_between_filters,
+	get_additional_filters_from_hooks,
+	sbool,
+)
 
 _convert_type_for_between_filters = convert_type_for_between_filters  # bw compatibility
 
@@ -773,8 +777,6 @@ from {tables}
 		filters and the exists candidates grouped by child doctype, both as
 		(filter, parsed filter) pairs so no filter is parsed twice.
 		"""
-		from frappe.boot import get_additional_filters_from_hooks
-
 		joined: list = []
 		exists_groups: dict[str, list] = {}
 		if not filters:
@@ -954,11 +956,6 @@ from {tables}
 
 		ifnull(`tabDocType`.`fieldname`, fallback) operator "value"
 		"""
-
-		# TODO: refactor
-
-		from frappe.boot import get_additional_filters_from_hooks
-
 		additional_filters_config = get_additional_filters_from_hooks()
 		f: FilterTuple = (
 			parsed if parsed is not None else get_filter(self.doctype, ft, additional_filters_config)

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -4,6 +4,7 @@
 import io
 import json
 import os
+import subprocess
 import sys
 from datetime import UTC, date, datetime, time, timedelta, timezone
 from decimal import ROUND_HALF_UP, Decimal, localcontext
@@ -66,6 +67,7 @@ from frappe.utils.data import (
 	evaluate_filters,
 	expand_relative_urls,
 	format_duration,
+	get_additional_filters_from_hooks,
 	get_datetime,
 	get_first_day_of_week,
 	get_time,
@@ -107,6 +109,62 @@ class Capturing(list):
 		del self._stringio
 		sys.stdout = self._stdout
 
+class TestAdditionalFiltersFromHooks(UnitTestCase):
+	def test_query_layer_does_not_import_boot(self):
+		"""`frappe.database.query` must not pull in `frappe.boot` at import time.
+
+		`frappe.boot` is a desk-layer module that imports email, desk and
+		integrations at module scope. Importing it from the query layer creates a
+		cycle that only bites on a cold import in the wrong order, which is what
+		background workers do: every job died with `ImportError: cannot import
+		name 'convert_type_for_between_filters' from 'frappe.utils.data'`.
+
+		This has to run in a fresh interpreter. Inside the test process every
+		module is already in `sys.modules`, so the cycle cannot reproduce and an
+		in-process assertion would pass whether or not the bug is present.
+		"""
+		result = subprocess.run(
+			[
+				sys.executable,
+				"-c",
+				"import sys, frappe.database.query;"
+				" raise SystemExit('frappe.boot' in sys.modules)",
+			],
+			capture_output=True,
+			text=True,
+		)
+		self.assertEqual(
+			result.returncode,
+			0,
+			"frappe.database.query imported frappe.boot at module scope"
+			f"\n{result.stdout}{result.stderr}",
+		)
+
+	def test_importable_from_its_old_home(self):
+		"""`frappe.boot` re-exports it, so existing imports keep working."""
+		from frappe.boot import get_additional_filters_from_hooks as from_boot
+		from frappe.utils.data import get_additional_filters_from_hooks as from_utils
+
+		self.assertIs(from_boot, from_utils)
+
+	def test_returns_operators_contributed_by_hooks(self):
+		"""The `filters_config` hook is read and merged into one map."""
+		config = get_additional_filters_from_hooks()
+		self.assertIsInstance(config, dict)
+
+		with patch.object(
+			frappe,
+			"get_hooks",
+			return_value=["frappe.tests.test_utils._sample_filters_config"],
+		):
+			self.assertEqual(
+				get_additional_filters_from_hooks(),
+				{"sample operator": {"label": "Sample"}},
+			)
+
+
+def _sample_filters_config():
+	return {"sample operator": {"label": "Sample"}}
 
 class TestFilters(IntegrationTestCase):
 	def test_simple_dict(self):

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -2353,6 +2353,23 @@ def compare(val1: Any, condition: str, val2: Any, fieldtype: str | None = None) 
 	return False
 
 
+def get_additional_filters_from_hooks():
+	"""Custom filter operators contributed by apps through the `filters_config` hook.
+
+	Sits beside `get_filter`, which takes this map as its `filters_config`
+	argument, rather than in `frappe.boot`. `frappe.boot` is a desk-layer module
+	that imports email, desk and integrations at module scope, so reaching up to
+	it from the query layer put `frappe.database.query` inside an import cycle
+	that broke background workers.
+	"""
+	filter_config = frappe._dict()
+	filter_hooks = frappe.get_hooks("filters_config")
+	for hook in filter_hooks:
+		filter_config.update(frappe.get_attr(hook)())
+
+	return filter_config
+
+
 def get_filter(doctype: str, filters: FilterSignature, filters_config=None) -> "frappe._dict":
 	"""Return a `_dict` like:
 


### PR DESCRIPTION
<!--
Target branch: develop
Title: fix: don't import frappe.boot from the query layer (breaks background workers)
Replace #XXXX below with the issue number.
-->

closes #XXXX

## What this solves

`frappe/database/query.py` imports `frappe.boot` at module scope for a single six-line helper,
`get_additional_filters_from_hooks()`. `frappe.boot` is a desk-layer module with 22 module-level
imports (`email.inbox`, `desk.form.load`, `desk.desk_views`, `integrations.*`), so a bottom-layer
module reaching up to it creates an import cycle:

```
frappe.query_builder.utils.get_query()
  └─ frappe.database.query          (lazy, inside get_query)
       └─ frappe.boot               ← module scope: the bad edge
            └─ frappe.email.inbox → frappe.client → frappe.desk.search
                 └─ frappe.model.db_query
                      └─ frappe.utils.data   ← still partially initialised
```

Web and console requests warm these modules in an order that hides it. **Background workers do not.**
A worker's first action is deserialising a job, which calls `frappe.get_doc(dict)` → `get_controller`
→ `frappe.db.get_value` → `frappe.qb.get_query`, entering the cycle cold. Every job then dies with:

```
ImportError: cannot import name 'convert_type_for_between_filters' from 'frappe.utils.data'
```

### Why this is worse than "workers are down"

Because no job completes, **no `queue_action` lock is ever released**. Any app whose `fixtures`
include a DocType that calls `queue_action` in `on_update` — Frappe's own **Module Profile** does —
leaves a permanent lock behind, and `bench migrate` starts failing:

```
frappe.exceptions.DocumentLockedError: This document is currently locked and queued for execution.
```

On the affected bench that was 16 dead jobs, 30 stale lock files, and `bench migrate` exiting 1. The
failure surfaces as a migration problem several layers from its cause, which makes it easy to
misattribute to whichever app happens to own the locked fixture.

## The change

`get_additional_filters_from_hooks()` uses nothing from `frappe.boot` — only `frappe._dict`,
`frappe.get_hooks` and `frappe.get_attr`. It is in `boot.py` by historical accident.

It moves to **`frappe/utils/data.py`, directly above `get_filter()`**, its only consumer:

```python
additional_filters_config = get_additional_filters_from_hooks()
f = get_filter(self.doctype, ft, additional_filters_config)   # get_filter(..., filters_config=...)
```

That module already owns the filter-helper family (`evaluate_filters`, `get_filter`,
`make_filter_tuple`, `make_filter_dict`), and their tests already live in `frappe/tests/test_utils.py`
— so this joins an existing set rather than introducing a new concern in a foreign module.

`frappe.boot` imports it from the new location, so `from frappe.boot import
get_additional_filters_from_hooks` keeps working and `bootinfo.additional_filters_config` is
unchanged.

Also removes the lazy import and its `# TODO: refactor` in `frappe/model/db_query.py`, which was this
same problem already worked around in the sibling module.

**No behaviour change** — a move plus import updates.

## Tests

New `TestAdditionalFiltersFromHooks` in `frappe/tests/test_utils.py`:

- **`test_query_layer_does_not_import_boot`** — the regression guard. Spawns a fresh interpreter,
  imports `frappe.database.query`, asserts `frappe.boot` is not in `sys.modules`. It has to run in a
  subprocess: inside the test process every module is already loaded, so the cycle cannot reproduce
  and an in-process assertion would pass with or without the bug.
- **`test_importable_from_its_old_home`** — the `frappe.boot` re-export is the same object.
- **`test_returns_operators_contributed_by_hooks`** — the `filters_config` hook is read and merged.

The guard was checked against unpatched code: it fails there (`'frappe.boot' in sys.modules` is
`True`) and passes with the fix.

## Screenshots / output

This is an import-layering fix, so the evidence is terminal output rather than UI.

**Reproducer — no bench state needed:**

```console
$ python -c "import sys, frappe.database.query; print('frappe.boot' in sys.modules)"
True     # before
False    # after
```

**Worker before the fix** (`logs/worker.error.log`):

```
  File "frappe/desk/search.py", line 13, in <module>
    from frappe.model.db_query import get_order_by
  File "frappe/model/db_query.py", line 39, in <module>
    from frappe.utils.data import convert_type_for_between_filters, sbool
ImportError: cannot import name 'convert_type_for_between_filters' from 'frappe.utils.data'
```

**`bench migrate` before the fix:**

```console
$ bench --site <site> migrate; echo "exit=$?"
frappe.exceptions.DocumentLockedError: This document is currently locked and queued for execution.
exit=1
```

**After:**

| | Before | After |
| --- | --- | --- |
| `bench migrate` | exit 1 | exit 0 |
| Stale `Module Profile` locks | 30 | 0 |
| Background jobs | 16 failed, none completing | complete, 0 new failures |

Also verified: all four import paths (`frappe.boot`, `frappe.utils.data`, `frappe.database.query`,
`frappe.model.db_query`) resolve to the same object, and the `filters_config` hook still works end to
end — ERPNext's `fiscal year` custom operator returns rows through both callers, `frappe.get_list`
and `frappe.qb.get_query`.

## Checklist notes

- **Target branch:** `develop`. Found on **v16.31.0** (`6a329d0684`); worth a backport label if v16 is
  still receiving fixes.
- **Conventional commit:** `fix: don't import frappe.boot from the query layer (breaks background
  workers)`.
- **Tests:** the three new tests are `UnitTestCase` and pass locally, along with the rest of
  `frappe.tests.test_utils`'s unit tests. `ruff check` is clean on all touched files. I could **not**
  run the integration suite locally — it needs a dedicated test site, and `frappe.tests.test_db_query`
  additionally fails on that bench with `OutgoingEmailError: Email Account not setup`, unrelated to
  this change. Relying on CI for those.
- **Docs:** no user-facing behaviour change, so no documentation update.
- **Server-side:** yes, entirely.
