### PR TITLE
fix: cancel linked documents in dependency order

### DIFF
--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -462,16 +462,21 @@ def capture_pending_side_effects() -> dict:
 	return {
 		"before_commit": len(frappe.db.before_commit),
 		"after_commit": len(frappe.db.after_commit),
+		"before_rollback": len(frappe.db.before_rollback),
+		"after_rollback": len(frappe.db.after_rollback),
 		"realtime_log": len(frappe.local._realtime_log) if hasattr(frappe.local, "_realtime_log") else None,
 		"webhook_queue": len(getattr(frappe.local, "_webhook_queue", None) or []),
 	}
 
 
 def discard_side_effects_since(counts: dict):
-	"""Drop side effects queued after capture: the commit hooks, realtime events
-	and webhook executions of a rolled-back attempt would otherwise still run."""
+	"""Drop side effects queued after capture: the commit and rollback hooks,
+	realtime events and webhook executions of a rolled-back attempt would
+	otherwise still run."""
 	frappe.db.before_commit.truncate(counts["before_commit"])
 	frappe.db.after_commit.truncate(counts["after_commit"])
+	frappe.db.before_rollback.truncate(counts["before_rollback"])
+	frappe.db.after_rollback.truncate(counts["after_rollback"])
 
 	if counts["realtime_log"] is None:
 		if hasattr(frappe.local, "_realtime_log"):

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -50,6 +50,10 @@ def get_submitted_linked_docs(
 	for dt, names in visited_documents.items():
 		docs.extend([{"doctype": dt, "name": name, "docstatus": 1} for name in names])
 
+	# Deepest documents first, so referencing documents get cancelled before
+	# the documents they reference.
+	docs.sort(key=lambda doc: tree.depth_by_document[doc["doctype"], doc["name"]], reverse=True)
+
 	return {"docs": docs, "count": len(docs)}
 
 
@@ -69,6 +73,7 @@ class SubmittableDocumentTree:
 		# Documents those are yet to be visited for linked documents.
 		self.to_be_visited_documents = {doctype: [name]}
 		self.visited_documents = defaultdict(list)
+		self.depth_by_document = {(doctype, name): 0}
 
 		self._submittable_doctypes = None  # All submittable doctypes in the system
 		self._references_across_doctypes = None  # doctype wise links/references
@@ -77,23 +82,22 @@ class SubmittableDocumentTree:
 		"""Get all nodes of a tree except the root node (all the nested submitted
 		documents those are present in referencing tables dependent tables).
 		"""
+		depth = 0
 		while self.to_be_visited_documents:
+			depth += 1
+			current_level = self.visit_current_level(ignore_doctypes_on_cancel_all)
 			next_level_children = defaultdict(list)
-			for parent_dt in list(self.to_be_visited_documents):
-				parent_docs = self.to_be_visited_documents.get(parent_dt)
-				if not parent_docs or (
-					ignore_doctypes_on_cancel_all and parent_dt in ignore_doctypes_on_cancel_all
-				):
-					del self.to_be_visited_documents[parent_dt]
-					continue
-
+			for parent_dt, parent_docs in current_level.items():
 				child_docs = self.get_next_level_children(parent_dt, parent_docs)
-				self.visited_documents[parent_dt].extend(parent_docs)
 				for linked_dt, linked_names in child_docs.items():
-					not_visited_child_docs = set(linked_names) - set(
-						self.visited_documents.get(linked_dt, [])
+					new_child_docs = (
+						set(linked_names)
+						- set(self.visited_documents.get(linked_dt, []))
+						- set(next_level_children[linked_dt])
 					)
-					next_level_children[linked_dt].extend(not_visited_child_docs)
+					next_level_children[linked_dt].extend(new_child_docs)
+					for linked_name in new_child_docs:
+						self.depth_by_document[(linked_dt, linked_name)] = depth
 
 			self.to_be_visited_documents = next_level_children
 
@@ -105,6 +109,19 @@ class SubmittableDocumentTree:
 			"root document must be excluded from linked children"
 		)
 		return self.visited_documents
+
+	def visit_current_level(self, ignore_doctypes_on_cancel_all):
+		"""Mark all documents of the current level as visited before expanding them,
+		so a document referenced from its own level is not visited twice."""
+		current_level = {}
+		for parent_dt, parent_docs in self.to_be_visited_documents.items():
+			if not parent_docs or (
+				ignore_doctypes_on_cancel_all and parent_dt in ignore_doctypes_on_cancel_all
+			):
+				continue
+			current_level[parent_dt] = parent_docs
+			self.visited_documents[parent_dt].extend(parent_docs)
+		return current_level
 
 	def get_next_level_children(self, parent_dt, parent_names):
 		"""Get immediate children of a Node(parent_dt, parent_names)"""
@@ -372,6 +389,9 @@ def cancel_all_linked_docs(docs: str | list, ignore_doctypes_on_cancel_all: str 
 	"""
 	Cancel all linked doctype, optionally ignore doctypes specified in a list.
 
+	A document that other submitted documents still reference is deferred and
+	retried after the rest, so callers need not pass docs in dependency order.
+
 	Arguments:
 	        docs (json str) - It contains list of dictionaries of a linked documents.
 	        ignore_doctypes_on_cancel_all (list) - List of doctypes to ignore while cancelling.
@@ -381,11 +401,51 @@ def cancel_all_linked_docs(docs: str | list, ignore_doctypes_on_cancel_all: str 
 
 	docs = frappe.parse_json(docs)
 	ignore_doctypes_on_cancel_all = frappe.parse_json(ignore_doctypes_on_cancel_all)
-	for i, doc in enumerate(docs, 1):
-		if validate_linked_doc(doc, ignore_doctypes_on_cancel_all):
-			linked_doc = frappe.get_doc(doc.get("doctype"), doc.get("name"))
-			linked_doc.cancel()
-		frappe.publish_progress(percent=i / len(docs) * 100, title=_("Cancelling documents"))
+
+	to_cancel = []
+	seen = set()
+	for doc in docs:
+		key = (doc.get("doctype"), doc.get("name"))
+		if key not in seen and validate_linked_doc(doc, ignore_doctypes_on_cancel_all):
+			seen.add(key)
+			to_cancel.append(doc)
+
+	total = len(to_cancel)
+	cancelled = 0
+	while to_cancel:
+		deferred = []
+		for doc in to_cancel:
+			if not cancel_linked_doc(doc):
+				deferred.append(doc)
+				continue
+			cancelled += 1
+			frappe.publish_progress(percent=cancelled / total * 100, title=_("Cancelling documents"))
+
+		if len(deferred) == len(to_cancel):
+			# A full pass cancelled nothing, so a document outside `docs` blocks
+			# cancellation. Cancel without catching to surface the link error.
+			frappe.get_doc(deferred[0].get("doctype"), deferred[0].get("name")).cancel()
+		to_cancel = deferred
+
+
+def cancel_linked_doc(docinfo) -> bool:
+	"""Cancel a document, returning False when a submitted document still references it."""
+	doc = frappe.get_doc(docinfo.get("doctype"), docinfo.get("name"))
+	if not doc.docstatus.is_submitted():
+		# already cancelled, possibly by the on_cancel hook of another document
+		return True
+
+	save_point = "cancel_linked_doc"
+	frappe.db.savepoint(save_point)
+	try:
+		doc.cancel()
+	except frappe.LinkExistsError:
+		# cancel runs on_cancel before the back-link check; roll its writes back
+		frappe.db.rollback(save_point=save_point)
+		return False
+
+	frappe.db.release_savepoint(save_point)
+	return True
 
 
 def validate_linked_doc(docinfo, ignore_doctypes_on_cancel_all=None):

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -402,50 +402,56 @@ def cancel_all_linked_docs(docs: str | list, ignore_doctypes_on_cancel_all: str 
 	docs = frappe.parse_json(docs)
 	ignore_doctypes_on_cancel_all = frappe.parse_json(ignore_doctypes_on_cancel_all)
 
-	to_cancel = []
+	to_cancel = [doc for doc in deduplicated(docs) if validate_linked_doc(doc, ignore_doctypes_on_cancel_all)]
+	process_linked_docs_in_dependency_order(to_cancel, cancel_linked_doc, _("Cancelling documents"))
+
+
+def cancel_linked_doc(docinfo):
+	"""Cancel a document unless the on_cancel hook of another document already cancelled it."""
+	doc = frappe.get_doc(docinfo.get("doctype"), docinfo.get("name"))
+	if doc.docstatus.is_submitted():
+		doc.cancel()
+
+
+def deduplicated(docs):
+	"""Preserve order, dropping repeated (doctype, name) entries."""
 	seen = set()
+	unique = []
 	for doc in docs:
 		key = (doc.get("doctype"), doc.get("name"))
-		if key not in seen and validate_linked_doc(doc, ignore_doctypes_on_cancel_all):
+		if key not in seen:
 			seen.add(key)
-			to_cancel.append(doc)
+			unique.append(doc)
+	return unique
 
-	total = len(to_cancel)
-	cancelled = 0
-	while to_cancel:
+
+def process_linked_docs_in_dependency_order(docs, process, progress_title):
+	"""Run process over docs, deferring a document blocked by a linked document
+	to a later pass, until a full pass makes no progress."""
+	total = len(docs)
+	processed = 0
+	save_point = "process_linked_doc"
+	while docs:
 		deferred = []
-		for doc in to_cancel:
-			if not cancel_linked_doc(doc):
+		for doc in docs:
+			frappe.db.savepoint(save_point)
+			try:
+				process(doc)
+			except frappe.LinkExistsError:
+				# cancel and delete both run their hooks before the link check,
+				# so roll their writes back before deferring
+				frappe.db.rollback(save_point=save_point)
 				deferred.append(doc)
 				continue
-			cancelled += 1
-			frappe.publish_progress(percent=cancelled / total * 100, title=_("Cancelling documents"))
+			frappe.db.release_savepoint(save_point)
+			processed += 1
+			frappe.publish_progress(percent=processed / total * 100, title=progress_title)
 
-		if len(deferred) == len(to_cancel):
-			# A full pass cancelled nothing, so a document outside `docs` blocks
-			# cancellation. Cancel without catching to surface the link error.
-			frappe.get_doc(deferred[0].get("doctype"), deferred[0].get("name")).cancel()
-		to_cancel = deferred
-
-
-def cancel_linked_doc(docinfo) -> bool:
-	"""Cancel a document, returning False when a submitted document still references it."""
-	doc = frappe.get_doc(docinfo.get("doctype"), docinfo.get("name"))
-	if not doc.docstatus.is_submitted():
-		# already cancelled, possibly by the on_cancel hook of another document
-		return True
-
-	save_point = "cancel_linked_doc"
-	frappe.db.savepoint(save_point)
-	try:
-		doc.cancel()
-	except frappe.LinkExistsError:
-		# cancel runs on_cancel before the back-link check; roll its writes back
-		frappe.db.rollback(save_point=save_point)
-		return False
-
-	frappe.db.release_savepoint(save_point)
-	return True
+		if len(deferred) == len(docs):
+			# A full pass processed nothing, so a document outside `docs` blocks
+			# it. Process without catching to surface the link error.
+			process(deferred[0])
+		docs = deferred
 
 
 def validate_linked_doc(docinfo, ignore_doctypes_on_cancel_all=None):

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -434,18 +434,16 @@ def process_linked_docs_in_dependency_order(docs, process, progress_title):
 	while docs:
 		deferred = []
 		for doc in docs:
-			before_commit_count = len(frappe.db.before_commit)
-			after_commit_count = len(frappe.db.after_commit)
+			side_effect_counts = capture_pending_side_effects()
 			frappe.db.savepoint(save_point)
 			try:
 				process(doc)
 			except frappe.LinkExistsError:
 				# cancel and delete both run their hooks before the link check, so
 				# roll back the writes of the failed attempt before deferring, and
-				# drop the commit hooks it queued, which savepoints cannot undo
+				# drop the side effects it queued, which savepoints cannot undo
 				frappe.db.rollback(save_point=save_point)
-				frappe.db.before_commit.truncate(before_commit_count)
-				frappe.db.after_commit.truncate(after_commit_count)
+				discard_side_effects_since(side_effect_counts)
 				deferred.append(doc)
 				continue
 			frappe.db.release_savepoint(save_point)
@@ -457,6 +455,34 @@ def process_linked_docs_in_dependency_order(docs, process, progress_title):
 			# it. Process without catching to surface the link error.
 			process(deferred[0])
 		docs = deferred
+
+
+def capture_pending_side_effects() -> dict:
+	"""Lengths of the queues of pending side effects, which savepoints cannot restore."""
+	return {
+		"before_commit": len(frappe.db.before_commit),
+		"after_commit": len(frappe.db.after_commit),
+		"realtime_log": len(frappe.local._realtime_log) if hasattr(frappe.local, "_realtime_log") else None,
+		"webhook_queue": len(getattr(frappe.local, "_webhook_queue", None) or []),
+	}
+
+
+def discard_side_effects_since(counts: dict):
+	"""Drop side effects queued after capture: the commit hooks, realtime events
+	and webhook executions of a rolled-back attempt would otherwise still run."""
+	frappe.db.before_commit.truncate(counts["before_commit"])
+	frappe.db.after_commit.truncate(counts["after_commit"])
+
+	if counts["realtime_log"] is None:
+		if hasattr(frappe.local, "_realtime_log"):
+			# the attempt created the log and its flush hook, which the truncation
+			# above removed; drop the log so the next event re-registers the flush
+			del frappe.local._realtime_log
+	elif hasattr(frappe.local, "_realtime_log"):
+		frappe.local._realtime_log = frappe.local._realtime_log[: counts["realtime_log"]]
+
+	if getattr(frappe.local, "_webhook_queue", None):
+		frappe.local._webhook_queue = frappe.local._webhook_queue[: counts["webhook_queue"]]
 
 
 def validate_linked_doc(docinfo, ignore_doctypes_on_cancel_all=None):

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -434,13 +434,18 @@ def process_linked_docs_in_dependency_order(docs, process, progress_title):
 	while docs:
 		deferred = []
 		for doc in docs:
+			before_commit_count = len(frappe.db.before_commit)
+			after_commit_count = len(frappe.db.after_commit)
 			frappe.db.savepoint(save_point)
 			try:
 				process(doc)
 			except frappe.LinkExistsError:
-				# cancel and delete both run their hooks before the link check,
-				# so roll their writes back before deferring
+				# cancel and delete both run their hooks before the link check, so
+				# roll back the writes of the failed attempt before deferring, and
+				# drop the commit hooks it queued, which savepoints cannot undo
 				frappe.db.rollback(save_point=save_point)
+				frappe.db.before_commit.truncate(before_commit_count)
+				frappe.db.after_commit.truncate(after_commit_count)
 				deferred.append(doc)
 				continue
 			frappe.db.release_savepoint(save_point)

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -207,17 +207,20 @@ class TestLinkedWith(IntegrationTestCase):
 		self.assertTrue(child2.reload().docstatus.is_cancelled())
 
 	def test_deferred_attempts_drop_queued_commit_hooks(self):
-		"""A rolled-back attempt must not leave its commit hooks queued, or the
-		eventual commit runs side effects of work that never happened."""
+		"""A rolled-back attempt must not leave its commit or rollback hooks
+		queued, or a later commit or rollback runs side effects of work that
+		never happened."""
 		attempts = []
 
 		def process(docinfo):
 			frappe.db.after_commit.add(lambda: None)
+			frappe.db.after_rollback.add(lambda: None)
 			attempts.append(docinfo["name"])
 			if docinfo["name"] == "blocked" and attempts.count("blocked") == 1:
 				raise frappe.LinkExistsError
 
 		after_commit_count = len(frappe.db.after_commit)
+		after_rollback_count = len(frappe.db.after_rollback)
 		linked_with.process_linked_docs_in_dependency_order(
 			[
 				{"doctype": "Parent DocType", "name": "blocked"},
@@ -230,6 +233,7 @@ class TestLinkedWith(IntegrationTestCase):
 		# three attempts, two successful: only their hooks survive
 		self.assertEqual(attempts, ["blocked", "free", "blocked"])
 		self.assertEqual(len(frappe.db.after_commit), after_commit_count + 2)
+		self.assertEqual(len(frappe.db.after_rollback), after_rollback_count + 2)
 
 	def test_deferred_attempts_drop_queued_realtime_events(self):
 		"""Realtime events queued by a rolled-back attempt must not stay in the

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -242,7 +242,12 @@ class TestLinkedWith(IntegrationTestCase):
 
 		def process(docinfo):
 			attempts.append(docinfo["name"])
-			frappe.publish_realtime("test_dependency_order", {"attempt": len(attempts)}, after_commit=True)
+			frappe.publish_realtime(
+				"test_dependency_order",
+				{"attempt": len(attempts)},
+				user=frappe.session.user,
+				after_commit=True,
+			)
 			if docinfo["name"] == "blocked" and attempts.count("blocked") == 1:
 				raise frappe.LinkExistsError
 

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -206,6 +206,31 @@ class TestLinkedWith(IntegrationTestCase):
 		self.assertTrue(child1.reload().docstatus.is_cancelled())
 		self.assertTrue(child2.reload().docstatus.is_cancelled())
 
+	def test_deferred_attempts_drop_queued_commit_hooks(self):
+		"""A rolled-back attempt must not leave its commit hooks queued, or the
+		eventual commit runs side effects of work that never happened."""
+		attempts = []
+
+		def process(docinfo):
+			frappe.db.after_commit.add(lambda: None)
+			attempts.append(docinfo["name"])
+			if docinfo["name"] == "blocked" and attempts.count("blocked") == 1:
+				raise frappe.LinkExistsError
+
+		after_commit_count = len(frappe.db.after_commit)
+		linked_with.process_linked_docs_in_dependency_order(
+			[
+				{"doctype": "Parent DocType", "name": "blocked"},
+				{"doctype": "Parent DocType", "name": "free"},
+			],
+			process,
+			"Processing",
+		)
+
+		# three attempts, two successful: only their hooks survive
+		self.assertEqual(attempts, ["blocked", "free", "blocked"])
+		self.assertEqual(len(frappe.db.after_commit), after_commit_count + 2)
+
 	def test_get_submitted_linked_docs_accepts_native_ignore_list(self):
 		parent_record = frappe.get_doc({"doctype": "Parent DocType"}).insert()
 

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -151,6 +151,61 @@ class TestLinkedWith(IntegrationTestCase):
 		self.assertEqual(frappe.db.get_value("Parent DocType", doc.name, "docstatus"), 2)
 		doc.reload().delete()
 
+	def test_get_submitted_linked_docs_deepest_first(self):
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert().submit()
+		child1 = (
+			frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert().submit()
+		)
+		child2 = (
+			frappe.get_doc({"doctype": "Child DocType2", "child_doctype1": child1.name}).insert().submit()
+		)
+
+		docs = linked_with.get_submitted_linked_docs(parent.doctype, parent.name)["docs"]
+
+		# child2 references child1, so it must come first to be cancellable in list order
+		self.assertEqual([doc["name"] for doc in docs], [child2.name, child1.name])
+
+	def test_get_submitted_linked_docs_has_no_duplicates(self):
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert().submit()
+		child1 = (
+			frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert().submit()
+		)
+		frappe.get_doc(
+			{"doctype": "Child DocType2", "parent_doctype": parent.name, "child_doctype1": child1.name}
+		).insert().submit()
+
+		result = linked_with.get_submitted_linked_docs(parent.doctype, parent.name)
+
+		keys = [(doc["doctype"], doc["name"]) for doc in result["docs"]]
+		self.assertEqual(len(keys), len(set(keys)))
+		self.assertEqual(result["count"], 2)
+
+	def test_cancel_all_linked_docs_defers_blocked_docs(self):
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert().submit()
+		child1 = (
+			frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert().submit()
+		)
+		child2 = (
+			frappe.get_doc(
+				{"doctype": "Child DocType2", "parent_doctype": parent.name, "child_doctype1": child1.name}
+			)
+			.insert()
+			.submit()
+		)
+
+		# child1 is blocked by child2 and passed first (with a duplicate); it must
+		# get deferred and cancelled on a later pass instead of failing
+		linked_with.cancel_all_linked_docs(
+			docs=[
+				{"doctype": "Child DocType1", "name": child1.name, "docstatus": 1},
+				{"doctype": "Child DocType1", "name": child1.name, "docstatus": 1},
+				{"doctype": "Child DocType2", "name": child2.name, "docstatus": 1},
+			]
+		)
+
+		self.assertTrue(child1.reload().docstatus.is_cancelled())
+		self.assertTrue(child2.reload().docstatus.is_cancelled())
+
 	def test_get_submitted_linked_docs_accepts_native_ignore_list(self):
 		parent_record = frappe.get_doc({"doctype": "Parent DocType"}).insert()
 

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -231,6 +231,32 @@ class TestLinkedWith(IntegrationTestCase):
 		self.assertEqual(attempts, ["blocked", "free", "blocked"])
 		self.assertEqual(len(frappe.db.after_commit), after_commit_count + 2)
 
+	def test_deferred_attempts_drop_queued_realtime_events(self):
+		"""Realtime events queued by a rolled-back attempt must not stay in the
+		log that gets flushed on commit."""
+		attempts = []
+
+		def process(docinfo):
+			attempts.append(docinfo["name"])
+			frappe.publish_realtime("test_dependency_order", {"attempt": len(attempts)}, after_commit=True)
+			if docinfo["name"] == "blocked" and attempts.count("blocked") == 1:
+				raise frappe.LinkExistsError
+
+		linked_with.process_linked_docs_in_dependency_order(
+			[
+				{"doctype": "Parent DocType", "name": "blocked"},
+				{"doctype": "Parent DocType", "name": "free"},
+			],
+			process,
+			"Processing",
+		)
+
+		events = [
+			message for event, message, room in frappe.local._realtime_log if event == "test_dependency_order"
+		]
+		# only the events of the two successful attempts survive
+		self.assertEqual(events, [{"attempt": 2}, {"attempt": 3}])
+
 	def test_get_submitted_linked_docs_accepts_native_ignore_list(self):
 		parent_record = frappe.get_doc({"doctype": "Parent DocType"}).insert()
 

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -1154,6 +1154,18 @@ class CallbackManager:
 	def reset(self):
 		self._functions.clear()
 
+	def __len__(self) -> int:
+		return len(self._functions)
+
+	def __bool__(self) -> bool:
+		# stay truthy when empty; callers use `if callbacks:` as a None check
+		return True
+
+	def truncate(self, count: int) -> None:
+		"""Drop functions queued after the first `count`."""
+		while len(self._functions) > count:
+			self._functions.pop()
+
 
 def safe_eval(code, eval_globals=None, eval_locals=None):
 	"""A safer `eval`"""


### PR DESCRIPTION
Cancel All Documents collects every linked document but cancels them in BFS order from the root, so a document is often attempted while submitted documents still reference it and the run dies with `LinkExistsError` (e.g. Work Order → Job Cards → Stock Entries: a Job Card is attempted before the Stock Entries referencing it).

- `get_submitted_linked_docs` returns documents deepest first, so referencing documents come before the documents they reference
- `cancel_all_linked_docs` defers a blocked document and retries it on a later pass, rolling back to a savepoint since `on_cancel` runs before the back-link check; it raises only when a full pass makes no progress, i.e. the blocker is outside the list
- a document already cancelled by another document's `on_cancel` hook is skipped based on live docstatus instead of the stale client payload
- the traversal marks each BFS level visited before expanding it, so a document reachable from its own level is no longer visited twice and the dialog no longer lists duplicate names