### PR TITLE
feat: delete all linked documents in dependency order

### DIFF
--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -389,8 +389,10 @@ def cancel_all_linked_docs(docs: str | list, ignore_doctypes_on_cancel_all: str 
 	"""
 	Cancel all linked doctype, optionally ignore doctypes specified in a list.
 
-	A document that other submitted documents still reference is deferred and
-	retried after the rest, so callers need not pass docs in dependency order.
+	A document whose cancellation another document blocks, through a link or a
+	controller check that wants the other document cancelled first, is deferred
+	and retried after the rest, so callers need not pass docs in dependency
+	order.
 
 	Arguments:
 	        docs (json str) - It contains list of dictionaries of a linked documents.
@@ -465,20 +467,10 @@ def delete_all_linked_docs(docs: str | list) -> dict:
 	"""
 	to_delete = deduplicated(frappe.parse_json(docs))
 
-	# Defer any validation or permission failure, not just link errors: some
-	# documents cannot be deleted directly (e.g. submitted ledger entries that
-	# grant delete to no role and that only the on_trash hook of their voucher
-	# removes) and get retried until deleting the documents around them makes
-	# them deletable or removes them.
 	# No realtime progress here: the events race the requests and navigation
 	# that follow deletion and can strand the progress dialog; the freeze
 	# overlay of the call covers the feedback.
-	skipped = process_linked_docs_in_dependency_order(
-		to_delete,
-		delete_linked_doc,
-		defer_on=(frappe.ValidationError, frappe.PermissionError),
-		raise_when_stuck=False,
-	)
+	skipped = process_linked_docs_in_dependency_order(to_delete, delete_linked_doc, raise_when_stuck=False)
 	return {"deleted": [doc for doc in to_delete if doc not in skipped], "skipped": skipped}
 
 
@@ -499,11 +491,15 @@ def deduplicated(docs):
 	return unique
 
 
-def process_linked_docs_in_dependency_order(
-	docs, process, progress_title=None, defer_on=frappe.LinkExistsError, raise_when_stuck=True
-):
-	"""Run process over docs, deferring a document blocked by a linked document
+def process_linked_docs_in_dependency_order(docs, process, progress_title=None, raise_when_stuck=True):
+	"""Run process over docs, deferring a document blocked by another document
 	to a later pass, until a full pass makes no progress.
+
+	Any validation or permission failure defers, not just link errors: a
+	controller may block cancellation until a referencing document is cancelled
+	first, and some documents cannot be processed directly but stop being in
+	the way as a side effect of processing a document near them (e.g. ledger
+	entries that only the on_trash hook of their voucher removes).
 
 	Once stuck, either surface the error of the first blocked document or, with
 	raise_when_stuck disabled, keep the progress made and return the blocked
@@ -519,7 +515,7 @@ def process_linked_docs_in_dependency_order(
 			frappe.db.savepoint(save_point)
 			try:
 				process(doc)
-			except defer_on:
+			except (frappe.ValidationError, frappe.PermissionError):
 				# cancel and delete both run their hooks before the link check, so
 				# roll back the writes of the failed attempt before deferring, and
 				# drop the messages and side effects it queued, which savepoints

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -420,6 +420,9 @@ def get_linked_docs_to_delete(doctype: str, name: str) -> dict:
 	"""Get all documents that block deletion of the given document, including
 	documents that block deletion of those documents, and so on.
 
+	Documents the user cannot read are neither returned nor traversed, so their
+	identities stay hidden and their deletion fails with the regular link error.
+
 	Deepest documents come first, so deleting in list order resolves the links.
 	"""
 	from frappe.model.delete_doc import get_dynamic_linked_docs
@@ -439,7 +442,7 @@ def get_linked_docs_to_delete(doctype: str, name: str) -> dict:
 		)
 		for link in links:
 			key = (link["reference_doctype"], link["reference_docname"])
-			if key not in depth_by_document:
+			if key not in depth_by_document and frappe.has_permission(key[0], doc=key[1]):
 				depth_by_document[key] = depth_by_document[parent_key] + 1
 				queue.append(key)
 

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -462,16 +462,21 @@ def capture_pending_side_effects() -> dict:
 	return {
 		"before_commit": len(frappe.db.before_commit),
 		"after_commit": len(frappe.db.after_commit),
+		"before_rollback": len(frappe.db.before_rollback),
+		"after_rollback": len(frappe.db.after_rollback),
 		"realtime_log": len(frappe.local._realtime_log) if hasattr(frappe.local, "_realtime_log") else None,
 		"webhook_queue": len(getattr(frappe.local, "_webhook_queue", None) or []),
 	}
 
 
 def discard_side_effects_since(counts: dict):
-	"""Drop side effects queued after capture: the commit hooks, realtime events
-	and webhook executions of a rolled-back attempt would otherwise still run."""
+	"""Drop side effects queued after capture: the commit and rollback hooks,
+	realtime events and webhook executions of a rolled-back attempt would
+	otherwise still run."""
 	frappe.db.before_commit.truncate(counts["before_commit"])
 	frappe.db.after_commit.truncate(counts["after_commit"])
+	frappe.db.before_rollback.truncate(counts["before_rollback"])
+	frappe.db.after_rollback.truncate(counts["after_rollback"])
 
 	if counts["realtime_log"] is None:
 		if hasattr(frappe.local, "_realtime_log"):

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -50,6 +50,10 @@ def get_submitted_linked_docs(
 	for dt, names in visited_documents.items():
 		docs.extend([{"doctype": dt, "name": name, "docstatus": 1} for name in names])
 
+	# Deepest documents first, so referencing documents get cancelled before
+	# the documents they reference.
+	docs.sort(key=lambda doc: tree.depth_by_document[doc["doctype"], doc["name"]], reverse=True)
+
 	return {"docs": docs, "count": len(docs)}
 
 
@@ -69,6 +73,7 @@ class SubmittableDocumentTree:
 		# Documents those are yet to be visited for linked documents.
 		self.to_be_visited_documents = {doctype: [name]}
 		self.visited_documents = defaultdict(list)
+		self.depth_by_document = {(doctype, name): 0}
 
 		self._submittable_doctypes = None  # All submittable doctypes in the system
 		self._references_across_doctypes = None  # doctype wise links/references
@@ -77,23 +82,22 @@ class SubmittableDocumentTree:
 		"""Get all nodes of a tree except the root node (all the nested submitted
 		documents those are present in referencing tables dependent tables).
 		"""
+		depth = 0
 		while self.to_be_visited_documents:
+			depth += 1
+			current_level = self.visit_current_level(ignore_doctypes_on_cancel_all)
 			next_level_children = defaultdict(list)
-			for parent_dt in list(self.to_be_visited_documents):
-				parent_docs = self.to_be_visited_documents.get(parent_dt)
-				if not parent_docs or (
-					ignore_doctypes_on_cancel_all and parent_dt in ignore_doctypes_on_cancel_all
-				):
-					del self.to_be_visited_documents[parent_dt]
-					continue
-
+			for parent_dt, parent_docs in current_level.items():
 				child_docs = self.get_next_level_children(parent_dt, parent_docs)
-				self.visited_documents[parent_dt].extend(parent_docs)
 				for linked_dt, linked_names in child_docs.items():
-					not_visited_child_docs = set(linked_names) - set(
-						self.visited_documents.get(linked_dt, [])
+					new_child_docs = (
+						set(linked_names)
+						- set(self.visited_documents.get(linked_dt, []))
+						- set(next_level_children[linked_dt])
 					)
-					next_level_children[linked_dt].extend(not_visited_child_docs)
+					next_level_children[linked_dt].extend(new_child_docs)
+					for linked_name in new_child_docs:
+						self.depth_by_document[(linked_dt, linked_name)] = depth
 
 			self.to_be_visited_documents = next_level_children
 
@@ -105,6 +109,19 @@ class SubmittableDocumentTree:
 			"root document must be excluded from linked children"
 		)
 		return self.visited_documents
+
+	def visit_current_level(self, ignore_doctypes_on_cancel_all):
+		"""Mark all documents of the current level as visited before expanding them,
+		so a document referenced from its own level is not visited twice."""
+		current_level = {}
+		for parent_dt, parent_docs in self.to_be_visited_documents.items():
+			if not parent_docs or (
+				ignore_doctypes_on_cancel_all and parent_dt in ignore_doctypes_on_cancel_all
+			):
+				continue
+			current_level[parent_dt] = parent_docs
+			self.visited_documents[parent_dt].extend(parent_docs)
+		return current_level
 
 	def get_next_level_children(self, parent_dt, parent_names):
 		"""Get immediate children of a Node(parent_dt, parent_names)"""
@@ -372,6 +389,9 @@ def cancel_all_linked_docs(docs: str | list, ignore_doctypes_on_cancel_all: str 
 	"""
 	Cancel all linked doctype, optionally ignore doctypes specified in a list.
 
+	A document that other submitted documents still reference is deferred and
+	retried after the rest, so callers need not pass docs in dependency order.
+
 	Arguments:
 	        docs (json str) - It contains list of dictionaries of a linked documents.
 	        ignore_doctypes_on_cancel_all (list) - List of doctypes to ignore while cancelling.
@@ -381,11 +401,51 @@ def cancel_all_linked_docs(docs: str | list, ignore_doctypes_on_cancel_all: str 
 
 	docs = frappe.parse_json(docs)
 	ignore_doctypes_on_cancel_all = frappe.parse_json(ignore_doctypes_on_cancel_all)
-	for i, doc in enumerate(docs, 1):
-		if validate_linked_doc(doc, ignore_doctypes_on_cancel_all):
-			linked_doc = frappe.get_doc(doc.get("doctype"), doc.get("name"))
-			linked_doc.cancel()
-		frappe.publish_progress(percent=i / len(docs) * 100, title=_("Cancelling documents"))
+
+	to_cancel = []
+	seen = set()
+	for doc in docs:
+		key = (doc.get("doctype"), doc.get("name"))
+		if key not in seen and validate_linked_doc(doc, ignore_doctypes_on_cancel_all):
+			seen.add(key)
+			to_cancel.append(doc)
+
+	total = len(to_cancel)
+	cancelled = 0
+	while to_cancel:
+		deferred = []
+		for doc in to_cancel:
+			if not cancel_linked_doc(doc):
+				deferred.append(doc)
+				continue
+			cancelled += 1
+			frappe.publish_progress(percent=cancelled / total * 100, title=_("Cancelling documents"))
+
+		if len(deferred) == len(to_cancel):
+			# A full pass cancelled nothing, so a document outside `docs` blocks
+			# cancellation. Cancel without catching to surface the link error.
+			frappe.get_doc(deferred[0].get("doctype"), deferred[0].get("name")).cancel()
+		to_cancel = deferred
+
+
+def cancel_linked_doc(docinfo) -> bool:
+	"""Cancel a document, returning False when a submitted document still references it."""
+	doc = frappe.get_doc(docinfo.get("doctype"), docinfo.get("name"))
+	if not doc.docstatus.is_submitted():
+		# already cancelled, possibly by the on_cancel hook of another document
+		return True
+
+	save_point = "cancel_linked_doc"
+	frappe.db.savepoint(save_point)
+	try:
+		doc.cancel()
+	except frappe.LinkExistsError:
+		# cancel runs on_cancel before the back-link check; roll its writes back
+		frappe.db.rollback(save_point=save_point)
+		return False
+
+	frappe.db.release_savepoint(save_point)
+	return True
 
 
 def validate_linked_doc(docinfo, ignore_doctypes_on_cancel_all=None):

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -402,50 +402,56 @@ def cancel_all_linked_docs(docs: str | list, ignore_doctypes_on_cancel_all: str 
 	docs = frappe.parse_json(docs)
 	ignore_doctypes_on_cancel_all = frappe.parse_json(ignore_doctypes_on_cancel_all)
 
-	to_cancel = []
+	to_cancel = [doc for doc in deduplicated(docs) if validate_linked_doc(doc, ignore_doctypes_on_cancel_all)]
+	process_linked_docs_in_dependency_order(to_cancel, cancel_linked_doc, _("Cancelling documents"))
+
+
+def cancel_linked_doc(docinfo):
+	"""Cancel a document unless the on_cancel hook of another document already cancelled it."""
+	doc = frappe.get_doc(docinfo.get("doctype"), docinfo.get("name"))
+	if doc.docstatus.is_submitted():
+		doc.cancel()
+
+
+def deduplicated(docs):
+	"""Preserve order, dropping repeated (doctype, name) entries."""
 	seen = set()
+	unique = []
 	for doc in docs:
 		key = (doc.get("doctype"), doc.get("name"))
-		if key not in seen and validate_linked_doc(doc, ignore_doctypes_on_cancel_all):
+		if key not in seen:
 			seen.add(key)
-			to_cancel.append(doc)
+			unique.append(doc)
+	return unique
 
-	total = len(to_cancel)
-	cancelled = 0
-	while to_cancel:
+
+def process_linked_docs_in_dependency_order(docs, process, progress_title):
+	"""Run process over docs, deferring a document blocked by a linked document
+	to a later pass, until a full pass makes no progress."""
+	total = len(docs)
+	processed = 0
+	save_point = "process_linked_doc"
+	while docs:
 		deferred = []
-		for doc in to_cancel:
-			if not cancel_linked_doc(doc):
+		for doc in docs:
+			frappe.db.savepoint(save_point)
+			try:
+				process(doc)
+			except frappe.LinkExistsError:
+				# cancel and delete both run their hooks before the link check,
+				# so roll their writes back before deferring
+				frappe.db.rollback(save_point=save_point)
 				deferred.append(doc)
 				continue
-			cancelled += 1
-			frappe.publish_progress(percent=cancelled / total * 100, title=_("Cancelling documents"))
+			frappe.db.release_savepoint(save_point)
+			processed += 1
+			frappe.publish_progress(percent=processed / total * 100, title=progress_title)
 
-		if len(deferred) == len(to_cancel):
-			# A full pass cancelled nothing, so a document outside `docs` blocks
-			# cancellation. Cancel without catching to surface the link error.
-			frappe.get_doc(deferred[0].get("doctype"), deferred[0].get("name")).cancel()
-		to_cancel = deferred
-
-
-def cancel_linked_doc(docinfo) -> bool:
-	"""Cancel a document, returning False when a submitted document still references it."""
-	doc = frappe.get_doc(docinfo.get("doctype"), docinfo.get("name"))
-	if not doc.docstatus.is_submitted():
-		# already cancelled, possibly by the on_cancel hook of another document
-		return True
-
-	save_point = "cancel_linked_doc"
-	frappe.db.savepoint(save_point)
-	try:
-		doc.cancel()
-	except frappe.LinkExistsError:
-		# cancel runs on_cancel before the back-link check; roll its writes back
-		frappe.db.rollback(save_point=save_point)
-		return False
-
-	frappe.db.release_savepoint(save_point)
-	return True
+		if len(deferred) == len(docs):
+			# A full pass processed nothing, so a document outside `docs` blocks
+			# it. Process without catching to surface the link error.
+			process(deferred[0])
+		docs = deferred
 
 
 def validate_linked_doc(docinfo, ignore_doctypes_on_cancel_all=None):

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -434,18 +434,16 @@ def process_linked_docs_in_dependency_order(docs, process, progress_title):
 	while docs:
 		deferred = []
 		for doc in docs:
-			before_commit_count = len(frappe.db.before_commit)
-			after_commit_count = len(frappe.db.after_commit)
+			side_effect_counts = capture_pending_side_effects()
 			frappe.db.savepoint(save_point)
 			try:
 				process(doc)
 			except frappe.LinkExistsError:
 				# cancel and delete both run their hooks before the link check, so
 				# roll back the writes of the failed attempt before deferring, and
-				# drop the commit hooks it queued, which savepoints cannot undo
+				# drop the side effects it queued, which savepoints cannot undo
 				frappe.db.rollback(save_point=save_point)
-				frappe.db.before_commit.truncate(before_commit_count)
-				frappe.db.after_commit.truncate(after_commit_count)
+				discard_side_effects_since(side_effect_counts)
 				deferred.append(doc)
 				continue
 			frappe.db.release_savepoint(save_point)
@@ -457,6 +455,34 @@ def process_linked_docs_in_dependency_order(docs, process, progress_title):
 			# it. Process without catching to surface the link error.
 			process(deferred[0])
 		docs = deferred
+
+
+def capture_pending_side_effects() -> dict:
+	"""Lengths of the queues of pending side effects, which savepoints cannot restore."""
+	return {
+		"before_commit": len(frappe.db.before_commit),
+		"after_commit": len(frappe.db.after_commit),
+		"realtime_log": len(frappe.local._realtime_log) if hasattr(frappe.local, "_realtime_log") else None,
+		"webhook_queue": len(getattr(frappe.local, "_webhook_queue", None) or []),
+	}
+
+
+def discard_side_effects_since(counts: dict):
+	"""Drop side effects queued after capture: the commit hooks, realtime events
+	and webhook executions of a rolled-back attempt would otherwise still run."""
+	frappe.db.before_commit.truncate(counts["before_commit"])
+	frappe.db.after_commit.truncate(counts["after_commit"])
+
+	if counts["realtime_log"] is None:
+		if hasattr(frappe.local, "_realtime_log"):
+			# the attempt created the log and its flush hook, which the truncation
+			# above removed; drop the log so the next event re-registers the flush
+			del frappe.local._realtime_log
+	elif hasattr(frappe.local, "_realtime_log"):
+		frappe.local._realtime_log = frappe.local._realtime_log[: counts["realtime_log"]]
+
+	if getattr(frappe.local, "_webhook_queue", None):
+		frappe.local._webhook_queue = frappe.local._webhook_queue[: counts["webhook_queue"]]
 
 
 def validate_linked_doc(docinfo, ignore_doctypes_on_cancel_all=None):

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -434,13 +434,18 @@ def process_linked_docs_in_dependency_order(docs, process, progress_title):
 	while docs:
 		deferred = []
 		for doc in docs:
+			before_commit_count = len(frappe.db.before_commit)
+			after_commit_count = len(frappe.db.after_commit)
 			frappe.db.savepoint(save_point)
 			try:
 				process(doc)
 			except frappe.LinkExistsError:
-				# cancel and delete both run their hooks before the link check,
-				# so roll their writes back before deferring
+				# cancel and delete both run their hooks before the link check, so
+				# roll back the writes of the failed attempt before deferring, and
+				# drop the commit hooks it queued, which savepoints cannot undo
 				frappe.db.rollback(save_point=save_point)
+				frappe.db.before_commit.truncate(before_commit_count)
+				frappe.db.after_commit.truncate(after_commit_count)
 				deferred.append(doc)
 				continue
 			frappe.db.release_savepoint(save_point)

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -2,7 +2,7 @@
 # License: MIT. See LICENSE
 
 import itertools
-from collections import defaultdict
+from collections import defaultdict, deque
 
 import frappe
 import frappe.desk.form.load
@@ -413,6 +413,80 @@ def cancel_linked_doc(docinfo):
 		doc.cancel()
 
 
+@frappe.whitelist()
+def get_linked_docs_to_delete(doctype: str, name: str) -> dict:
+	"""Get all documents that block deletion of the given document, including
+	documents that block deletion of those documents, and so on.
+
+	Deepest documents come first, so deleting in list order resolves the links.
+	"""
+	from frappe.model.delete_doc import get_dynamic_linked_docs
+	from frappe.model.delete_doc import get_linked_docs as get_statically_linked_docs
+
+	frappe.has_permission(doctype, doc=name, throw=True)
+
+	depth_by_document = {(doctype, name): 0}
+	docstatus_by_document = {}
+	queue = deque([(doctype, name)])
+	while queue:
+		parent_key = queue.popleft()
+		parent_doc = frappe.get_doc(*parent_key)
+		docstatus_by_document[parent_key] = parent_doc.docstatus
+		links = get_statically_linked_docs(parent_doc, method="Delete") + get_dynamic_linked_docs(
+			parent_doc, method="Delete"
+		)
+		for link in links:
+			key = (link["reference_doctype"], link["reference_docname"])
+			if key not in depth_by_document:
+				depth_by_document[key] = depth_by_document[parent_key] + 1
+				queue.append(key)
+
+	docs = [
+		{"doctype": dt, "name": docname, "docstatus": docstatus_by_document[(dt, docname)]}
+		for dt, docname in depth_by_document
+		if (dt, docname) != (doctype, name)
+	]
+	docs.sort(key=lambda doc: depth_by_document[doc["doctype"], doc["name"]], reverse=True)
+	return {"docs": docs, "count": len(docs)}
+
+
+@frappe.whitelist()
+def delete_all_linked_docs(docs: str | list) -> dict:
+	"""
+	Delete as many of the given documents as their links allow.
+
+	A document that other documents still reference is deferred and retried
+	after the rest, so callers need not pass docs in dependency order. A
+	document that stays undeletable is skipped without undoing the rest.
+	Return the deleted and the skipped documents.
+
+	Arguments:
+	        docs (json str) - It contains list of dictionaries of the documents to delete.
+	"""
+	to_delete = deduplicated(frappe.parse_json(docs))
+
+	# Defer any validation or permission failure, not just link errors: some
+	# documents cannot be deleted directly (e.g. submitted ledger entries that
+	# grant delete to no role and that only the on_trash hook of their voucher
+	# removes) and get retried until deleting the documents around them makes
+	# them deletable or removes them.
+	# No realtime progress here: the events race the requests and navigation
+	# that follow deletion and can strand the progress dialog; the freeze
+	# overlay of the call covers the feedback.
+	skipped = process_linked_docs_in_dependency_order(
+		to_delete,
+		delete_linked_doc,
+		defer_on=(frappe.ValidationError, frappe.PermissionError),
+		raise_when_stuck=False,
+	)
+	return {"deleted": [doc for doc in to_delete if doc not in skipped], "skipped": skipped}
+
+
+def delete_linked_doc(docinfo):
+	"""Delete a document; one already removed by another document's on_trash hook is ignored."""
+	frappe.delete_doc(docinfo.get("doctype"), docinfo.get("name"))
+
+
 def deduplicated(docs):
 	"""Preserve order, dropping repeated (doctype, name) entries."""
 	seen = set()
@@ -425,36 +499,49 @@ def deduplicated(docs):
 	return unique
 
 
-def process_linked_docs_in_dependency_order(docs, process, progress_title):
+def process_linked_docs_in_dependency_order(
+	docs, process, progress_title=None, defer_on=frappe.LinkExistsError, raise_when_stuck=True
+):
 	"""Run process over docs, deferring a document blocked by a linked document
-	to a later pass, until a full pass makes no progress."""
+	to a later pass, until a full pass makes no progress.
+
+	Once stuck, either surface the error of the first blocked document or, with
+	raise_when_stuck disabled, keep the progress made and return the blocked
+	documents."""
 	total = len(docs)
 	processed = 0
 	save_point = "process_linked_doc"
 	while docs:
 		deferred = []
 		for doc in docs:
+			message_count = len(frappe.local.message_log)
 			side_effect_counts = capture_pending_side_effects()
 			frappe.db.savepoint(save_point)
 			try:
 				process(doc)
-			except frappe.LinkExistsError:
+			except defer_on:
 				# cancel and delete both run their hooks before the link check, so
 				# roll back the writes of the failed attempt before deferring, and
-				# drop the side effects it queued, which savepoints cannot undo
+				# drop the messages and side effects it queued, which savepoints
+				# cannot undo
 				frappe.db.rollback(save_point=save_point)
+				frappe.local.message_log = frappe.local.message_log[:message_count]
 				discard_side_effects_since(side_effect_counts)
 				deferred.append(doc)
 				continue
 			frappe.db.release_savepoint(save_point)
 			processed += 1
-			frappe.publish_progress(percent=processed / total * 100, title=progress_title)
+			if progress_title:
+				frappe.publish_progress(percent=processed / total * 100, title=progress_title)
 
 		if len(deferred) == len(docs):
-			# A full pass processed nothing, so a document outside `docs` blocks
-			# it. Process without catching to surface the link error.
-			process(deferred[0])
+			if raise_when_stuck:
+				# a document outside `docs` blocks the rest; process without
+				# catching to surface the link error
+				process(deferred[0])
+			return deferred
 		docs = deferred
+	return []
 
 
 def capture_pending_side_effects() -> dict:

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1100,7 +1100,7 @@ frappe.ui.form.Form = class FrappeForm {
 				.map((link) =>
 					as_links
 						? frappe.utils.get_form_link(link.doctype, link.name, true)
-						: cstr(link.name)
+						: frappe.utils.escape_html(cstr(link.name))
 				)
 				.join(", ");
 			links_text += `<li><strong>${__(doctype)}</strong>: ${docnames}</li>`;

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1090,26 +1090,35 @@ frappe.ui.form.Form = class FrappeForm {
 			});
 	}
 
+	_linked_docs_list_html(links, as_links = true) {
+		let links_text = "";
+		const doctypes = Array.from(new Set(links.map((link) => link.doctype)));
+
+		for (let doctype of doctypes) {
+			let docnames = links
+				.filter((link) => link.doctype == doctype)
+				.map((link) =>
+					as_links
+						? frappe.utils.get_form_link(link.doctype, link.name, true)
+						: cstr(link.name)
+				)
+				.join(", ");
+			links_text += `<li><strong>${__(doctype)}</strong>: ${docnames}</li>`;
+		}
+		return `<ul>${links_text}</ul>`;
+	}
+
 	_cancel_all(r, btn, callback, on_error) {
 		const me = this;
 
 		// add confirmation message for cancelling all linked docs
-		let links_text = "";
 		let links = r.message.docs;
-		const doctypes = Array.from(new Set(links.map((link) => link.doctype)));
 
 		me.ignore_doctypes_on_cancel_all = me.ignore_doctypes_on_cancel_all || [];
 
-		for (let doctype of doctypes) {
-			if (!me.ignore_doctypes_on_cancel_all.includes(doctype)) {
-				let docnames = links
-					.filter((link) => link.doctype == doctype)
-					.map((link) => frappe.utils.get_form_link(link.doctype, link.name, true))
-					.join(", ");
-				links_text += `<li><strong>${__(doctype)}</strong>: ${docnames}</li>`;
-			}
-		}
-		links_text = `<ul>${links_text}</ul>`;
+		let links_text = me._linked_docs_list_html(
+			links.filter((link) => !me.ignore_doctypes_on_cancel_all.includes(link.doctype))
+		);
 
 		let confirm_message = __("{0} {1} is linked with the following submitted documents: {2}", [
 			__(me.doc.doctype).bold(),
@@ -1255,10 +1264,102 @@ frappe.ui.form.Form = class FrappeForm {
 	}
 
 	savetrash() {
+		const me = this;
 		this.validate_form_action("Delete");
-		frappe.model.delete_doc(this.doctype, this.docname, function () {
-			window.history.back();
+		frappe
+			.call({
+				method: "frappe.desk.form.linked_with.get_linked_docs_to_delete",
+				args: {
+					doctype: me.doctype,
+					name: cstr(me.docname),
+				},
+				freeze: true,
+			})
+			.then((r) => {
+				if (!r.exc && (r.message.docs || []).length) {
+					return me._delete_all(r);
+				}
+				me._delete();
+			});
+	}
+
+	_delete(skip_confirm) {
+		frappe.model.delete_doc(
+			this.doctype,
+			this.docname,
+			function () {
+				window.history.back();
+			},
+			skip_confirm
+		);
+	}
+
+	_delete_all(r) {
+		const me = this;
+		const links = r.message.docs;
+
+		let confirm_message = __("{0} {1} is linked with the following documents: {2}", [
+			__(me.doctype).bold(),
+			me.docname,
+			me._linked_docs_list_html(links),
+		]);
+		confirm_message += __("Do you want to delete {0} along with all linked documents?", [
+			cstr(me.docname).bold(),
+		]);
+
+		const d = new frappe.ui.Dialog({
+			title: __("Delete All Documents"),
+			fields: [
+				{
+					fieldtype: "HTML",
+					options: `<p class="frappe-confirm-message">${confirm_message}</p>`,
+				},
+			],
 		});
+
+		d.set_primary_action(__("Delete All"), () => {
+			d.hide();
+			frappe.call({
+				method: "frappe.desk.form.linked_with.delete_all_linked_docs",
+				args: {
+					docs: links,
+				},
+				freeze: true,
+				freeze_message: __("Deleting documents..."),
+				callback: (resp) => {
+					if (resp.exc) {
+						return;
+					}
+					const skipped = resp.message.skipped || [];
+					if (!skipped.length) {
+						return me._delete(true);
+					}
+					me.reload_doc();
+					const deleted = resp.message.deleted || [];
+					let message = "";
+					if (deleted.length) {
+						message += __("The following documents were deleted: {0}", [
+							me._linked_docs_list_html(deleted, false),
+						]);
+					}
+					message += __(
+						"{0} {1} was kept because the following documents could not be deleted: {2}",
+						[
+							__(me.doctype),
+							cstr(me.docname).bold(),
+							me._linked_docs_list_html(skipped),
+						]
+					);
+					frappe.msgprint({
+						title: __("Partially Deleted"),
+						indicator: "orange",
+						message: message,
+					});
+				},
+			});
+		});
+
+		d.show();
 	}
 
 	amend_doc() {

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -732,7 +732,7 @@ $.extend(frappe.model, {
 		return no_copy_list;
 	},
 
-	delete_doc: function (doctype, docname, callback) {
+	delete_doc: function (doctype, docname, callback, skip_confirm) {
 		let title = docname.toString();
 		const title_field = frappe.get_meta(doctype).title_field;
 		if (title_field) {
@@ -741,28 +741,33 @@ $.extend(frappe.model, {
 				title = `${value} (${docname})`;
 			}
 		}
+		const perform_delete = function () {
+			return frappe.call({
+				method: "frappe.client.delete",
+				args: {
+					doctype: doctype,
+					name: docname,
+				},
+				freeze: true,
+				freeze_message: __("Deleting {0}...", [title]),
+				callback: function (r, rt) {
+					if (!r.exc) {
+						frappe.utils.play_sound("delete");
+						frappe.model.delete_from_locals(doctype, docname);
+						if (callback) callback(r, rt);
+					}
+				},
+			});
+		};
+		if (skip_confirm) {
+			perform_delete();
+			return;
+		}
 		// destructive: red primary via frappe.warn, not a neutral confirm
 		frappe.warn(
 			__("Confirm"),
 			__("Permanently delete {0}?", [title.bold()]),
-			function () {
-				return frappe.call({
-					method: "frappe.client.delete",
-					args: {
-						doctype: doctype,
-						name: docname,
-					},
-					freeze: true,
-					freeze_message: __("Deleting {0}...", [title]),
-					callback: function (r, rt) {
-						if (!r.exc) {
-							frappe.utils.play_sound("delete");
-							frappe.model.delete_from_locals(doctype, docname);
-							if (callback) callback(r, rt);
-						}
-					},
-				});
-			},
+			perform_delete,
 			__("Delete")
 		);
 	},

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -207,17 +207,20 @@ class TestLinkedWith(IntegrationTestCase):
 		self.assertTrue(child2.reload().docstatus.is_cancelled())
 
 	def test_deferred_attempts_drop_queued_commit_hooks(self):
-		"""A rolled-back attempt must not leave its commit hooks queued, or the
-		eventual commit runs side effects of work that never happened."""
+		"""A rolled-back attempt must not leave its commit or rollback hooks
+		queued, or a later commit or rollback runs side effects of work that
+		never happened."""
 		attempts = []
 
 		def process(docinfo):
 			frappe.db.after_commit.add(lambda: None)
+			frappe.db.after_rollback.add(lambda: None)
 			attempts.append(docinfo["name"])
 			if docinfo["name"] == "blocked" and attempts.count("blocked") == 1:
 				raise frappe.LinkExistsError
 
 		after_commit_count = len(frappe.db.after_commit)
+		after_rollback_count = len(frappe.db.after_rollback)
 		linked_with.process_linked_docs_in_dependency_order(
 			[
 				{"doctype": "Parent DocType", "name": "blocked"},
@@ -230,6 +233,7 @@ class TestLinkedWith(IntegrationTestCase):
 		# three attempts, two successful: only their hooks survive
 		self.assertEqual(attempts, ["blocked", "free", "blocked"])
 		self.assertEqual(len(frappe.db.after_commit), after_commit_count + 2)
+		self.assertEqual(len(frappe.db.after_rollback), after_rollback_count + 2)
 
 	def test_deferred_attempts_drop_queued_realtime_events(self):
 		"""Realtime events queued by a rolled-back attempt must not stay in the

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -242,7 +242,12 @@ class TestLinkedWith(IntegrationTestCase):
 
 		def process(docinfo):
 			attempts.append(docinfo["name"])
-			frappe.publish_realtime("test_dependency_order", {"attempt": len(attempts)}, after_commit=True)
+			frappe.publish_realtime(
+				"test_dependency_order",
+				{"attempt": len(attempts)},
+				user=frappe.session.user,
+				after_commit=True,
+			)
 			if docinfo["name"] == "blocked" and attempts.count("blocked") == 1:
 				raise frappe.LinkExistsError
 

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -206,6 +206,31 @@ class TestLinkedWith(IntegrationTestCase):
 		self.assertTrue(child1.reload().docstatus.is_cancelled())
 		self.assertTrue(child2.reload().docstatus.is_cancelled())
 
+	def test_deferred_attempts_drop_queued_commit_hooks(self):
+		"""A rolled-back attempt must not leave its commit hooks queued, or the
+		eventual commit runs side effects of work that never happened."""
+		attempts = []
+
+		def process(docinfo):
+			frappe.db.after_commit.add(lambda: None)
+			attempts.append(docinfo["name"])
+			if docinfo["name"] == "blocked" and attempts.count("blocked") == 1:
+				raise frappe.LinkExistsError
+
+		after_commit_count = len(frappe.db.after_commit)
+		linked_with.process_linked_docs_in_dependency_order(
+			[
+				{"doctype": "Parent DocType", "name": "blocked"},
+				{"doctype": "Parent DocType", "name": "free"},
+			],
+			process,
+			"Processing",
+		)
+
+		# three attempts, two successful: only their hooks survive
+		self.assertEqual(attempts, ["blocked", "free", "blocked"])
+		self.assertEqual(len(frappe.db.after_commit), after_commit_count + 2)
+
 	def test_get_submitted_linked_docs_accepts_native_ignore_list(self):
 		parent_record = frappe.get_doc({"doctype": "Parent DocType"}).insert()
 

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -16,7 +16,7 @@ def hard_delete_referencing_child2_records(doc, method=None):
 def block_cancel_while_child2_submitted(doc, method=None):
 	"""Mimic a controller that wants referencing documents cancelled first."""
 	if frappe.db.exists("Child DocType2", {"child_doctype1": doc.name, "docstatus": 1}):
-		frappe.throw("Cancel the referencing document first")
+		frappe.throw(frappe._("Cancel the referencing document first"))
 
 
 class TestLinkedWith(IntegrationTestCase):
@@ -309,6 +309,22 @@ class TestLinkedWith(IntegrationTestCase):
 
 		# child2 references child1, so it must come first to be deletable in list order
 		self.assertEqual([doc["name"] for doc in docs], [child2.name, child1.name])
+
+	def test_get_linked_docs_to_delete_excludes_unreadable_docs(self):
+		"""Linked documents the user cannot read must stay hidden from the listing."""
+		from frappe.permissions import add_permission
+
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert()
+		child1 = frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert()
+		frappe.get_doc({"doctype": "Child DocType2", "parent_doctype": parent.name}).insert()
+
+		add_permission("Parent DocType", "All")
+		add_permission("Child DocType1", "All")
+
+		with self.set_user("test1@example.com"):
+			docs = linked_with.get_linked_docs_to_delete(parent.doctype, parent.name)["docs"]
+
+		self.assertEqual(docs, [{"doctype": "Child DocType1", "name": child1.name, "docstatus": 0}])
 
 	def test_delete_all_linked_docs_defers_blocked_docs(self):
 		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert()

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -8,6 +8,11 @@ from frappe.desk.form import linked_with
 from frappe.tests import IntegrationTestCase
 
 
+def hard_delete_referencing_child2_records(doc, method=None):
+	"""Mimic a voucher on_trash that removes its submitted ledger rows."""
+	frappe.db.delete("Child DocType2", {"child_doctype1": doc.name})
+
+
 class TestLinkedWith(IntegrationTestCase):
 	def setUp(self):
 		parent_doctype = new_doctype("Parent DocType")
@@ -265,6 +270,89 @@ class TestLinkedWith(IntegrationTestCase):
 		]
 		# only the events of the two successful attempts survive
 		self.assertEqual(events, [{"attempt": 2}, {"attempt": 3}])
+
+	def test_get_linked_docs_to_delete_deepest_first(self):
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert()
+		child1 = frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert()
+		child2 = frappe.get_doc({"doctype": "Child DocType2", "child_doctype1": child1.name}).insert()
+
+		docs = linked_with.get_linked_docs_to_delete(parent.doctype, parent.name)["docs"]
+
+		# child2 references child1, so it must come first to be deletable in list order
+		self.assertEqual([doc["name"] for doc in docs], [child2.name, child1.name])
+
+	def test_delete_all_linked_docs_defers_blocked_docs(self):
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert()
+		child1 = frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert()
+		child2 = frappe.get_doc(
+			{"doctype": "Child DocType2", "parent_doctype": parent.name, "child_doctype1": child1.name}
+		).insert()
+
+		# child1 is blocked by child2 and passed first; it must get deferred
+		# and deleted on a later pass instead of failing
+		result = linked_with.delete_all_linked_docs(
+			docs=[
+				{"doctype": "Child DocType1", "name": child1.name},
+				{"doctype": "Child DocType2", "name": child2.name},
+			]
+		)
+
+		self.assertEqual(
+			result,
+			{
+				"deleted": [
+					{"doctype": "Child DocType1", "name": child1.name},
+					{"doctype": "Child DocType2", "name": child2.name},
+				],
+				"skipped": [],
+			},
+		)
+		self.assertFalse(frappe.db.exists("Child DocType1", child1.name))
+		self.assertFalse(frappe.db.exists("Child DocType2", child2.name))
+		parent.delete()
+
+	def test_delete_all_linked_docs_waits_for_on_trash_cleanup(self):
+		"""A submitted document that only an on_trash hook removes (like a ledger
+		entry removed with its voucher) must get deferred, not fail the run."""
+		child1 = frappe.get_doc({"doctype": "Child DocType1"}).insert()
+		child2 = (
+			frappe.get_doc({"doctype": "Child DocType2", "child_doctype1": child1.name}).insert().submit()
+		)
+
+		hook = f"{__name__}.hard_delete_referencing_child2_records"
+		self.addCleanup(setattr, frappe.local, "doc_events_hooks", None)
+		with self.patch_hooks({"doc_events": {"Child DocType1": {"on_trash": [hook]}}}):
+			frappe.local.doc_events_hooks = None
+			linked_with.delete_all_linked_docs(
+				docs=[
+					{"doctype": "Child DocType2", "name": child2.name},
+					{"doctype": "Child DocType1", "name": child1.name},
+				]
+			)
+
+		self.assertFalse(frappe.db.exists("Child DocType1", child1.name))
+		self.assertFalse(frappe.db.exists("Child DocType2", child2.name))
+
+	def test_delete_all_linked_docs_skips_undeletable_docs(self):
+		"""A document that stays undeletable must get skipped and reported without
+		undoing the deleted documents or leaking messages of failed attempts."""
+		child1 = frappe.get_doc({"doctype": "Child DocType1"}).insert().submit()
+		child2 = frappe.get_doc({"doctype": "Child DocType2"}).insert()
+		message_count = len(frappe.local.message_log)
+
+		result = linked_with.delete_all_linked_docs(
+			docs=[
+				{"doctype": "Child DocType1", "name": child1.name},
+				{"doctype": "Child DocType2", "name": child2.name},
+			]
+		)
+
+		self.assertEqual(result["deleted"], [{"doctype": "Child DocType2", "name": child2.name}])
+		self.assertEqual(result["skipped"], [{"doctype": "Child DocType1", "name": child1.name}])
+		self.assertTrue(frappe.db.exists("Child DocType1", child1.name))
+		self.assertFalse(frappe.db.exists("Child DocType2", child2.name))
+		self.assertEqual(len(frappe.local.message_log), message_count)
+		child1.reload().cancel()
 
 	def test_get_submitted_linked_docs_accepts_native_ignore_list(self):
 		parent_record = frappe.get_doc({"doctype": "Parent DocType"}).insert()

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -13,6 +13,12 @@ def hard_delete_referencing_child2_records(doc, method=None):
 	frappe.db.delete("Child DocType2", {"child_doctype1": doc.name})
 
 
+def block_cancel_while_child2_submitted(doc, method=None):
+	"""Mimic a controller that wants referencing documents cancelled first."""
+	if frappe.db.exists("Child DocType2", {"child_doctype1": doc.name, "docstatus": 1}):
+		frappe.throw("Cancel the referencing document first")
+
+
 class TestLinkedWith(IntegrationTestCase):
 	def setUp(self):
 		parent_doctype = new_doctype("Parent DocType")
@@ -270,6 +276,29 @@ class TestLinkedWith(IntegrationTestCase):
 		]
 		# only the events of the two successful attempts survive
 		self.assertEqual(events, [{"attempt": 2}, {"attempt": 3}])
+
+	def test_cancel_all_linked_docs_defers_controller_blocked_docs(self):
+		"""A controller check that wants a referencing document cancelled first
+		raises a plain ValidationError; the document must get deferred, not fail
+		the run."""
+		child1 = frappe.get_doc({"doctype": "Child DocType1"}).insert().submit()
+		child2 = (
+			frappe.get_doc({"doctype": "Child DocType2", "child_doctype1": child1.name}).insert().submit()
+		)
+
+		hook = f"{__name__}.block_cancel_while_child2_submitted"
+		self.addCleanup(setattr, frappe.local, "doc_events_hooks", None)
+		with self.patch_hooks({"doc_events": {"Child DocType1": {"before_cancel": [hook]}}}):
+			frappe.local.doc_events_hooks = None
+			linked_with.cancel_all_linked_docs(
+				docs=[
+					{"doctype": "Child DocType1", "name": child1.name, "docstatus": 1},
+					{"doctype": "Child DocType2", "name": child2.name, "docstatus": 1},
+				]
+			)
+
+		self.assertTrue(child1.reload().docstatus.is_cancelled())
+		self.assertTrue(child2.reload().docstatus.is_cancelled())
 
 	def test_get_linked_docs_to_delete_deepest_first(self):
 		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert()

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -151,6 +151,61 @@ class TestLinkedWith(IntegrationTestCase):
 		self.assertEqual(frappe.db.get_value("Parent DocType", doc.name, "docstatus"), 2)
 		doc.reload().delete()
 
+	def test_get_submitted_linked_docs_deepest_first(self):
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert().submit()
+		child1 = (
+			frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert().submit()
+		)
+		child2 = (
+			frappe.get_doc({"doctype": "Child DocType2", "child_doctype1": child1.name}).insert().submit()
+		)
+
+		docs = linked_with.get_submitted_linked_docs(parent.doctype, parent.name)["docs"]
+
+		# child2 references child1, so it must come first to be cancellable in list order
+		self.assertEqual([doc["name"] for doc in docs], [child2.name, child1.name])
+
+	def test_get_submitted_linked_docs_has_no_duplicates(self):
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert().submit()
+		child1 = (
+			frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert().submit()
+		)
+		frappe.get_doc(
+			{"doctype": "Child DocType2", "parent_doctype": parent.name, "child_doctype1": child1.name}
+		).insert().submit()
+
+		result = linked_with.get_submitted_linked_docs(parent.doctype, parent.name)
+
+		keys = [(doc["doctype"], doc["name"]) for doc in result["docs"]]
+		self.assertEqual(len(keys), len(set(keys)))
+		self.assertEqual(result["count"], 2)
+
+	def test_cancel_all_linked_docs_defers_blocked_docs(self):
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert().submit()
+		child1 = (
+			frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert().submit()
+		)
+		child2 = (
+			frappe.get_doc(
+				{"doctype": "Child DocType2", "parent_doctype": parent.name, "child_doctype1": child1.name}
+			)
+			.insert()
+			.submit()
+		)
+
+		# child1 is blocked by child2 and passed first (with a duplicate); it must
+		# get deferred and cancelled on a later pass instead of failing
+		linked_with.cancel_all_linked_docs(
+			docs=[
+				{"doctype": "Child DocType1", "name": child1.name, "docstatus": 1},
+				{"doctype": "Child DocType1", "name": child1.name, "docstatus": 1},
+				{"doctype": "Child DocType2", "name": child2.name, "docstatus": 1},
+			]
+		)
+
+		self.assertTrue(child1.reload().docstatus.is_cancelled())
+		self.assertTrue(child2.reload().docstatus.is_cancelled())
+
 	def test_get_submitted_linked_docs_accepts_native_ignore_list(self):
 		parent_record = frappe.get_doc({"doctype": "Parent DocType"}).insert()
 

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -231,6 +231,32 @@ class TestLinkedWith(IntegrationTestCase):
 		self.assertEqual(attempts, ["blocked", "free", "blocked"])
 		self.assertEqual(len(frappe.db.after_commit), after_commit_count + 2)
 
+	def test_deferred_attempts_drop_queued_realtime_events(self):
+		"""Realtime events queued by a rolled-back attempt must not stay in the
+		log that gets flushed on commit."""
+		attempts = []
+
+		def process(docinfo):
+			attempts.append(docinfo["name"])
+			frappe.publish_realtime("test_dependency_order", {"attempt": len(attempts)}, after_commit=True)
+			if docinfo["name"] == "blocked" and attempts.count("blocked") == 1:
+				raise frappe.LinkExistsError
+
+		linked_with.process_linked_docs_in_dependency_order(
+			[
+				{"doctype": "Parent DocType", "name": "blocked"},
+				{"doctype": "Parent DocType", "name": "free"},
+			],
+			process,
+			"Processing",
+		)
+
+		events = [
+			message for event, message, room in frappe.local._realtime_log if event == "test_dependency_order"
+		]
+		# only the events of the two successful attempts survive
+		self.assertEqual(events, [{"attempt": 2}, {"attempt": 3}])
+
 	def test_get_submitted_linked_docs_accepts_native_ignore_list(self):
 		parent_record = frappe.get_doc({"doctype": "Parent DocType"}).insert()
 

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -1154,6 +1154,18 @@ class CallbackManager:
 	def reset(self):
 		self._functions.clear()
 
+	def __len__(self) -> int:
+		return len(self._functions)
+
+	def __bool__(self) -> bool:
+		# stay truthy when empty; callers use `if callbacks:` as a None check
+		return True
+
+	def truncate(self, count: int) -> None:
+		"""Drop functions queued after the first `count`."""
+		while len(self._functions) > count:
+			self._functions.pop()
+
 
 def safe_eval(code, eval_globals=None, eval_locals=None):
 	"""A safer `eval`"""


### PR DESCRIPTION
Builds on #42046 (includes its commits; review the last four).

Deleting a document that draft or cancelled documents still reference fails with `LinkExistsError`, with no way forward except deleting each blocking document by hand, innermost first.

- deleting from the form now fetches every document that blocks deletion (recursively, using the same link semantics as the delete link check) and shows a Delete All Documents dialog mirroring the Cancel All flow; on confirmation the linked documents are deleted deepest first through the same defer-and-retry runner, then the root document
- deletion is best-effort: a document that stays undeletable (e.g. a submitted Stock Ledger Entry that grants delete to no role and that only its voucher's `on_trash` removes) is skipped and reported, and the root is kept, instead of the run failing and rolling everything back
- messages queued by failed attempts are dropped with the savepoint rollback, so retries do not flood the user with one error per blocked document
- cancellation now also defers on controller validation errors, not just link errors — e.g. a Purchase Order that refuses to cancel while its submitted Purchase Invoice exists gets retried after the invoice is cancelled; such dependencies live in controller code, so link-based ordering cannot see them

no-docs
