### PR TITLE
feat(ldap): map LDAP groups to Role Profiles

### DIFF
--- a/frappe/integrations/doctype/ldap_group_mapping/ldap_group_mapping.json
+++ b/frappe/integrations/doctype/ldap_group_mapping/ldap_group_mapping.json
@@ -6,7 +6,8 @@
  "engine": "InnoDB",
  "field_order": [
   "ldap_group",
-  "erpnext_role"
+  "erpnext_role",
+  "role_profile"
  ],
  "fields": [
   {
@@ -17,17 +18,25 @@
    "reqd": 1
   },
   {
+   "description": "Role granted to members of this LDAP group. Either this or Role Profile must be set.",
    "fieldname": "erpnext_role",
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "User Role",
-   "options": "Role",
-   "reqd": 1
+   "options": "Role"
+  },
+  {
+   "description": "Role Profile granted to members of this LDAP group. A user matching several groups receives every mapped profile.",
+   "fieldname": "role_profile",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Role Profile",
+   "options": "Role Profile"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-03-23 16:03:28.603657",
+ "modified": "2026-08-24 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "LDAP Group Mapping",

--- a/frappe/integrations/doctype/ldap_group_mapping/ldap_group_mapping.py
+++ b/frappe/integrations/doctype/ldap_group_mapping/ldap_group_mapping.py
@@ -16,11 +16,12 @@ class LDAPGroupMapping(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		erpnext_role: DF.Link
+		erpnext_role: DF.Link | None
 		ldap_group: DF.Data
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
+		role_profile: DF.Link | None
 	# end: auto-generated types
 
 	pass

--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.py
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.py
@@ -25,6 +25,10 @@ if TYPE_CHECKING:
 	from frappe.core.doctype.user.user import User
 
 
+def get_role_profile_roles(role_profile: str) -> set[str]:
+	return {role.role for role in frappe.get_cached_doc("Role Profile", role_profile).roles}
+
+
 class LDAPSettings(Document):
 	_DOCTYPE_NAME = "LDAP Settings"
 
@@ -72,6 +76,8 @@ class LDAPSettings(Document):
 
 		if not self.enabled:
 			return
+
+		self.validate_group_mappings()
 
 		if not self.flags.ignore_mandatory:
 			if (
@@ -134,6 +140,16 @@ class LDAPSettings(Document):
 					)
 				)
 
+	def validate_group_mappings(self):
+		for mapping in self.ldap_groups:
+			if not mapping.erpnext_role and not mapping.role_profile:
+				frappe.throw(
+					_("Row #{0}: Set a User Role or a Role Profile for LDAP group {1}").format(
+						mapping.idx, frappe.bold(mapping.ldap_group)
+					),
+					title=_("Misconfigured"),
+				)
+
 	def connect_to_ldap(self, base_dn, password, read_only=True) -> ldap3.Connection:
 		try:
 			if self.require_trusted_certificate == "Yes":
@@ -187,24 +203,47 @@ class LDAPSettings(Document):
 		user.save(ignore_permissions=True)
 
 	def sync_roles(self, user: "User", additional_groups: list | None = None):
-		current_roles = {d.role for d in user.get("roles")}
-		if self.default_user_type == "System User":
-			needed_roles = {self.default_role}
-		else:
-			needed_roles = set()
-		lower_groups = [g.lower() for g in additional_groups or []]
+		lower_groups = {g.lower() for g in additional_groups or []}
 
-		all_mapped_roles = {r.erpnext_role for r in self.ldap_groups}
-		matched_roles = {r.erpnext_role for r in self.ldap_groups if r.ldap_group.lower() in lower_groups}
-		unmatched_roles = all_mapped_roles.difference(matched_roles)
-		needed_roles.update(matched_roles)
-		roles_to_remove = current_roles.intersection(unmatched_roles)
+		mapped_roles, matched_roles = set(), set()
+		mapped_profiles, matched_profiles = set(), set()
 
-		if not needed_roles.issubset(current_roles):
-			missing_roles = needed_roles.difference(current_roles)
-			user.add_roles(*missing_roles)
+		for mapping in self.ldap_groups:
+			is_member = mapping.ldap_group.lower() in lower_groups
+			if mapping.erpnext_role:
+				mapped_roles.add(mapping.erpnext_role)
+				if is_member:
+					matched_roles.add(mapping.erpnext_role)
+			if mapping.role_profile:
+				mapped_profiles.add(mapping.role_profile)
+				if is_member:
+					matched_profiles.add(mapping.role_profile)
 
-		user.remove_roles(*roles_to_remove)
+		# profiles assigned outside of LDAP are left alone, LDAP only owns the ones it maps
+		current_profiles = {p.role_profile for p in user.get("role_profiles")}
+		needed_profiles = (current_profiles - mapped_profiles) | matched_profiles
+
+		needed_roles = set(matched_roles)
+		if self.default_user_type == "System User" and self.default_role:
+			needed_roles.add(self.default_role)
+		for role_profile in needed_profiles:
+			needed_roles.update(get_role_profile_roles(role_profile))
+
+		# losing a group must also withdraw the roles that group's profile granted
+		revoked_roles = mapped_roles - matched_roles
+		for role_profile in mapped_profiles - matched_profiles:
+			revoked_roles.update(get_role_profile_roles(role_profile))
+		revoked_roles -= needed_roles
+
+		if needed_profiles != current_profiles:
+			user.set("role_profiles", [{"role_profile": p} for p in sorted(needed_profiles)])
+
+		user.append_roles(*needed_roles)
+		for role in list(user.get("roles")):
+			if role.role in revoked_roles:
+				user.get("roles").remove(role)
+
+		user.save()
 
 	def create_or_update_user(self, user_data: dict, groups: list | None = None):
 		user: User = None

--- a/frappe/integrations/doctype/ldap_settings/test_ldap_settings.py
+++ b/frappe/integrations/doctype/ldap_settings/test_ldap_settings.py
@@ -443,6 +443,55 @@ class LDAP_TestCase:
 				)
 
 	@mock_ldap_connection
+	def test_sync_role_profiles(self):
+		profile_roles = {
+			"_Test LDAP Profile A": "Blogger",
+			"_Test LDAP Profile B": "Newsletter Manager",
+		}
+		for profile, role in profile_roles.items():
+			if not frappe.db.exists("Role Profile", profile):
+				frappe.get_doc(
+					{"doctype": "Role Profile", "role_profile": profile, "roles": [{"role": role}]}
+				).insert(ignore_permissions=True)
+
+		settings = self.test_class
+		settings.ldap_groups = []
+		settings.append("ldap_groups", {"ldap_group": "group-a", "role_profile": "_Test LDAP Profile A"})
+		settings.append("ldap_groups", {"ldap_group": "group-b", "role_profile": "_Test LDAP Profile B"})
+
+		user = frappe.get_doc("User", "posix.user1@unit.testing")
+
+		# a single matched group grants that group's profile
+		settings.sync_roles(user, ["group-a"])
+		user.reload()
+		self.assertEqual({p.role_profile for p in user.role_profiles}, {"_Test LDAP Profile A"})
+		self.assertIn("Blogger", {r.role for r in user.roles})
+
+		# a user matching several groups accumulates every mapped profile
+		settings.sync_roles(user, ["group-a", "group-b"])
+		user.reload()
+		self.assertEqual(
+			{p.role_profile for p in user.role_profiles},
+			{"_Test LDAP Profile A", "_Test LDAP Profile B"},
+		)
+		self.assertEqual({r.role for r in user.roles}, {"Blogger", "Newsletter Manager"})
+
+		# losing the groups withdraws both the profiles and the roles they granted
+		settings.sync_roles(user, [])
+		user.reload()
+		self.assertEqual([p.role_profile for p in user.role_profiles], [])
+		for role in profile_roles.values():
+			self.assertNotIn(role, {r.role for r in user.roles})
+
+	@mock_ldap_connection
+	def test_group_mapping_requires_role_or_profile(self):
+		settings = self.test_class
+		settings.ldap_groups = []
+		settings.append("ldap_groups", {"ldap_group": "group-without-target"})
+
+		self.assertRaises(ValidationError, settings.validate_group_mappings)
+
+	@mock_ldap_connection
 	def test_create_or_update_user(self):
 		test_user_data = {
 			"posix.user1": [


### PR DESCRIPTION
LDAP group mappings could only grant a single Role each, so expressing a real-world group as a set of permissions meant creating one mapping row per role and keeping them in sync by hand.

Add a `role_profile` field to LDAP Group Mapping alongside the existing `erpnext_role`. A mapping row may now set either one, and `erpnext_role` is no longer mandatory. A user matching several groups accumulates every mapped profile, since User.role_profiles is a multi-select table.

sync_roles() now reconciles profiles the same way it reconciles roles: only profiles that LDAP maps are considered, so a profile assigned by hand outside of LDAP is left untouched. Losing a group withdraws that group's profile and the roles the profile granted, which the previous role-only logic did not cover, because User.populate_role_profile_roles() returns early once role_profiles is empty and so would leave those roles behind.

Roles and profiles are applied in a single save so that populate_role_profile_roles() sees both, rather than the two saves the earlier add_roles()/remove_roles() pair performed.

<!--

Note: Your PR will be automatically closed if you're not in list of [vouched users](https://github.com/frappe/frappe/blob/develop/.github/VOUCHED.td).

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](https://www.conventionalcommits.org/en/v1.0.0/).
 3. All tests pass locally, UI and Unit tests.
 4. All business logic and validations must be on the server-side.
 5. Update necessary documentation.
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation
- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md
- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->
