### PR TITLE
fix: correct pointer-events property in desktop title input

### DIFF
--- a/frappe/desk/page/desktop/desktop.css
+++ b/frappe/desk/page/desktop/desktop.css
@@ -543,7 +543,7 @@
   color: var(--neutral-white);
   line-height: 22px;
   z-index: 1;
-  pointers-events: none;
+  pointer-events: none;
   width: 100%;
     text-align: center;
 }


### PR DESCRIPTION
## What does this PR do?

Fixes a typo in the `.title-input-label` CSS rule.

Changed:

`pointers-events: none;`

to:

`pointer-events: none;`

This ensures the `pointer-events` CSS property works as intended.

Fixes #41783