### PR TITLE
fix: validate submission in web forms

### DIFF
--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -397,8 +397,8 @@ export default class WebForm extends frappe.ui.FieldGroup {
 			return false;
 		}
 
-		// validation hack: get_values will check for missing data
-		let doc_values = super.get_values(this.allow_incomplete);
+		// validation hack: get_values will check for missing and invalid data
+		let doc_values = super.get_values(this.allow_incomplete, true);
 
 		if (!doc_values) return false;
 

--- a/frappe/website/doctype/web_form/test_web_form.py
+++ b/frappe/website/doctype/web_form/test_web_form.py
@@ -30,6 +30,144 @@ class TestWebForm(IntegrationTestCase):
 		frappe.local.request = None
 		frappe.set_user("Administrator")
 
+	def make_temp_web_form(self, **kwargs):
+		"""A throwaway Web Form on Event, so field tweaks don't leak into other tests."""
+		fields = kwargs.pop("web_form_fields", None) or [
+			{"fieldname": "subject", "fieldtype": "Data", "label": "Title", "reqd": 1},
+			{"fieldname": "description", "fieldtype": "Text", "label": "Description"},
+		]
+		web_form = frappe.get_doc(
+			{
+				"doctype": "Web Form",
+				"title": "_Test Validation Web Form",
+				"route": "test-validation-web-form",
+				"doc_type": "Event",
+				"module": "Website",
+				"published": 1,
+				"login_required": 1,
+				"allow_multiple": 1,
+				"web_form_fields": fields,
+				**kwargs,
+			}
+		).insert(ignore_permissions=True)
+
+		self.addCleanup(frappe.delete_doc, "Web Form", web_form.name, force=True, ignore_permissions=True)
+		return web_form
+
+	def test_web_form_mandatory_is_enforced_on_server(self):
+		"""A field mandatory only on the Web Form must not pass just because the
+		browser was skipped."""
+		frappe.set_user("Administrator")
+
+		# `description` is optional on Event, mandatory only on this Web Form
+		web_form = self.make_temp_web_form(
+			web_form_fields=[
+				{"fieldname": "subject", "fieldtype": "Data", "label": "Title", "reqd": 1},
+				{"fieldname": "description", "fieldtype": "Text", "label": "Description", "reqd": 1},
+			]
+		)
+
+		doc = {
+			"doctype": "Event",
+			"subject": "_Test Event Without Description",
+			"starts_on": "2014-09-09",
+		}
+
+		self.assertRaises(frappe.ValidationError, accept, web_form=web_form.name, data=json.dumps(doc))
+		self.assertFalse(frappe.db.exists("Event", {"subject": "_Test Event Without Description"}))
+
+	def test_web_form_data_field_options_are_enforced_on_server(self):
+		"""Email/Phone/URL set on a Web Form Field is not on the DocType, so the
+		document's own check never sees it."""
+		frappe.set_user("Administrator")
+
+		# Event.subject carries no data field options; the Web Form types it as an Email
+		web_form = self.make_temp_web_form(
+			web_form_fields=[
+				{
+					"fieldname": "subject",
+					"fieldtype": "Data",
+					"label": "Title",
+					"reqd": 1,
+					"options": "Email",
+				}
+			]
+		)
+
+		doc = {
+			"doctype": "Event",
+			"subject": "definitely not an email",
+			"starts_on": "2014-09-09",
+		}
+
+		self.assertRaises(
+			frappe.InvalidEmailAddressError, accept, web_form=web_form.name, data=json.dumps(doc)
+		)
+
+		accept(
+			web_form=web_form.name,
+			data=json.dumps({**doc, "subject": "someone@example.com"}),
+		)
+		self.assertTrue(frappe.db.exists("Event", {"subject": "someone@example.com"}))
+
+	def test_guest_cannot_skip_web_form_validation(self):
+		"""The reported case: an unauthenticated submission got a success page."""
+		web_form = self.make_temp_web_form(
+			login_required=0,
+			web_form_fields=[
+				{"fieldname": "subject", "fieldtype": "Data", "label": "Title", "reqd": 1},
+				{"fieldname": "description", "fieldtype": "Text", "label": "Description", "reqd": 1},
+			],
+		)
+
+		frappe.set_user("Guest")
+
+		doc = {
+			"doctype": "Event",
+			"subject": "_Test Guest Event Without Description",
+			"starts_on": "2014-09-09",
+		}
+
+		self.assertRaises(frappe.ValidationError, accept, web_form=web_form.name, data=json.dumps(doc))
+		frappe.set_user("Administrator")
+		self.assertFalse(frappe.db.exists("Event", {"subject": "_Test Guest Event Without Description"}))
+
+	def test_allow_incomplete_still_skips_mandatory(self):
+		frappe.set_user("Administrator")
+
+		web_form = self.make_temp_web_form(
+			allow_incomplete=1,
+			web_form_fields=[
+				{"fieldname": "subject", "fieldtype": "Data", "label": "Title", "reqd": 1},
+				{"fieldname": "description", "fieldtype": "Text", "label": "Description", "reqd": 1},
+			],
+		)
+
+		accept(
+			web_form=web_form.name,
+			data=json.dumps(
+				{"doctype": "Event", "subject": "_Test Incomplete Event", "starts_on": "2014-09-09"}
+			),
+		)
+		self.assertTrue(frappe.db.exists("Event", {"subject": "_Test Incomplete Event"}))
+
+	def test_mandatory_check_skips_fields_awaiting_upload(self):
+		"""An attach field is emptied while its file is written, so it must not read
+		as a missing mandatory value."""
+		web_form = self.make_temp_web_form(
+			web_form_fields=[
+				{"fieldname": "subject", "fieldtype": "Data", "label": "Title", "reqd": 1},
+				{"fieldname": "description", "fieldtype": "Text", "label": "Description", "reqd": 1},
+			]
+		)
+
+		doc = frappe.new_doc("Event")
+		doc.subject = "_Test Event Awaiting Upload"
+
+		self.assertRaises(frappe.ValidationError, web_form.validate_mandatory, doc)
+		# no exception once the field is declared as pending
+		web_form.validate_mandatory(doc, uploaded_fields={"description"})
+
 	def test_accept(self):
 		frappe.set_user("Administrator")
 

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -644,15 +644,78 @@ def get_context(context):
 
 		return parents
 
-	def validate_mandatory(self, doc):
-		"""Validate mandatory web form fields"""
-		missing = [f for f in self.web_form_fields if f.reqd and doc.get(f.fieldname) in (None, [], "")]
+	def validate_submission(self, doc, uploaded_fields=None):
+		"""Check the submitted values against the rules set on the Web Form itself.
+
+		`reqd` and Data `options` on a Web Form Field row belong to the Web Form, not
+		to the target DocType, so `doc.insert()` never looks at them. Without this the
+		browser is the only thing enforcing them, which anyone can walk past by posting
+		straight to `accept` -- guests included, since the endpoint allows them.
+		"""
+		if not self.allow_incomplete:
+			self.validate_mandatory(doc, uploaded_fields)
+
+		self.validate_data_field_options(doc)
+
+	def validate_mandatory(self, doc, uploaded_fields=None):
+		"""Validate mandatory web form fields.
+
+		`uploaded_fields` are attach fields whose file is still being written, so the
+		document does not carry their value yet.
+		"""
+		uploaded_fields = uploaded_fields or set()
+		missing = [
+			f
+			for f in self.web_form_fields
+			if f.reqd and f.fieldname not in uploaded_fields and doc.get(f.fieldname) in (None, [], "")
+		]
 		if missing:
 			frappe.throw(
 				_("Mandatory Information missing:")
 				+ "<br><br>"
 				+ "<br>".join(f"{d.label} ({d.fieldtype})" for d in missing)
 			)
+
+	def validate_data_field_options(self, doc):
+		"""Validate Data fields the Web Form types as Email, Name, Phone or URL.
+
+		Options that the DocType field already carries are left alone, so the document's
+		own check reports them and the message stays the same.
+		"""
+		from frappe.utils import (
+			split_emails,
+			validate_email_address,
+			validate_name,
+			validate_phone_number,
+			validate_url,
+		)
+
+		meta = frappe.get_meta(self.doc_type)
+
+		for field in self.web_form_fields:
+			if field.fieldtype != "Data" or not field.options:
+				continue
+
+			df = meta.get_field(field.fieldname)
+			if df and df.fieldtype == "Data" and df.options == field.options:
+				continue
+
+			value = doc.get(field.fieldname)
+			if not value:
+				continue
+
+			if field.options == "Email":
+				for email_address in split_emails(value):
+					validate_email_address(email_address, throw=True)
+
+			elif field.options == "Name":
+				validate_name(value, throw=True)
+
+			elif field.options == "Phone":
+				validate_phone_number(value, throw=True)
+
+			elif field.options == "URL":
+				validate_url(value, throw=True)
 
 	def allow_website_search_indexing(self):
 		return False
@@ -805,6 +868,8 @@ def accept(web_form: str, data: str | dict, web_form_request_key: str | None = N
 		for fieldname, value in web_form_request.get_doc_values().items():
 			if meta.has_field(fieldname):
 				doc.set(fieldname, value)
+
+	web_form.validate_submission(doc, uploaded_fields={fieldname for fieldname, _ in files})
 
 	if doc.name:
 		if web_form_request:


### PR DESCRIPTION
When logged out, validation for some fields wasn't working
