### PR TITLE
feat: delete all linked documents in dependency order

### DIFF
--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -456,20 +456,10 @@ def delete_all_linked_docs(docs: str | list) -> dict:
 	"""
 	to_delete = deduplicated(frappe.parse_json(docs))
 
-	# Defer any validation or permission failure, not just link errors: some
-	# documents cannot be deleted directly (e.g. submitted ledger entries that
-	# grant delete to no role and that only the on_trash hook of their voucher
-	# removes) and get retried until deleting the documents around them makes
-	# them deletable or removes them.
 	# No realtime progress here: the events race the requests and navigation
 	# that follow deletion and can strand the progress dialog; the freeze
 	# overlay of the call covers the feedback.
-	skipped = process_linked_docs_in_dependency_order(
-		to_delete,
-		delete_linked_doc,
-		defer_on=(frappe.ValidationError, frappe.PermissionError),
-		raise_when_stuck=False,
-	)
+	skipped = process_linked_docs_in_dependency_order(to_delete, delete_linked_doc, raise_when_stuck=False)
 	return {"deleted": [doc for doc in to_delete if doc not in skipped], "skipped": skipped}
 
 
@@ -490,11 +480,15 @@ def deduplicated(docs):
 	return unique
 
 
-def process_linked_docs_in_dependency_order(
-	docs, process, progress_title=None, defer_on=frappe.LinkExistsError, raise_when_stuck=True
-):
-	"""Run process over docs, deferring a document blocked by a linked document
+def process_linked_docs_in_dependency_order(docs, process, progress_title=None, raise_when_stuck=True):
+	"""Run process over docs, deferring a document blocked by another document
 	to a later pass, until a full pass makes no progress.
+
+	Any validation or permission failure defers, not just link errors: a
+	controller may block cancellation until a referencing document is cancelled
+	first, and some documents cannot be processed directly but stop being in
+	the way as a side effect of processing a document near them (e.g. ledger
+	entries that only the on_trash hook of their voucher removes).
 
 	Once stuck, either surface the error of the first blocked document or, with
 	raise_when_stuck disabled, keep the progress made and return the blocked
@@ -510,7 +504,7 @@ def process_linked_docs_in_dependency_order(
 			frappe.db.savepoint(save_point)
 			try:
 				process(doc)
-			except defer_on:
+			except (frappe.ValidationError, frappe.PermissionError):
 				# hooks ran before the failing check; undo their writes and side effects
 				frappe.db.rollback(save_point=save_point)
 				frappe.local.message_log = frappe.local.message_log[:message_count]

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -491,13 +491,9 @@ def process_linked_docs_in_dependency_order(docs, process, progress_title=None):
 			frappe.db.savepoint(save_point)
 			try:
 				process(doc)
-			except (
-				frappe.ValidationError,
-				frappe.PermissionError,
-				frappe.QueryTimeoutError,
-				frappe.QueryDeadlockError,
-			):
+			except (frappe.ValidationError, frappe.PermissionError, frappe.QueryTimeoutError):
 				# hooks ran before the failing check; undo their writes and side effects
+				# (not on a deadlock: the database has already rolled the whole transaction back)
 				frappe.db.rollback(save_point=save_point)
 				discard_side_effects_since(side_effect_counts)
 				deferred.append(doc)

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -446,14 +446,12 @@ def get_linked_docs_to_delete(doctype: str, name: str) -> dict:
 
 
 @frappe.whitelist()
-def delete_all_linked_docs(docs: str | list) -> dict:
-	"""Delete the given documents best effort, deferring blocked ones; returns
-	the deleted and the skipped documents."""
+def delete_all_linked_docs(docs: str | list):
+	"""Delete the given documents in dependency order; a blocked one fails the whole request."""
 	to_delete = deduplicated(frappe.parse_json(docs))
 
 	# no realtime progress: late events strand the dialog; the freeze overlay suffices
-	skipped = process_linked_docs_in_dependency_order(to_delete, delete_linked_doc, raise_when_stuck=False)
-	return {"deleted": [doc for doc in to_delete if doc not in skipped], "skipped": skipped}
+	process_linked_docs_in_dependency_order(to_delete, delete_linked_doc)
 
 
 def delete_linked_doc(docinfo):
@@ -473,10 +471,9 @@ def deduplicated(docs):
 	return unique
 
 
-def process_linked_docs_in_dependency_order(docs, process, progress_title=None, raise_when_stuck=True):
+def process_linked_docs_in_dependency_order(docs, process, progress_title=None):
 	"""Run process over docs, deferring blocked ones to later passes until a
-	pass makes no progress; then raise the first blocker's error, or with
-	raise_when_stuck disabled return the blocked docs."""
+	pass makes no progress, then raise the first blocker's error."""
 	total = len(docs)
 	processed = 0
 	save_point = "process_linked_doc"
@@ -509,14 +506,11 @@ def process_linked_docs_in_dependency_order(docs, process, progress_title=None, 
 			mark_processed()
 
 		if len(deferred) == len(docs):
-			if not raise_when_stuck:
-				return deferred
 			# surface the blocker's error; a success means the block was transient
 			process(deferred[0])
 			mark_processed()
 			deferred = deferred[1:]
 		docs = deferred
-	return []
 
 
 def capture_pending_side_effects() -> dict:

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -2,7 +2,7 @@
 # License: MIT. See LICENSE
 
 import itertools
-from collections import defaultdict
+from collections import defaultdict, deque
 
 import frappe
 import frappe.desk.form.load
@@ -404,6 +404,80 @@ def cancel_linked_doc(docinfo):
 		doc.cancel()
 
 
+@frappe.whitelist()
+def get_linked_docs_to_delete(doctype: str, name: str) -> dict:
+	"""Get all documents that block deletion of the given document, including
+	documents that block deletion of those documents, and so on.
+
+	Deepest documents come first, so deleting in list order resolves the links.
+	"""
+	from frappe.model.delete_doc import get_dynamic_linked_docs
+	from frappe.model.delete_doc import get_linked_docs as get_statically_linked_docs
+
+	frappe.has_permission(doctype, doc=name, throw=True)
+
+	depth_by_document = {(doctype, name): 0}
+	docstatus_by_document = {}
+	queue = deque([(doctype, name)])
+	while queue:
+		parent_key = queue.popleft()
+		parent_doc = frappe.get_doc(*parent_key)
+		docstatus_by_document[parent_key] = parent_doc.docstatus
+		links = get_statically_linked_docs(parent_doc, method="Delete") + get_dynamic_linked_docs(
+			parent_doc, method="Delete"
+		)
+		for link in links:
+			key = (link["reference_doctype"], link["reference_docname"])
+			if key not in depth_by_document:
+				depth_by_document[key] = depth_by_document[parent_key] + 1
+				queue.append(key)
+
+	docs = [
+		{"doctype": dt, "name": docname, "docstatus": docstatus_by_document[(dt, docname)]}
+		for dt, docname in depth_by_document
+		if (dt, docname) != (doctype, name)
+	]
+	docs.sort(key=lambda doc: depth_by_document[doc["doctype"], doc["name"]], reverse=True)
+	return {"docs": docs, "count": len(docs)}
+
+
+@frappe.whitelist()
+def delete_all_linked_docs(docs: str | list) -> dict:
+	"""
+	Delete as many of the given documents as their links allow.
+
+	A document that other documents still reference is deferred and retried
+	after the rest, so callers need not pass docs in dependency order. A
+	document that stays undeletable is skipped without undoing the rest.
+	Return the deleted and the skipped documents.
+
+	Arguments:
+	        docs (json str) - It contains list of dictionaries of the documents to delete.
+	"""
+	to_delete = deduplicated(frappe.parse_json(docs))
+
+	# Defer any validation or permission failure, not just link errors: some
+	# documents cannot be deleted directly (e.g. submitted ledger entries that
+	# grant delete to no role and that only the on_trash hook of their voucher
+	# removes) and get retried until deleting the documents around them makes
+	# them deletable or removes them.
+	# No realtime progress here: the events race the requests and navigation
+	# that follow deletion and can strand the progress dialog; the freeze
+	# overlay of the call covers the feedback.
+	skipped = process_linked_docs_in_dependency_order(
+		to_delete,
+		delete_linked_doc,
+		defer_on=(frappe.ValidationError, frappe.PermissionError),
+		raise_when_stuck=False,
+	)
+	return {"deleted": [doc for doc in to_delete if doc not in skipped], "skipped": skipped}
+
+
+def delete_linked_doc(docinfo):
+	"""Delete a document; one already removed by another document's on_trash hook is ignored."""
+	frappe.delete_doc(docinfo.get("doctype"), docinfo.get("name"))
+
+
 def deduplicated(docs):
 	"""Preserve order, dropping repeated (doctype, name) entries."""
 	seen = set()
@@ -416,33 +490,45 @@ def deduplicated(docs):
 	return unique
 
 
-def process_linked_docs_in_dependency_order(docs, process, progress_title):
+def process_linked_docs_in_dependency_order(
+	docs, process, progress_title=None, defer_on=frappe.LinkExistsError, raise_when_stuck=True
+):
 	"""Run process over docs, deferring a document blocked by a linked document
-	to a later pass, until a full pass makes no progress."""
+	to a later pass, until a full pass makes no progress.
+
+	Once stuck, either surface the error of the first blocked document or, with
+	raise_when_stuck disabled, keep the progress made and return the blocked
+	documents."""
 	total = len(docs)
 	processed = 0
 	save_point = "process_linked_doc"
 	while docs:
 		deferred = []
 		for doc in docs:
+			message_count = len(frappe.local.message_log)
 			side_effect_counts = capture_pending_side_effects()
 			frappe.db.savepoint(save_point)
 			try:
 				process(doc)
-			except frappe.LinkExistsError:
-				# hooks ran before the link check; undo their writes and side effects
+			except defer_on:
+				# hooks ran before the failing check; undo their writes and side effects
 				frappe.db.rollback(save_point=save_point)
+				frappe.local.message_log = frappe.local.message_log[:message_count]
 				discard_side_effects_since(side_effect_counts)
 				deferred.append(doc)
 				continue
 			frappe.db.release_savepoint(save_point)
 			processed += 1
-			frappe.publish_progress(percent=processed / total * 100, title=progress_title)
+			if progress_title:
+				frappe.publish_progress(percent=processed / total * 100, title=progress_title)
 
 		if len(deferred) == len(docs):
-			# nothing progressed: a document outside the set blocks it; surface the error
-			process(deferred[0])
+			if raise_when_stuck:
+				# nothing progressed: a document outside the set blocks it; surface the error
+				process(deferred[0])
+			return deferred
 		docs = deferred
+	return []
 
 
 def capture_pending_side_effects() -> dict:

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -409,18 +409,9 @@ MAX_LINKED_DELETE_DOCUMENTS = 500
 
 @frappe.whitelist()
 def get_linked_docs_to_delete(doctype: str, name: str) -> dict:
-	"""Get all documents that block deletion of the given document, including
-	documents that block deletion of those documents, and so on.
-
-	Documents the user cannot read are neither returned nor traversed, so their
-	identities stay hidden and their deletion fails with the regular link error.
-
-	Deepest documents come first, so deleting in list order resolves the links.
-
-	Traversal stops once MAX_LINKED_DELETE_DOCUMENTS is exceeded and returns no
-	documents, so deleting a heavily referenced document falls back to a plain
-	delete instead of tying up the worker walking its graph.
-	"""
+	"""Get the documents blocking deletion of the given document, recursively,
+	deepest first; unreadable ones are neither returned nor traversed. Past
+	MAX_LINKED_DELETE_DOCUMENTS the result is empty and marked truncated."""
 	from frappe.model.delete_doc import get_dynamic_linked_docs
 	from frappe.model.delete_doc import get_linked_docs as get_statically_linked_docs
 
@@ -431,8 +422,7 @@ def get_linked_docs_to_delete(doctype: str, name: str) -> dict:
 	queue = deque([root_key])
 	while queue:
 		parent_key = queue.popleft()
-		# a lightweight stand-in is enough for the link lookups; loading the
-		# full document of every node is too expensive on this request path
+		# lightweight stand-in; a full get_doc per node is too expensive
 		parent = frappe._dict(doctype=parent_key[0], name=parent_key[1])
 		links = get_statically_linked_docs(parent, method="Delete") + get_dynamic_linked_docs(
 			parent, method="Delete"
@@ -457,22 +447,11 @@ def get_linked_docs_to_delete(doctype: str, name: str) -> dict:
 
 @frappe.whitelist()
 def delete_all_linked_docs(docs: str | list) -> dict:
-	"""
-	Delete as many of the given documents as their links allow.
-
-	A document that other documents still reference is deferred and retried
-	after the rest, so callers need not pass docs in dependency order. A
-	document that stays undeletable is skipped without undoing the rest.
-	Return the deleted and the skipped documents.
-
-	Arguments:
-	        docs (json str) - It contains list of dictionaries of the documents to delete.
-	"""
+	"""Delete the given documents best effort, deferring blocked ones; returns
+	the deleted and the skipped documents."""
 	to_delete = deduplicated(frappe.parse_json(docs))
 
-	# No realtime progress here: the events race the requests and navigation
-	# that follow deletion and can strand the progress dialog; the freeze
-	# overlay of the call covers the feedback.
+	# no realtime progress: late events strand the dialog; the freeze overlay suffices
 	skipped = process_linked_docs_in_dependency_order(to_delete, delete_linked_doc, raise_when_stuck=False)
 	return {"deleted": [doc for doc in to_delete if doc not in skipped], "skipped": skipped}
 
@@ -495,20 +474,9 @@ def deduplicated(docs):
 
 
 def process_linked_docs_in_dependency_order(docs, process, progress_title=None, raise_when_stuck=True):
-	"""Run process over docs, deferring a document blocked by another document
-	to a later pass, until a full pass makes no progress.
-
-	Any validation or permission failure defers, not just link errors: a
-	controller may block cancellation until a referencing document is cancelled
-	first, and some documents cannot be processed directly but stop being in
-	the way as a side effect of processing a document near them (e.g. ledger
-	entries that only the on_trash hook of their voucher removes). A document
-	locked by another session or caught in a deadlock defers too, since the
-	lock may be gone by the retry pass.
-
-	Once stuck, either surface the error of the first blocked document or, with
-	raise_when_stuck disabled, keep the progress made and return the blocked
-	documents."""
+	"""Run process over docs, deferring blocked ones to later passes until a
+	pass makes no progress; then raise the first blocker's error, or with
+	raise_when_stuck disabled return the blocked docs."""
 	total = len(docs)
 	processed = 0
 	save_point = "process_linked_doc"

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -404,6 +404,9 @@ def cancel_linked_doc(docinfo):
 		doc.cancel()
 
 
+MAX_LINKED_DELETE_DOCUMENTS = 500
+
+
 @frappe.whitelist()
 def get_linked_docs_to_delete(doctype: str, name: str) -> dict:
 	"""Get all documents that block deletion of the given document, including
@@ -413,35 +416,43 @@ def get_linked_docs_to_delete(doctype: str, name: str) -> dict:
 	identities stay hidden and their deletion fails with the regular link error.
 
 	Deepest documents come first, so deleting in list order resolves the links.
+
+	Traversal stops once MAX_LINKED_DELETE_DOCUMENTS is exceeded and returns no
+	documents, so deleting a heavily referenced document falls back to a plain
+	delete instead of tying up the worker walking its graph.
 	"""
 	from frappe.model.delete_doc import get_dynamic_linked_docs
 	from frappe.model.delete_doc import get_linked_docs as get_statically_linked_docs
 
 	frappe.has_permission(doctype, doc=name, throw=True)
 
-	depth_by_document = {(doctype, name): 0}
-	docstatus_by_document = {}
-	queue = deque([(doctype, name)])
+	root_key = (doctype, name)
+	depth_by_document = {root_key: 0}
+	queue = deque([root_key])
 	while queue:
 		parent_key = queue.popleft()
-		parent_doc = frappe.get_doc(*parent_key)
-		docstatus_by_document[parent_key] = parent_doc.docstatus
-		links = get_statically_linked_docs(parent_doc, method="Delete") + get_dynamic_linked_docs(
-			parent_doc, method="Delete"
+		# a lightweight stand-in is enough for the link lookups; loading the
+		# full document of every node is too expensive on this request path
+		parent = frappe._dict(doctype=parent_key[0], name=parent_key[1])
+		links = get_statically_linked_docs(parent, method="Delete") + get_dynamic_linked_docs(
+			parent, method="Delete"
 		)
 		for link in links:
 			key = (link["reference_doctype"], link["reference_docname"])
-			if key not in depth_by_document and frappe.has_permission(key[0], doc=key[1]):
-				depth_by_document[key] = depth_by_document[parent_key] + 1
-				queue.append(key)
+			if key in depth_by_document:
+				continue
+			if len(depth_by_document) > MAX_LINKED_DELETE_DOCUMENTS:
+				return {"docs": [], "count": 0, "truncated": True}
+			if not frappe.has_permission(key[0], doc=key[1]):
+				continue
+			depth_by_document[key] = depth_by_document[parent_key] + 1
+			queue.append(key)
 
 	docs = [
-		{"doctype": dt, "name": docname, "docstatus": docstatus_by_document[(dt, docname)]}
-		for dt, docname in depth_by_document
-		if (dt, docname) != (doctype, name)
+		{"doctype": dt, "name": docname} for dt, docname in depth_by_document if (dt, docname) != root_key
 	]
 	docs.sort(key=lambda doc: depth_by_document[doc["doctype"], doc["name"]], reverse=True)
-	return {"docs": docs, "count": len(docs)}
+	return {"docs": docs, "count": len(docs), "truncated": False}
 
 
 @frappe.whitelist()

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -502,7 +502,6 @@ def process_linked_docs_in_dependency_order(docs, process, progress_title=None, 
 	while docs:
 		deferred = []
 		for doc in docs:
-			message_count = len(frappe.local.message_log)
 			side_effect_counts = capture_pending_side_effects()
 			frappe.db.savepoint(save_point)
 			try:
@@ -510,7 +509,6 @@ def process_linked_docs_in_dependency_order(docs, process, progress_title=None, 
 			except (frappe.ValidationError, frappe.PermissionError):
 				# hooks ran before the failing check; undo their writes and side effects
 				frappe.db.rollback(save_point=save_point)
-				frappe.local.message_log = frappe.local.message_log[:message_count]
 				discard_side_effects_since(side_effect_counts)
 				deferred.append(doc)
 				continue

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -409,6 +409,9 @@ def get_linked_docs_to_delete(doctype: str, name: str) -> dict:
 	"""Get all documents that block deletion of the given document, including
 	documents that block deletion of those documents, and so on.
 
+	Documents the user cannot read are neither returned nor traversed, so their
+	identities stay hidden and their deletion fails with the regular link error.
+
 	Deepest documents come first, so deleting in list order resolves the links.
 	"""
 	from frappe.model.delete_doc import get_dynamic_linked_docs
@@ -428,7 +431,7 @@ def get_linked_docs_to_delete(doctype: str, name: str) -> dict:
 		)
 		for link in links:
 			key = (link["reference_doctype"], link["reference_docname"])
-			if key not in depth_by_document:
+			if key not in depth_by_document and frappe.has_permission(key[0], doc=key[1]):
 				depth_by_document[key] = depth_by_document[parent_key] + 1
 				queue.append(key)
 

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -502,7 +502,9 @@ def process_linked_docs_in_dependency_order(docs, process, progress_title=None, 
 	controller may block cancellation until a referencing document is cancelled
 	first, and some documents cannot be processed directly but stop being in
 	the way as a side effect of processing a document near them (e.g. ledger
-	entries that only the on_trash hook of their voucher removes).
+	entries that only the on_trash hook of their voucher removes). A document
+	locked by another session or caught in a deadlock defers too, since the
+	lock may be gone by the retry pass.
 
 	Once stuck, either surface the error of the first blocked document or, with
 	raise_when_stuck disabled, keep the progress made and return the blocked
@@ -517,7 +519,12 @@ def process_linked_docs_in_dependency_order(docs, process, progress_title=None, 
 			frappe.db.savepoint(save_point)
 			try:
 				process(doc)
-			except (frappe.ValidationError, frappe.PermissionError):
+			except (
+				frappe.ValidationError,
+				frappe.PermissionError,
+				frappe.QueryTimeoutError,
+				frappe.QueryDeadlockError,
+			):
 				# hooks ran before the failing check; undo their writes and side effects
 				frappe.db.rollback(save_point=save_point)
 				discard_side_effects_since(side_effect_counts)

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -512,6 +512,13 @@ def process_linked_docs_in_dependency_order(docs, process, progress_title=None, 
 	total = len(docs)
 	processed = 0
 	save_point = "process_linked_doc"
+
+	def mark_processed():
+		nonlocal processed
+		processed += 1
+		if progress_title:
+			frappe.publish_progress(percent=processed / total * 100, title=progress_title)
+
 	while docs:
 		deferred = []
 		for doc in docs:
@@ -531,15 +538,15 @@ def process_linked_docs_in_dependency_order(docs, process, progress_title=None, 
 				deferred.append(doc)
 				continue
 			frappe.db.release_savepoint(save_point)
-			processed += 1
-			if progress_title:
-				frappe.publish_progress(percent=processed / total * 100, title=progress_title)
+			mark_processed()
 
 		if len(deferred) == len(docs):
-			if raise_when_stuck:
-				# nothing progressed: a document outside the set blocks it; surface the error
-				process(deferred[0])
-			return deferred
+			if not raise_when_stuck:
+				return deferred
+			# surface the blocker's error; a success means the block was transient
+			process(deferred[0])
+			mark_processed()
+			deferred = deferred[1:]
 		docs = deferred
 	return []
 

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -148,12 +148,13 @@ def delete_doc(
 			# Lock the doc without waiting
 			try:
 				frappe.db.get_value(doctype, name, for_update=True, wait=False)
-			except (frappe.QueryTimeoutError, frappe.QueryDeadlockError):
+			except (frappe.QueryTimeoutError, frappe.QueryDeadlockError) as error:
+				# keep the type: a deadlock has already rolled the transaction back
 				frappe.throw(
 					_(
 						"This document can not be deleted right now as it's being modified by another user. Please try again after some time."
 					),
-					exc=frappe.QueryTimeoutError,
+					exc=type(error),
 				)
 			doc = frappe.get_doc(doctype, name)
 

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1091,18 +1091,24 @@ frappe.ui.form.Form = class FrappeForm {
 	}
 
 	_linked_docs_list_html(links, as_links = true) {
+		// never render an absurdly long list; the count carries the scale
+		const max_names_per_doctype = 10;
 		let links_text = "";
 		const doctypes = Array.from(new Set(links.map((link) => link.doctype)));
 
 		for (let doctype of doctypes) {
-			let docnames = links
-				.filter((link) => link.doctype == doctype)
+			const of_doctype = links.filter((link) => link.doctype == doctype);
+			let docnames = of_doctype
+				.slice(0, max_names_per_doctype)
 				.map((link) =>
 					as_links
 						? frappe.utils.get_form_link(link.doctype, link.name, true)
 						: frappe.utils.escape_html(cstr(link.name))
 				)
 				.join(", ");
+			if (of_doctype.length > max_names_per_doctype) {
+				docnames += ", " + __("and {0} more", [of_doctype.length - max_names_per_doctype]);
+			}
 			links_text += `<li><strong>${__(doctype)}</strong>: ${docnames}</li>`;
 		}
 		return `<ul>${links_text}</ul>`;

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1100,7 +1100,7 @@ frappe.ui.form.Form = class FrappeForm {
 				.map((link) =>
 					as_links
 						? frappe.utils.get_form_link(link.doctype, link.name, true)
-						: cstr(link.name)
+						: frappe.utils.escape_html(cstr(link.name))
 				)
 				.join(", ");
 			links_text += `<li><strong>${__(doctype)}</strong>: ${docnames}</li>`;

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1090,26 +1090,35 @@ frappe.ui.form.Form = class FrappeForm {
 			});
 	}
 
+	_linked_docs_list_html(links, as_links = true) {
+		let links_text = "";
+		const doctypes = Array.from(new Set(links.map((link) => link.doctype)));
+
+		for (let doctype of doctypes) {
+			let docnames = links
+				.filter((link) => link.doctype == doctype)
+				.map((link) =>
+					as_links
+						? frappe.utils.get_form_link(link.doctype, link.name, true)
+						: cstr(link.name)
+				)
+				.join(", ");
+			links_text += `<li><strong>${__(doctype)}</strong>: ${docnames}</li>`;
+		}
+		return `<ul>${links_text}</ul>`;
+	}
+
 	_cancel_all(r, btn, callback, on_error) {
 		const me = this;
 
 		// add confirmation message for cancelling all linked docs
-		let links_text = "";
 		let links = r.message.docs;
-		const doctypes = Array.from(new Set(links.map((link) => link.doctype)));
 
 		me.ignore_doctypes_on_cancel_all = me.ignore_doctypes_on_cancel_all || [];
 
-		for (let doctype of doctypes) {
-			if (!me.ignore_doctypes_on_cancel_all.includes(doctype)) {
-				let docnames = links
-					.filter((link) => link.doctype == doctype)
-					.map((link) => frappe.utils.get_form_link(link.doctype, link.name, true))
-					.join(", ");
-				links_text += `<li><strong>${__(doctype)}</strong>: ${docnames}</li>`;
-			}
-		}
-		links_text = `<ul>${links_text}</ul>`;
+		let links_text = me._linked_docs_list_html(
+			links.filter((link) => !me.ignore_doctypes_on_cancel_all.includes(link.doctype))
+		);
 
 		let confirm_message = __("{0} {1} is linked with the following submitted documents: {2}", [
 			__(me.doc.doctype).bold(),
@@ -1255,10 +1264,102 @@ frappe.ui.form.Form = class FrappeForm {
 	}
 
 	savetrash() {
+		const me = this;
 		this.validate_form_action("Delete");
-		frappe.model.delete_doc(this.doctype, this.docname, function () {
-			window.history.back();
+		frappe
+			.call({
+				method: "frappe.desk.form.linked_with.get_linked_docs_to_delete",
+				args: {
+					doctype: me.doctype,
+					name: cstr(me.docname),
+				},
+				freeze: true,
+			})
+			.then((r) => {
+				if (!r.exc && (r.message.docs || []).length) {
+					return me._delete_all(r);
+				}
+				me._delete();
+			});
+	}
+
+	_delete(skip_confirm) {
+		frappe.model.delete_doc(
+			this.doctype,
+			this.docname,
+			function () {
+				window.history.back();
+			},
+			skip_confirm
+		);
+	}
+
+	_delete_all(r) {
+		const me = this;
+		const links = r.message.docs;
+
+		let confirm_message = __("{0} {1} is linked with the following documents: {2}", [
+			__(me.doctype).bold(),
+			me.docname,
+			me._linked_docs_list_html(links),
+		]);
+		confirm_message += __("Do you want to delete {0} along with all linked documents?", [
+			cstr(me.docname).bold(),
+		]);
+
+		const d = new frappe.ui.Dialog({
+			title: __("Delete All Documents"),
+			fields: [
+				{
+					fieldtype: "HTML",
+					options: `<p class="frappe-confirm-message">${confirm_message}</p>`,
+				},
+			],
 		});
+
+		d.set_primary_action(__("Delete All"), () => {
+			d.hide();
+			frappe.call({
+				method: "frappe.desk.form.linked_with.delete_all_linked_docs",
+				args: {
+					docs: links,
+				},
+				freeze: true,
+				freeze_message: __("Deleting documents..."),
+				callback: (resp) => {
+					if (resp.exc) {
+						return;
+					}
+					const skipped = resp.message.skipped || [];
+					if (!skipped.length) {
+						return me._delete(true);
+					}
+					me.reload_doc();
+					const deleted = resp.message.deleted || [];
+					let message = "";
+					if (deleted.length) {
+						message += __("The following documents were deleted: {0}", [
+							me._linked_docs_list_html(deleted, false),
+						]);
+					}
+					message += __(
+						"{0} {1} was kept because the following documents could not be deleted: {2}",
+						[
+							__(me.doctype),
+							cstr(me.docname).bold(),
+							me._linked_docs_list_html(skipped),
+						]
+					);
+					frappe.msgprint({
+						title: __("Partially Deleted"),
+						indicator: "orange",
+						message: message,
+					});
+				},
+			});
+		});
+
+		d.show();
 	}
 
 	amend_doc() {

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1143,14 +1143,13 @@ frappe.ui.form.Form = class FrappeForm {
 		let d = new frappe.ui.Dialog(
 			{
 				title: __("Cancel All Documents"),
-				fields: [
-					{
-						fieldtype: "HTML",
-						options: `<p class="frappe-confirm-message">${confirm_message}</p>`,
-					},
-				],
+				fields: [{ fieldtype: "HTML", fieldname: "message" }],
 			},
 			() => me.handle_save_fail(btn, on_error)
+		);
+		// set directly: HTML field options get template-rendered, and names are user input
+		d.fields_dict.message.$wrapper.html(
+			`<p class="frappe-confirm-message">${confirm_message}</p>`
 		);
 
 		// if user can cancel all linked docs, add action to the dialog
@@ -1315,13 +1314,12 @@ frappe.ui.form.Form = class FrappeForm {
 
 		const d = new frappe.ui.Dialog({
 			title: __("Delete All Documents"),
-			fields: [
-				{
-					fieldtype: "HTML",
-					options: `<p class="frappe-confirm-message">${confirm_message}</p>`,
-				},
-			],
+			fields: [{ fieldtype: "HTML", fieldname: "message" }],
 		});
+		// set directly: HTML field options get template-rendered, and names are user input
+		d.fields_dict.message.$wrapper.html(
+			`<p class="frappe-confirm-message">${confirm_message}</p>`
+		);
 
 		d.set_primary_action(__("Delete All"), () => {
 			d.hide();

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1090,7 +1090,7 @@ frappe.ui.form.Form = class FrappeForm {
 			});
 	}
 
-	_linked_docs_list_html(links, as_links = true) {
+	_linked_docs_list_html(links) {
 		// never render an absurdly long list; the count carries the scale
 		const max_names_per_doctype = 10;
 		let links_text = "";
@@ -1100,11 +1100,7 @@ frappe.ui.form.Form = class FrappeForm {
 			const of_doctype = links.filter((link) => link.doctype == doctype);
 			let docnames = of_doctype
 				.slice(0, max_names_per_doctype)
-				.map((link) =>
-					as_links
-						? frappe.utils.get_form_link(link.doctype, link.name, true)
-						: frappe.utils.escape_html(cstr(link.name))
-				)
+				.map((link) => frappe.utils.get_form_link(link.doctype, link.name, true))
 				.join(", ");
 			if (of_doctype.length > max_names_per_doctype) {
 				docnames += ", " + __("and {0} more", [of_doctype.length - max_names_per_doctype]);
@@ -1331,34 +1327,9 @@ frappe.ui.form.Form = class FrappeForm {
 				freeze: true,
 				freeze_message: __("Deleting documents..."),
 				callback: (resp) => {
-					if (resp.exc) {
-						return;
+					if (!resp.exc) {
+						me._delete(true);
 					}
-					const skipped = resp.message.skipped || [];
-					if (!skipped.length) {
-						return me._delete(true);
-					}
-					me.reload_doc();
-					const deleted = resp.message.deleted || [];
-					let message = "";
-					if (deleted.length) {
-						message += __("The following documents were deleted: {0}", [
-							me._linked_docs_list_html(deleted, false),
-						]);
-					}
-					message += __(
-						"{0} {1} was kept because the following documents could not be deleted: {2}",
-						[
-							__(me.doctype),
-							cstr(me.docname).bold(),
-							me._linked_docs_list_html(skipped),
-						]
-					);
-					frappe.msgprint({
-						title: __("Partially Deleted"),
-						indicator: "orange",
-						message: message,
-					});
 				},
 			});
 		});

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -732,7 +732,7 @@ $.extend(frappe.model, {
 		return no_copy_list;
 	},
 
-	delete_doc: function (doctype, docname, callback) {
+	delete_doc: function (doctype, docname, callback, skip_confirm) {
 		let title = docname.toString();
 		const title_field = frappe.get_meta(doctype).title_field;
 		if (title_field) {
@@ -741,28 +741,33 @@ $.extend(frappe.model, {
 				title = `${value} (${docname})`;
 			}
 		}
+		const perform_delete = function () {
+			return frappe.call({
+				method: "frappe.client.delete",
+				args: {
+					doctype: doctype,
+					name: docname,
+				},
+				freeze: true,
+				freeze_message: __("Deleting {0}...", [title]),
+				callback: function (r, rt) {
+					if (!r.exc) {
+						frappe.utils.play_sound("delete");
+						frappe.model.delete_from_locals(doctype, docname);
+						if (callback) callback(r, rt);
+					}
+				},
+			});
+		};
+		if (skip_confirm) {
+			perform_delete();
+			return;
+		}
 		// destructive: red primary via frappe.warn, not a neutral confirm
 		frappe.warn(
 			__("Confirm"),
 			__("Permanently delete {0}?", [title.bold()]),
-			function () {
-				return frappe.call({
-					method: "frappe.client.delete",
-					args: {
-						doctype: doctype,
-						name: docname,
-					},
-					freeze: true,
-					freeze_message: __("Deleting {0}...", [title]),
-					callback: function (r, rt) {
-						if (!r.exc) {
-							frappe.utils.play_sound("delete");
-							frappe.model.delete_from_locals(doctype, docname);
-							if (callback) callback(r, rt);
-						}
-					},
-				});
-			},
+			perform_delete,
 			__("Delete")
 		);
 	},

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -16,7 +16,7 @@ def hard_delete_referencing_child2_records(doc, method=None):
 def block_cancel_while_child2_submitted(doc, method=None):
 	"""Mimic a controller that wants referencing documents cancelled first."""
 	if frappe.db.exists("Child DocType2", {"child_doctype1": doc.name, "docstatus": 1}):
-		frappe.throw("Cancel the referencing document first")
+		frappe.throw(frappe._("Cancel the referencing document first"))
 
 
 class TestLinkedWith(IntegrationTestCase):
@@ -387,6 +387,22 @@ class TestLinkedWith(IntegrationTestCase):
 
 		# child2 references child1, so it must come first to be deletable in list order
 		self.assertEqual([doc["name"] for doc in docs], [child2.name, child1.name])
+
+	def test_get_linked_docs_to_delete_excludes_unreadable_docs(self):
+		"""Linked documents the user cannot read must stay hidden from the listing."""
+		from frappe.permissions import add_permission
+
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert()
+		child1 = frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert()
+		frappe.get_doc({"doctype": "Child DocType2", "parent_doctype": parent.name}).insert()
+
+		add_permission("Parent DocType", "All")
+		add_permission("Child DocType1", "All")
+
+		with self.set_user("test1@example.com"):
+			docs = linked_with.get_linked_docs_to_delete(parent.doctype, parent.name)["docs"]
+
+		self.assertEqual(docs, [{"doctype": "Child DocType1", "name": child1.name, "docstatus": 0}])
 
 	def test_delete_all_linked_docs_defers_blocked_docs(self):
 		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert()

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -8,6 +8,11 @@ from frappe.desk.form import linked_with
 from frappe.tests import IntegrationTestCase
 
 
+def hard_delete_referencing_child2_records(doc, method=None):
+	"""Mimic a voucher on_trash that removes its submitted ledger rows."""
+	frappe.db.delete("Child DocType2", {"child_doctype1": doc.name})
+
+
 class TestLinkedWith(IntegrationTestCase):
 	def setUp(self):
 		parent_doctype = new_doctype("Parent DocType")
@@ -343,6 +348,89 @@ class TestLinkedWith(IntegrationTestCase):
 			self.assertEqual(frappe.local.message_log, ["kept"])
 		finally:
 			frappe.local.message_log = original
+
+	def test_get_linked_docs_to_delete_deepest_first(self):
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert()
+		child1 = frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert()
+		child2 = frappe.get_doc({"doctype": "Child DocType2", "child_doctype1": child1.name}).insert()
+
+		docs = linked_with.get_linked_docs_to_delete(parent.doctype, parent.name)["docs"]
+
+		# child2 references child1, so it must come first to be deletable in list order
+		self.assertEqual([doc["name"] for doc in docs], [child2.name, child1.name])
+
+	def test_delete_all_linked_docs_defers_blocked_docs(self):
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert()
+		child1 = frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert()
+		child2 = frappe.get_doc(
+			{"doctype": "Child DocType2", "parent_doctype": parent.name, "child_doctype1": child1.name}
+		).insert()
+
+		# child1 is blocked by child2 and passed first; it must get deferred
+		# and deleted on a later pass instead of failing
+		result = linked_with.delete_all_linked_docs(
+			docs=[
+				{"doctype": "Child DocType1", "name": child1.name},
+				{"doctype": "Child DocType2", "name": child2.name},
+			]
+		)
+
+		self.assertEqual(
+			result,
+			{
+				"deleted": [
+					{"doctype": "Child DocType1", "name": child1.name},
+					{"doctype": "Child DocType2", "name": child2.name},
+				],
+				"skipped": [],
+			},
+		)
+		self.assertFalse(frappe.db.exists("Child DocType1", child1.name))
+		self.assertFalse(frappe.db.exists("Child DocType2", child2.name))
+		parent.delete()
+
+	def test_delete_all_linked_docs_waits_for_on_trash_cleanup(self):
+		"""A submitted document that only an on_trash hook removes (like a ledger
+		entry removed with its voucher) must get deferred, not fail the run."""
+		child1 = frappe.get_doc({"doctype": "Child DocType1"}).insert()
+		child2 = (
+			frappe.get_doc({"doctype": "Child DocType2", "child_doctype1": child1.name}).insert().submit()
+		)
+
+		hook = f"{__name__}.hard_delete_referencing_child2_records"
+		self.addCleanup(setattr, frappe.local, "doc_events_hooks", None)
+		with self.patch_hooks({"doc_events": {"Child DocType1": {"on_trash": [hook]}}}):
+			frappe.local.doc_events_hooks = None
+			linked_with.delete_all_linked_docs(
+				docs=[
+					{"doctype": "Child DocType2", "name": child2.name},
+					{"doctype": "Child DocType1", "name": child1.name},
+				]
+			)
+
+		self.assertFalse(frappe.db.exists("Child DocType1", child1.name))
+		self.assertFalse(frappe.db.exists("Child DocType2", child2.name))
+
+	def test_delete_all_linked_docs_skips_undeletable_docs(self):
+		"""A document that stays undeletable must get skipped and reported without
+		undoing the deleted documents or leaking messages of failed attempts."""
+		child1 = frappe.get_doc({"doctype": "Child DocType1"}).insert().submit()
+		child2 = frappe.get_doc({"doctype": "Child DocType2"}).insert()
+		message_count = len(frappe.local.message_log)
+
+		result = linked_with.delete_all_linked_docs(
+			docs=[
+				{"doctype": "Child DocType1", "name": child1.name},
+				{"doctype": "Child DocType2", "name": child2.name},
+			]
+		)
+
+		self.assertEqual(result["deleted"], [{"doctype": "Child DocType2", "name": child2.name}])
+		self.assertEqual(result["skipped"], [{"doctype": "Child DocType1", "name": child1.name}])
+		self.assertTrue(frappe.db.exists("Child DocType1", child1.name))
+		self.assertFalse(frappe.db.exists("Child DocType2", child2.name))
+		self.assertEqual(len(frappe.local.message_log), message_count)
+		child1.reload().cancel()
 
 	def test_get_submitted_linked_docs_accepts_native_ignore_list(self):
 		parent_record = frappe.get_doc({"doctype": "Parent DocType"}).insert()

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -356,6 +356,27 @@ class TestLinkedWith(IntegrationTestCase):
 		finally:
 			frappe.local.message_log = original
 
+	def test_deferred_attempts_include_locked_documents(self):
+		"""A document locked by another session must get deferred and retried,
+		not abort the run."""
+		attempts = []
+
+		def process(docinfo):
+			attempts.append(docinfo["name"])
+			if docinfo["name"] == "locked" and attempts.count("locked") == 1:
+				raise frappe.QueryTimeoutError
+
+		linked_with.process_linked_docs_in_dependency_order(
+			[
+				{"doctype": "Parent DocType", "name": "locked"},
+				{"doctype": "Parent DocType", "name": "free"},
+			],
+			process,
+			"Processing",
+		)
+
+		self.assertEqual(attempts, ["locked", "free", "locked"])
+
 	def test_cancel_all_linked_docs_defers_controller_blocked_docs(self):
 		"""A controller check that wants a referencing document cancelled first
 		raises a plain ValidationError; the document must get deferred, not fail

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -13,6 +13,12 @@ def hard_delete_referencing_child2_records(doc, method=None):
 	frappe.db.delete("Child DocType2", {"child_doctype1": doc.name})
 
 
+def block_cancel_while_child2_submitted(doc, method=None):
+	"""Mimic a controller that wants referencing documents cancelled first."""
+	if frappe.db.exists("Child DocType2", {"child_doctype1": doc.name, "docstatus": 1}):
+		frappe.throw("Cancel the referencing document first")
+
+
 class TestLinkedWith(IntegrationTestCase):
 	def setUp(self):
 		parent_doctype = new_doctype("Parent DocType")
@@ -348,6 +354,29 @@ class TestLinkedWith(IntegrationTestCase):
 			self.assertEqual(frappe.local.message_log, ["kept"])
 		finally:
 			frappe.local.message_log = original
+
+	def test_cancel_all_linked_docs_defers_controller_blocked_docs(self):
+		"""A controller check that wants a referencing document cancelled first
+		raises a plain ValidationError; the document must get deferred, not fail
+		the run."""
+		child1 = frappe.get_doc({"doctype": "Child DocType1"}).insert().submit()
+		child2 = (
+			frappe.get_doc({"doctype": "Child DocType2", "child_doctype1": child1.name}).insert().submit()
+		)
+
+		hook = f"{__name__}.block_cancel_while_child2_submitted"
+		self.addCleanup(setattr, frappe.local, "doc_events_hooks", None)
+		with self.patch_hooks({"doc_events": {"Child DocType1": {"before_cancel": [hook]}}}):
+			frappe.local.doc_events_hooks = None
+			linked_with.cancel_all_linked_docs(
+				docs=[
+					{"doctype": "Child DocType1", "name": child1.name, "docstatus": 1},
+					{"doctype": "Child DocType2", "name": child2.name, "docstatus": 1},
+				]
+			)
+
+		self.assertTrue(child1.reload().docstatus.is_cancelled())
+		self.assertTrue(child2.reload().docstatus.is_cancelled())
 
 	def test_get_linked_docs_to_delete_deepest_first(self):
 		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert()

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -1,5 +1,6 @@
 import random
 import string
+from unittest.mock import patch
 
 import frappe
 from frappe.core.doctype.doctype.test_doctype import new_doctype
@@ -402,7 +403,18 @@ class TestLinkedWith(IntegrationTestCase):
 		with self.set_user("test1@example.com"):
 			docs = linked_with.get_linked_docs_to_delete(parent.doctype, parent.name)["docs"]
 
-		self.assertEqual(docs, [{"doctype": "Child DocType1", "name": child1.name, "docstatus": 0}])
+		self.assertEqual(docs, [{"doctype": "Child DocType1", "name": child1.name}])
+
+	def test_get_linked_docs_to_delete_truncates_large_graphs(self):
+		"""A graph larger than the cap returns no documents, so the caller falls
+		back to a plain delete instead of walking everything."""
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert()
+		frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert()
+
+		with patch.object(linked_with, "MAX_LINKED_DELETE_DOCUMENTS", 0):
+			result = linked_with.get_linked_docs_to_delete(parent.doctype, parent.name)
+
+		self.assertEqual(result, {"docs": [], "count": 0, "truncated": True})
 
 	def test_delete_all_linked_docs_defers_blocked_docs(self):
 		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert()

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -389,6 +389,21 @@ class TestLinkedWith(IntegrationTestCase):
 				[{"doctype": "Parent DocType", "name": "deadlocked"}], process
 			)
 
+	def test_delete_doc_keeps_a_deadlock_a_deadlock(self):
+		"""The lock query's deadlock must not come out as a lock timeout, or the
+		run would defer it and roll back to a savepoint the database discarded."""
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert()
+		get_value = frappe.db.get_value
+
+		def deadlock_on_lock(*args, **kwargs):
+			if kwargs.get("for_update"):
+				raise frappe.QueryDeadlockError("deadlock")
+			return get_value(*args, **kwargs)
+
+		with patch.object(frappe.db, "get_value", deadlock_on_lock):
+			with self.assertRaises(frappe.QueryDeadlockError):
+				frappe.delete_doc("Parent DocType", parent.name)
+
 	def test_stuck_pass_continues_when_the_retry_succeeds(self):
 		"""If the surfacing attempt succeeds (a lock cleared), the rest must still
 		be processed instead of being abandoned."""

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -377,6 +377,18 @@ class TestLinkedWith(IntegrationTestCase):
 
 		self.assertEqual(attempts, ["locked", "free", "locked"])
 
+	def test_deadlocks_are_not_deferred(self):
+		"""A deadlock has already rolled the whole transaction back, savepoints
+		included, so the run must surface it instead of retrying."""
+
+		def process(docinfo):
+			raise frappe.QueryDeadlockError
+
+		with self.assertRaises(frappe.QueryDeadlockError):
+			linked_with.process_linked_docs_in_dependency_order(
+				[{"doctype": "Parent DocType", "name": "deadlocked"}], process
+			)
+
 	def test_stuck_pass_continues_when_the_retry_succeeds(self):
 		"""If the surfacing attempt succeeds (a lock cleared), the rest must still
 		be processed instead of being abandoned."""

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -377,6 +377,27 @@ class TestLinkedWith(IntegrationTestCase):
 
 		self.assertEqual(attempts, ["locked", "free", "locked"])
 
+	def test_stuck_pass_continues_when_the_retry_succeeds(self):
+		"""If the surfacing attempt succeeds (a lock cleared), the rest must still
+		be processed instead of being abandoned as skipped."""
+		attempts = []
+
+		def process(docinfo):
+			attempts.append(docinfo["name"])
+			if attempts.count(docinfo["name"]) == 1:
+				raise frappe.QueryTimeoutError
+
+		skipped = linked_with.process_linked_docs_in_dependency_order(
+			[
+				{"doctype": "Parent DocType", "name": "first"},
+				{"doctype": "Parent DocType", "name": "second"},
+			],
+			process,
+		)
+
+		self.assertEqual(attempts, ["first", "second", "first", "second"])
+		self.assertEqual(skipped, [])
+
 	def test_cancel_all_linked_docs_defers_controller_blocked_docs(self):
 		"""A controller check that wants a referencing document cancelled first
 		raises a plain ValidationError; the document must get deferred, not fail

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -379,7 +379,7 @@ class TestLinkedWith(IntegrationTestCase):
 
 	def test_stuck_pass_continues_when_the_retry_succeeds(self):
 		"""If the surfacing attempt succeeds (a lock cleared), the rest must still
-		be processed instead of being abandoned as skipped."""
+		be processed instead of being abandoned."""
 		attempts = []
 
 		def process(docinfo):
@@ -387,7 +387,7 @@ class TestLinkedWith(IntegrationTestCase):
 			if attempts.count(docinfo["name"]) == 1:
 				raise frappe.QueryTimeoutError
 
-		skipped = linked_with.process_linked_docs_in_dependency_order(
+		linked_with.process_linked_docs_in_dependency_order(
 			[
 				{"doctype": "Parent DocType", "name": "first"},
 				{"doctype": "Parent DocType", "name": "second"},
@@ -396,7 +396,6 @@ class TestLinkedWith(IntegrationTestCase):
 		)
 
 		self.assertEqual(attempts, ["first", "second", "first", "second"])
-		self.assertEqual(skipped, [])
 
 	def test_cancel_all_linked_docs_defers_controller_blocked_docs(self):
 		"""A controller check that wants a referencing document cancelled first
@@ -467,23 +466,13 @@ class TestLinkedWith(IntegrationTestCase):
 
 		# child1 is blocked by child2 and passed first; it must get deferred
 		# and deleted on a later pass instead of failing
-		result = linked_with.delete_all_linked_docs(
+		linked_with.delete_all_linked_docs(
 			docs=[
 				{"doctype": "Child DocType1", "name": child1.name},
 				{"doctype": "Child DocType2", "name": child2.name},
 			]
 		)
 
-		self.assertEqual(
-			result,
-			{
-				"deleted": [
-					{"doctype": "Child DocType1", "name": child1.name},
-					{"doctype": "Child DocType2", "name": child2.name},
-				],
-				"skipped": [],
-			},
-		)
 		self.assertFalse(frappe.db.exists("Child DocType1", child1.name))
 		self.assertFalse(frappe.db.exists("Child DocType2", child2.name))
 		parent.delete()
@@ -510,25 +499,25 @@ class TestLinkedWith(IntegrationTestCase):
 		self.assertFalse(frappe.db.exists("Child DocType1", child1.name))
 		self.assertFalse(frappe.db.exists("Child DocType2", child2.name))
 
-	def test_delete_all_linked_docs_skips_undeletable_docs(self):
-		"""A document that stays undeletable must get skipped and reported without
-		undoing the deleted documents or leaking messages of failed attempts."""
+	def test_delete_all_linked_docs_fails_when_a_doc_stays_undeletable(self):
+		"""A document nothing in the run can delete must fail the run with its
+		own error, once, instead of leaving the other documents deleted."""
 		child1 = frappe.get_doc({"doctype": "Child DocType1"}).insert().submit()
 		child2 = frappe.get_doc({"doctype": "Child DocType2"}).insert()
 		message_count = len(frappe.local.message_log)
 
-		result = linked_with.delete_all_linked_docs(
-			docs=[
-				{"doctype": "Child DocType1", "name": child1.name},
-				{"doctype": "Child DocType2", "name": child2.name},
-			]
-		)
+		with savepoint(frappe.ValidationError):
+			linked_with.delete_all_linked_docs(
+				docs=[
+					{"doctype": "Child DocType1", "name": child1.name},
+					{"doctype": "Child DocType2", "name": child2.name},
+				]
+			)
+			self.fail("a submitted document should have failed the run")
 
-		self.assertEqual(result["deleted"], [{"doctype": "Child DocType2", "name": child2.name}])
-		self.assertEqual(result["skipped"], [{"doctype": "Child DocType1", "name": child1.name}])
 		self.assertTrue(frappe.db.exists("Child DocType1", child1.name))
-		self.assertFalse(frappe.db.exists("Child DocType2", child2.name))
-		self.assertEqual(len(frappe.local.message_log), message_count)
+		self.assertTrue(frappe.db.exists("Child DocType2", child2.name))
+		self.assertEqual(len(frappe.local.message_log), message_count + 1)
 		child1.reload().cancel()
 
 	def test_get_submitted_linked_docs_accepts_native_ignore_list(self):


### PR DESCRIPTION
Stacked on #42054.

Deleting a document that draft or cancelled documents still reference fails with `LinkExistsError`, with no way forward except deleting each blocking document by hand, innermost first.

- deleting from the form now fetches every document that blocks deletion (recursively, using the same link semantics as the delete link check) and shows a Delete All Documents dialog mirroring the Cancel All flow; on confirmation the linked documents are deleted deepest first through the same defer-and-retry runner, then the root document
- documents the user cannot read are neither listed nor traversed, and document names are escaped before entering the dialog HTML
- deletion is all or nothing, like cancel: a document that stays undeletable fails the request with its own error and nothing is deleted; a document that only another document's `on_trash` removes (e.g. a Stock Ledger Entry deleted with its voucher) is deferred until that happens
- messages queued by failed attempts are dropped with the savepoint rollback, so the user sees the blocker's error once, not one per retry
- cancellation now also defers on controller validation errors, not just link errors — e.g. a Purchase Order that refuses to cancel while its submitted Purchase Invoice exists gets retried after the invoice is cancelled; such dependencies live in controller code, so link-based ordering cannot see them

Supersedes #42047 (recreated from an in-repo branch to allow stacking).

no-docs