### PR TITLE
ci: install mariadb client tools from ubuntu archives

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -83,11 +83,8 @@ runs:
       start_time=$(date +%s)
 
       install_system_deps() {
-        # --skip-verify: the version check does its own request to dlm.mariadb.com, which
-        # answers 502 often enough to break the build. apt fetches the repo anyway, so a
-        # version that does not exist still fails, and it fails where the cause is clear.
-        curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | sudo bash -s -- --mariadb-server-version="mariadb-11.8.5" --skip-maxscale --skip-verify
-
+        # the mariadb server runs as a service container; the client tools come
+        # from ubuntu's archives so CI does not depend on mariadb.com mirrors
         sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
         wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 


### PR DESCRIPTION
Environment Setup fetched the mariadb repo setup script from r.mariadb.com and piped it into root bash. Two failure modes hit this weekend: a rate-limited download executed the error body (`bash: line 1: error: command not found`), and a full mirror outage (dlm.mariadb.com returning 504) failed every integration matrix even with retries — see #42054/#42055.

The mariadb server already runs as the `mariadb:11.8` service container from Docker Hub; the runner only needs `mariadb-client` and `libmariadb-dev` for the CLI bootstrap statements and bench, and ubuntu's archives ship both. Install them from there and drop the mariadb.com repo entirely — no third-party single point of failure, no pipe-to-shell.

This PR's own integration jobs exercise the changed setup action, so a green run here is the proof (the mirror is down right now; these jobs pass anyway).