### PR TITLE
fix: honour Currency Precision = 0 in System Settings

### DIFF
--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -966,8 +966,12 @@ def get_field_precision(df, doc=None, currency=None):
 		precision = cint(df.precision)
 
 	elif df.fieldtype == "Currency":
-		precision = cint(frappe.db.get_default("currency_precision"))
-		if not precision:
+		currency_precision = frappe.db.get_default("currency_precision")
+		if currency_precision not in (None, ""):
+			# an explicit precision of 0 must be honoured, not treated the same
+			# as "not set" (cint(0) is falsy, so `... or fallback` would discard it)
+			precision = cint(currency_precision)
+		else:
 			precision = get_precision_from_currency_format(currency or get_field_currency(df, doc))
 	else:
 		precision = cint(frappe.db.get_default("float_precision")) or 3

--- a/frappe/public/js/frappe/model/meta.js
+++ b/frappe/public/js/frappe/model/meta.js
@@ -335,8 +335,12 @@ $.extend(frappe.meta, {
 		if (df && df.precision) {
 			precision = cint(df.precision);
 		} else if (df && df.fieldtype === "Currency") {
-			precision = cint(frappe.defaults.get_default("currency_precision"));
-			if (!precision) {
+			var currency_precision = frappe.defaults.get_default("currency_precision");
+			// an explicit precision of 0 must be honoured, not treated the same
+			// as "not set" (cint(0) is falsy, so `if (!precision)` would discard it)
+			if (currency_precision !== null && currency_precision !== undefined && currency_precision !== "") {
+				precision = cint(currency_precision);
+			} else {
 				var currency = frappe.meta.get_field_currency(df, doc);
 				var number_format = get_number_format(currency);
 				var number_format_info = get_number_format_info(number_format);

--- a/frappe/tests/test_fmt_money.py
+++ b/frappe/tests/test_fmt_money.py
@@ -81,6 +81,16 @@ class TestFmtMoney(IntegrationTestCase):
 		self.assertEqual(fmt_money(1000000000.2718272637), "1,000,000,000.2718")
 		frappe.db.set_default("currency_precision", "")
 
+	def test_currency_precision_zero(self):
+		# an explicitly configured Currency Precision of 0 must be honoured,
+		# not treated the same as "not set" (cint("0") is the falsy int 0)
+		frappe.db.set_default("currency_precision", "0")
+		frappe.db.set_default("number_format", "#,###.##")
+		self.assertEqual(fmt_money(100), "100")
+		self.assertEqual(fmt_money(1000.6), "1,001")
+		self.assertEqual(fmt_money(100000.23), "100,000")
+		frappe.db.set_default("currency_precision", "")
+
 	def test_currency_precision_de_format(self):
 		frappe.db.set_default("currency_precision", "4")
 		frappe.db.set_default("number_format", "#.###,##")

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1417,7 +1417,10 @@ def fmt_money(
 	number_format = NumberFormat.from_string(format) if format else get_number_format()
 
 	if precision is None:
-		precision = cint(frappe.db.get_default("currency_precision")) or None
+		currency_precision = frappe.db.get_default("currency_precision")
+		# an explicit precision of 0 must be honoured, not treated the same as
+		# "not set" (cint(0) is falsy, so `... or None` would discard it)
+		precision = cint(currency_precision) if currency_precision not in (None, "") else None
 
 	if precision is None:
 		precision = number_format.precision


### PR DESCRIPTION
Fixes #42058

### Problem

Setting **System Settings → Currency Precision = 0** has no effect anywhere it's consumed — it silently behaves exactly like "not set" and falls back to the Number Format's own precision (typically 2 decimals) instead of forcing 0 decimal places.

Three places share the identical root cause: precision is resolved with a plain truthiness/falsy check instead of an explicit "was this actually configured" check. Since `cint("0")` is the integer `0`, and `0` is falsy in both Python and JavaScript, an explicit `0` can't be distinguished from "unset":

- `frappe/model/meta.py` — `get_field_precision()`
- `frappe/utils/data.py` — `fmt_money()`
- `frappe/public/js/frappe/model/meta.js` — `get_field_precision()` (client-side; used by the `Currency` cell formatter in `frappe/public/js/frappe/form/formatters.js`)

### Fix

Each location now checks whether the stored default is genuinely unset (`None`/empty string) rather than relying on truthiness, so `0` is treated as a valid, explicit value:

```python
currency_precision = frappe.db.get_default("currency_precision")
if currency_precision not in (None, ""):
    precision = cint(currency_precision)
else:
    precision = get_precision_from_currency_format(...)
```

```js
var currency_precision = frappe.defaults.get_default("currency_precision");
if (currency_precision !== null && currency_precision !== undefined && currency_precision !== "") {
    precision = cint(currency_precision);
} else {
    ...
}
```

### Testing

- Added `test_currency_precision_zero` to `frappe/tests/test_fmt_money.py`, mirroring the existing `test_currency_precision` test but asserting 0-decimal output.
- Manually verified against a real site: with Currency Precision explicitly set to `0`, `fmt_money(575, currency="BDT")` returned `"৳ 575.00"` before this fix and `"৳ 575"` after, with `precision` passed explicitly.
- Confirmed via browser console that `frappe.boot.sysdefaults.currency_precision` correctly holds the string `"0"` in the affected case, ruling out a boot-info/caching issue and isolating the bug to this resolution logic.

### Note on the JS regression

An earlier point release's `Currency` cell formatter resolved precision inline (`docfield.precision || frappe.boot.sysdefaults.currency_precision || 2`) before any `cint()` cast — since `frappe.boot.sysdefaults.currency_precision` arrives as the *string* `"0"`, which is truthy in JS, that inline check happened to avoid the bug. A later refactor moved this into the shared `get_field_precision()` helper, which casts to a number first, exposing the same bug that already existed in the Python code. This PR fixes both the original bug and that regression.
