### PR TITLE
fix(desk): translate workspace names in the sidebar switcher

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -1112,7 +1112,9 @@ frappe.ui.Sidebar = class Sidebar {
 		let sidebar_name = workspace.name || label;
 		return {
 			name: label.toLowerCase(),
-			label: label,
+			// name stays untranslated: it is a lookup key into
+			// boot.workspace_sidebar_item and the basis of the route slug
+			label: __(label),
 			// land on the workspace's first sidebar link, falling back to the workspace page
 			url: this.get_first_link_route(workspace) || this.workspace_route(workspace),
 			icon: workspace.icon,


### PR DESCRIPTION
## Problem

`Sidebar.workspace_to_item()` passes the workspace name straight to `label`, so the workspace switcher renders English on an otherwise fully translated desk. Every neighbouring entry built in the same file — Settings, Manage Dock, Reload, Logout — already goes through `__()`.

On a site running in Lao, the desk translates the page title, the sidebar links and the reports, but the switcher across the top still reads `HR Setup`, `Tenure`, `Recruitment`, `Shift & Attendance`, `Leaves`, ...

### To reproduce

1. Set a site and a user to any non-English language with workspace names translated (they are, via the standard `.po` files).
2. Open `/desk`.
3. The workspace switcher is in English; everything around it is not.

## Fix

One word, on the rendered field only:

```js
name: label.toLowerCase(),
label: __(label),
```

The scope is deliberately narrow. The same `label` variable also feeds `name`, which is lowercased into a lookup key for `frappe.boot.workspace_sidebar_item` and into the route slug via `sidebar_name`. Translating it there breaks navigation — the lookup misses and the click goes nowhere. Keeping the key untranslated and translating only what is painted leaves routing untouched.

## Verified

On a Lao site, reading back what the switcher now builds:

| workspace            | rendered                     | key                  | key resolves |
| -------------------- | ---------------------------- | -------------------- | ------------ |
| `HR Setup`           | `ການຕັ້ງຄ່າຝ່າຍບຸກຄະລາກອນ`  | `hr setup`           | yes          |
| `Leaves`             | `ການລາພັກ`                   | `leaves`             | yes          |
| `Shift & Attendance` | `ກະເຮັດວຽກແລະການເຂົ້າວຽກ`    | `shift & attendance` | yes          |
| `Payroll`            | `ບັນຊີເງິນເດືອນ`             | `payroll`            | yes          |

Switching still routes: `ການລາພັກ` → `ບັນຊີເງິນເດືອນ`, landing on `/desk/payroll`.
