### PR TITLE
fix: show field name in fieldtype-change error

### DIFF
--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -201,7 +201,9 @@ class CustomField(Document):
 			and not CustomizeForm.allow_fieldtype_change(old_fieldtype, self.fieldtype)
 		):
 			frappe.throw(
-				_("Fieldtype cannot be changed from {0} to {1}").format(old_fieldtype, self.fieldtype)
+				_("Fieldtype of {0} in {1} cannot be changed from {2} to {3}").format(
+					frappe.bold(self.fieldname), self.dt, old_fieldtype, self.fieldtype
+				)
 			)
 
 		if not self.fieldname:


### PR DESCRIPTION
- Include the field name and its DocType in the "Fieldtype cannot be changed" error.

Why: it printed only the two fieldtypes, so a bulk `create_custom_fields()` failure (e.g. during migration) gave no way to find the offending field.

Before: `Fieldtype cannot be changed from Data to Attach`
After: `Fieldtype of transport_document in Sales Order cannot be changed from Data to Attach`
