### PR TITLE
fix: honour an explicit Currency Precision of 0 in System Settings

### DIFF
--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -963,8 +963,12 @@ def get_field_precision(df, doc=None, currency=None):
 		precision = cint(df.precision)
 
 	elif df.fieldtype == "Currency":
-		precision = cint(frappe.db.get_default("currency_precision"))
-		if not precision:
+		currency_precision = frappe.db.get_default("currency_precision")
+		if currency_precision not in (None, ""):
+			# an explicit precision of 0 must be honoured, not treated the same
+			# as "not set" (cint(0) is falsy, so `... or fallback` would discard it)
+			precision = cint(currency_precision)
+		else:
 			precision = get_precision_from_currency_format(currency or get_field_currency(df, doc))
 	else:
 		precision = cint(frappe.db.get_default("float_precision")) or 3

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -42,7 +42,7 @@ from frappe.model.workflow import get_workflow_name
 from frappe.modules import load_doctype_module
 from frappe.utils import cached_property, cast, cint, cstr
 from frappe.utils.caching import site_cache
-from frappe.utils.data import add_to_date, get_datetime
+from frappe.utils.data import add_to_date, get_currency_precision, get_datetime
 
 ListOrTuple = list | tuple
 SerializableTypes = str | int | float | datetime
@@ -963,11 +963,9 @@ def get_field_precision(df, doc=None, currency=None):
 		precision = cint(df.precision)
 
 	elif df.fieldtype == "Currency":
-		currency_precision = frappe.db.get_default("currency_precision")
-		if currency_precision not in (None, ""):
-			# an explicit precision of 0 must be honoured, not treated the same
-			# as "not set" (cint(0) is falsy, so `... or fallback` would discard it)
-			precision = cint(currency_precision)
+		currency_precision = get_currency_precision()
+		if currency_precision is not None:
+			precision = currency_precision
 		else:
 			precision = get_precision_from_currency_format(currency or get_field_currency(df, doc))
 	else:

--- a/frappe/public/js/frappe/model/meta.js
+++ b/frappe/public/js/frappe/model/meta.js
@@ -338,7 +338,11 @@ $.extend(frappe.meta, {
 			var currency_precision = frappe.defaults.get_default("currency_precision");
 			// an explicit precision of 0 must be honoured, not treated the same
 			// as "not set" (cint(0) is falsy, so `if (!precision)` would discard it)
-			if (currency_precision !== null && currency_precision !== undefined && currency_precision !== "") {
+			if (
+				currency_precision !== null &&
+				currency_precision !== undefined &&
+				currency_precision !== ""
+			) {
 				precision = cint(currency_precision);
 			} else {
 				var currency = frappe.meta.get_field_currency(df, doc);

--- a/frappe/public/js/frappe/model/meta.js
+++ b/frappe/public/js/frappe/model/meta.js
@@ -335,8 +335,12 @@ $.extend(frappe.meta, {
 		if (df && df.precision) {
 			precision = cint(df.precision);
 		} else if (df && df.fieldtype === "Currency") {
-			precision = cint(frappe.defaults.get_default("currency_precision"));
-			if (!precision) {
+			var currency_precision = frappe.defaults.get_default("currency_precision");
+			// an explicit precision of 0 must be honoured, not treated the same
+			// as "not set" (cint(0) is falsy, so `if (!precision)` would discard it)
+			if (currency_precision !== null && currency_precision !== undefined && currency_precision !== "") {
+				precision = cint(currency_precision);
+			} else {
 				var currency = frappe.meta.get_field_currency(df, doc);
 				var number_format = get_number_format(currency);
 				var number_format_info = get_number_format_info(number_format);

--- a/frappe/public/js/frappe/model/meta.js
+++ b/frappe/public/js/frappe/model/meta.js
@@ -336,8 +336,6 @@ $.extend(frappe.meta, {
 			precision = cint(df.precision);
 		} else if (df && df.fieldtype === "Currency") {
 			var currency_precision = frappe.defaults.get_default("currency_precision");
-			// an explicit precision of 0 must be honoured, not treated the same
-			// as "not set" (cint(0) is falsy, so `if (!precision)` would discard it)
 			if (
 				currency_precision !== null &&
 				currency_precision !== undefined &&

--- a/frappe/tests/test_fmt_money.py
+++ b/frappe/tests/test_fmt_money.py
@@ -81,6 +81,16 @@ class TestFmtMoney(IntegrationTestCase):
 		self.assertEqual(fmt_money(1000000000.2718272637), "1,000,000,000.2718")
 		frappe.db.set_default("currency_precision", "")
 
+	def test_currency_precision_zero(self):
+		# an explicitly configured Currency Precision of 0 must be honoured,
+		# not treated the same as "not set" (cint("0") is the falsy int 0)
+		frappe.db.set_default("currency_precision", "0")
+		frappe.db.set_default("number_format", "#,###.##")
+		self.assertEqual(fmt_money(100), "100")
+		self.assertEqual(fmt_money(1000.6), "1,001")
+		self.assertEqual(fmt_money(100000.23), "100,000")
+		frappe.db.set_default("currency_precision", "")
+
 	def test_currency_precision_de_format(self):
 		frappe.db.set_default("currency_precision", "4")
 		frappe.db.set_default("number_format", "#.###,##")

--- a/frappe/tests/test_fmt_money.py
+++ b/frappe/tests/test_fmt_money.py
@@ -1,11 +1,18 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 import frappe
+from frappe.model.meta import get_field_precision
 from frappe.tests import IntegrationTestCase
 from frappe.utils import fmt_money
 
 
 class TestFmtMoney(IntegrationTestCase):
+	def set_defaults(self, **defaults):
+		"""Set System Settings defaults for a test, restoring the previous values on cleanup."""
+		for key, value in defaults.items():
+			self.addCleanup(frappe.db.set_default, key, frappe.db.get_default(key))
+			frappe.db.set_default(key, value)
+
 	def test_standard(self):
 		frappe.db.set_default("number_format", "#,###.##")
 		self.assertEqual(fmt_money(100), "100.00")
@@ -82,14 +89,15 @@ class TestFmtMoney(IntegrationTestCase):
 		frappe.db.set_default("currency_precision", "")
 
 	def test_currency_precision_zero(self):
-		# an explicitly configured Currency Precision of 0 must be honoured,
-		# not treated the same as "not set" (cint("0") is the falsy int 0)
-		frappe.db.set_default("currency_precision", "0")
-		frappe.db.set_default("number_format", "#,###.##")
+		self.set_defaults(currency_precision="0", number_format="#,###.##")
 		self.assertEqual(fmt_money(100), "100")
 		self.assertEqual(fmt_money(1000.6), "1,001")
 		self.assertEqual(fmt_money(100000.23), "100,000")
-		frappe.db.set_default("currency_precision", "")
+
+	def test_get_field_precision_currency_zero(self):
+		self.set_defaults(currency_precision="0")
+		df = frappe._dict(fieldtype="Currency", precision="")
+		self.assertEqual(get_field_precision(df), 0)
 
 	def test_currency_precision_de_format(self):
 		frappe.db.set_default("currency_precision", "4")

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1428,7 +1428,10 @@ def fmt_money(
 	number_format = NumberFormat.from_string(format) if format else get_number_format()
 
 	if precision is None:
-		precision = cint(frappe.db.get_default("currency_precision")) or None
+		currency_precision = frappe.db.get_default("currency_precision")
+		# an explicit precision of 0 must be honoured, not treated the same as
+		# "not set" (cint(0) is falsy, so `... or None` would discard it)
+		precision = cint(currency_precision) if currency_precision not in (None, "") else None
 
 	if precision is None:
 		precision = number_format.precision

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1418,6 +1418,12 @@ def parse_val(v):
 	return v
 
 
+def get_currency_precision() -> int | None:
+	"""Return the configured Currency Precision, or None if it isn't set."""
+	currency_precision = frappe.db.get_default("currency_precision")
+	return cint(currency_precision) if currency_precision not in (None, "") else None
+
+
 def fmt_money(
 	amount: str | float | int | None,
 	precision: int | None = None,
@@ -1428,10 +1434,7 @@ def fmt_money(
 	number_format = NumberFormat.from_string(format) if format else get_number_format()
 
 	if precision is None:
-		currency_precision = frappe.db.get_default("currency_precision")
-		# an explicit precision of 0 must be honoured, not treated the same as
-		# "not set" (cint(0) is falsy, so `... or None` would discard it)
-		precision = cint(currency_precision) if currency_precision not in (None, "") else None
+		precision = get_currency_precision()
 
 	if precision is None:
 		precision = number_format.precision

--- a/frappe/utils/xlsxutils.py
+++ b/frappe/utils/xlsxutils.py
@@ -18,6 +18,7 @@ from frappe import _
 from frappe.core.utils import html2text
 from frappe.utils import cint
 from frappe.utils.csvutils import FORMULA_TRIGGER_CHARS
+from frappe.utils.data import get_currency_precision
 from frappe.utils.html_utils import unescape_html
 
 ILLEGAL_CHARACTERS_RE = re.compile(
@@ -404,7 +405,8 @@ class XLSXStyleBuilder:
 		precision = number_format.precision
 
 		if fieldtype == "Currency":
-			precision = cint(frappe.db.get_default("currency_precision")) or precision
+			currency_precision = get_currency_precision()
+			precision = currency_precision if currency_precision is not None else precision
 			format_str = XLSXStyleBuilder._build_number_format(thousands_sep, precision)
 			currency_symbol, symbol_on_right = XLSXStyleBuilder._get_currency_symbol_info(currency)
 			return XLSXStyleBuilder._build_currency_format(format_str, currency_symbol, symbol_on_right)


### PR DESCRIPTION
get_field_precision() (frappe/model/meta.py and the client-side frappe/public/js/frappe/model/meta.js) and fmt_money() (frappe/utils/data.py) all resolve the System Settings Currency Precision value the same way:

    precision = cint(frappe.db.get_default("currency_precision"))
    if not precision:
        ...fall back to the Number Format's own precision...

cint("0") is the integer 0, which is falsy in both Python and JavaScript, so an explicitly configured Currency Precision of 0 is indistinguishable from "not set" and silently discarded in favour of the Number Format's precision (typically 2 decimals).

Fixed by checking whether the stored default is actually unset (None or an empty string) instead of relying on truthiness, so 0 is treated as a valid, explicit value everywhere it's resolved.

Fixes #42058

