### PR TITLE
fix: handle workspace rendering

### DIFF
--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -64,7 +64,12 @@ frappe.views.Workspace = class Workspace {
 		this.workspaces.map((workspace) => {
 			workspace.is_editable = !workspace.public || me.has_access;
 			if (typeof workspace.content == "string") {
-				workspace.content = JSON.parse(workspace.content);
+				try {
+					workspace.content = JSON.parse(workspace.content);
+				} catch (e) {
+					console.log(`Failed to parse workspace content for ${workspace.name}:`, e);
+					workspace.content = [];
+				}
 			}
 		});
 	}


### PR DESCRIPTION
Workspace rendering should be more robust. Bad json should not stop all rendering
