### PR TITLE
fix(monitor): validate request trace ID format

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -32,7 +32,7 @@ from frappe.database.utils import (
 	is_query_type,
 )
 from frappe.exceptions import DoesNotExistError, ImplicitCommitError
-from frappe.monitor import get_trace_id
+from frappe.monitor import TRACE_ID_PATTERN, get_trace_id
 from frappe.query_builder import Case
 from frappe.query_builder.functions import Count
 from frappe.utils import (
@@ -280,7 +280,7 @@ class Database:
 
 		query, values = self._transform_query(query, values)
 
-		if trace_id := get_trace_id():
+		if (trace_id := get_trace_id()) and TRACE_ID_PATTERN.fullmatch(trace_id):
 			query += f" /* FRAPPE_TRACE_ID: {trace_id} */"
 
 		try:

--- a/frappe/monitor.py
+++ b/frappe/monitor.py
@@ -4,6 +4,7 @@
 import datetime
 import json
 import os
+import re
 import traceback
 import uuid
 
@@ -15,6 +16,9 @@ from frappe.utils.synchronization import filelock
 
 MONITOR_REDIS_KEY = "monitor-transactions"
 MONITOR_MAX_ENTRIES = 1000000
+
+# Trace IDs are only ever meant to look like a UUID; anything else is rejected outright.
+TRACE_ID_PATTERN = re.compile(r"[0-9a-fA-F-]{8,64}")
 
 
 def start(transaction_type="request", method=None, kwargs=None):
@@ -74,7 +78,9 @@ class Monitor:
 			}
 		)
 
-		if request_id := frappe.request.headers.get("X-Frappe-Request-Id"):
+		if (request_id := frappe.request.headers.get("X-Frappe-Request-Id")) and TRACE_ID_PATTERN.fullmatch(
+			request_id
+		):
 			self.data.uuid = request_id
 
 	def collect_job_meta(self, method, kwargs):

--- a/frappe/tests/test_monitor.py
+++ b/frappe/tests/test_monitor.py
@@ -108,3 +108,27 @@ class TestMonitor(IntegrationTestCase):
 		frappe.db.sql("select 1")
 		self.assertIn(get_trace_id(), str(frappe.db.last_query))
 		frappe.monitor.stop(response)
+
+	def test_trace_id_rejects_unsafe_header(self):
+		"""A request ID that doesn't match the expected format must be ignored."""
+		malformed = "*/ or sleep(0) -- "
+		set_request(method="GET", path="/api/method/frappe.ping", headers={"X-Frappe-Request-Id": malformed})
+		response = build_response("json")
+		frappe.monitor.start()
+		frappe.db.sql("select 1")
+
+		self.assertNotIn(malformed, str(frappe.db.last_query))
+		self.assertTrue(frappe.monitor.TRACE_ID_PATTERN.fullmatch(get_trace_id()))
+		frappe.monitor.stop(response)
+
+	def test_trace_id_accepts_valid_header(self):
+		"""A request ID matching the expected format is passed through as-is."""
+		request_id = "7f037421-6b54-4ee6-8c8a-e7698f67b7a5"
+		set_request(method="GET", path="/api/method/frappe.ping", headers={"X-Frappe-Request-Id": request_id})
+		response = build_response("json")
+		frappe.monitor.start()
+		frappe.db.sql("select 1")
+
+		self.assertEqual(get_trace_id(), request_id)
+		self.assertIn(request_id, str(frappe.db.last_query))
+		frappe.monitor.stop(response)


### PR DESCRIPTION
This PR adds a validation layer to X-Frappe-Request-Id handling, ensuring the trace ID matches the expected format before it's ever used in a query.

closes Ticket 76639