### PR TITLE
fix: ignore reindexed uids when building IMAP sync rule

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -1061,6 +1061,7 @@ def get_max_email_uid(email_account):
 			"communication_medium": "Email",
 			"sent_or_received": "Received",
 			"email_account": email_account,
+			"uid": (">", 0),
 		},
 		fields=[{"MAX": "uid", "as": "uid"}],
 	):

--- a/frappe/email/doctype/email_account/test_email_account.py
+++ b/frappe/email/doctype/email_account/test_email_account.py
@@ -470,6 +470,32 @@ class TestEmailAccount(IntegrationTestCase):
 		self.assertEqual(inbox_mails, 2)
 		self.assertEqual(test_folder_mails, 1)
 
+	def test_email_sync_rule_ignores_reindexed_uids(self):
+		email_account = frappe.get_doc(
+			doctype="Email Account",
+			email_account_name="Synthink RFQ",
+			email_id="enquiry@synthinkchemicals.com",
+			use_imap=1,
+			email_sync_option="ALL",
+			initial_sync_count=100,
+			imap_folder=[{"folder_name": "INBOX", "append_to": "Communication"}],
+		).insert(ignore_permissions=True)
+		self.addCleanup(email_account.delete)
+
+		communication = frappe.get_doc(
+			doctype="Communication",
+			communication_type="Communication",
+			communication_medium="Email",
+			sent_or_received="Received",
+			email_account=email_account.name,
+			subject="Quotation request for chromatography columns",
+			sender="purchase@synthinkchemicals.com",
+			uid=-1,
+		).insert(ignore_permissions=True)
+		self.addCleanup(communication.delete)
+
+		self.assertEqual(email_account.build_email_sync_rule(), "UID 1:101")
+
 	@patch("frappe.email.receive.EmailServer.select_imap_folder", return_value=True)
 	@patch("frappe.email.receive.EmailServer.logout", side_effect=lambda: None)
 	def mocked_get_inbound_mails(

--- a/frappe/email/doctype/email_account/test_email_account.py
+++ b/frappe/email/doctype/email_account/test_email_account.py
@@ -473,8 +473,8 @@ class TestEmailAccount(IntegrationTestCase):
 	def test_email_sync_rule_ignores_reindexed_uids(self):
 		email_account = frappe.get_doc(
 			doctype="Email Account",
-			email_account_name="Synthink RFQ",
-			email_id="enquiry@synthinkchemicals.com",
+			email_account_name="Test IMAP Account",
+			email_id="test@example.com",
 			use_imap=1,
 			email_sync_option="ALL",
 			initial_sync_count=100,
@@ -488,8 +488,8 @@ class TestEmailAccount(IntegrationTestCase):
 			communication_medium="Email",
 			sent_or_received="Received",
 			email_account=email_account.name,
-			subject="Quotation request for chromatography columns",
-			sender="purchase@synthinkchemicals.com",
+			subject="Quotation request",
+			sender="sender@example.com",
 			uid=-1,
 		).insert(ignore_permissions=True)
 		self.addCleanup(communication.delete)


### PR DESCRIPTION
## Description

When an IMAP server changes `UIDVALIDITY`, existing Communications get `uid = -1`. `get_max_email_uid()` then returns `0`, causing the sync to send the invalid request `UID 0:*`.

Strict servers like Zoho reject this request, which stops the entire email sync. Since no new UIDs are saved, the same error happens on every run.

This fix ignores `uid = -1` when calculating the maximum UID. If no valid UID exists, the account uses the existing initial-sync flow instead.

Accounts with valid UIDs are unaffected, and `is_exist_in_system()` prevents duplicate emails during re-imports.

---

Ref: https://support.frappe.io/helpdesk/tickets/76462?view=VIEW-HD+Ticket-1252