### PR TITLE
ci: derive a test impact map from coverage, log selection in shadow mode

### DIFF
--- a/.github/helper/ci.py
+++ b/.github/helper/ci.py
@@ -13,6 +13,7 @@ import os
 import sys
 from pathlib import Path
 
+import impact_map
 from coverage import Coverage
 
 STANDARD_INCLUSIONS = ["*.py"]
@@ -75,10 +76,12 @@ class CodeCoverage:
 	applying the appropriate inclusion and exclusion patterns.
 	"""
 
-	def __init__(self, with_coverage, app, outfile="coverage.xml"):
+	def __init__(self, with_coverage, app, outfile="coverage.xml", impact_map_outfile=None):
 		self.with_coverage = with_coverage
 		self.app = app or "frappe"
 		self.outfile = outfile
+		# Recording per-test attribution costs ~10-30% runtime, so it is opt-in (nightly only).
+		self.impact_map_outfile = impact_map_outfile
 
 	def __enter__(self):
 		if self.with_coverage:
@@ -91,6 +94,10 @@ class CodeCoverage:
 
 			self.coverage = Coverage(source=[source_path], omit=omit, include=STANDARD_INCLUSIONS)
 
+			if self.impact_map_outfile:
+				# Tag every covered line with the test that ran it. Not a constructor argument.
+				self.coverage.set_option("run:dynamic_context", "test_function")
+
 			assert "frappe" not in sys.modules, "frappe already imported, coverage will be inaccurate"
 			self.coverage.start()
 		return self
@@ -102,18 +109,32 @@ class CodeCoverage:
 			self.coverage.xml_report(outfile=self.outfile)
 			print("Saved Coverage")
 
+			if self.impact_map_outfile:
+				self.save_impact_map()
+
+	def save_impact_map(self):
+		"""Invert this runner's coverage into `{source_file: [test_file]}` for `roulette.py`."""
+		app_path = os.path.join(get_bench_path(), "apps", self.app)
+		built = impact_map.build(self.coverage.get_data(), app_path)
+
+		with open(self.impact_map_outfile, "w") as f:
+			json.dump(built, f)
+
+		print(f"Saved impact map for {len(built['map'])} source files to {self.impact_map_outfile}")
+
 
 if __name__ == "__main__":
 	app = "frappe"
 	site = os.environ.get("SITE") or "test_site"
 	with_coverage = json.loads(os.environ.get("CAPTURE_COVERAGE", "true").lower())
+	impact_map_outfile = os.environ.get("IMPACT_MAP_OUTFILE")
 
 	# Parse build information from environment variables
 	build_number = int(os.environ.get("BUILD_NUMBER"))
 	total_builds = int(os.environ.get("TOTAL_BUILDS"))
 
 	# Run tests with code coverage
-	with CodeCoverage(with_coverage=with_coverage, app=app):
+	with CodeCoverage(with_coverage=with_coverage, app=app, impact_map_outfile=impact_map_outfile):
 		from frappe.parallel_test_runner import ParallelTestRunner
 
 		runner = ParallelTestRunner(app, site=site, build_number=build_number, total_builds=total_builds)

--- a/.github/helper/impact_map.py
+++ b/.github/helper/impact_map.py
@@ -1,0 +1,150 @@
+"""
+Test impact map: which test modules exercise which source files.
+
+Built from the nightly coverage run (see `ci.py`), where coverage is measured with
+`dynamic_context="test_function"` so every covered line records the test that ran it.
+Inverting that gives `{source_file: [test_files]}`, both repo-relative.
+
+Coverage observes what actually executed, so it captures Frappe's runtime dispatch
+(`frappe.get_attr`, `hooks.py` dotted paths, `frappe.get_doc` controller binding) that a
+static import graph cannot see.
+
+Consumed by `roulette.py` to decide which tests a pull request needs.
+
+Usage:
+    python impact_map.py merge <out.json> <part.json>...
+    python impact_map.py selftest
+"""
+
+import json
+import os
+import sys
+from datetime import UTC, datetime, timedelta, timezone
+from functools import cache
+
+# A map older than this is not trusted; callers fall back to the full suite.
+MAX_AGE = timedelta(days=7)
+
+
+@cache
+def module_to_path(context: str, root: str) -> str | None:
+	"""Resolve a coverage context to the test file it lives in.
+
+	`frappe.tests.test_x.TestX.test_y` -> `frappe/tests/test_x.py`
+
+	The split between module, class and method is ambiguous, so try each dotted prefix
+	shortest-first and take the one that is an actual file on disk.
+	"""
+	parts = context.split(".")
+	for i in range(1, len(parts) + 1):
+		relpath = os.path.join(*parts[:i]) + ".py"
+		if os.path.exists(os.path.join(root, relpath)):
+			# Shared base classes resolve to non-test modules; those are not test files.
+			return relpath if parts[i - 1].startswith("test_") else None
+	return None
+
+
+def build(coverage_data, root: str) -> dict:
+	"""Invert coverage data into `{source_file: [test_file]}`, paths relative to `root`."""
+	# ponytail: one SQLite query per measured file. Only runs in the nightly, after the
+	# suite; batch it if it ever shows up as a meaningful share of that job.
+	impact = {}
+	for measured_file in coverage_data.measured_files():
+		tests = set()
+		for contexts in coverage_data.contexts_by_lineno(measured_file).values():
+			for context in contexts:
+				if context and (test_file := module_to_path(context, root)):
+					tests.add(test_file)
+		impact[os.path.relpath(measured_file, root)] = sorted(tests)
+
+	return {"generated_at": datetime.now(UTC).isoformat(), "map": impact}
+
+
+def merge(maps: list[dict]) -> dict:
+	"""Combine the per-runner maps of one CI run into a single map."""
+	merged = {}
+	for part in maps:
+		for source_file, tests in part["map"].items():
+			merged.setdefault(source_file, set()).update(tests)
+
+	return {
+		# Oldest wins: the map is only as fresh as its stalest part.
+		"generated_at": min(part["generated_at"] for part in maps),
+		"map": {source_file: sorted(tests) for source_file, tests in merged.items()},
+	}
+
+
+def is_stale(impact_map: dict) -> bool:
+	generated_at = datetime.fromisoformat(impact_map["generated_at"])
+	return datetime.now(UTC) - generated_at > MAX_AGE
+
+
+def select(impact_map: dict, py_files: list[str]) -> list[str] | None:
+	"""Test files needed for `py_files`, or None if the map cannot answer.
+
+	Returning None means "run everything". A file maps to no tests when it is brand new, when
+	no test imports it, or when it only ever ran at import time (`__init__.py` and the like) --
+	none of which is evidence that changing it is safe.
+	"""
+	if is_stale(impact_map):
+		return None
+
+	tests = set()
+	for py_file in py_files:
+		if not (tests_for_file := impact_map["map"].get(py_file)):
+			return None
+		tests.update(tests_for_file)
+
+	return sorted(tests)
+
+
+def all_tests(impact_map: dict) -> set[str]:
+	return {test for tests in impact_map["map"].values() for test in tests}
+
+
+def _selftest():
+	fresh = datetime.now(UTC).isoformat()
+	old = (datetime.now(UTC) - MAX_AGE - timedelta(days=1)).isoformat()
+
+	one = {"generated_at": fresh, "map": {"frappe/a.py": ["frappe/tests/test_a.py"]}}
+	two = {
+		"generated_at": old,
+		"map": {"frappe/a.py": ["frappe/tests/test_b.py"], "frappe/c.py": ["frappe/tests/test_c.py"]},
+	}
+
+	merged = merge([one, two])
+	assert merged["generated_at"] == old
+	assert merged["map"]["frappe/a.py"] == ["frappe/tests/test_a.py", "frappe/tests/test_b.py"]
+	assert merged["map"]["frappe/c.py"] == ["frappe/tests/test_c.py"]
+
+	assert select(one, ["frappe/a.py"]) == ["frappe/tests/test_a.py"]
+	assert select(one, ["frappe/a.py", "frappe/unknown.py"]) is None, "unmapped file must bail out"
+	import_only = {"generated_at": fresh, "map": {"frappe/__init__.py": []}}
+	assert select(import_only, ["frappe/__init__.py"]) is None, "import-time-only file must bail out"
+	assert select(one, []) == [], "no python changes selects no tests"
+	assert select({**one, "generated_at": old}, ["frappe/a.py"]) is None, "stale map must bail out"
+
+	assert all_tests(merged) == {
+		"frappe/tests/test_a.py",
+		"frappe/tests/test_b.py",
+		"frappe/tests/test_c.py",
+	}
+
+	assert module_to_path("frappe.does.not.exist", os.getcwd()) is None
+	print("impact_map selftest OK")
+
+
+if __name__ == "__main__":
+	command, *args = sys.argv[1:]
+
+	if command == "selftest":
+		_selftest()
+	elif command == "merge":
+		outfile, *infiles = args
+		parts = [json.loads(open(f).read()) for f in infiles]
+		merged = merge(parts)
+		with open(outfile, "w") as f:
+			json.dump(merged, f)
+		print(f"Merged {len(infiles)} maps -> {outfile}: {len(merged['map'])} source files")
+	else:
+		sys.exit(f"unknown command: {command}")

--- a/.github/helper/roulette.py
+++ b/.github/helper/roulette.py
@@ -29,6 +29,21 @@ import urllib.request
 from functools import cache
 from urllib.error import HTTPError
 
+import impact_map
+
+# Restored from the nightly run by the workflow; absent means "run everything".
+IMPACT_MAP_FILE = "impact-map.json"
+
+# A change here can affect any test, so the map's answer is not worth trusting.
+CORE_PATHS = (
+	"frappe/__init__.py",
+	"frappe/hooks.py",
+	"frappe/database/",
+	"frappe/model/",
+	"frappe/parallel_test_runner.py",
+	"frappe/tests/",
+)
+
 
 @cache
 def fetch_pr_data(pr_number, repo, endpoint=""):
@@ -152,6 +167,36 @@ def matches_postgres_filenames(files_list):
 	return any(any(word in f.lower() for word in db_keywords) for f in files_list)
 
 
+def report_shadow_selection(files_list):
+	"""Log which test modules the impact map would have selected, without acting on it.
+
+	Shadow mode: the full suite still runs. The point is to measure how much a real
+	selector would skip, and how often it has to bail out, before enabling it. See #42028.
+	"""
+	try:
+		with open(IMPACT_MAP_FILE) as f:
+			loaded_map = json.load(f)
+	except (OSError, ValueError) as exc:
+		print(f"SHADOW: would run full suite, no usable impact map ({exc})")
+		return
+
+	relevant_files = [f for f in files_list if f.endswith((".py", ".json", ".po"))]
+
+	if schema_files := [f for f in relevant_files if not f.endswith(".py")]:
+		print(f"SHADOW: would run full suite, schema/translation changes: {schema_files}")
+	elif core_files := [f for f in relevant_files if f.startswith(CORE_PATHS)]:
+		print(f"SHADOW: would run full suite, core changes: {core_files}")
+	elif impact_map.is_stale(loaded_map):
+		print(f"SHADOW: would run full suite, map from {loaded_map['generated_at']} is stale")
+	elif (selected := impact_map.select(loaded_map, relevant_files)) is None:
+		print("SHADOW: would run full suite, some changed files are absent from the map")
+	else:
+		total = len(impact_map.all_tests(loaded_map))
+		print(f"SHADOW: would run {len(selected)}/{total} test modules for {relevant_files}:")
+		for test_file in selected:
+			print(f"SHADOW:   {test_file}")
+
+
 def is_docs(file):
 	"""Check if the file is documentation or image."""
 	regex = re.compile(r"\.(md|png|jpg|jpeg|csv|svg)$|^.github|LICENSE")
@@ -210,5 +255,8 @@ if __name__ == "__main__":
 		sys.exit(0)
 
 	# If we reach here, run the build
+	if build_type == "server":
+		report_shadow_selection(files_list)
+
 	os.system('echo "build=strawberry" >> $GITHUB_OUTPUT')
 	os.system(f'echo "run_postgres={"true" if run_postgres else "false"}" >> $GITHUB_OUTPUT')

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -100,12 +100,20 @@ jobs:
           BUILD_NUMBER: ${{ matrix.index }}
           TOTAL_BUILDS: 2
           FRAPPE_SENTRY_DSN: ${{ secrets.SENTRY_DSN || '' }}
+          IMPACT_MAP_OUTFILE: ${{ github.event_name == 'schedule' && format('impact-map-{0}-{1}.json', matrix.db, matrix.index) || '' }}
 
       - name: Upload coverage data
         uses: actions/upload-artifact@v7
         with:
           name: coverage-${{ matrix.db }}-${{ matrix.index }}
           path: ./sites/*coverage*.xml
+
+      - name: Upload test impact map
+        if: ${{ github.event_name == 'schedule' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: impact-map-${{ matrix.db }}-${{ matrix.index }}
+          path: ./sites/impact-map-*.json
 
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
@@ -243,6 +251,17 @@ jobs:
           fail_ci_if_error: true
           verbose: true
           flags: server
+
+      - name: Merge test impact maps
+        if: ${{ github.event_name == 'schedule' }}
+        run: python .github/helper/impact_map.py merge impact-map.json impact-map-*/impact-map-*.json
+
+      - name: Publish test impact map
+        if: ${{ github.event_name == 'schedule' }}
+        uses: actions/cache/save@v4
+        with:
+          path: impact-map.json
+          key: impact-map-${{ github.sha }}
 
   # TIP: Require this single check in branch protection, e.g. Server / Success
   success:

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -25,6 +25,12 @@ jobs:
     steps:
       - name: Clone
         uses: actions/checkout@v7
+      - name: Restore test impact map
+        uses: actions/cache/restore@v4
+        with:
+          path: impact-map.json
+          key: impact-map-${{ github.sha }}
+          restore-keys: impact-map-
       - name: Check if unit tests should be run
         id: check-build
         run: |

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Clone
         uses: actions/checkout@v7
       - name: Restore test impact map
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: impact-map.json
           key: impact-map-${{ github.sha }}
@@ -264,7 +264,7 @@ jobs:
 
       - name: Publish test impact map
         if: ${{ github.event_name == 'schedule' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           path: impact-map.json
           key: impact-map-${{ github.sha }}


### PR DESCRIPTION
Part of #42028 — steps 1 and 2 of the three-step sequencing proposed there. **No CI behaviour changes in this PR.**

## Why

`server-tests.yml` runs all 315 test modules whenever any `.py` file changes. `roulette.py` decides *whether* to run tests, never *which*.

A static import graph cannot answer "which tests cover this file" in Frappe — `frappe.get_attr`, dotted paths in `hooks.py`, whitelisted endpoints called over HTTP, and `frappe.get_doc` binding a controller by doctype name are all edges an AST pass cannot see. Missing an edge means silently skipping the test that would have caught the regression.

Coverage does not have that problem: it records what actually executed. `.github/helper/ci.py` already runs the suite under `coverage.Coverage(...)` — it just discards the per-test attribution.

## What this does

**Step 1 — build the map (`ci: build a test impact map in the nightly run`)**

Sets `run:dynamic_context = test_function` so every covered line records the test that ran it, then inverts the result into `{source_file: [test_files]}`, both repo-relative.

Each parallel runner writes its own partial map; the wrap-up job merges them and saves the result to the Actions cache. The merge matters — a source file is usually reached by tests in both runner shards, so neither partial map is complete on its own.

Attribution costs roughly 10–30% extra runtime, so it is opt-in via `IMPACT_MAP_OUTFILE` and set only on the scheduled nightly. Pull requests do not pay for it.

**Step 2 — shadow mode (`ci: log which tests the impact map would select`)**

`roulette.py` restores the map, intersects it with the PR's changed files, and logs what it *would* have run:

```
SHADOW: would run 3/315 test modules for ['frappe/core/doctype/user/user.py']:
SHADOW:   frappe/core/doctype/user/test_user.py
SHADOW:   frappe/tests/test_api.py
SHADOW:   frappe/website/doctype/web_form/test_web_form.py
```

The full suite still runs. `GITHUB_OUTPUT` is untouched.

It bails out to the full suite — and says why — when the map is missing, older than seven days, or when a changed file is one it cannot answer for:

| Bail-out | Reason |
|---|---|
| doctype `.json` / `.po` change | schema and translations reach past the map |
| `frappe/__init__.py`, `hooks.py`, `model/`, `database/`, `tests/`, `parallel_test_runner.py` | a change here can affect any test |
| `.py` file with no tests attributed | new file, untested file, or one that only ever runs at import time — none of which is evidence that changing it is safe |

## What this deliberately does not do

Nothing skips any test yet. Step 3 (`ParallelTestRunner` consuming the subset) is intentionally left out: the issue estimates 31–53% off Integration runner-time, but the one input that determines where in that range we land — how much test time a typical narrow change's coverage closure actually pulls in — is unmeasured. That is precisely what the shadow logs will tell us.

The plan is to leave this running for a week, read the logs, and only then decide whether selection is worth enabling.

## Testing

`.github/helper/impact_map.py selftest` covers merge, staleness, and every bail-out case.

Beyond that, the build/merge/select chain was rehearsed end-to-end locally against real `coverage` 7.10 on a synthetic two-module package split across two runners, confirming that:

- `contexts_by_lineno()` yields the attribution in the expected form
- a source file touched by tests in *both* shards is correctly unioned by the merge
- `__init__.py` and other import-time-only files land with an empty test list and correctly trigger the full-suite bail-out

The one thing local rehearsal cannot cover is the nightly's real runtime cost and the real closure size — the first scheduled run answers both.
