### PR TITLE
feat(hooks): streaming_request_paths hook to skip request body buffering

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -198,13 +198,17 @@ def init_request(request):
 		else:
 			raise frappe.SessionStopped("Session Stopped")
 
-	if request.path.startswith("/api/method/upload_file"):
-		from frappe.core.api.file import get_max_file_size
-
-		request.max_content_length = get_max_file_size()
+	if _claims_raw_body(request):
+		# the claiming app enforces its own body limits and consumes request.stream itself
+		request.max_content_length = None
 	else:
-		request.max_content_length = cint(frappe.local.conf.get("max_file_size")) or 25 * 1024 * 1024
-	make_form_dict(request)
+		if request.path.startswith("/api/method/upload_file"):
+			from frappe.core.api.file import get_max_file_size
+
+			request.max_content_length = get_max_file_size()
+		else:
+			request.max_content_length = cint(frappe.local.conf.get("max_file_size")) or 25 * 1024 * 1024
+		make_form_dict(request)
 
 	if request.method != "OPTIONS":
 		frappe.local.http_request = HTTPRequest()
@@ -326,6 +330,18 @@ def set_authenticate_headers(response: Response):
 		"WWW-Authenticate": f'Bearer resource_metadata="{get_resource_url()}/.well-known/oauth-protected-resource"'
 	}
 	response.headers.update(headers)
+
+
+def _claims_raw_body(request: Request) -> bool:
+	"""Whether an app claims this path's request body via the `streaming_request_paths` hook.
+
+	An app may claim path prefixes whose request bodies it consumes itself (streaming
+	uploads, WebDAV, webhook receivers). For claimed paths the body is neither size-capped
+	nor buffered into form_dict — `frappe.form_dict` stays empty and query args remain
+	available on `request.args`.
+	"""
+	prefixes = frappe.get_hooks("streaming_request_paths")
+	return bool(prefixes) and any(request.path.startswith(prefix) for prefix in prefixes)
 
 
 def make_form_dict(request: Request):

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -201,6 +201,10 @@ def init_request(request):
 	if _claims_raw_body(request):
 		# the claiming app enforces its own body limits and consumes request.stream itself
 		request.max_content_length = None
+		# tell pre-handler auth (validate_oauth) not to read/buffer the body: it is uncapped
+		# here and must stay intact for the claiming app. `HTTP_`-prefixed keys come from
+		# request headers, so this dotted environ key cannot be spoofed by a client.
+		request.environ["frappe.claims_raw_body"] = True
 	else:
 		if request.path.startswith("/api/method/upload_file"):
 			from frappe.core.api.file import get_max_file_size
@@ -339,9 +343,25 @@ def _claims_raw_body(request: Request) -> bool:
 	uploads, WebDAV, webhook receivers). For claimed paths the body is neither size-capped
 	nor buffered into form_dict — `frappe.form_dict` stays empty and query args remain
 	available on `request.args`.
+
+	Matching is on a path-segment boundary (a `/foo` prefix matches `/foo` and `/foo/...`
+	but not `/foobar`), and empty / `"/"` / non-string prefixes are ignored so a
+	misconfigured hook cannot strip body handling for every request on the site.
 	"""
 	prefixes = frappe.get_hooks("streaming_request_paths")
-	return bool(prefixes) and any(request.path.startswith(prefix) for prefix in prefixes)
+	if not prefixes:
+		return False
+
+	path = request.path
+	for prefix in prefixes:
+		if not isinstance(prefix, str) or prefix in ("", "/"):
+			continue
+		if prefix.endswith("/"):
+			if path.startswith(prefix):
+				return True
+		elif path == prefix or path.startswith(prefix + "/"):
+			return True
+	return False
 
 
 def make_form_dict(request: Request):

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -336,6 +336,14 @@ def set_authenticate_headers(response: Response):
 	response.headers.update(headers)
 
 
+# Framework-owned path namespaces that an app must never be able to claim via
+# `streaming_request_paths`: routing, auth and — for `/api` — the API layer's own
+# body read live here, so stripping the size cap / form_dict on these would reopen an
+# uncapped read on a core route. A request under any of these is never claimed,
+# whatever prefixes an app registers.
+_RESERVED_PATH_PREFIXES = ("/api", "/app", "/backups", "/private")
+
+
 def _claims_raw_body(request: Request) -> bool:
 	"""Whether an app claims this path's request body via the `streaming_request_paths` hook.
 
@@ -346,13 +354,17 @@ def _claims_raw_body(request: Request) -> bool:
 
 	Matching is on a path-segment boundary (a `/foo` prefix matches `/foo` and `/foo/...`
 	but not `/foobar`), and empty / `"/"` / non-string prefixes are ignored so a
-	misconfigured hook cannot strip body handling for every request on the site.
+	misconfigured hook cannot strip body handling for every request on the site. Requests
+	to framework-owned namespaces (`_RESERVED_PATH_PREFIXES`) are never claimed.
 	"""
 	prefixes = frappe.get_hooks("streaming_request_paths")
 	if not prefixes:
 		return False
 
 	path = request.path
+	if any(path == reserved or path.startswith(reserved + "/") for reserved in _RESERVED_PATH_PREFIXES):
+		return False
+
 	for prefix in prefixes:
 		if not isinstance(prefix, str) or prefix in ("", "/"):
 			continue

--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -688,9 +688,6 @@ def validate_oauth(authorization_header):
 	uri = parsed_url.scheme + "://" + parsed_url.netloc + parsed_url.path + "?" + urlencode(access_token)
 	http_method = req.method
 	headers = req.headers
-	body = req.get_data()
-	if req.content_type and "multipart/form-data" in req.content_type:
-		body = None
 
 	try:
 		token_hash = get_oauth_token_hash(token)
@@ -700,6 +697,17 @@ def validate_oauth(authorization_header):
 		)
 		if not token_details:
 			return
+		# Read the body only after the token is known to exist — an unauthenticated request
+		# must never reach get_data(). On a path that claims the raw body the cap is disabled
+		# (max_content_length is None), so reading here would buffer an unbounded body and
+		# drain request.stream before the claiming app runs; bearer auth lives in the header,
+		# so the body is not needed for verification there.
+		if req.environ.get("frappe.claims_raw_body") or (
+			req.content_type and "multipart/form-data" in req.content_type
+		):
+			body = None
+		else:
+			body = req.get_data()
 		required_scopes = token_details.scopes.split(get_url_delimiter())
 		valid, _oauthlib_request = get_oauth_server().verify_request(
 			uri, http_method, body, headers, required_scopes

--- a/frappe/tests/test_streaming_request_paths.py
+++ b/frappe/tests/test_streaming_request_paths.py
@@ -3,8 +3,14 @@
 
 import frappe
 from frappe.app import _claims_raw_body, init_request
+from frappe.auth import validate_oauth
 from frappe.tests import IntegrationTestCase
 from frappe.utils import set_request
+
+# A synthetic prefix used for init_request-level tests. It must be a prefix that no
+# installed app actually claims (via a `before_request`/streaming hook), so these tests
+# stay hermetic regardless of which apps are present on the test site.
+PREFIX = "/streamtest/"
 
 
 class TestStreamingRequestPaths(IntegrationTestCase):
@@ -28,24 +34,43 @@ class TestStreamingRequestPaths(IntegrationTestCase):
 		return frappe.local.request
 
 	def test_claims_raw_body_matches_registered_prefixes_only(self):
-		with self.patch_hooks({"streaming_request_paths": ["/dav/"]}):
-			set_request(method="PUT", path="/dav/file.bin")
+		with self.patch_hooks({"streaming_request_paths": [PREFIX]}):
+			set_request(method="PUT", path=f"{PREFIX}file.bin")
 			self.assertTrue(_claims_raw_body(frappe.local.request))
 
-			set_request(method="PUT", path="/davsomething")
+			set_request(method="PUT", path="/streamtestsomething")
 			self.assertFalse(_claims_raw_body(frappe.local.request))
 
 			set_request(method="PUT", path="/api/method/ping")
 			self.assertFalse(_claims_raw_body(frappe.local.request))
 
-	def test_claims_nothing_when_hook_absent(self):
-		set_request(method="PUT", path="/dav/file.bin")
-		self.assertFalse(_claims_raw_body(frappe.local.request))
+	def test_claims_nothing_when_hook_empty(self):
+		with self.patch_hooks({"streaming_request_paths": []}):
+			set_request(method="PUT", path=f"{PREFIX}file.bin")
+			self.assertFalse(_claims_raw_body(frappe.local.request))
+
+	def test_match_enforces_path_segment_boundary(self):
+		# a prefix without a trailing slash must not leak onto sibling routes
+		with self.patch_hooks({"streaming_request_paths": ["/streamtest"]}):
+			for path, claimed in (
+				("/streamtest", True),
+				("/streamtest/file.bin", True),
+				("/streamtestsomething", False),
+			):
+				set_request(method="PUT", path=path)
+				self.assertEqual(_claims_raw_body(frappe.local.request), claimed, path)
+
+	def test_unsafe_prefixes_are_ignored(self):
+		# empty / "/" / non-string prefixes must not disable body handling site-wide
+		for prefix in ("", "/", 123):
+			with self.patch_hooks({"streaming_request_paths": [prefix]}):
+				set_request(method="PUT", path="/api/method/ping")
+				self.assertFalse(_claims_raw_body(frappe.local.request), repr(prefix))
 
 	def test_claimed_path_skips_cap_and_form_dict(self):
 		body = b"\x00\x01binary body" * 100
-		with self.patch_hooks({"streaming_request_paths": ["/dav/"]}):
-			request = self._init_request("/dav/file.bin?foo=bar", data=body)
+		with self.patch_hooks({"streaming_request_paths": [PREFIX]}):
+			request = self._init_request(f"{PREFIX}file.bin?foo=bar", data=body)
 
 		self.assertIsNone(request.max_content_length)
 		self.assertEqual(frappe.local.form_dict, {})
@@ -54,10 +79,28 @@ class TestStreamingRequestPaths(IntegrationTestCase):
 		# query args stay reachable outside form_dict
 		self.assertEqual(request.args["foo"], "bar")
 
+	def test_claimed_path_sets_environ_flag(self):
+		with self.patch_hooks({"streaming_request_paths": [PREFIX]}):
+			request = self._init_request(f"{PREFIX}file.bin", data=b"x")
+		# the flag tells pre-handler auth (validate_oauth) not to read the raw body
+		self.assertTrue(request.environ.get("frappe.claims_raw_body"))
+
+	def test_oauth_bearer_does_not_consume_claimed_stream(self):
+		"""A pre-auth bearer request on a claimed path must not read/buffer the body:
+		an invalid token must return before get_data(), leaving request.stream intact
+		(guards the unbounded-read DoS and the stream-truncation regression)."""
+		body = b"streamed-put-body" * 200
+		with self.patch_hooks({"streaming_request_paths": [PREFIX]}):
+			request = self._init_request(f"{PREFIX}file.bin", data=body)
+			validate_oauth(["Bearer", "an-invalid-token"])
+
+		self.assertEqual(request.stream.read(), body)
+
 	def test_unclaimed_path_behaves_as_before(self):
-		request = self._init_request(
-			"/unclaimed", data=b'{"hello": "world"}', content_type="application/json"
-		)
+		with self.patch_hooks({"streaming_request_paths": [PREFIX]}):
+			request = self._init_request(
+				"/unclaimed", data=b'{"hello": "world"}', content_type="application/json"
+			)
 
 		self.assertIsNotNone(request.max_content_length)
 		self.assertGreater(request.max_content_length, 0)

--- a/frappe/tests/test_streaming_request_paths.py
+++ b/frappe/tests/test_streaming_request_paths.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+
+import frappe
+from frappe.app import _claims_raw_body, init_request
+from frappe.tests import IntegrationTestCase
+from frappe.utils import set_request
+
+
+class TestStreamingRequestPaths(IntegrationTestCase):
+	"""The `streaming_request_paths` hook lets an app claim path prefixes whose
+	request bodies it consumes itself: no max_content_length cap, no form_dict
+	buffering, request.stream left intact."""
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		super().tearDown()
+
+	def _init_request(self, path: str, data: bytes = b"", content_type: str = "application/octet-stream"):
+		set_request(
+			method="PUT",
+			path=path,
+			data=data,
+			content_type=content_type,
+			headers={"X-Frappe-Site-Name": frappe.local.site},
+		)
+		init_request(frappe.local.request)
+		return frappe.local.request
+
+	def test_claims_raw_body_matches_registered_prefixes_only(self):
+		with self.patch_hooks({"streaming_request_paths": ["/dav/"]}):
+			set_request(method="PUT", path="/dav/file.bin")
+			self.assertTrue(_claims_raw_body(frappe.local.request))
+
+			set_request(method="PUT", path="/davsomething")
+			self.assertFalse(_claims_raw_body(frappe.local.request))
+
+			set_request(method="PUT", path="/api/method/ping")
+			self.assertFalse(_claims_raw_body(frappe.local.request))
+
+	def test_claims_nothing_when_hook_absent(self):
+		set_request(method="PUT", path="/dav/file.bin")
+		self.assertFalse(_claims_raw_body(frappe.local.request))
+
+	def test_claimed_path_skips_cap_and_form_dict(self):
+		body = b"\x00\x01binary body" * 100
+		with self.patch_hooks({"streaming_request_paths": ["/dav/"]}):
+			request = self._init_request("/dav/file.bin?foo=bar", data=body)
+
+		self.assertIsNone(request.max_content_length)
+		self.assertEqual(frappe.local.form_dict, {})
+		# body was not consumed by form parsing and streams intact
+		self.assertEqual(request.stream.read(), body)
+		# query args stay reachable outside form_dict
+		self.assertEqual(request.args["foo"], "bar")
+
+	def test_unclaimed_path_behaves_as_before(self):
+		request = self._init_request(
+			"/unclaimed", data=b'{"hello": "world"}', content_type="application/json"
+		)
+
+		self.assertIsNotNone(request.max_content_length)
+		self.assertGreater(request.max_content_length, 0)
+		self.assertEqual(frappe.local.form_dict.get("hello"), "world")

--- a/frappe/tests/test_streaming_request_paths.py
+++ b/frappe/tests/test_streaming_request_paths.py
@@ -64,8 +64,20 @@ class TestStreamingRequestPaths(IntegrationTestCase):
 		# empty / "/" / non-string prefixes must not disable body handling site-wide
 		for prefix in ("", "/", 123):
 			with self.patch_hooks({"streaming_request_paths": [prefix]}):
-				set_request(method="PUT", path="/api/method/ping")
+				set_request(method="PUT", path="/streamtest/x")
 				self.assertFalse(_claims_raw_body(frappe.local.request), repr(prefix))
+
+	def test_reserved_core_prefixes_are_never_claimed(self):
+		# even if an app registers a framework-owned prefix, core routes must not be claimed
+		for prefix, path in (
+			("/api/", "/api/method/frappe.ping"),
+			("/app", "/app/todo"),
+			("/backups", "/backups/site.sql.gz"),
+			("/private/", "/private/files/secret.pdf"),
+		):
+			with self.patch_hooks({"streaming_request_paths": [prefix]}):
+				set_request(method="PUT", path=path)
+				self.assertFalse(_claims_raw_body(frappe.local.request), f"{prefix} -> {path}")
 
 	def test_claimed_path_skips_cap_and_form_dict(self):
 		body = b"\x00\x01binary body" * 100


### PR DESCRIPTION
## Summary
- New list hook `streaming_request_paths`: an app claims path prefixes whose request bodies it consumes itself (streaming uploads, WebDAV, webhook receivers)
- For claimed paths, `init_request` skips both the `max_content_length` cap and `make_form_dict`'s full-body read, leaving `request.stream` intact for incremental consumption; `frappe.form_dict` stays empty and query args remain available on `request.args`
- Today every request body is buffered into memory before any hook runs, capped at `max_file_size` (25 MB default) — so an app serving large uploads on its own endpoint (e.g. a WebDAV `PUT`) 413s before its code ever executes, with no extension point early enough to intervene
- Safe by construction: `frappe.init` pre-sets an empty `form_dict`, so the `cmd` dispatch and CSRF form-token reads are no-ops; gunicorn and the werkzeug dev server both dechunk with `wsgi.input_terminated`, so `request.stream` yields the raw body incrementally
- Unclaimed paths behave exactly as before; the hook is additive and unknown to older apps

First consumer: Drive's WebDAV server (`streaming_request_paths = ["/dav/"]` in the suite app), which spools PUT bodies to disk in 1 MiB chunks with constant memory.

## Test plan
- `bench --site <site> run-tests --module frappe.tests.test_streaming_request_paths` — 4 tests: prefix matching (exact-prefix only), no-op when the hook is absent, claimed path leaves the cap unset / form_dict empty / stream consumable / query args reachable, unclaimed path parses form_dict and keeps the cap as before