### PR TITLE
fix: don't break job system on invalid workers config

### DIFF
--- a/frappe/tests/test_background_jobs.py
+++ b/frappe/tests/test_background_jobs.py
@@ -14,6 +14,7 @@ from frappe.utils.background_jobs import (
 	create_job_id,
 	execute_job,
 	generate_qname,
+	get_queues_timeout,
 	get_redis_conn,
 )
 
@@ -37,6 +38,22 @@ class TestBackgroundJobs(IntegrationTestCase):
 			if queue.name == generate_qname("short"):
 				fail_registry = queue.failed_job_registry
 				self.assertEqual(fail_registry.count, 0)
+
+	def test_get_queues_timeout_tolerates_invalid_workers_config(self):
+		builtin = {"short", "default", "long"}
+		self.addCleanup(get_queues_timeout.cache_clear)
+
+		with patch("frappe.get_conf", return_value={"workers": 8}):
+			get_queues_timeout.cache_clear()
+			timeouts = get_queues_timeout()
+		self.assertEqual(set(timeouts), builtin)
+
+		with patch("frappe.get_conf", return_value={"workers": {"long": 999, "custom": {"timeout": 5000}}}):
+			get_queues_timeout.cache_clear()
+			timeouts = get_queues_timeout()
+		self.assertEqual(timeouts["custom"], 5000)
+		self.assertEqual(timeouts["long"], 1500)
+		self.assertLessEqual(builtin, set(timeouts))
 
 	def test_enqueue_at_front(self):
 		kwargs = {

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -58,8 +58,11 @@ def get_queues_timeout() -> dict[str, int]:
 	:return: Dictionary of queue name to timeout
 	"""
 	common_site_config = frappe.get_conf()
-	custom_workers_config = common_site_config.get("workers", {})
+	custom_workers_config = common_site_config.get("workers") or {}
 	default_timeout = 300
+
+	if not isinstance(custom_workers_config, dict):
+		custom_workers_config = {}
 
 	# Note: Order matters here
 	# If no queues are specified then RQ prioritizes queues in specified order
@@ -68,7 +71,9 @@ def get_queues_timeout() -> dict[str, int]:
 		"default": default_timeout,
 		"long": 1500,
 		**{
-			worker: config.get("timeout", default_timeout) for worker, config in custom_workers_config.items()
+			worker: config.get("timeout", default_timeout)
+			for worker, config in custom_workers_config.items()
+			if isinstance(config, dict)
 		},
 	}
 	# The three built-in queues must always be present; queue validation relies on this.


### PR DESCRIPTION
- Guard `get_queues_timeout()` when the `workers` config (or a per-worker entry) is not a dict — fall back to the built-in queue defaults instead of raising.

Why: a bare int like `"workers": 8` in config made `get_queues_timeout()` throw `'int' object has no attribute 'items'`. Since it runs on the enqueue, worker-startup, migrate and `show-pending-jobs` paths, one bad value took down all background jobs on the bench.
