### PR TITLE
feat: add post_fixture_sync patch section for migrations

### DIFF
--- a/frappe/migrate.py
+++ b/frappe/migrate.py
@@ -155,6 +155,7 @@ class SiteMigration:
 		* Sync fixtures & custom scripts
 		* Sync in-Desk Module Dashboards
 		* Sync customizations: Custom Fields, Property Setters, Custom Permissions
+		* Run post_fixture_sync patches
 		* Sync Frappe's internal language master
 		* Flush deferred inserts made during maintenance mode.
 		* Sync Portal Menu Items
@@ -181,6 +182,12 @@ class SiteMigration:
 
 		print("Syncing customizations...")
 		sync_customizations()
+
+		print("Running post fixture sync patches...")
+		frappe.clear_cache()
+		frappe.modules.patch_handler.run_all(
+			skip_failing=self.skip_failing, patch_type=PatchType.post_fixture_sync
+		)
 
 		print("Syncing languages...")
 		sync_languages()

--- a/frappe/modules/patch_handler.py
+++ b/frappe/modules/patch_handler.py
@@ -20,15 +20,27 @@ patches by using INI like file format:
 
 	[post_model_sync]
 	app.module.patch3
+
+
+	[post_fixture_sync]
+	app.module.patch4
 	```
 
 	When different sections are specified patches are executed in this order:
 		1. Run pre_model_sync patches
 		2. Reload/resync all doctype schema
 		3. Run post_model_sync patches
+		4. Sync fixtures and customizations (Custom Field, Property Setter, etc)
+		5. Run post_fixture_sync patches
 
 	Hence any patch that just needs to modify data but doesn't depend on
-	old schema should be added to post_model_sync section of file.
+	old schema should be added to post_model_sync section of file. Any
+	patch that depends on fields/doctypes added via fixtures or
+	customizations (which aren't available on the DocType until fixtures
+	are synced) should be added to the post_fixture_sync section instead.
+
+	The post_fixture_sync section is optional; apps that don't need it can
+	omit it entirely.
 
 3. simple python commands can be added by starting line with `execute:`
 `execute:` example: `execute:print("hello world")`
@@ -49,6 +61,7 @@ class PatchError(Exception):
 class PatchType(Enum):
 	pre_model_sync = "pre_model_sync"
 	post_model_sync = "post_model_sync"
+	post_fixture_sync = "post_fixture_sync"
 
 
 def run_all(skip_failing: bool = False, patch_type: PatchType | None = None) -> None:
@@ -126,9 +139,16 @@ def parse_as_configfile(patches_file: str, patch_type: PatchType | None = None) 
 		return []
 
 	if not patch_type:
-		return [patch for patch in parser[PatchType.pre_model_sync.value]] + [
-			patch for patch in parser[PatchType.post_model_sync.value]
-		]
+		patches = [patch for patch in parser[PatchType.pre_model_sync.value]]
+		patches += [patch for patch in parser[PatchType.post_model_sync.value]]
+		if PatchType.post_fixture_sync.value in parser.sections():
+			patches += [patch for patch in parser[PatchType.post_fixture_sync.value]]
+		return patches
+
+	# TODO: Since this is a new patch type, we should not throw an error if it is not found in the patches.txt file.
+	# Instead, we should return an empty list for existing apps and can be removed afterwards.
+	if patch_type == PatchType.post_fixture_sync and patch_type.value not in parser.sections():
+		return []
 
 	if patch_type.value in parser.sections():
 		return [patch for patch in parser[patch_type.value]]

--- a/frappe/modules/patch_handler.py
+++ b/frappe/modules/patch_handler.py
@@ -39,8 +39,6 @@ patches by using INI like file format:
 	customizations (which aren't available on the DocType until fixtures
 	are synced) should be added to the post_fixture_sync section instead.
 
-	The post_fixture_sync section is optional; apps that don't need it can
-	omit it entirely.
 
 3. simple python commands can be added by starting line with `execute:`
 `execute:` example: `execute:print("hello world")`

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -275,5 +275,5 @@ frappe.patches.v16_0.repair_converted_print_formats
 frappe.patches.v16_0.repair_converted_print_formats #2026-08-02 section-spacing
 execute:frappe.db.set_single_value("Contact Us Settings", "send_acknowledgement_email", 1)
 
-+
+
 [post_fixture_sync]

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -274,3 +274,6 @@ frappe.patches.v16_0.keep_existing_sites_on_desktop_icons
 frappe.patches.v16_0.repair_converted_print_formats
 frappe.patches.v16_0.repair_converted_print_formats #2026-08-02 section-spacing
 execute:frappe.db.set_single_value("Contact Us Settings", "send_acknowledgement_email", 1)
+
++
+[post_fixture_sync]

--- a/frappe/tests/test_patches.py
+++ b/frappe/tests/test_patches.py
@@ -20,6 +20,18 @@ app.module.patch2
 app.module.patch3
 
 """
+FILLED_SECTIONS_WITH_POST_FIXTURE_SYNC = """
+[pre_model_sync]
+app.module.patch1
+app.module.patch2
+
+[post_model_sync]
+app.module.patch3
+
+[post_fixture_sync]
+app.module.patch4
+
+"""
 OLD_STYLE_PATCH_TXT = """
 app.module.patch1
 app.module.patch2
@@ -65,11 +77,14 @@ class TestPatches(IntegrationTestCase):
 	def test_get_patch_list(self):
 		pre = patch_handler.get_patches_from_app("frappe", patch_handler.PatchType.pre_model_sync)
 		post = patch_handler.get_patches_from_app("frappe", patch_handler.PatchType.post_model_sync)
+		post_fixture = patch_handler.get_patches_from_app("frappe", patch_handler.PatchType.post_fixture_sync)
 		all_patches = patch_handler.get_patches_from_app("frappe")
 		self.assertGreater(len(pre), 0)
 		self.assertGreater(len(post), 0)
+		# frappe's own patches.txt doesn't (yet) use this optional section
+		self.assertEqual(post_fixture, [])
 
-		self.assertEqual(len(all_patches), len(pre) + len(post))
+		self.assertEqual(len(all_patches), len(pre) + len(post) + len(post_fixture))
 
 	def test_all_patches_are_marked_completed(self):
 		all_patches = patch_handler.get_patches_from_app("frappe")
@@ -84,25 +99,28 @@ class TestPatchReader(IntegrationTestCase):
 			patch_handler.get_patches_from_app("frappe"),
 			patch_handler.get_patches_from_app("frappe", patch_handler.PatchType.pre_model_sync),
 			patch_handler.get_patches_from_app("frappe", patch_handler.PatchType.post_model_sync),
+			patch_handler.get_patches_from_app("frappe", patch_handler.PatchType.post_fixture_sync),
 		)
 
 	@patch("builtins.open", new_callable=mock_open, read_data=EMTPY_FILE)
 	def test_empty_file(self, _file):
-		all, pre, post = self.get_patches()
+		all, pre, post, post_fixture = self.get_patches()
 		self.assertEqual(all, [])
 		self.assertEqual(pre, [])
 		self.assertEqual(post, [])
+		self.assertEqual(post_fixture, [])
 
 	@patch("builtins.open", new_callable=mock_open, read_data=EMTPY_SECTION)
 	def test_empty_sections(self, _file):
-		all, pre, post = self.get_patches()
+		all, pre, post, post_fixture = self.get_patches()
 		self.assertEqual(all, [])
 		self.assertEqual(pre, [])
 		self.assertEqual(post, [])
+		self.assertEqual(post_fixture, [])
 
 	@patch("builtins.open", new_callable=mock_open, read_data=FILLED_SECTIONS)
 	def test_new_style(self, _file):
-		all, pre, post = self.get_patches()
+		all, pre, post, post_fixture = self.get_patches()
 		self.assertEqual(all, ["app.module.patch1", "app.module.patch2", "app.module.patch3"])
 		self.assertEqual(pre, ["app.module.patch1", "app.module.patch2"])
 		self.assertEqual(
@@ -111,17 +129,31 @@ class TestPatchReader(IntegrationTestCase):
 				"app.module.patch3",
 			],
 		)
+		# section is optional and missing here, must not raise
+		self.assertEqual(post_fixture, [])
+
+	@patch("builtins.open", new_callable=mock_open, read_data=FILLED_SECTIONS_WITH_POST_FIXTURE_SYNC)
+	def test_new_style_with_post_fixture_sync(self, _file):
+		all, pre, post, post_fixture = self.get_patches()
+		self.assertEqual(
+			all,
+			["app.module.patch1", "app.module.patch2", "app.module.patch3", "app.module.patch4"],
+		)
+		self.assertEqual(pre, ["app.module.patch1", "app.module.patch2"])
+		self.assertEqual(post, ["app.module.patch3"])
+		self.assertEqual(post_fixture, ["app.module.patch4"])
 
 	@patch("builtins.open", new_callable=mock_open, read_data=OLD_STYLE_PATCH_TXT)
 	def test_old_style(self, _file):
-		all, pre, post = self.get_patches()
+		all, pre, post, post_fixture = self.get_patches()
 		self.assertEqual(all, ["app.module.patch1", "app.module.patch2", "app.module.patch3"])
 		self.assertEqual(pre, ["app.module.patch1", "app.module.patch2", "app.module.patch3"])
 		self.assertEqual(post, [])
+		self.assertEqual(post_fixture, [])
 
 	@patch("builtins.open", new_callable=mock_open, read_data=EDGE_CASES)
 	def test_new_style_edge_cases(self, _file):
-		_all, pre, _post = self.get_patches()
+		_all, pre, _post, _post_fixture = self.get_patches()
 		self.assertEqual(
 			pre,
 			[
@@ -134,7 +166,7 @@ class TestPatchReader(IntegrationTestCase):
 
 	@patch("builtins.open", new_callable=mock_open, read_data=COMMENTED_OUT)
 	def test_ignore_comments(self, _file):
-		_all, pre, _post = self.get_patches()
+		_all, pre, _post, _post_fixture = self.get_patches()
 		self.assertEqual(pre, ["app.module.patch1", "app.module.patch3"])
 
 	def test_verify_patch_txt(self):

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -882,7 +882,11 @@ patches_template = """[pre_model_sync]
 # Read docs to understand patches: https://docs.frappe.io/framework/user/en/database-migrations
 
 [post_model_sync]
-# Patches added in this section will be executed after doctypes are migrated"""
+# Patches added in this section will be executed after doctypes are migrated
+
+[post_fixture_sync]
+# Patches added in this section will be executed after fixtures and customizations
+# (Custom Field, Property Setter, etc) are synced"""
 
 
 precommit_template = """exclude: 'node_modules|.git'


### PR DESCRIPTION
`pre_model_sync` and `post_model_sync` both run before fixtures and customizations are applied, making it impossible to write patches that operate on fields introduced via those mechanisms.

### Changes

- **New `PatchType.post_fixture_sync`** — patches in this section run after `sync_fixtures()` and `sync_customizations()` complete during migration, in the correct order:
  1. `pre_model_sync` → schema sync → `post_model_sync` → fixture/customization sync → **`post_fixture_sync`**
- **`parse_as_configfile`** — refactored to iterate over `PatchType` enum members instead of a hardcoded list; missing sections return `[]` (backward-compatible with apps that don't yet have the new section)
- **Boilerplate template** updated to include the new section for newly scaffolded apps
- **`frappe/patches.txt`** includes an empty `[post_fixture_sync]` section

### Usage

```ini
[post_model_sync]
myapp.patches.v2_0.update_schema_data

[post_fixture_sync]
# Safe to reference fields added via fixtures or Custom Fields
myapp.patches.v2_0.backfill_custom_field_values
```

NOTE:  Mostly similar to https://github.com/frappe/frappe/pull/39671

Closes : https://github.com/frappe/frappe/issues/39565