### PR TITLE
fix: allow non-system managers to print report with print format

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -60,7 +60,7 @@ def get_report_doc(report_name):
 
 
 @frappe.whitelist()
-def get_print_format_html_and_css(print_format: str):
+def get_print_format_data(print_format: str):
 	pf = frappe.db.get_value(
 		"Print Format",
 		{"name": print_format, "disabled": 0, "print_format_for": "Report"},

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -68,7 +68,10 @@ def get_print_format_data(print_format: str):
 		as_dict=True,
 	)
 	if not pf:
-		frappe.throw(_("Print Format {0} not found").format(print_format), frappe.DoesNotExistError)
+		frappe.throw(
+			_("{0} is not an enabled Print Format for a Report").format(frappe.bold(print_format)),
+			frappe.DoesNotExistError,
+		)
 
 	# get_report_doc enforces the referenced Report's own permission model before we hand out its print format
 	report = get_report_doc(pf.report)

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -68,8 +68,9 @@ def get_print_format_html_and_css(print_format: str):
 		as_dict=True,
 	)
 	if not pf:
-		return
+		frappe.throw(_("Print Format {0} not found").format(print_format), frappe.DoesNotExistError)
 
+	# get_report_doc enforces the referenced Report's own permission model before we hand out its print format
 	report = get_report_doc(pf.report)
 
 	if not frappe.has_permission(report.ref_doctype, "print"):

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -62,7 +62,10 @@ def get_report_doc(report_name):
 @frappe.whitelist()
 def get_print_format_html_and_css(print_format: str):
 	pf = frappe.db.get_value(
-		"Print Format", {"name": print_format, "disabled": 0}, ["report", "html", "css"], as_dict=True
+		"Print Format",
+		{"name": print_format, "disabled": 0, "print_format_for": "Report"},
+		["report", "html", "css"],
+		as_dict=True,
 	)
 	if not pf:
 		return

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -59,6 +59,25 @@ def get_report_doc(report_name):
 	return doc
 
 
+@frappe.whitelist()
+def get_print_format_html_and_css(print_format: str):
+	pf = frappe.db.get_value(
+		"Print Format", {"name": print_format, "disabled": 0}, ["report", "html", "css"], as_dict=True
+	)
+	if not pf:
+		return
+
+	report = get_report_doc(pf.report)
+
+	if not frappe.has_permission(report.ref_doctype, "print"):
+		frappe.throw(
+			_("You don't have permission to print: {0}").format(_(report.ref_doctype)),
+			frappe.PermissionError,
+		)
+
+	return {"html": pf.html, "css": pf.css}
+
+
 def get_report_result(report, filters):
 	res = None
 

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1754,7 +1754,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 	async get_report_print_format(print_format) {
 		const r = await frappe.call({
-			method: "frappe.desk.query_report.get_print_format_html_and_css",
+			method: "frappe.desk.query_report.get_print_format_data",
 			args: { print_format },
 		});
 		if (r && r.message && r.message.html) {

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1752,12 +1752,11 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		return print_settings.columns?.length || !custom_format ? "print_grid" : custom_format;
 	}
 
-	async get_report_print_format(report_name) {
-		const filters = {
-			name: report_name,
-			disabled: 0,
-		};
-		const r = await frappe.db.get_value("Print Format", filters, ["html", "css"]);
+	async get_report_print_format(print_format) {
+		const r = await frappe.call({
+			method: "frappe.desk.query_report.get_print_format_html_and_css",
+			args: { print_format },
+		});
 		if (r && r.message && r.message.html) {
 			const css = r.message.css || "";
 			const html = r.message.html || "";


### PR DESCRIPTION
Closes: #41994

fix: printing a report with a custom print format fails for non-System Manager users

### Problem

`QueryReport.get_report_print_format()` fetched the print format's `html`/`css` straight from the client with `frappe.db.get_value("Print Format", ...)`. That call runs a full read-permission check on **Print Format**, which regular desk users don't have — so printing/PDF of any report with a custom print format applied, threw a `PermissionError` instead of rendering.

### Fix

Added a whitelisted endpoint `frappe.desk.query_report.get_print_format_html_and_css` that returns the `html` and `css` of an enabled print format with necessary permission checks:

1. `get_report_doc()` — the user must be in the report's role table (or own it) **and** hold the `report` permission on the report's `ref_doctype`.
2. `frappe.has_permission(report.ref_doctype, "print")` — the user must hold the `print` permission on the report's `ref_doctype`.