### PR TITLE
fix: 'Select All' in MultiSelectList picks only the first 10 items

### DIFF
--- a/frappe/public/js/frappe/db.js
+++ b/frappe/public/js/frappe/db.js
@@ -115,7 +115,7 @@ frappe.db = {
 			limit,
 		});
 	},
-	get_link_options(doctype, txt = "", filters = {}) {
+	get_link_options(doctype, txt = "", filters = {}, page_length) {
 		return new Promise((resolve) => {
 			frappe.call({
 				type: "GET",
@@ -124,6 +124,7 @@ frappe.db = {
 					doctype,
 					txt,
 					filters,
+					...(page_length ? { page_length } : {}),
 				},
 				callback(r) {
 					resolve(r.message);

--- a/frappe/public/js/frappe/form/controls/multiselect_list.js
+++ b/frappe/public/js/frappe/form/controls/multiselect_list.js
@@ -136,13 +136,29 @@ frappe.ui.form.ControlMultiSelectList = class ControlMultiSelectList extends (
 		// The dropdown's loaded options are capped to a small page for performance
 		// (e.g. the first 10 search results). Ask the data source for everything
 		// matching the current search text before selecting "all" of it.
+		//
+		// Most get_data callbacks aren't written to know about "select all" — they
+		// just delegate straight to frappe.db.get_link_options. Temporarily make
+		// that call request a much larger page so those callbacks return everything
+		// without needing to be updated individually. Callbacks that want explicit
+		// control can still branch on the second (for_select_all) argument.
 		let all_options = this._options;
 		if (this.df.get_data) {
 			let txt = this.$filter_input.val();
-			let value = this.df.get_data(txt, true);
-			if (value && value.then) {
-				value = await value;
+			const get_link_options = frappe.db.get_link_options;
+			frappe.db.get_link_options = (doctype, t, filters) =>
+				get_link_options(doctype, t, filters, 25000);
+
+			let value;
+			try {
+				value = this.df.get_data(txt, true);
+				if (value && value.then) {
+					value = await value;
+				}
+			} finally {
+				frappe.db.get_link_options = get_link_options;
 			}
+
 			if (value) {
 				all_options = this.process_options(value);
 			}

--- a/frappe/public/js/frappe/form/controls/multiselect_list.js
+++ b/frappe/public/js/frappe/form/controls/multiselect_list.js
@@ -132,9 +132,24 @@ frappe.ui.form.ControlMultiSelectList = class ControlMultiSelectList extends (
 		this.parse_validate_and_set_in_model("");
 	}
 
-	select_all_options() {
-		this.values = this._options.map((opt) => opt.value);
-		this._selected_values = this._options.slice();
+	async select_all_options() {
+		// The dropdown's loaded options are capped to a small page for performance
+		// (e.g. the first 10 search results). Ask the data source for everything
+		// matching the current search text before selecting "all" of it.
+		let all_options = this._options;
+		if (this.df.get_data) {
+			let txt = this.$filter_input.val();
+			let value = this.df.get_data(txt, true);
+			if (value && value.then) {
+				value = await value;
+			}
+			if (value) {
+				all_options = this.process_options(value);
+			}
+		}
+
+		this.values = all_options.map((opt) => opt.value);
+		this._selected_values = all_options.slice();
 		this.update_status();
 		this.set_selectable_items(this._options);
 		this.parse_validate_and_set_in_model("");


### PR DESCRIPTION
Backport of #41991.

"Select All" on MultiSelectList filters only selected the first 10 loaded results instead of everything matching. Fixed by fetching the complete list on demand when Select All is clicked, and widening the underlying page size for the duration of that call so it works even for get_data callbacks that don't know about "select all."