### PR TITLE
feat(ui): Composer — intuitive API, host extensions, real-life stories

### DIFF
--- a/ui/src/components/Composer/CommentComposer/CommentComposer.vue
+++ b/ui/src/components/Composer/CommentComposer/CommentComposer.vue
@@ -4,6 +4,7 @@
 		:placeholder="placeholder"
 		:submit-label="submitLabel"
 		:upload-function="uploadFunction"
+		:extensions="extensions"
 		:mentions="mentions"
 		v-model:body="body"
 		@submit="emit('submit', $event)"

--- a/ui/src/components/Composer/CommentComposer/CommentComposer.vue
+++ b/ui/src/components/Composer/CommentComposer/CommentComposer.vue
@@ -5,6 +5,7 @@
 		:submit-label="submitLabel"
 		:upload-function="uploadFunction"
 		:extensions="extensions"
+		:max-attachments="maxAttachments"
 		:mentions="mentions"
 		v-model:body="body"
 		@submit="emit('submit', $event)"

--- a/ui/src/components/Composer/ComposerEditor.vue
+++ b/ui/src/components/Composer/ComposerEditor.vue
@@ -56,24 +56,23 @@
 					</div>
 
 					<div class="mt-auto">
-						<div
-							v-if="attachments.length"
-							ref="attachmentRow"
-							class="my-2 flex overflow-x-auto gap-2 px-2.5"
-						>
+						<div v-if="attachments.length" class="my-2 flex flex-wrap gap-2 px-2.5">
 							<Button
 								v-for="attachment in attachments"
 								:key="attachment.file_url"
 								theme="gray"
 								variant="subtle"
-								:label="compactAttachments ? undefined : attachment.file_name"
+								:label="attachment.file_name"
 								:title="attachment.file_name"
-								:class="compactAttachments ? 'w-8 shrink-0' : 'min-w-0 max-w-36'"
+								class="min-w-0 max-w-36"
 							>
 								<template #prefix>
-									<LucideFileImage class="size-3.5 shrink-0" />
+									<component
+										:is="attachmentIcon(attachment)"
+										class="size-3.5 shrink-0"
+									/>
 								</template>
-								<template v-if="!compactAttachments" #suffix>
+								<template #suffix>
 									<span
 										class="lucide-x size-3.5 cursor-pointer shrink-0"
 										@click.self.stop="removeAttachment(attachment)"
@@ -96,7 +95,9 @@
 										:icon="LucidePaperclip"
 										aria-label="Attach file"
 										class="shrink-0"
-										:disabled="isUploading"
+										:disabled="
+											isUploading || attachments.length >= maxAttachments
+										"
 										@click="attachInput?.click()"
 									/>
 									<input
@@ -161,7 +162,14 @@
 import { computed, nextTick, ref, useTemplateRef, watch } from "vue";
 import { useScroll } from "@vueuse/core";
 import { Button, toast } from "frappe-ui";
+import LucideFile from "~icons/lucide/file";
+import LucideFileArchive from "~icons/lucide/file-archive";
+import LucideFileAudio from "~icons/lucide/file-audio";
+import LucideFileCode from "~icons/lucide/file-code";
 import LucideFileImage from "~icons/lucide/file-image";
+import LucideFileSpreadsheet from "~icons/lucide/file-spreadsheet";
+import LucideFileText from "~icons/lucide/file-text";
+import LucideFileVideo from "~icons/lucide/file-video";
 import LucidePaperclip from "~icons/lucide/paperclip";
 import {
 	Editor,
@@ -223,6 +231,7 @@ const emailToolbar = [
 const props = withDefaults(defineProps<ComposerEditorProps>(), {
 	placeholder: "Type your message…",
 	submitLabel: "Send",
+	maxAttachments: 10,
 });
 
 const emit = defineEmits<{
@@ -336,27 +345,28 @@ function buildMessage() {
 
 const attachments = ref<UploadedFile[]>([]);
 const isUploading = ref(false);
-const attachmentRow = useTemplateRef<HTMLElement>("attachmentRow");
-const compactAttachments = ref(false);
-
-watch(attachmentRow, (el, _prev, onCleanup) => {
-	if (!el) return;
-	const observer = new ResizeObserver(() => {
-		compactAttachments.value = el.scrollWidth > el.clientWidth;
-	});
-	observer.observe(el);
-	onCleanup(() => observer.disconnect());
-});
-
-watch(attachments, () => {
-	nextTick(() => {
-		const el = attachmentRow.value;
-		if (el) compactAttachments.value = el.scrollWidth > el.clientWidth;
-	});
-});
-
 function addAttachment(file: UploadedFile) {
+	if (attachments.value.length >= props.maxAttachments) {
+		toast.error(`Attachment limit reached (${props.maxAttachments}).`);
+		return;
+	}
 	attachments.value.push(file);
+}
+
+// Chip icon by MIME type.
+function attachmentIcon(file: UploadedFile) {
+	const type = file.file_type ?? "";
+	if (type.startsWith("image/")) return LucideFileImage;
+	if (type.startsWith("video/")) return LucideFileVideo;
+	if (type.startsWith("audio/")) return LucideFileAudio;
+	if (type.includes("csv") || type.includes("sheet") || type.includes("excel"))
+		return LucideFileSpreadsheet;
+	if (type.includes("zip") || type.includes("tar") || type.includes("compressed"))
+		return LucideFileArchive;
+	if (type.includes("json") || type.includes("xml") || type.includes("html"))
+		return LucideFileCode;
+	if (type.includes("pdf") || type.startsWith("text/")) return LucideFileText;
+	return LucideFile;
 }
 
 function setUploading(value: boolean) {

--- a/ui/src/components/Composer/ComposerEditor.vue
+++ b/ui/src/components/Composer/ComposerEditor.vue
@@ -83,13 +83,13 @@
 						</div>
 
 						<div class="flex items-center justify-between gap-2 px-2.5 pb-2.5">
-							<!-- -ml-1.5 offsets the scroller's p-0.5 plus the ghost button's icon inset
-							     so the first icon's ink sits on the content edge, mirroring Send's right. -->
+							<!-- Wrapper -ml-1.5 + scroller ml-1 tune the first icon's ink against the
+							     content edge, mirroring Send's flush right. -->
 							<div class="relative -ml-1.5 overflow-hidden" style="max-width: 70%">
 								<!-- p-0.5 keeps button focus rings from being clipped by overflow-x-auto. -->
 								<div
 									ref="toolbarScroller"
-									class="flex items-center gap-1 overflow-x-auto p-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+									class="ml-1 flex items-center gap-1 overflow-x-auto p-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
 								>
 									<Button
 										v-if="uploadFunction"

--- a/ui/src/components/Composer/ComposerEditor.vue
+++ b/ui/src/components/Composer/ComposerEditor.vue
@@ -27,7 +27,7 @@
 						class="flex max-h-[50vh] min-h-0 flex-1 flex-col overflow-y-auto px-2.5 pb-2.5"
 					>
 						<EditorContent
-							class="prose-sm max-w-full flex-1 pb-8 pt-2 [&_p.reply-to-content]:hidden"
+							class="prose-sm max-w-full flex-1 pb-8 pt-4 [&_p.reply-to-content]:hidden"
 						/>
 						<!--
 							Quoted reply lives outside the editor: tiptap parses HTML into its
@@ -42,7 +42,7 @@
 							@toggle="onQuoteToggle"
 						>
 							<summary
-								class="w-fit cursor-pointer select-none rounded px-1 text-sm leading-none text-ink-gray-5 bg-surface-gray-2 list-none [&::-webkit-details-marker]:hidden"
+								class="w-fit cursor-pointer select-none rounded px-1 text-sm font-bold leading-[1.15] text-ink-gray-5 bg-surface-gray-2 list-none [&::-webkit-details-marker]:hidden"
 							>
 								•••
 							</summary>
@@ -83,21 +83,24 @@
 						</div>
 
 						<div class="flex items-center justify-between gap-2 px-2.5 pb-2.5">
-							<div class="relative overflow-hidden" style="max-width: 70%">
+							<!-- -ml-1.5 offsets the scroller's p-0.5 plus the ghost button's icon inset
+							     so the first icon's ink sits on the content edge, mirroring Send's right. -->
+							<div class="relative -ml-1.5 overflow-hidden" style="max-width: 70%">
 								<!-- p-0.5 keeps button focus rings from being clipped by overflow-x-auto. -->
 								<div
+									ref="toolbarScroller"
 									class="flex items-center gap-1 overflow-x-auto p-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
 								>
-									<button
+									<Button
 										v-if="uploadFunction"
-										type="button"
+										variant="ghost"
+										size="sm"
+										:icon="LucidePaperclip"
 										aria-label="Attach file"
-										class="flex shrink-0 rounded p-1 text-ink-gray-8 transition-colors hover:bg-surface-gray-3 disabled:opacity-50"
+										class="shrink-0"
 										:disabled="isUploading"
 										@click="attachInput?.click()"
-									>
-										<LucidePaperclip class="h-4 w-4" />
-									</button>
+									/>
 									<input
 										ref="attachInput"
 										type="file"
@@ -108,9 +111,27 @@
 										name="actions"
 										v-bind="{ addAttachment, setUploading }"
 									/>
+									<!-- Same divider the menu uses between its own sections. -->
+									<span
+										v-if="uploadFunction || $slots.actions"
+										class="mx-1 h-5 w-px shrink-0 bg-surface-gray-3"
+										aria-hidden="true"
+									/>
 									<EditorFixedMenu :items="emailToolbar" button-size="sm" />
 								</div>
 								<div
+									v-show="!toolbarArrived.left"
+									class="pointer-events-none absolute inset-y-0 left-0 w-8"
+									style="
+										background: linear-gradient(
+											to right,
+											var(--surface-base, white),
+											transparent
+										);
+									"
+								/>
+								<div
+									v-show="!toolbarArrived.right"
 									class="pointer-events-none absolute inset-y-0 right-0 w-8"
 									style="
 										background: linear-gradient(
@@ -122,7 +143,7 @@
 								/>
 							</div>
 							<div class="flex shrink-0 items-center gap-2">
-								<Button label="Discard" :disabled="isEmpty" @click="reset" />
+								<Button v-if="!isEmpty" label="Discard" @click="reset" />
 								<Button
 									variant="solid"
 									:label="submitLabel"
@@ -140,6 +161,7 @@
 
 <script setup lang="ts">
 import { computed, nextTick, ref, useTemplateRef, watch } from "vue";
+import { useScroll } from "@vueuse/core";
 import { Button, toast } from "frappe-ui";
 import LucideFileImage from "~icons/lucide/file-image";
 import LucidePaperclip from "~icons/lucide/paperclip";
@@ -215,6 +237,10 @@ const emit = defineEmits<{
 const editorRef = ref<InstanceType<typeof Editor> | null>(null);
 const editor = computed(() => editorRef.value?.editor);
 
+// Edge fades track scroll position so each side fades only while clipped.
+const toolbarScroller = useTemplateRef<HTMLElement>("toolbarScroller");
+const { arrivedState: toolbarArrived } = useScroll(toolbarScroller);
+
 const mentionItems = computed(() =>
 	(props.mentions ?? []).map((option) => ({
 		id: option.value,
@@ -222,12 +248,14 @@ const mentionItems = computed(() =>
 	}))
 );
 
-// Built once so the editor isn't torn down on change; reactive bits thread in via getters.
+// Built once so the editor isn't torn down on change; reactive bits thread in via
+// getters. Host extensions land after RichTextKit so they can override its defaults.
 const extensions = [
 	RichTextKit.configure({
 		heading: { levels: [2, 3, 4, 5, 6] },
 		mention: { items: () => mentionItems.value },
 	}),
+	...(props.extensions ?? []),
 ];
 
 const body = defineModel<string>("body", { default: "" });

--- a/ui/src/components/Composer/ComposerEditor.vue
+++ b/ui/src/components/Composer/ComposerEditor.vue
@@ -83,8 +83,6 @@
 						</div>
 
 						<div class="flex items-center justify-between gap-2 px-2.5 pb-2.5">
-							<!-- Wrapper -ml-1.5 + scroller ml-1 tune the first icon's ink against the
-							     content edge, mirroring Send's flush right. -->
 							<div class="relative -ml-1.5 overflow-hidden" style="max-width: 70%">
 								<!-- p-0.5 keeps button focus rings from being clipped by overflow-x-auto. -->
 								<div

--- a/ui/src/components/Composer/EmailComposer/EmailComposer.vue
+++ b/ui/src/components/Composer/EmailComposer/EmailComposer.vue
@@ -5,6 +5,7 @@
 		:submit-label="submitLabel"
 		:upload-function="uploadFunction"
 		:extensions="extensions"
+		:max-attachments="maxAttachments"
 		v-model:body="body"
 		v-model:quoted="quoted"
 		@submit="handleSubmit"

--- a/ui/src/components/Composer/EmailComposer/EmailComposer.vue
+++ b/ui/src/components/Composer/EmailComposer/EmailComposer.vue
@@ -4,6 +4,7 @@
 		:placeholder="placeholder"
 		:submit-label="submitLabel"
 		:upload-function="uploadFunction"
+		:extensions="extensions"
 		v-model:body="body"
 		v-model:quoted="quoted"
 		@submit="handleSubmit"
@@ -13,11 +14,17 @@
 		<template #top>
 			<slot v-if="$slots.header" name="header" />
 			<HeaderFields
-				v-else-if="headerFields.length"
-				v-model="recipients"
+				v-else-if="hasHeader"
+				v-model:to="to"
+				v-model:cc="cc"
+				v-model:bcc="bcc"
 				v-model:subject="subject"
 				v-model:from="from"
-				:fields="headerFields"
+				:show-to="showTo"
+				:show-cc="showCc"
+				:show-bcc="showBcc"
+				:show-from="showFrom"
+				:show-subject="showSubject"
 				:senders="senders"
 				:search="searchRecipients"
 			/>
@@ -38,21 +45,29 @@ import type {
 	EmailComposerEmits,
 	EmailComposerProps,
 	EmailComposerSlots,
-	Recipients,
+	Recipient,
 } from "../types";
 
-withDefaults(defineProps<EmailComposerProps>(), {
-	headerFields: () => ["to", "cc", "bcc"],
+const props = withDefaults(defineProps<EmailComposerProps>(), {
+	showTo: true,
+	showCc: true,
+	showBcc: true,
+	showFrom: false,
+	showSubject: false,
 });
+
+const hasHeader = computed(
+	() => props.showTo || props.showCc || props.showBcc || props.showFrom || props.showSubject
+);
 
 const emit = defineEmits<EmailComposerEmits>();
 defineSlots<EmailComposerSlots>();
 
 const body = defineModel<string>({ default: "" });
 const quoted = defineModel<string | null>("quoted", { default: null });
-const recipients = defineModel<Recipients>("recipients", {
-	default: () => ({ to: [], cc: [], bcc: [] }),
-});
+const to = defineModel<Recipient[]>("to", { default: () => [] });
+const cc = defineModel<Recipient[]>("cc", { default: () => [] });
+const bcc = defineModel<Recipient[]>("bcc", { default: () => [] });
 const subject = defineModel<string>("subject", { default: "" });
 const from = defineModel<string>("from", { default: "" });
 
@@ -64,14 +79,18 @@ function handleSubmit({ body: message, attachments }: CoreSubmitPayload) {
 		from: from.value,
 		subject: subject.value,
 		body: message,
-		recipients: recipients.value,
+		to: to.value,
+		cc: cc.value,
+		bcc: bcc.value,
 		attachments,
 	});
 }
 
 // `from` survives reset — the sender identity carries over.
 function reset() {
-	recipients.value = { to: [], cc: [], bcc: [] };
+	to.value = [];
+	cc.value = [];
+	bcc.value = [];
 	subject.value = "";
 	core.value?.reset();
 }

--- a/ui/src/components/Composer/EmailComposer/HeaderFields.vue
+++ b/ui/src/components/Composer/EmailComposer/HeaderFields.vue
@@ -1,8 +1,8 @@
 <template>
 	<div class="px-2.5">
 		<Row v-if="showFrom" label="From" :items-center="true">
-			<!-- -ml-2 cancels the ghost trigger's px-2 so text aligns with the inputs below. -->
-			<Select v-model="from" :options="senderOptions" variant="ghost" class="-ml-2" />
+			<!-- -ml-1 offsets the ghost trigger's px-2 so its text sits 12px from the label. -->
+			<Select v-model="from" :options="senderOptions" variant="ghost" class="-ml-1" />
 		</Row>
 
 		<Row v-if="showSubject" label="Subject" :items-center="true">
@@ -14,56 +14,64 @@
 		</Row>
 
 		<Row v-if="showTo" label="To">
-			<RecipientSelect v-model="model.to" class="flex-1" :search="search" />
-			<div v-if="rows.length" class="flex shrink-0 items-center gap-1">
+			<RecipientSelect v-model="to" class="flex-1" :search="search" />
+			<div v-if="showCc || showBcc" class="flex shrink-0 items-center gap-1">
 				<Button
-					v-for="field in rows"
-					:key="field"
+					v-if="showCc"
 					variant="ghost"
-					:label="field.toUpperCase()"
-					:class="open[field] ? '!bg-surface-gray-4' : '!text-ink-gray-5'"
-					@click="toggle(field)"
+					label="CC"
+					:class="openCc ? '!bg-surface-gray-4' : '!text-ink-gray-5'"
 					size="xs"
+					@click="toggleCc"
+				/>
+				<Button
+					v-if="showBcc"
+					variant="ghost"
+					label="BCC"
+					:class="openBcc ? '!bg-surface-gray-4' : '!text-ink-gray-5'"
+					size="xs"
+					@click="toggleBcc"
 				/>
 			</div>
 		</Row>
 
-		<template v-for="field in rows" :key="field">
-			<Row v-if="open[field]" :label="field.toUpperCase()">
-				<RecipientSelect v-model="model[field]" class="flex-1" :search="search" />
-			</Row>
-		</template>
-		<div class="border-b bg-surface-gray-1 mt-1"></div>
+		<Row v-if="showCc && openCc" label="CC">
+			<RecipientSelect v-model="cc" class="flex-1" :search="search" />
+		</Row>
+		<Row v-if="showBcc && openBcc" label="BCC">
+			<RecipientSelect v-model="bcc" class="flex-1" :search="search" />
+		</Row>
+		<div class="border-b bg-surface-gray-1 mt-2"></div>
 	</div>
 </template>
 
 <script setup lang="ts">
-import { computed, reactive, watch } from "vue";
+import { computed, ref, watch } from "vue";
 import { Button, Select } from "frappe-ui";
 import RecipientSelect from "./RecipientSelect.vue";
 import Row from "./HeaderRow.vue";
-import type { HeaderField, Recipient, Recipients, RecipientSearch } from "../types";
+import type { Recipient, RecipientSearch } from "../types";
 
+// Private to EmailComposer, which always passes every flag — required props
+// keep the defaults in one place (EmailComposerProps).
 const props = withDefaults(
 	defineProps<{
-		fields?: HeaderField[];
+		showTo: boolean;
+		showCc: boolean;
+		showBcc: boolean;
+		showFrom: boolean;
+		showSubject: boolean;
 		senders?: Recipient[];
 		search?: RecipientSearch;
 	}>(),
-	{ fields: () => ["to", "cc", "bcc"], senders: () => [] }
+	{ senders: () => [] }
 );
 
-const model = defineModel<Recipients>({ required: true });
+const to = defineModel<Recipient[]>("to", { default: () => [] });
+const cc = defineModel<Recipient[]>("cc", { default: () => [] });
+const bcc = defineModel<Recipient[]>("bcc", { default: () => [] });
 const subject = defineModel<string>("subject", { default: "" });
 const from = defineModel<string>("from", { default: "" });
-
-const OPTIONAL = ["cc", "bcc"] as const;
-type OptionalField = "cc" | "bcc";
-
-const showFrom = computed(() => props.fields.includes("from"));
-const showSubject = computed(() => props.fields.includes("subject"));
-const showTo = computed(() => props.fields.includes("to"));
-const rows = computed(() => OPTIONAL.filter((field) => props.fields.includes(field)));
 
 const senderOptions = computed(() =>
 	props.senders.map((sender) => ({
@@ -74,29 +82,39 @@ const senderOptions = computed(() =>
 
 // Default to the first sender so the From row never sits unselected.
 watch(
-	[showFrom, () => props.senders],
+	[() => props.showFrom, () => props.senders],
 	([show, senders]) => {
 		if (show && !from.value && senders.length) from.value = senders[0].email;
 	},
 	{ immediate: true }
 );
 
-const open = reactive<Record<OptionalField, boolean>>({ cc: false, bcc: false });
+const openCc = ref(false);
+const openBcc = ref(false);
 
 // Prefilled recipients auto-open their row.
-for (const field of OPTIONAL) {
-	watch(
-		() => model.value[field].length,
-		(count) => {
-			if (count) open[field] = true;
-		},
-		{ immediate: true }
-	);
-}
+watch(
+	() => cc.value.length,
+	(count) => {
+		if (count) openCc.value = true;
+	},
+	{ immediate: true }
+);
+watch(
+	() => bcc.value.length,
+	(count) => {
+		if (count) openBcc.value = true;
+	},
+	{ immediate: true }
+);
 
 // Closing a row drops its recipients so none are sent invisibly.
-function toggle(field: OptionalField) {
-	open[field] = !open[field];
-	if (!open[field]) model.value[field] = [];
+function toggleCc() {
+	openCc.value = !openCc.value;
+	if (!openCc.value) cc.value = [];
+}
+function toggleBcc() {
+	openBcc.value = !openBcc.value;
+	if (!openBcc.value) bcc.value = [];
 }
 </script>

--- a/ui/src/components/Composer/EmailComposer/HeaderFields.vue
+++ b/ui/src/components/Composer/EmailComposer/HeaderFields.vue
@@ -52,7 +52,7 @@ import RecipientSelect from "./RecipientSelect.vue";
 import Row from "./HeaderRow.vue";
 import type { Recipient, RecipientSearch } from "../types";
 
-// Private to EmailComposer, which always passes every flag — required props
+// Private to EmailComposer, which always passes every flag; required props
 // keep the defaults in one place (EmailComposerProps).
 const props = withDefaults(
 	defineProps<{

--- a/ui/src/components/Composer/EmailComposer/HeaderFields.vue
+++ b/ui/src/components/Composer/EmailComposer/HeaderFields.vue
@@ -1,7 +1,6 @@
 <template>
 	<div class="px-2.5">
 		<Row v-if="showFrom" label="From" :items-center="true">
-			<!-- -ml-1 offsets the ghost trigger's px-2 so its text sits 12px from the label. -->
 			<Select v-model="from" :options="senderOptions" variant="ghost" class="-ml-1" />
 		</Row>
 

--- a/ui/src/components/Composer/EmailComposer/HeaderRow.vue
+++ b/ui/src/components/Composer/EmailComposer/HeaderRow.vue
@@ -1,8 +1,11 @@
 <template>
 	<div class="flex gap-2 py-1.5" :class="itemsCenter ? 'items-center' : 'items-start'">
+		<!-- leading-6 = the recipient control's min-h-6, so the label centers on the
+		     first line of chips regardless of how many lines they wrap to; bottom-px
+		     mirrors the chip text's own mb-0.5 raise. -->
 		<span
 			class="shrink-0 text-p-sm text-ink-gray-4"
-			:class="itemsCenter ? '' : 'mt-1 relative bottom-0.5'"
+			:class="itemsCenter ? '' : 'relative bottom-px leading-6'"
 			>{{ label }}</span
 		>
 		<slot />

--- a/ui/src/components/Composer/EmailComposer/HeaderRow.vue
+++ b/ui/src/components/Composer/EmailComposer/HeaderRow.vue
@@ -1,8 +1,5 @@
 <template>
 	<div class="flex gap-2 py-1.5" :class="itemsCenter ? 'items-center' : 'items-start'">
-		<!-- leading-6 = the recipient control's min-h-6, so the label centers on the
-		     first line of chips regardless of how many lines they wrap to; bottom-px
-		     mirrors the chip text's own mb-0.5 raise. -->
 		<span
 			class="shrink-0 text-p-sm text-ink-gray-4"
 			:class="itemsCenter ? '' : 'relative bottom-px leading-6'"

--- a/ui/src/components/Composer/EmailComposer/HeaderRow.vue
+++ b/ui/src/components/Composer/EmailComposer/HeaderRow.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="flex gap-2 py-1.5" :class="itemsCenter ? 'items-center' : 'items-start'">
 		<span
-			class="w-[52px] shrink-0 text-p-sm text-ink-gray-4"
+			class="shrink-0 text-p-sm text-ink-gray-4"
 			:class="itemsCenter ? '' : 'mt-1 relative bottom-0.5'"
 			>{{ label }}</span
 		>

--- a/ui/src/components/Composer/EmailComposer/RecipientSelect.vue
+++ b/ui/src/components/Composer/EmailComposer/RecipientSelect.vue
@@ -6,13 +6,13 @@
 			:options="options"
 			:loading="loading"
 			:placeholder="placeholder"
-			class="!gap-1 !bg-transparent !p-0"
+			class="mt-px !gap-1 !bg-transparent !p-0"
 			@update:query="onQuery"
 		>
 			<!-- Always show the avatar; the default hides it when imageless. -->
 			<template #tag="{ value, option, removeTag }">
 				<Avatar size="xs" :image="option?.image" :label="option?.label || value" />
-				<span class="truncate">{{ option?.label || value }}</span>
+				<span class="mb-0.5 truncate">{{ option?.label || value }}</span>
 				<button
 					class="grid size-4 place-items-center rounded-sm text-ink-gray-5 hover:bg-surface-gray-4"
 					@click.stop="removeTag"

--- a/ui/src/components/Composer/EmailComposer/RecipientSelect.vue
+++ b/ui/src/components/Composer/EmailComposer/RecipientSelect.vue
@@ -1,18 +1,20 @@
 <!-- Wrapper div so flex-1 applies: MultiEmailInput puts attrs.class on its inner box. -->
 <template>
 	<div class="w-full flex-1">
+		<!-- min-h-6 covers the chip height so the first chip doesn't grow the row. -->
 		<MultiEmailInput
 			v-model="emails"
 			:options="options"
 			:loading="loading"
 			:placeholder="placeholder"
-			class="mt-px !gap-1 !bg-transparent !p-0"
+			class="min-h-6 !gap-1 !bg-transparent !p-0"
 			@update:query="onQuery"
 		>
 			<!-- Always show the avatar; the default hides it when imageless. -->
 			<template #tag="{ value, option, removeTag }">
 				<Avatar size="xs" :image="option?.image" :label="option?.label || value" />
-				<span class="mb-0.5 truncate">{{ option?.label || value }}</span>
+				<!-- leading-4 fits descender ink; truncate's overflow clips tighter leadings. -->
+				<span class="mb-0.5 leading-4 truncate">{{ option?.label || value }}</span>
 				<button
 					class="grid size-4 place-items-center rounded-sm text-ink-gray-5 hover:bg-surface-gray-4"
 					@click.stop="removeTag"
@@ -97,5 +99,12 @@ const searchResults = computedAsync<Recipient[]>(
 /* Clear outline on chips against the transparent container. */
 :deep([data-slot="tag"]) {
 	@apply border-outline-gray-2;
+}
+
+/* Backspace selects the last chip (aria-current). Its own ring utilities are
+   often missing (consumers rarely scan frappe-ui/experimental for Tailwind
+   content), so compile the ring here. */
+:deep([data-slot="tag"][aria-current="true"]) {
+	@apply ring-2 ring-outline-gray-3;
 }
 </style>

--- a/ui/src/components/Composer/EmailComposer/RecipientSelect.vue
+++ b/ui/src/components/Composer/EmailComposer/RecipientSelect.vue
@@ -1,7 +1,6 @@
 <!-- Wrapper div so flex-1 applies: MultiEmailInput puts attrs.class on its inner box. -->
 <template>
 	<div class="w-full flex-1">
-		<!-- min-h-6 covers the chip height so the first chip doesn't grow the row. -->
 		<MultiEmailInput
 			v-model="emails"
 			:options="options"
@@ -13,7 +12,6 @@
 			<!-- Always show the avatar; the default hides it when imageless. -->
 			<template #tag="{ value, option, removeTag }">
 				<Avatar size="xs" :image="option?.image" :label="option?.label || value" />
-				<!-- leading-4 fits descender ink; truncate's overflow clips tighter leadings. -->
 				<span class="mb-0.5 leading-4 truncate">{{ option?.label || value }}</span>
 				<button
 					class="grid size-4 place-items-center rounded-sm text-ink-gray-5 hover:bg-surface-gray-4"

--- a/ui/src/components/Composer/index.ts
+++ b/ui/src/components/Composer/index.ts
@@ -13,11 +13,9 @@ export type {
   EmailComposerProps,
   EmailComposerSlots,
   EmailPayload,
-  HeaderField,
   MentionOption,
   Recipient,
   RecipientSearch,
-  Recipients,
   UploadedFile,
   UploadFunction,
 } from "./types";

--- a/ui/src/components/Composer/stories/CommentThread.vue
+++ b/ui/src/components/Composer/stories/CommentThread.vue
@@ -1,0 +1,72 @@
+<template>
+	<div class="rounded-md border border-outline-gray-2 bg-surface-base p-4">
+		<div class="flex flex-col gap-4">
+			<div v-for="comment in comments" :key="comment.id" class="flex gap-3">
+				<Avatar size="md" :label="comment.author" />
+				<div class="min-w-0">
+					<div class="flex items-baseline gap-2">
+						<span class="text-sm-medium text-ink-gray-8">{{ comment.author }}</span>
+						<span class="text-p-sm text-ink-gray-4">{{ comment.time }}</span>
+					</div>
+					<!-- Story-local static HTML only. -->
+					<div class="prose-sm mt-0.5 max-w-none text-ink-gray-7" v-html="comment.body" />
+				</div>
+			</div>
+		</div>
+
+		<div class="mt-4 flex gap-3 border-t border-outline-gray-1 pt-4">
+			<Avatar size="md" label="Sydney" />
+			<div class="min-w-0 flex-1 rounded-md border border-outline-gray-2">
+				<CommentComposer
+					ref="composerRef"
+					v-model="draft"
+					:mentions="teammates"
+					@submit="onComment"
+				/>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { Avatar } from "frappe-ui";
+import { CommentComposer } from "../index";
+import type { CommentPayload, MentionOption } from "../types";
+
+interface Comment {
+	id: number;
+	author: string;
+	time: string;
+	body: string;
+}
+
+const comments = ref<Comment[]>([
+	{
+		id: 1,
+		author: "Ada Lovelace",
+		time: "3 hours ago",
+		body: "<p>Deploy looks good — error rate is back to baseline.</p>",
+	},
+	{
+		id: 2,
+		author: "Alan Turing",
+		time: "1 hour ago",
+		body: "<p>Nice. I'll close the incident after one more quiet hour.</p>",
+	},
+]);
+
+const teammates: MentionOption[] = [
+	{ label: "Ada Lovelace", value: "ada@example.com" },
+	{ label: "Alan Turing", value: "alan@example.com" },
+	{ label: "Katherine Johnson", value: "katherine@example.com" },
+];
+
+const draft = ref("");
+const composerRef = ref<InstanceType<typeof CommentComposer> | null>(null);
+
+function onComment(payload: CommentPayload) {
+	comments.value.push({ id: Date.now(), author: "Sydney", time: "Just now", body: payload.body });
+	composerRef.value?.reset();
+}
+</script>

--- a/ui/src/components/Composer/stories/CommentThread.vue
+++ b/ui/src/components/Composer/stories/CommentThread.vue
@@ -9,7 +9,10 @@
 						<span class="text-p-sm text-ink-gray-4">{{ comment.time }}</span>
 					</div>
 					<!-- Story-local static HTML only. -->
-					<div class="prose-sm mt-0.5 max-w-none text-ink-gray-7" v-html="comment.body" />
+					<div
+						class="prose-sm mt-0.5 max-w-none text-ink-gray-7"
+						v-html="comment.body"
+					/>
 				</div>
 			</div>
 		</div>
@@ -66,7 +69,12 @@ const draft = ref("");
 const composerRef = ref<InstanceType<typeof CommentComposer> | null>(null);
 
 function onComment(payload: CommentPayload) {
-	comments.value.push({ id: Date.now(), author: "Sydney", time: "Just now", body: payload.body });
+	comments.value.push({
+		id: Date.now(),
+		author: "Sydney",
+		time: "Just now",
+		body: payload.body,
+	});
 	composerRef.value?.reset();
 }
 </script>

--- a/ui/src/components/Composer/stories/CommentThread.vue
+++ b/ui/src/components/Composer/stories/CommentThread.vue
@@ -46,7 +46,7 @@ const comments = ref<Comment[]>([
 		id: 1,
 		author: "Ada Lovelace",
 		time: "3 hours ago",
-		body: "<p>Deploy looks good — error rate is back to baseline.</p>",
+		body: "<p>Deploy looks good, error rate is back to baseline.</p>",
 	},
 	{
 		id: 2,

--- a/ui/src/components/Composer/stories/Composer.story.vue
+++ b/ui/src/components/Composer/stories/Composer.story.vue
@@ -1,261 +1,146 @@
 <template>
 	<div class="mx-auto max-w-4xl p-6">
 		<h3 class="mb-1 text-xl-semibold text-ink-gray-9">Composers</h3>
-		<p class="mb-6 text-p-sm text-ink-gray-6">
+		<p class="mb-8 text-p-sm text-ink-gray-6">
 			Two standalone, inline message composers. <code>EmailComposer</code> stacks email
-			header rows (From/Subject/To/Cc/Bcc, per <code>headerFields</code>) plus an optional
+			header rows (From/Subject/To/Cc/Bcc, per the <code>show*</code> props) plus an optional
 			quoted reply above the editor; <code>CommentComposer</code> is the editor alone, with
 			@-mentions, for internal notes. Both are transport-agnostic — <code>submit</code> hands
 			back a payload and the host performs the send, then calls the exposed
-			<code>reset()</code>. They render in normal document flow: an Email/Comment tab
-			switcher (§1) and a docked reply window (§2) are a few host lines, not library surface.
+			<code>reset()</code>. Each scene below is a real host pattern, built from a few lines
+			around the inline composer.
 		</p>
 
-		<section class="mb-6 rounded-lg border border-outline-gray-2 p-4">
-			<div class="mb-3 text-sm-medium text-ink-gray-7">Controls</div>
-
-			<div class="flex flex-wrap items-center gap-x-8 gap-y-4">
-				<div class="flex items-center gap-3">
-					<span class="text-p-sm text-ink-gray-6">headerFields</span>
-					<Checkbox v-model="fieldFrom" label="from" />
-					<Checkbox v-model="fieldTo" label="to" />
-					<Checkbox v-model="fieldSubject" label="subject" />
-					<Checkbox v-model="fieldCc" label="cc" />
-					<Checkbox v-model="fieldBcc" label="bcc" />
-				</div>
-			</div>
-
-			<div
-				class="mt-4 flex flex-wrap items-center gap-2 border-t border-outline-gray-1 pt-4"
-			>
-				<span class="mr-1 text-p-sm text-ink-gray-6">actions</span>
-				<Button label="Focus" @click="activeComposer?.focus()" />
-				<Button label="Reset" @click="activeComposer?.reset()" />
-				<Button label="Submit" @click="activeComposer?.submit()" />
-				<Button label="Seed quoted reply" @click="seedReply" />
-				<span class="ml-auto text-p-sm text-ink-gray-5">
-					channel: <b>{{ channel }}</b>
-				</span>
-			</div>
-		</section>
-
-		<section class="mb-8">
-			<div class="mb-2 text-sm-medium text-ink-gray-7">
-				Switchable composer — Email and Comment share one area via
-				<code>TabButtons</code>; each draft survives a tab switch because both stay mounted
-				(<code>v-show</code>, not <code>v-if</code>)
-			</div>
-			<div class="rounded-md border border-outline-gray-2 bg-surface-base">
-				<div class="border-b border-outline-gray-2 p-2">
-					<TabButtons v-model="channel" :options="channelOptions" />
-				</div>
-
-				<div v-show="channel === 'email'" class="p-2">
-					<EmailComposer
-						ref="emailRef"
-						v-model="emailBody"
-						v-model:recipients="recipients"
-						v-model:subject="subject"
-						v-model:quoted="quoted"
-						v-model:from="fromEmail"
-						:header-fields="headerFields"
-						:senders="senders"
-						:search-recipients="searchRecipients"
-						:upload-function="mockUpload"
-						placeholder="Write a reply…"
-						@submit="(payload) => log('email:submit', payload)"
-						@remove-attachment="(file) => log('email:remove-attachment', file)"
-					/>
-				</div>
-
-				<div v-show="channel === 'comment'" class="p-2">
-					<CommentComposer
-						ref="commentRef"
-						v-model="commentBody"
-						:mentions="mentions"
-						:upload-function="mockUpload"
-						placeholder="Leave an internal note — type @ to mention…"
-						@submit="(payload) => log('comment:submit', payload)"
-						@remove-attachment="(file) => log('comment:remove-attachment', file)"
-					/>
-				</div>
-			</div>
+		<section class="mb-10">
+			<div class="text-base font-medium text-ink-gray-8">Ticket reply</div>
+			<p class="mb-3 mt-1 text-p-sm text-ink-gray-6">
+				A support thread with an Email/Comment switcher. The quoted customer message rides
+				<code>v-model:quoted</code> and is appended on send; both drafts survive tab
+				switches because the composers stay mounted (<code>v-show</code>, not
+				<code>v-if</code>).
+			</p>
+			<TicketReply />
 			<pre
 				class="mt-3 overflow-auto rounded-lg bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
-			><code>{{ tabbedCode }}</code></pre>
+			><code>{{ ticketSnippet }}</code></pre>
 		</section>
 
-		<section class="mb-8">
-			<div class="mb-2 text-sm-medium text-ink-gray-7">
-				A docked reply window is the host's own <code>FloatingWindow</code> around an
-				inline composer — the library stays out of the window business (FP1)
-			</div>
+		<section class="mb-10">
+			<div class="text-base font-medium text-ink-gray-8">Docked compose window</div>
+			<p class="mb-3 mt-1 text-p-sm text-ink-gray-6">
+				A Gmail-style floating composer. The window is the host's own fixed card (FP1 — the
+				library stays out of the window business); <code>show-from</code> and
+				<code>show-subject</code> turn on the full header.
+			</p>
+			<DockedCompose />
 			<pre
-				class="overflow-auto rounded-lg bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
-			><code>{{ windowRecipe }}</code></pre>
+				class="mt-3 overflow-auto rounded-lg bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
+			><code>{{ dockedSnippet }}</code></pre>
 		</section>
 
-		<section class="mb-8">
-			<div class="mb-2 text-sm-medium text-ink-gray-7">
-				<code>#header</code> replaces the built-in header rows wholesale — provide it empty
-				to render no header at all
-			</div>
+		<section class="mb-10">
+			<div class="text-base font-medium text-ink-gray-8">Comment thread</div>
+			<p class="mb-3 mt-1 text-p-sm text-ink-gray-6">
+				An activity feed with <code>CommentComposer</code> pinned underneath — type
+				<code>@</code> to mention a teammate. Submitted comments join the feed and the host
+				calls <code>reset()</code>.
+			</p>
+			<CommentThread />
 			<pre
-				class="overflow-auto rounded-lg bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
-			><code>{{ headerRecipe }}</code></pre>
+				class="mt-3 overflow-auto rounded-lg bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
+			><code>{{ commentSnippet }}</code></pre>
 		</section>
 
-		<div class="text-sm-medium text-ink-gray-7">Events</div>
-		<pre
-			class="mt-2 max-h-64 overflow-auto rounded-lg bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
-			>{{
-				events.length
-					? events.join("\n")
-					: "— interact above to see submit / attachment events —"
-			}}</pre
-		>
+		<section class="mb-10">
+			<div class="text-base font-medium text-ink-gray-8">Quick reply, custom header</div>
+			<p class="mb-3 mt-1 text-p-sm text-ink-gray-6">
+				A body-only reply under a message. <code>#header</code> replaces the built-in rows
+				wholesale — here a "Replying to" pill — while the host seeds
+				<code>v-model:to</code> so the payload still carries the recipient.
+			</p>
+			<QuickReply />
+			<pre
+				class="mt-3 overflow-auto rounded-lg bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
+			><code>{{ quickSnippet }}</code></pre>
+		</section>
+
+		<section class="mb-4">
+			<div class="text-base font-medium text-ink-gray-8">Custom utilities</div>
+			<p class="mb-3 mt-1 text-p-sm text-ink-gray-6">
+				Extending the editor: a host tiptap extension via <code>extensions</code>
+				(press <kbd>⌘⇧E</kbd> to stamp today's date) and a canned-responses menu in the
+				<code>#actions</code> slot, driven through the exposed <code>editor</code>.
+			</p>
+			<CustomUtility />
+			<pre
+				class="mt-3 overflow-auto rounded-lg bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
+			><code>{{ utilitySnippet }}</code></pre>
+		</section>
 	</div>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
-import { Button, Checkbox, TabButtons } from "frappe-ui";
-import { CommentComposer, EmailComposer } from "../index";
-import type {
-	CommentPayload,
-	EmailPayload,
-	HeaderField,
-	MentionOption,
-	Recipient,
-	Recipients,
-	UploadedFile,
-	UploadFunction,
-} from "../types";
+import CommentThread from "./CommentThread.vue";
+import CustomUtility from "./CustomUtility.vue";
+import DockedCompose from "./DockedCompose.vue";
+import QuickReply from "./QuickReply.vue";
+import TicketReply from "./TicketReply.vue";
 
-const channel = ref("email");
-const channelOptions = [
-	{ label: "Email", value: "email" },
-	{ label: "Comment", value: "comment" },
-];
+const ticketSnippet = `<TabButtons v-model="channel" :options="channels" />
 
-const fieldFrom = ref(true);
-const fieldTo = ref(true);
-const fieldSubject = ref(true);
-const fieldCc = ref(true);
-const fieldBcc = ref(false);
-const headerFields = computed<HeaderField[]>(() =>
-	(
-		[
-			["from", fieldFrom.value],
-			["to", fieldTo.value],
-			["subject", fieldSubject.value],
-			["cc", fieldCc.value],
-			["bcc", fieldBcc.value],
-		] as const
-	)
-		.filter(([, on]) => on)
-		.map(([name]) => name)
-);
-
-// Draft state — host-owned via v-model, survives tab switches.
-const emailBody = ref("");
-const commentBody = ref("");
-const subject = ref("");
-const quoted = ref<string | null>(null);
-const recipients = ref<Recipients>({
-	to: [{ email: "grace@example.com", label: "Grace Hopper" }],
-	cc: [],
-	bcc: [],
-});
-
-const emailRef = ref<InstanceType<typeof EmailComposer> | null>(null);
-const commentRef = ref<InstanceType<typeof CommentComposer> | null>(null);
-const activeComposer = computed(() =>
-	channel.value === "comment" ? commentRef.value : emailRef.value
-);
-function seedReply() {
-	channel.value = "email";
-	quoted.value = "<p>On Tue, Grace wrote:</p><p>Can we ship the composer this week?</p>";
-	emailRef.value?.focus();
-}
-
-const senders: Recipient[] = [
-	{ label: "Support", email: "support@example.com" },
-	{ label: "Sales", email: "sales@example.com" },
-];
-const fromEmail = ref(senders[0].email);
-
-// Mocked transports — a real host wires these to its backend.
-const mockUpload: UploadFunction = async (file) => {
-	await new Promise((resolve) => setTimeout(resolve, 600));
-	return {
-		name: `mock-${Date.now()}`,
-		file_name: file.name,
-		file_url: URL.createObjectURL(file),
-		file_size: file.size,
-		file_type: file.type,
-	};
-};
-
-const directory: Recipient[] = [
-	{ label: "Grace Hopper", email: "grace@example.com" },
-	{ label: "Ada Lovelace", email: "ada@example.com" },
-	{ label: "Alan Turing", email: "alan@example.com" },
-	{ label: "Katherine Johnson", email: "katherine@example.com" },
-];
-function searchRecipients(query: string): Promise<Recipient[]> {
-	const text = query.trim().toLowerCase();
-	const matches = text
-		? directory.filter(
-				(person) =>
-					person.label!.toLowerCase().includes(text) ||
-					person.email.toLowerCase().includes(text)
-		  )
-		: directory;
-	// Short queries resolve slower, so typing fast forces the out-of-order case.
-	const delay = text.length < 3 ? 900 : 150;
-	return new Promise((resolve) => setTimeout(() => resolve(matches), delay));
-}
-
-const mentions: MentionOption[] = [
-	{ label: "Grace Hopper", value: "grace@example.com" },
-	{ label: "Ada Lovelace", value: "ada@example.com" },
-	{ label: "Alan Turing", value: "alan@example.com" },
-];
-
-const tabbedCode = `<TabButtons v-model="channel" :options="channelOptions" />
-
-<div v-show="channel === 'email'">
+<div v-show="channel === 'reply'">
   <EmailComposer
-    v-model="emailBody"
-    v-model:recipients="recipients"
+    v-model="replyBody"
+    v-model:to="to"
+    v-model:quoted="quoted"
     :search-recipients="searchRecipients"
-    @submit="onSendEmail"
+    @submit="onReply"
   />
 </div>
 <div v-show="channel === 'comment'">
-  <CommentComposer v-model="commentBody" :mentions="mentions" @submit="onComment" />
+  <CommentComposer v-model="commentBody" :mentions="agents" @submit="onComment" />
 </div>`;
 
-const windowRecipe = `<FloatingWindow v-model:open="open">
-  <EmailComposer v-model="body" v-model:recipients="recipients" @submit="onSend" />
-</FloatingWindow>`;
+const dockedSnippet = `<!-- The window is host chrome: a fixed card, a Dialog, whatever fits. -->
+<div class="fixed bottom-0 right-6 w-[440px] rounded-t-xl border shadow-2xl">
+  <EmailComposer
+    v-model="body"
+    v-model:to="to"
+    v-model:subject="subject"
+    v-model:from="from"
+    show-from
+    show-subject
+    :senders="senders"
+    @submit="onSend"
+  />
+</div>`;
 
-const headerRecipe = `<!-- Custom addressing UI -->
-<EmailComposer v-model="body" v-model:recipients="recipients" @submit="onSend">
+const commentSnippet = `<CommentComposer v-model="draft" :mentions="teammates" @submit="onComment" />
+
+async function onComment(payload) {
+  await call("add_comment", payload); // { body, attachments }
+  composer.value?.reset();
+}`;
+
+const quickSnippet = `<EmailComposer v-model="body" v-model:to="to" @submit="onSend">
   <template #header>
-    <MyAddressBar v-model="recipients" />
+    <ReplyingToPill :recipient="to[0]" />
   </template>
-</EmailComposer>
-
-<!-- No header at all — body-only reply, recipients seeded by the host -->
-<EmailComposer v-model="body" v-model:recipients="recipients" @submit="onSend">
-  <template #header />
 </EmailComposer>`;
 
-const events = ref<string[]>([]);
-function log(name: string, payload?: EmailPayload | CommentPayload | UploadedFile) {
-	const time = new Date().toLocaleTimeString();
-	events.value.unshift(`[${time}] ${name}${payload ? " " + JSON.stringify(payload) : ""}`);
-}
+const utilitySnippet = `const insertDate = Extension.create({
+  name: "insertDate",
+  addKeyboardShortcuts() {
+    return {
+      "Mod-Shift-e": ({ editor }) =>
+        editor.commands.insertContent(new Date().toLocaleDateString()),
+    };
+  },
+});
+
+<EmailComposer ref="composer" v-model="body" :extensions="[insertDate]">
+  <template #actions>
+    <Dropdown :options="templates"><Button label="Templates" /></Dropdown>
+  </template>
+</EmailComposer>`;
 </script>

--- a/ui/src/components/Composer/stories/Composer.story.vue
+++ b/ui/src/components/Composer/stories/Composer.story.vue
@@ -5,7 +5,7 @@
 			Two standalone, inline message composers. <code>EmailComposer</code> stacks email
 			header rows (From/Subject/To/Cc/Bcc, per the <code>show*</code> props) plus an optional
 			quoted reply above the editor; <code>CommentComposer</code> is the editor alone, with
-			@-mentions, for internal notes. Both are transport-agnostic — <code>submit</code> hands
+			@-mentions, for internal notes. Both are transport-agnostic: <code>submit</code> hands
 			back a payload and the host performs the send, then calls the exposed
 			<code>reset()</code>. Each scene below is a real host pattern, built from a few lines
 			around the inline composer.
@@ -17,7 +17,9 @@
 				A support thread with an Email/Comment switcher. The quoted customer message rides
 				<code>v-model:quoted</code> and is appended on send; both drafts survive tab
 				switches because the composers stay mounted (<code>v-show</code>, not
-				<code>v-if</code>).
+				<code>v-if</code>). The whole reply section lives in frappe-ui's
+				<code>FloatingWindow</code>: docked it renders in-flow, and its title bar pops it
+				out to a draggable window; the same instance moves, so no draft is lost.
 			</p>
 			<TicketReply />
 			<pre
@@ -28,8 +30,9 @@
 		<section class="mb-10">
 			<div class="text-base font-medium text-ink-gray-8">Docked compose window</div>
 			<p class="mb-3 mt-1 text-p-sm text-ink-gray-6">
-				A Gmail-style floating composer. The window is the host's own fixed card (FP1 — the
-				library stays out of the window business); <code>show-from</code> and
+				A Gmail-style compose window: frappe-ui's <code>FloatingWindow</code> around the
+				inline composer (FP1: the composer stays out of the window business). Pop it out
+				and drag it, or minimize it to the tray; <code>show-from</code> and
 				<code>show-subject</code> turn on the full header.
 			</p>
 			<DockedCompose />
@@ -41,7 +44,7 @@
 		<section class="mb-10">
 			<div class="text-base font-medium text-ink-gray-8">Comment thread</div>
 			<p class="mb-3 mt-1 text-p-sm text-ink-gray-6">
-				An activity feed with <code>CommentComposer</code> pinned underneath — type
+				An activity feed with <code>CommentComposer</code> pinned underneath. Type
 				<code>@</code> to mention a teammate. Submitted comments join the feed and the host
 				calls <code>reset()</code>.
 			</p>
@@ -55,7 +58,7 @@
 			<div class="text-base font-medium text-ink-gray-8">Quick reply, custom header</div>
 			<p class="mb-3 mt-1 text-p-sm text-ink-gray-6">
 				A body-only reply under a message. <code>#header</code> replaces the built-in rows
-				wholesale — here a "Replying to" pill — while the host seeds
+				wholesale, here a "Replying to" pill, while the host seeds
 				<code>v-model:to</code> so the payload still carries the recipient.
 			</p>
 			<QuickReply />
@@ -67,9 +70,8 @@
 		<section class="mb-4">
 			<div class="text-base font-medium text-ink-gray-8">Custom utilities</div>
 			<p class="mb-3 mt-1 text-p-sm text-ink-gray-6">
-				Extending the editor: a host tiptap extension via <code>extensions</code>
-				(press <kbd>⌘⇧E</kbd> to stamp today's date) and a canned-responses menu in the
-				<code>#actions</code> slot, driven through the exposed <code>editor</code>.
+				Host utilities in the <code>#actions</code> slot: a canned replies menu beside the
+				built-in attach button, inserting through the exposed <code>editor</code>.
 			</p>
 			<CustomUtility />
 			<pre
@@ -86,23 +88,25 @@ import DockedCompose from "./DockedCompose.vue";
 import QuickReply from "./QuickReply.vue";
 import TicketReply from "./TicketReply.vue";
 
-const ticketSnippet = `<TabButtons v-model="channel" :options="channels" />
+const ticketSnippet = `<!-- Docked renders in-flow; the title bar pops the whole section out. -->
+<FloatingWindow title="TICKET-1042 Reply" :minimizable="false">
+  <TabButtons v-model="channel" :options="channels" />
 
-<div v-show="channel === 'reply'">
-  <EmailComposer
-    v-model="replyBody"
-    v-model:to="to"
-    v-model:quoted="quoted"
-    :search-recipients="searchRecipients"
-    @submit="onReply"
-  />
-</div>
-<div v-show="channel === 'comment'">
-  <CommentComposer v-model="commentBody" :mentions="agents" @submit="onComment" />
-</div>`;
+  <div v-show="channel === 'reply'">
+    <EmailComposer
+      v-model="replyBody"
+      v-model:to="to"
+      v-model:quoted="quoted"
+      :search-recipients="searchRecipients"
+      @submit="onReply"
+    />
+  </div>
+  <div v-show="channel === 'comment'">
+    <CommentComposer v-model="commentBody" :mentions="agents" @submit="onComment" />
+  </div>
+</FloatingWindow>`;
 
-const dockedSnippet = `<!-- The window is host chrome: a fixed card, a Dialog, whatever fits. -->
-<div class="fixed bottom-0 right-6 w-[440px] rounded-t-xl border shadow-2xl">
+const dockedSnippet = `<FloatingWindow title="New message">
   <EmailComposer
     v-model="body"
     v-model:to="to"
@@ -113,7 +117,7 @@ const dockedSnippet = `<!-- The window is host chrome: a fixed card, a Dialog, w
     :senders="senders"
     @submit="onSend"
   />
-</div>`;
+</FloatingWindow>`;
 
 const commentSnippet = `<CommentComposer v-model="draft" :mentions="teammates" @submit="onComment" />
 
@@ -128,19 +132,9 @@ const quickSnippet = `<EmailComposer v-model="body" v-model:to="to" @submit="onS
   </template>
 </EmailComposer>`;
 
-const utilitySnippet = `const insertDate = Extension.create({
-  name: "insertDate",
-  addKeyboardShortcuts() {
-    return {
-      "Mod-Shift-e": ({ editor }) =>
-        editor.commands.insertContent(new Date().toLocaleDateString()),
-    };
-  },
-});
-
-<EmailComposer ref="composer" v-model="body" :extensions="[insertDate]">
+const utilitySnippet = `<EmailComposer ref="composer" v-model="body">
   <template #actions>
-    <Dropdown :options="templates"><Button label="Templates" /></Dropdown>
+    <Dropdown :options="cannedReplies"><Button :icon="LucideZap" /></Dropdown>
   </template>
 </EmailComposer>`;
 </script>

--- a/ui/src/components/Composer/stories/CustomUtility.vue
+++ b/ui/src/components/Composer/stories/CustomUtility.vue
@@ -4,16 +4,23 @@
 			ref="composerRef"
 			v-model="body"
 			v-model:to="to"
-			:extensions="[insertDate]"
 			:upload-function="mockUpload"
-			placeholder="Try ⌘⇧E for today's date, or insert a template…"
+			placeholder="Insert a canned reply…"
 			@submit="onSend"
 		>
-			<!-- #actions adds host utilities beside the built-in attach button. -->
+			<!-- #actions adds host utilities beside the built-in attach button,
+			     inserting through the exposed editor. -->
 			<template #actions>
-				<Dropdown :options="templateOptions">
-					<Button variant="ghost" size="sm" label="Templates" />
-				</Dropdown>
+				<Tooltip text="Canned replies">
+					<Dropdown :options="cannedReplyOptions">
+						<Button
+							variant="ghost"
+							size="sm"
+							:icon="LucideZap"
+							aria-label="Canned replies"
+						/>
+					</Dropdown>
+				</Tooltip>
 			</template>
 		</EmailComposer>
 	</div>
@@ -22,8 +29,8 @@
 
 <script setup lang="ts">
 import { ref } from "vue";
-import { Extension } from "@tiptap/core";
-import { Button, Dropdown } from "frappe-ui";
+import { Button, Dropdown, Tooltip } from "frappe-ui";
+import LucideZap from "~icons/lucide/zap";
 import { EmailComposer } from "../index";
 import type { Recipient, UploadFunction } from "../types";
 
@@ -31,26 +38,16 @@ const body = ref("");
 const to = ref<Recipient[]>([{ email: "grace@example.com", label: "Grace Hopper" }]);
 const sent = ref(false);
 
-// A host tiptap extension, appended after the built-in RichTextKit.
-const insertDate = Extension.create({
-	name: "insertDate",
-	addKeyboardShortcuts() {
-		return {
-			"Mod-Shift-e": ({ editor }) =>
-				editor.commands.insertContent(new Date().toLocaleDateString()),
-		};
-	},
-});
+const composerRef = ref<InstanceType<typeof EmailComposer> | null>(null);
 
-const templates = [
+const cannedReplies = [
 	{ label: "Greeting", body: "<p>Hi Grace, thanks for reaching out!</p>" },
-	{ label: "Fix shipped", body: "<p>The fix is live — please refresh and try again.</p>" },
+	{ label: "Fix shipped", body: "<p>The fix is live. Please refresh and try again.</p>" },
 	{ label: "Sign-off", body: "<p>Best regards,<br>Sydney</p>" },
 ];
-const composerRef = ref<InstanceType<typeof EmailComposer> | null>(null);
-const templateOptions = templates.map((template) => ({
-	label: template.label,
-	onClick: () => composerRef.value?.editor?.commands.insertContent(template.body),
+const cannedReplyOptions = cannedReplies.map((reply) => ({
+	label: reply.label,
+	onClick: () => composerRef.value?.editor?.commands.insertContent(reply.body),
 }));
 
 const mockUpload: UploadFunction = async (file) => ({

--- a/ui/src/components/Composer/stories/CustomUtility.vue
+++ b/ui/src/components/Composer/stories/CustomUtility.vue
@@ -1,0 +1,68 @@
+<template>
+	<div class="rounded-md border border-outline-gray-2 bg-surface-base p-2">
+		<EmailComposer
+			ref="composerRef"
+			v-model="body"
+			v-model:to="to"
+			:extensions="[insertDate]"
+			:upload-function="mockUpload"
+			placeholder="Try ⌘⇧E for today's date, or insert a template…"
+			@submit="onSend"
+		>
+			<!-- #actions adds host utilities beside the built-in attach button. -->
+			<template #actions>
+				<Dropdown :options="templateOptions">
+					<Button variant="ghost" size="sm" label="Templates" />
+				</Dropdown>
+			</template>
+		</EmailComposer>
+	</div>
+	<p v-if="sent" class="mt-2 text-p-sm text-ink-gray-5">Sent ✓</p>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { Extension } from "@tiptap/core";
+import { Button, Dropdown } from "frappe-ui";
+import { EmailComposer } from "../index";
+import type { Recipient, UploadFunction } from "../types";
+
+const body = ref("");
+const to = ref<Recipient[]>([{ email: "grace@example.com", label: "Grace Hopper" }]);
+const sent = ref(false);
+
+// A host tiptap extension, appended after the built-in RichTextKit.
+const insertDate = Extension.create({
+	name: "insertDate",
+	addKeyboardShortcuts() {
+		return {
+			"Mod-Shift-e": ({ editor }) =>
+				editor.commands.insertContent(new Date().toLocaleDateString()),
+		};
+	},
+});
+
+const templates = [
+	{ label: "Greeting", body: "<p>Hi Grace, thanks for reaching out!</p>" },
+	{ label: "Fix shipped", body: "<p>The fix is live — please refresh and try again.</p>" },
+	{ label: "Sign-off", body: "<p>Best regards,<br>Sydney</p>" },
+];
+const composerRef = ref<InstanceType<typeof EmailComposer> | null>(null);
+const templateOptions = templates.map((template) => ({
+	label: template.label,
+	onClick: () => composerRef.value?.editor?.commands.insertContent(template.body),
+}));
+
+const mockUpload: UploadFunction = async (file) => ({
+	name: `mock-${Date.now()}`,
+	file_name: file.name,
+	file_url: URL.createObjectURL(file),
+	file_size: file.size,
+	file_type: file.type,
+});
+
+function onSend() {
+	sent.value = true;
+	composerRef.value?.reset();
+}
+</script>

--- a/ui/src/components/Composer/stories/CustomUtility.vue
+++ b/ui/src/components/Composer/stories/CustomUtility.vue
@@ -50,10 +50,11 @@ const cannedReplyOptions = cannedReplies.map((reply) => ({
 	onClick: () => composerRef.value?.editor?.commands.insertContent(reply.body),
 }));
 
+// Frappe-style server path; the editor rejects non-http(s) URLs like blob:.
 const mockUpload: UploadFunction = async (file) => ({
 	name: `mock-${Date.now()}`,
 	file_name: file.name,
-	file_url: URL.createObjectURL(file),
+	file_url: `/files/${file.name}`,
 	file_size: file.size,
 	file_type: file.type,
 });

--- a/ui/src/components/Composer/stories/DockedCompose.vue
+++ b/ui/src/components/Composer/stories/DockedCompose.vue
@@ -1,0 +1,86 @@
+<template>
+	<div class="flex h-24 items-center gap-3 rounded-md border border-outline-gray-2 p-4">
+		<Button variant="solid" label="New email" @click="open = true" />
+		<span v-if="lastSent" class="text-p-sm text-ink-gray-5">Sent “{{ lastSent }}” ✓</span>
+	</div>
+
+	<!-- The window is host chrome (FP1): a fixed card around the inline composer. -->
+	<div
+		v-if="open"
+		class="fixed bottom-0 right-6 z-30 w-[440px] overflow-hidden rounded-t-xl border border-b-0 border-outline-gray-3 bg-surface-base shadow-2xl"
+	>
+		<div
+			class="flex items-center justify-between border-b border-outline-gray-2 bg-surface-gray-2 py-1 pl-3 pr-1"
+		>
+			<span class="text-sm-medium text-ink-gray-8">New message</span>
+			<div class="flex items-center">
+				<Button
+					variant="ghost"
+					:icon="collapsed ? LucideChevronUp : LucideMinus"
+					:aria-label="collapsed ? 'Expand' : 'Minimize'"
+					@click="collapsed = !collapsed"
+				/>
+				<Button variant="ghost" :icon="LucideX" aria-label="Close" @click="open = false" />
+			</div>
+		</div>
+
+		<div v-show="!collapsed">
+			<EmailComposer
+				ref="composerRef"
+				v-model="body"
+				v-model:to="to"
+				v-model:subject="subject"
+				v-model:from="from"
+				show-from
+				show-subject
+				:senders="senders"
+				:search-recipients="searchRecipients"
+				placeholder="Write your email…"
+				@submit="onSend"
+			/>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { Button } from "frappe-ui";
+import LucideChevronUp from "~icons/lucide/chevron-up";
+import LucideMinus from "~icons/lucide/minus";
+import LucideX from "~icons/lucide/x";
+import { EmailComposer } from "../index";
+import type { EmailPayload, Recipient } from "../types";
+
+const open = ref(false);
+const collapsed = ref(false);
+const lastSent = ref("");
+
+const body = ref("");
+const subject = ref("");
+const from = ref("");
+const to = ref<Recipient[]>([]);
+
+const senders: Recipient[] = [
+	{ label: "Support", email: "support@example.com" },
+	{ label: "Sales", email: "sales@example.com" },
+];
+
+const directory: Recipient[] = [
+	{ label: "Grace Hopper", email: "grace@example.com" },
+	{ label: "Ada Lovelace", email: "ada@example.com" },
+	{ label: "Alan Turing", email: "alan@example.com" },
+];
+async function searchRecipients(query: string): Promise<Recipient[]> {
+	const text = query.trim().toLowerCase();
+	if (!text) return directory;
+	return directory.filter((person) => person.label!.toLowerCase().includes(text));
+}
+
+const composerRef = ref<InstanceType<typeof EmailComposer> | null>(null);
+
+function onSend(payload: EmailPayload) {
+	lastSent.value = payload.subject || payload.to[0]?.email || "email";
+	composerRef.value?.reset();
+	open.value = false;
+}
+</script>

--- a/ui/src/components/Composer/stories/DockedCompose.vue
+++ b/ui/src/components/Composer/stories/DockedCompose.vue
@@ -1,32 +1,12 @@
 <template>
-	<div class="flex h-24 items-center gap-3 rounded-md border border-outline-gray-2 p-4">
-		<Button variant="solid" label="New email" @click="open = true" />
-		<span v-if="lastSent" class="text-p-sm text-ink-gray-5">Sent “{{ lastSent }}” ✓</span>
-	</div>
-
-	<!-- The window is host chrome (FP1): a fixed card around the inline composer. -->
-	<div
-		v-if="open"
-		class="fixed bottom-0 right-6 z-30 w-[440px] overflow-hidden rounded-t-xl border border-b-0 border-outline-gray-3 bg-surface-base shadow-2xl"
-	>
-		<div
-			class="flex items-center justify-between border-b border-outline-gray-2 bg-surface-gray-2 py-1 pl-3 pr-1"
-		>
-			<span class="text-sm-medium text-ink-gray-8">New message</span>
-			<div class="flex items-center">
-				<Button
-					variant="ghost"
-					:icon="collapsed ? LucideChevronUp : LucideMinus"
-					:aria-label="collapsed ? 'Expand' : 'Minimize'"
-					@click="collapsed = !collapsed"
-				/>
-				<Button variant="ghost" :icon="LucideX" aria-label="Close" @click="open = false" />
-			</div>
-		</div>
-
-		<div v-show="!collapsed">
+	<div class="rounded-md border border-outline-gray-2 p-4">
+		<p v-if="lastSent" class="mb-3 text-p-sm text-ink-gray-5">Sent “{{ lastSent }}” ✓</p>
+		<!-- FloatingWindow brings dock, float, and minimize; the draft rides along. -->
+		<FloatingWindow title="New message">
+			<!-- h-full so the composer's toolbar pins to the window bottom while floating. -->
 			<EmailComposer
 				ref="composerRef"
+				class="h-full"
 				v-model="body"
 				v-model:to="to"
 				v-model:subject="subject"
@@ -38,21 +18,16 @@
 				placeholder="Write your email…"
 				@submit="onSend"
 			/>
-		</div>
+		</FloatingWindow>
 	</div>
 </template>
 
 <script setup lang="ts">
 import { ref } from "vue";
-import { Button } from "frappe-ui";
-import LucideChevronUp from "~icons/lucide/chevron-up";
-import LucideMinus from "~icons/lucide/minus";
-import LucideX from "~icons/lucide/x";
+import { FloatingWindow } from "frappe-ui/experimental";
 import { EmailComposer } from "../index";
 import type { EmailPayload, Recipient } from "../types";
 
-const open = ref(false);
-const collapsed = ref(false);
 const lastSent = ref("");
 
 const body = ref("");
@@ -81,6 +56,5 @@ const composerRef = ref<InstanceType<typeof EmailComposer> | null>(null);
 function onSend(payload: EmailPayload) {
 	lastSent.value = payload.subject || payload.to[0]?.email || "email";
 	composerRef.value?.reset();
-	open.value = false;
 }
 </script>

--- a/ui/src/components/Composer/stories/QuickReply.vue
+++ b/ui/src/components/Composer/stories/QuickReply.vue
@@ -1,0 +1,52 @@
+<template>
+	<div class="rounded-md border border-outline-gray-2 bg-surface-base">
+		<div class="flex gap-3 border-b border-outline-gray-2 px-4 py-3">
+			<Avatar size="md" label="Grace Hopper" />
+			<div class="min-w-0">
+				<div class="flex items-baseline gap-2">
+					<span class="text-sm-medium text-ink-gray-8">Grace Hopper</span>
+					<span class="text-p-sm text-ink-gray-4">10 minutes ago</span>
+				</div>
+				<p class="mt-0.5 text-p-base text-ink-gray-7">
+					Thanks for the fix! Could you resend last month's usage report?
+				</p>
+			</div>
+		</div>
+
+		<div class="p-2">
+			<EmailComposer ref="composerRef" v-model="body" v-model:to="to" @submit="onSend">
+				<!-- #header replaces the built-in rows; recipients are host-seeded. -->
+				<template #header>
+					<div class="flex items-center gap-2 px-2.5 pb-1">
+						<span class="text-p-sm text-ink-gray-5">Replying to</span>
+						<span
+							class="flex items-center gap-1.5 rounded-full border border-outline-gray-2 py-0.5 pl-1 pr-2 text-p-sm text-ink-gray-7"
+						>
+							<Avatar size="xs" label="Grace Hopper" />
+							Grace Hopper
+						</span>
+					</div>
+				</template>
+			</EmailComposer>
+		</div>
+	</div>
+	<p v-if="sent" class="mt-2 text-p-sm text-ink-gray-5">Reply sent to grace@example.com ✓</p>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { Avatar } from "frappe-ui";
+import { EmailComposer } from "../index";
+import type { Recipient } from "../types";
+
+const body = ref("");
+const to = ref<Recipient[]>([{ email: "grace@example.com", label: "Grace Hopper" }]);
+const sent = ref(false);
+
+const composerRef = ref<InstanceType<typeof EmailComposer> | null>(null);
+
+function onSend() {
+	sent.value = true;
+	composerRef.value?.reset();
+}
+</script>

--- a/ui/src/components/Composer/stories/TicketReply.vue
+++ b/ui/src/components/Composer/stories/TicketReply.vue
@@ -25,7 +25,10 @@
 						<span class="text-p-sm text-ink-gray-4">{{ message.time }}</span>
 					</div>
 					<!-- Story-local static HTML only. -->
-					<div class="prose-sm mt-0.5 max-w-none text-ink-gray-7" v-html="message.body" />
+					<div
+						class="prose-sm mt-0.5 max-w-none text-ink-gray-7"
+						v-html="message.body"
+					/>
 				</div>
 			</div>
 		</div>
@@ -40,7 +43,10 @@
 						<TabButtons v-model="channel" :options="channelOptions" />
 					</div>
 					<!-- v-show keeps both mounted so each draft survives a tab switch. -->
-					<div v-show="channel === 'reply'" class="flex min-h-0 flex-1 flex-col px-2.5 py-2">
+					<div
+						v-show="channel === 'reply'"
+						class="flex min-h-0 flex-1 flex-col px-2.5 py-2"
+					>
 						<EmailComposer
 							ref="replyRef"
 							v-model="replyBody"
@@ -132,7 +138,12 @@ const replyRef = ref<InstanceType<typeof EmailComposer> | null>(null);
 const commentRef = ref<InstanceType<typeof CommentComposer> | null>(null);
 
 function onReply(payload: EmailPayload) {
-	messages.value.push({ id: Date.now(), author: "Sydney", time: "Just now", body: payload.body });
+	messages.value.push({
+		id: Date.now(),
+		author: "Sydney",
+		time: "Just now",
+		body: payload.body,
+	});
 	quoted.value = null;
 	replyRef.value?.reset();
 }

--- a/ui/src/components/Composer/stories/TicketReply.vue
+++ b/ui/src/components/Composer/stories/TicketReply.vue
@@ -30,32 +30,41 @@
 			</div>
 		</div>
 
-		<div class="border-t border-outline-gray-2">
-			<div class="border-b border-outline-gray-1 p-2">
-				<TabButtons v-model="channel" :options="channelOptions" />
-			</div>
-			<!-- v-show keeps both mounted so each draft survives a tab switch. -->
-			<div v-show="channel === 'reply'" class="p-2">
-				<EmailComposer
-					ref="replyRef"
-					v-model="replyBody"
-					v-model:to="to"
-					v-model:cc="cc"
-					v-model:bcc="bcc"
-					v-model:quoted="quoted"
-					:search-recipients="searchRecipients"
-					placeholder="Reply to Grace…"
-					@submit="onReply"
-				/>
-			</div>
-			<div v-show="channel === 'comment'" class="p-2">
-				<CommentComposer
-					ref="commentRef"
-					v-model="commentBody"
-					:mentions="agents"
-					@submit="onComment"
-				/>
-			</div>
+		<!-- FloatingWindow: docked renders in-flow; pop-out moves the same instance. -->
+		<div class="px-4 pb-4">
+			<FloatingWindow title="TICKET-1042 Reply" :minimizable="false">
+				<!-- Full-height column: the composer stretches, so its toolbar row
+				     pins to the window bottom while floating. -->
+				<div class="flex h-full min-h-0 flex-col">
+					<div class="shrink-0 px-2.5 pt-2">
+						<TabButtons v-model="channel" :options="channelOptions" />
+					</div>
+					<!-- v-show keeps both mounted so each draft survives a tab switch. -->
+					<div v-show="channel === 'reply'" class="flex min-h-0 flex-1 flex-col px-2.5 py-2">
+						<EmailComposer
+							ref="replyRef"
+							v-model="replyBody"
+							v-model:to="to"
+							v-model:cc="cc"
+							v-model:bcc="bcc"
+							v-model:quoted="quoted"
+							class="min-h-0 flex-1"
+							:search-recipients="searchRecipients"
+							placeholder="Reply to Grace…"
+							@submit="onReply"
+						/>
+					</div>
+					<div v-show="channel === 'comment'" class="flex min-h-0 flex-1 flex-col py-2">
+						<CommentComposer
+							ref="commentRef"
+							v-model="commentBody"
+							class="min-h-0 flex-1"
+							:mentions="agents"
+							@submit="onComment"
+						/>
+					</div>
+				</div>
+			</FloatingWindow>
 		</div>
 	</div>
 </template>
@@ -63,6 +72,7 @@
 <script setup lang="ts">
 import { ref } from "vue";
 import { Avatar, Badge, TabButtons } from "frappe-ui";
+import { FloatingWindow } from "frappe-ui/experimental";
 import { CommentComposer, EmailComposer } from "../index";
 import type { CommentPayload, EmailPayload, MentionOption, Recipient } from "../types";
 

--- a/ui/src/components/Composer/stories/TicketReply.vue
+++ b/ui/src/components/Composer/stories/TicketReply.vue
@@ -1,0 +1,140 @@
+<template>
+	<div class="rounded-md border border-outline-gray-2 bg-surface-base">
+		<div class="flex items-center justify-between border-b border-outline-gray-2 px-4 py-3">
+			<div>
+				<div class="text-base font-medium text-ink-gray-9">
+					Cannot access my invoices after the update
+				</div>
+				<div class="text-p-sm text-ink-gray-5">TICKET-1042 · grace@example.com</div>
+			</div>
+			<Badge label="Open" theme="orange" variant="subtle" />
+		</div>
+
+		<div class="flex flex-col gap-4 px-4 py-4">
+			<div v-for="message in messages" :key="message.id" class="flex gap-3">
+				<Avatar size="md" :label="message.author" />
+				<div class="min-w-0">
+					<div class="flex items-baseline gap-2">
+						<span class="text-sm-medium text-ink-gray-8">{{ message.author }}</span>
+						<Badge
+							v-if="message.internal"
+							label="Internal"
+							theme="gray"
+							variant="subtle"
+						/>
+						<span class="text-p-sm text-ink-gray-4">{{ message.time }}</span>
+					</div>
+					<!-- Story-local static HTML only. -->
+					<div class="prose-sm mt-0.5 max-w-none text-ink-gray-7" v-html="message.body" />
+				</div>
+			</div>
+		</div>
+
+		<div class="border-t border-outline-gray-2">
+			<div class="border-b border-outline-gray-1 p-2">
+				<TabButtons v-model="channel" :options="channelOptions" />
+			</div>
+			<!-- v-show keeps both mounted so each draft survives a tab switch. -->
+			<div v-show="channel === 'reply'" class="p-2">
+				<EmailComposer
+					ref="replyRef"
+					v-model="replyBody"
+					v-model:to="to"
+					v-model:cc="cc"
+					v-model:bcc="bcc"
+					v-model:quoted="quoted"
+					:search-recipients="searchRecipients"
+					placeholder="Reply to Grace…"
+					@submit="onReply"
+				/>
+			</div>
+			<div v-show="channel === 'comment'" class="p-2">
+				<CommentComposer
+					ref="commentRef"
+					v-model="commentBody"
+					:mentions="agents"
+					@submit="onComment"
+				/>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { Avatar, Badge, TabButtons } from "frappe-ui";
+import { CommentComposer, EmailComposer } from "../index";
+import type { CommentPayload, EmailPayload, MentionOption, Recipient } from "../types";
+
+interface Message {
+	id: number;
+	author: string;
+	time: string;
+	body: string;
+	internal?: boolean;
+}
+
+const messages = ref<Message[]>([
+	{
+		id: 1,
+		author: "Grace Hopper",
+		time: "2 days ago",
+		body: "<p>Since the update I get a blank page when I open Billing → Invoices.</p>",
+	},
+	{
+		id: 2,
+		author: "Sydney",
+		time: "1 day ago",
+		body: "<p>Thanks for the report! Could you tell me which browser you're on?</p>",
+	},
+]);
+
+const channel = ref("reply");
+const channelOptions = [
+	{ label: "Reply", value: "reply" },
+	{ label: "Comment", value: "comment" },
+];
+
+const replyBody = ref("");
+const commentBody = ref("");
+const to = ref<Recipient[]>([{ email: "grace@example.com", label: "Grace Hopper" }]);
+const cc = ref<Recipient[]>([]);
+const bcc = ref<Recipient[]>([]);
+// The last customer message, rendered as a collapsible block and appended on send.
+const quoted = ref<string | null>(messages.value[0].body);
+
+const agents: MentionOption[] = [
+	{ label: "Ada Lovelace", value: "ada@example.com" },
+	{ label: "Alan Turing", value: "alan@example.com" },
+];
+
+const directory: Recipient[] = [
+	{ label: "Grace Hopper", email: "grace@example.com" },
+	{ label: "Katherine Johnson", email: "katherine@example.com" },
+];
+async function searchRecipients(query: string): Promise<Recipient[]> {
+	const text = query.trim().toLowerCase();
+	if (!text) return directory;
+	return directory.filter((person) => person.label!.toLowerCase().includes(text));
+}
+
+const replyRef = ref<InstanceType<typeof EmailComposer> | null>(null);
+const commentRef = ref<InstanceType<typeof CommentComposer> | null>(null);
+
+function onReply(payload: EmailPayload) {
+	messages.value.push({ id: Date.now(), author: "Sydney", time: "Just now", body: payload.body });
+	quoted.value = null;
+	replyRef.value?.reset();
+}
+
+function onComment(payload: CommentPayload) {
+	messages.value.push({
+		id: Date.now(),
+		author: "Sydney",
+		time: "Just now",
+		body: payload.body,
+		internal: true,
+	});
+	commentRef.value?.reset();
+}
+</script>

--- a/ui/src/components/Composer/stories/TicketReply.vue
+++ b/ui/src/components/Composer/stories/TicketReply.vue
@@ -60,7 +60,10 @@
 							@submit="onReply"
 						/>
 					</div>
-					<div v-show="channel === 'comment'" class="flex min-h-0 flex-1 flex-col py-2">
+					<div
+						v-show="channel === 'comment'"
+						class="flex min-h-0 flex-1 flex-col px-2.5 py-2"
+					>
 						<CommentComposer
 							ref="commentRef"
 							v-model="commentBody"

--- a/ui/src/components/Composer/types.ts
+++ b/ui/src/components/Composer/types.ts
@@ -41,6 +41,8 @@ interface BaseComposerProps {
   uploadFunction?: UploadFunction;
   /** Extra tiptap extensions, appended after the built-in RichTextKit. Read once at mount. */
   extensions?: Extension[];
+  /** Maximum number of attachments. Defaults to 10. */
+  maxAttachments?: number;
 }
 
 export interface ComposerEditorProps extends BaseComposerProps {

--- a/ui/src/components/Composer/types.ts
+++ b/ui/src/components/Composer/types.ts
@@ -1,3 +1,4 @@
+import type { Extension } from "@tiptap/core";
 import type { UploadedFile as EditorUploadedFile } from "frappe-ui/editor";
 
 export interface Recipient {
@@ -6,16 +7,8 @@ export interface Recipient {
   image?: string;
 }
 
-export interface Recipients {
-  to: Recipient[];
-  cc: Recipient[];
-  bcc: Recipient[];
-}
-
 /** Host-supplied recipient lookup, called as the user types (and once with ""). */
 export type RecipientSearch = (query: string) => Promise<Recipient[]>;
-
-export type HeaderField = "from" | "to" | "subject" | "cc" | "bcc";
 
 /** A file as returned by FileUploader's `success` event. */
 export interface UploadedFile {
@@ -46,6 +39,8 @@ interface BaseComposerProps {
   placeholder?: string;
   submitLabel?: string;
   uploadFunction?: UploadFunction;
+  /** Extra tiptap extensions, appended after the built-in RichTextKit. Read once at mount. */
+  extensions?: Extension[];
 }
 
 export interface ComposerEditorProps extends BaseComposerProps {
@@ -73,14 +68,20 @@ interface BaseComposerEmits<Payload> {
 export interface EmailPayload extends CoreSubmitPayload {
   from: string;
   subject: string;
-  recipients: Recipients;
+  to: Recipient[];
+  cc: Recipient[];
+  bcc: Recipient[];
 }
 
-/** v-models: body (default), from, recipients, subject, quoted. */
+/** v-models: body (default), from, to, cc, bcc, subject, quoted. */
 export interface EmailComposerProps extends BaseComposerProps {
-  /** Built-in header rows to render. Defaults to ["to", "cc", "bcc"]. */
-  headerFields?: HeaderField[];
-  /** Sender identities for the From row (shown when `headerFields` includes "from"). */
+  /** Header rows. To/Cc/Bcc default on; From/Subject default off. */
+  showTo?: boolean;
+  showCc?: boolean;
+  showBcc?: boolean;
+  showFrom?: boolean;
+  showSubject?: boolean;
+  /** Sender identities for the From row (shown with `showFrom`). */
   senders?: Recipient[];
   /** Recipient lookup; omit for a plain creatable-email field. */
   searchRecipients?: RecipientSearch;


### PR DESCRIPTION
Follow-ups to #40280.

> [!WARNING]
> **Breaking change.** The `EmailComposer` prop and payload API changed. No consumer in this repo passes the old props, but external consumers must migrate:
>
> ```vue
> <!-- before -->
> <EmailComposer
>   :header-fields="['from', 'subject', 'to', 'cc']"
>   v-model:recipients="recipients"
>   @submit="onSend"
> />
>
> <!-- after -->
> <EmailComposer
>   show-from
>   show-subject
>   :show-bcc="false"
>   v-model:to="to"
>   v-model:cc="cc"
>   @submit="onSend"
> />
> ```
>
> - `headerFields` array is replaced by `showTo` / `showCc` / `showBcc` (default on) and `showFrom` / `showSubject` (default off). A field is shown when its flag is true, so list membership becomes a boolean. `headerFields: []` becomes all five flags false, or an empty `#header` slot.
> - `v-model:recipients` (one `{ to, cc, bcc }` object) is split into `v-model:to`, `v-model:cc`, `v-model:bcc`, each a `Recipient[]`.
> - The submit payload is flattened: read `payload.to` / `payload.cc` / `payload.bcc` instead of `payload.recipients.*`.
> - The `Recipients` and `HeaderField` types are removed; type against `Recipient[]`.

## API

- `headerFields` array replaced by `showTo` / `showCc` / `showBcc` / `showFrom` / `showSubject` booleans (same defaults: to/cc/bcc on).
- `v-model:recipients` object split into `v-model:to` / `v-model:cc` / `v-model:bcc`; the submit payload is flattened to match (`to`, `cc`, `bcc` arrays, no `recipients` key). `Recipients` and `HeaderField` types removed.
- New `extensions` prop on both composers: host tiptap extensions, appended after the built-in `RichTextKit` so they can override its defaults.

Every visibility flag now pairs with its data model: `show-cc`, `v-model:cc`, `payload.cc`.

## UI

| | Before | After |
|---|---|---|
| Header labels | fixed 52px label column | labels hug their fields and center on the first line of chips |
| Attach button | hand-rolled `<button>` | frappe-ui ghost `Button`, plus the menu's own section divider before the toolbar |
| Toolbar overflow | right fade always visible | both edges fade only while content is clipped on that side |
| Discard | always visible, disabled when empty | rendered only when there is something to discard |
| Chip selection | Backspace select invisible | selected chip shows its ring (utilities compiled in `RecipientSelect`) |
| Chip rows | first chip shifted the row; descenders clipped | `min-h-6` control and `leading-4` chip text |
| Attachments | single scroll row with an icon-only overflow mode | wrapping grid inside the padding, file-type icons, `maxAttachments` (default 10) |

## Stories

Five self-contained real-life scenes, each with a short usage snippet: ticket reply (Email/Comment tabs, quoted reply, whole section in frappe-ui `FloatingWindow` with pop-out), Gmail-style compose window on `FloatingWindow` (dock, drag, minimize), comment thread, quick reply via `#header`, and canned replies via `#actions`.

## Screenshots

Ticket reply, docked:

![Ticket reply docked](https://raw.githubusercontent.com/aerodeval/frappe/composer-pr-assets/ticket-reply-docked.jpg)

Ticket reply, popped out (toolbar pinned to the window bottom):

![Ticket reply floating](https://raw.githubusercontent.com/aerodeval/frappe/composer-pr-assets/ticket-reply-floating.jpg)

Custom utilities (canned replies beside attach):

![Custom utilities](https://raw.githubusercontent.com/aerodeval/frappe/composer-pr-assets/custom-utilities.jpg)

Attachment grid with file-type icons:

![Attachment grid](https://raw.githubusercontent.com/aerodeval/frappe/composer-pr-assets/attachment-grid.jpg)

no-docs
