### PR TITLE
feat(treeview): rearrange a tree by dragging, and edit a node in place

### DIFF
--- a/frappe/desk/treeview.py
+++ b/frappe/desk/treeview.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
+import json
+
 import frappe
 from frappe import _
 from frappe.query_builder import functions
@@ -94,3 +96,136 @@ def make_tree_args(**kwarg):
 		kwarg.update({parent_field: parent})
 
 	return frappe._dict(kwarg)
+
+
+# guards against a corrupted parent chain sending the ancestor walk into a long loop
+MAX_ANCESTOR_DEPTH = 100
+
+
+def get_parent_field(doctype: str) -> str:
+	"""Return the link field a node uses to point at its parent."""
+	meta = frappe.get_meta(doctype)
+	parent_field = meta.get("nsm_parent_field") or "parent_" + frappe.scrub(doctype)
+
+	if not meta.has_field(parent_field):
+		frappe.throw(
+			_("{0} has no parent field, so it cannot be arranged as a tree.").format(_(doctype)),
+			title=_("Not a Tree DocType"),
+		)
+
+	return parent_field
+
+
+def is_descendant(doctype: str, ancestor: str, candidate: str, parent_field: str) -> bool:
+	"""Whether `candidate` sits somewhere below `ancestor` in the tree.
+
+	Walks up from the candidate rather than reading lft/rgt, so it also holds
+	for tree DocTypes that are not nested sets.
+	"""
+	seen = set()
+	current = candidate
+
+	for _i in range(MAX_ANCESTOR_DEPTH):
+		if not current or current in seen:
+			return False
+		if current == ancestor:
+			return True
+		seen.add(current)
+		current = frappe.db.get_value(doctype, current, parent_field)
+
+	return False
+
+
+def validate_move(doctype: str, name: str, new_parent: str, parent_field: str) -> None:
+	if new_parent == name:
+		frappe.throw(_("{0} cannot be its own parent.").format(name))
+
+	meta = frappe.get_meta(doctype)
+	fields = ["name", "is_group"] if meta.has_field("is_group") else ["name"]
+	target = frappe.db.get_value(doctype, new_parent, fields, as_dict=True)
+
+	if not target:
+		frappe.throw(
+			_("{0} {1} does not exist.").format(_(doctype), new_parent),
+			frappe.DoesNotExistError,
+		)
+
+	if meta.has_field("is_group") and not target.is_group:
+		frappe.throw(_("{0} is not a group, so it cannot have children.").format(new_parent))
+
+	if is_descendant(doctype, name, new_parent, parent_field):
+		frappe.throw(_("Cannot move {0} into {1}, which is below it.").format(name, new_parent))
+
+
+def apply_move(doctype: str, name: str, new_parent: str, parent_field: str) -> bool:
+	"""Re-parent one node. Returns False when it already had that parent.
+
+	Saves through the document, so the DocType's own validations, permission
+	checks and nested set updates all still run.
+	"""
+	doc = frappe.get_doc(doctype, name)
+	doc.check_permission("write")
+
+	if (doc.get(parent_field) or "") == new_parent:
+		return False
+
+	if new_parent:
+		validate_move(doctype, name, new_parent, parent_field)
+
+	doc.set(parent_field, new_parent or None)
+	doc.save()
+	return True
+
+
+@frappe.whitelist(methods=["POST"])
+def move_node(doctype: str, name: str, new_parent: str | None = None):
+	"""Give one tree node a new parent.
+
+	The parent fieldname is derived here rather than taken from the request,
+	so this cannot be used to write arbitrary fields.
+	"""
+	if not doctype or not name:
+		frappe.throw(_("DocType and name are required."))
+
+	parent_field = get_parent_field(doctype)
+	new_parent = (new_parent or "").strip()
+	old_parent = frappe.db.get_value(doctype, name, parent_field) or ""
+
+	moved = apply_move(doctype, name, new_parent, parent_field)
+
+	return {"name": name, "parent": new_parent, "old_parent": old_parent, "moved": moved}
+
+
+@frappe.whitelist(methods=["POST"])
+def move_nodes(doctype: str, moves):
+	"""Apply a whole editing session's worth of moves as one unit.
+
+	Either all of them land or none do, so a move the tree cannot accept never
+	leaves the hierarchy half rearranged. The request is already wrapped in a
+	transaction, so throwing rolls the earlier saves back.
+	"""
+	if isinstance(moves, str):
+		moves = json.loads(moves)
+
+	if not moves:
+		return {"moved": 0, "names": []}
+
+	parent_field = get_parent_field(doctype)
+	applied = []
+
+	for move in moves:
+		name = (move.get("name") or "").strip()
+		new_parent = (move.get("parent") or "").strip()
+		if not name:
+			continue
+
+		try:
+			if apply_move(doctype, name, new_parent, parent_field):
+				applied.append(name)
+		except Exception as e:
+			frappe.throw(
+				_("{0} could not be moved: {1}").format(frappe.bold(name), str(e)),
+				title=_("Nothing was saved"),
+			)
+
+	return {"moved": len(applied), "names": applied}

--- a/frappe/public/js/frappe/ui/tree.js
+++ b/frappe/public/js/frappe/ui/tree.js
@@ -19,6 +19,7 @@ frappe.ui.Tree = class {
 		on_render,
 		on_click,
 		on_node_render,
+		on_children_render,
 	}) {
 		$.extend(this, arguments[0]);
 		if (root_value == null) {
@@ -195,9 +196,14 @@ frappe.ui.Tree = class {
 		// As children loaded
 		node.loaded = true;
 		this.expand_node(node);
+
+		this.on_children_render && this.on_children_render(node);
 	}
 
 	on_node_click(node) {
+		// a mouseup that ends a drag would otherwise read as a click on the row
+		if (this.suppress_click_until && Date.now() < this.suppress_click_until) return;
+
 		this.expand_node(node);
 		frappe.dom.activate(this.wrapper, node.$tree_link, "tree-link");
 		if (node.$toolbar) this.show_toolbar(node);

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -61,6 +61,7 @@ frappe.views.TreeView = class TreeView {
 		this.get_tree_nodes = me.opts.get_tree_nodes || "frappe.desk.treeview.get_children";
 
 		this.get_permissions();
+		this.editor = new frappe.views.TreeEditor(this);
 
 		this.make_page();
 		this.make_filters();
@@ -131,12 +132,14 @@ frappe.views.TreeView = class TreeView {
 		if (this.opts.show_expand_all) {
 			this.$collapse_all_btn = this.page
 				.add_menu_item(__("Collapse All"), function () {
+					if (me.editor.blocks_reload(me.tree.root_node, false)) return;
 					me.tree.load_children(me.tree.root_node, false);
 				})
 				.parent();
 
 			this.$expand_all_btn = this.page
 				.add_menu_item(__("Expand All"), function () {
+					if (me.editor.blocks_reload(me.tree.root_node, true)) return;
 					me.tree.load_children(me.tree.root_node, true);
 				})
 				.parent();
@@ -250,6 +253,7 @@ frappe.views.TreeView = class TreeView {
 				this.opts.on_node_render && this.opts.on_node_render(node, deep);
 				this.update_expand_collapse_buttons();
 			},
+			on_children_render: (node) => this.editor.make_sortable(node),
 			on_click: (node) => {
 				this.select_node(node);
 				// node.expanded is flipped synchronously right after this callback
@@ -260,6 +264,7 @@ frappe.views.TreeView = class TreeView {
 
 		cur_tree = this.tree;
 		cur_tree.view_name = "Tree";
+		this.editor.attach();
 		this.post_render();
 	}
 	get_expandable_nodes() {
@@ -338,7 +343,7 @@ frappe.views.TreeView = class TreeView {
 					return !node.is_root && me.can_read;
 				},
 				click: function (node) {
-					frappe.set_route("Form", me.doctype, node.label);
+					me.editor.quick_edit(node);
 				},
 			},
 			{
@@ -361,6 +366,7 @@ frappe.views.TreeView = class TreeView {
 					return !node.is_root && me.can_write && allow_rename;
 				},
 				click: function (node) {
+					if (me.editor.blocks_reload(node.parent_node, false)) return;
 					frappe.model.rename_doc(me.doctype, node.label, function (new_name) {
 						node.$tree_link.find("a").text(new_name);
 						node.label = new_name;
@@ -541,8 +547,16 @@ frappe.views.TreeView = class TreeView {
 			{
 				label: __("Refresh"),
 				action: function () {
+					if (me.editor.blocks_reload(null, true)) return;
 					me.make_tree();
 				},
+			},
+			{
+				label: __("Edit Tree"),
+				action: function () {
+					me.editor.toggle();
+				},
+				condition: "me.editor.can_edit",
 			},
 		];
 
@@ -554,6 +568,7 @@ frappe.views.TreeView = class TreeView {
 			this.menu_items.push({
 				label: __("Rebuild Tree"),
 				action: function () {
+					if (me.editor.blocks_reload(null, true)) return;
 					me.rebuild_tree();
 				},
 			});
@@ -570,7 +585,8 @@ frappe.views.TreeView = class TreeView {
 			}
 
 			if (has_perm) {
-				me.page.add_menu_item(menu_item["label"], menu_item["action"]);
+				let $item = me.page.add_menu_item(menu_item["label"], menu_item["action"]);
+				if (menu_item["label"] === __("Edit Tree")) me.editor.$menu_item = $item;
 			}
 		});
 	}

--- a/frappe/public/js/frappe/views/treeview_editor.js
+++ b/frappe/public/js/frappe/views/treeview_editor.js
@@ -1,0 +1,729 @@
+// Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+// MIT License. See license.txt
+
+// Rearranging a hierarchy otherwise means opening each record and editing its
+// parent field. This lets a tree view be rearranged in place instead.
+//
+// Editing works as a session: Edit Tree opens it, drops are recorded rather
+// than saved, and Save sends the whole set in one call that either lands
+// completely or not at all. A drop writes to the database only when the user
+// asks for it, so a stray drag over something like the Chart of Accounts
+// cannot quietly re-parent a record.
+//
+// The tree renders as nested lists:
+//
+//   div.tree
+//     span.tree-link            <- the root node
+//     ul.tree-children          <- the root's children
+//       li.tree-node
+//         span.tree-link
+//         ul.tree-children      <- this node's children
+//
+// so making every children list a sortable in one shared group turns
+// "drop a row into a different list" into "give this record a new parent".
+
+frappe.provide("frappe.views");
+
+const SORTABLE_GROUP = "tree-view-editor";
+// how long a click is ignored after a drag ends
+const CLICK_GUARD_MS = 400;
+// hovering a closed group for this long opens it, so you can drop inside
+const HOVER_EXPAND_MS = 600;
+
+// fieldtypes a quick edit dialog cannot usefully show
+const SKIP_FIELDTYPES = new Set([
+	"Table",
+	"Table MultiSelect",
+	"Button",
+	"HTML",
+	"Image",
+	"Fold",
+	"Barcode",
+	"Geolocation",
+	"Signature",
+]);
+
+const LAYOUT_FIELDTYPES = new Set(["Section Break", "Column Break"]);
+
+frappe.views.TreeEditor = class TreeEditor {
+	constructor(treeview) {
+		this.treeview = treeview;
+		this.doctype = treeview.doctype;
+		this.active = false;
+		// name -> the parent it should end up under
+		this.moves = new Map();
+		// name -> the parent it had when the session started
+		this.origins = new Map();
+	}
+
+	get tree() {
+		return this.treeview.tree;
+	}
+
+	get page() {
+		return this.treeview.page;
+	}
+
+	get count() {
+		return this.moves.size;
+	}
+
+	/** Whether this tree can be rearranged at all. */
+	get can_edit() {
+		return Boolean(
+			this.parent_field && this.treeview.can_write && !this.treeview.opts.disable_drag_drop
+		);
+	}
+
+	get parent_field() {
+		const meta = frappe.get_meta(this.doctype);
+		if (!meta) return null;
+
+		const parent_field = meta.nsm_parent_field || `parent_${frappe.scrub(this.doctype)}`;
+		return frappe.meta.has_field(this.doctype, parent_field) ? parent_field : null;
+	}
+
+	// --- wiring ------------------------------------------------------------
+
+	/** Called each time the tree view (re)builds its tree. */
+	attach() {
+		if (!this.tree || !this.can_edit) return;
+
+		// Some trees hang their nodes under a synthetic root, such as the
+		// Company in the Chart of Accounts, which is not a record of this
+		// DocType. Dropping there would mean becoming a second root, which
+		// nested sets reject, so those roots do not accept drops.
+		this.root_is_doc =
+			this.treeview.opts.get_tree_root !== false &&
+			Boolean(this.tree.root_node?.data?.value);
+
+		this.tree.on_children_render = (node) => this.make_sortable(node);
+		this.suppress_link_preview();
+		this.make_sortable(this.tree.root_node);
+
+		// a rebuilt tree inside an open session starts draggable again
+		if (this.active) this.refresh();
+	}
+
+	/**
+	 * Frappe pops a link preview over a row once the pointer rests on it.
+	 * That card sits on top of the row and swallows the mousedown that would
+	 * start a drag, so while editing, keep it from opening.
+	 *
+	 * The preview is delegated from document.body, so stopping the event on
+	 * the way down is enough; rows behave normally again after the session.
+	 */
+	suppress_link_preview() {
+		const wrapper = this.tree.wrapper.get(0);
+		if (!wrapper || wrapper.tree_preview_guard) return;
+		wrapper.tree_preview_guard = true;
+
+		wrapper.addEventListener(
+			"mouseover",
+			(event) => {
+				if (this.active && event.target.closest(".tree-link")) event.stopPropagation();
+			},
+			true
+		);
+	}
+
+	/** Close any preview already on screen when a session opens. */
+	close_link_previews() {
+		const preview = frappe.app && frappe.app.link_preview;
+		preview && preview.clear_all_popovers && preview.clear_all_popovers();
+	}
+
+	make_sortable(node) {
+		if (!node || !node.$ul || !this.can_edit) return;
+
+		const list = node.$ul.get(0);
+		if (!list) return;
+
+		if (list.tree_sortable) list.tree_sortable.destroy();
+		node.$ul.addClass("tree-sortable");
+
+		list.tree_sortable = new Sortable(list, {
+			disabled: !this.active,
+			group: {
+				name: SORTABLE_GROUP,
+				pull: true,
+				put: !node.is_root || this.root_is_doc,
+			},
+			draggable: "li.tree-node",
+			handle: ".tree-link",
+			animation: 150,
+			fallbackOnBody: true,
+			// the outer 40% of a row is the swap zone, which leaves room to
+			// aim at a nested list without the list above stealing the drop
+			swapThreshold: 0.6,
+			ghostClass: "tree-drag-ghost",
+			chosenClass: "tree-drag-chosen",
+			dragClass: "tree-drag-image",
+			onStart: () => this.on_drag_start(),
+			onMove: (evt) => this.on_drag_move(evt),
+			onEnd: (evt) => this.on_drag_end(evt),
+		});
+	}
+
+	// --- the session -------------------------------------------------------
+
+	toggle() {
+		this.active ? this.discard() : this.start();
+	}
+
+	start() {
+		if (this.active || !this.can_edit) return;
+
+		this.active = true;
+		this.moves.clear();
+		this.origins.clear();
+
+		this.close_link_previews();
+		this.page.clear_primary_action();
+		this.page.set_primary_action(__("Save"), () => this.save(), null, __("Saving"));
+		this.page.set_secondary_action(__("Discard"), () => this.discard());
+		this.guard_unload();
+		this.refresh();
+
+		frappe.show_alert({
+			message: __(
+				"Drag a row onto a group to move it. Nothing is saved until you press Save."
+			),
+			indicator: "blue",
+		});
+	}
+
+	stop() {
+		if (!this.active) return;
+
+		this.active = false;
+		this.moves.clear();
+		this.origins.clear();
+
+		this.release_unload_guard();
+		this.page.clear_primary_action();
+		this.page.clear_secondary_action();
+		this.page.clear_indicator();
+		// puts the tree's own "New" button back
+		this.treeview.set_primary_action();
+		this.refresh();
+	}
+
+	save() {
+		if (!this.count) return this.stop();
+
+		const moves = Array.from(this.moves, ([name, parent]) => ({ name, parent }));
+		frappe.dom.freeze(__("Saving {0} move(s)...", [moves.length]));
+
+		return frappe
+			.xcall("frappe.desk.treeview.move_nodes", { doctype: this.doctype, moves })
+			.then((result) => {
+				frappe.show_alert({
+					message: __("Saved {0} move(s)", [result.moved]),
+					indicator: "green",
+				});
+				this.stop();
+				this.treeview.make_tree();
+			})
+			.catch(() => {
+				// the server refused one of them and saved none, so stay in the
+				// session with everything still on screen
+			})
+			.finally(() => frappe.dom.unfreeze());
+	}
+
+	discard() {
+		if (!this.count) return this.stop();
+
+		frappe.confirm(__("Discard {0} unsaved move(s)?", [this.count]), () => {
+			this.stop();
+			this.treeview.make_tree();
+			frappe.show_alert({ message: __("Changes discarded"), indicator: "info" });
+		});
+	}
+
+	/** Remember where a dropped record should end up. */
+	record(name, new_parent, previous_parent) {
+		if (!this.active || !name) return;
+
+		if (!this.origins.has(name)) this.origins.set(name, previous_parent || "");
+
+		if (this.origins.get(name) === new_parent) {
+			// dragged back where it came from, so there is nothing to save
+			this.moves.delete(name);
+		} else {
+			this.moves.set(name, new_parent);
+		}
+
+		this.refresh();
+	}
+
+	/**
+	 * Re-reading a branch already on screen would replace rows the user has
+	 * moved but not yet saved. Opening a branch for the first time is fine,
+	 * and is how a closed group is reached mid-drag.
+	 */
+	blocks_reload(node, deep) {
+		if (!this.active || !this.count) return false;
+		if (!deep && !(node && node.loaded)) return false;
+
+		frappe.show_alert({
+			message: __("Save or discard your moves before reloading the tree."),
+			indicator: "orange",
+		});
+		return true;
+	}
+
+	/** A reload or a closed tab would take the unsaved moves with it. */
+	guard_unload() {
+		if (this.unload_guard) return;
+
+		this.unload_guard = (event) => {
+			if (!this.count) return;
+			event.preventDefault();
+			event.returnValue = "";
+			return "";
+		};
+
+		window.addEventListener("beforeunload", this.unload_guard);
+	}
+
+	release_unload_guard() {
+		if (!this.unload_guard) return;
+		window.removeEventListener("beforeunload", this.unload_guard);
+		this.unload_guard = null;
+	}
+
+	// --- what the user sees -------------------------------------------------
+
+	refresh() {
+		this.page.wrapper && this.page.wrapper.toggleClass("tree-editing", this.active);
+		this.set_dragging(this.active);
+		this.refresh_indicator();
+		this.refresh_banner();
+		this.refresh_moved_rows();
+
+		if (this.$menu_item) {
+			// the menu item wraps its text in .menu-item-label
+			const $label = this.$menu_item.find(".menu-item-label");
+			($label.length ? $label : this.$menu_item).text(
+				this.active ? __("Stop Editing") : __("Edit Tree")
+			);
+		}
+	}
+
+	set_dragging(on) {
+		if (!this.tree || !this.tree.wrapper) return;
+
+		this.tree.wrapper.toggleClass("tree-draggable", Boolean(on));
+		this.tree.wrapper.find("ul.tree-children.tree-sortable").each((i, list) => {
+			if (list.tree_sortable) list.tree_sortable.option("disabled", !on);
+		});
+	}
+
+	refresh_indicator() {
+		if (!this.active) return this.page.clear_indicator();
+
+		this.count
+			? this.page.set_indicator(__("{0} unsaved", [this.count]), "orange")
+			: this.page.set_indicator(__("Editing"), "blue");
+	}
+
+	refresh_banner() {
+		if (!this.active) {
+			this.$banner && this.$banner.remove();
+			this.$banner = null;
+			return;
+		}
+
+		if (!this.$banner) {
+			this.$banner = $('<div class="tree-edit-banner"></div>').prependTo(this.page.main);
+		}
+
+		this.$banner.text(
+			this.count
+				? __("Editing — {0} move(s) not saved yet. Press Save to apply them.", [
+						this.count,
+				  ])
+				: __("Editing — drag a row onto a group to give it a new parent.")
+		);
+	}
+
+	/** Mark the rows sitting somewhere new that is not saved yet. */
+	refresh_moved_rows() {
+		const wrapper = this.tree && this.tree.wrapper;
+		if (!wrapper) return;
+
+		wrapper.find(".tree-link.tree-link-moved").removeClass("tree-link-moved");
+		if (!this.active) return;
+
+		this.moves.forEach((parent, name) => {
+			wrapper
+				.find(`.tree-link[data-label="${CSS.escape(name)}"]`)
+				.addClass("tree-link-moved");
+		});
+	}
+
+	// --- dragging -----------------------------------------------------------
+
+	on_drag_start() {
+		this.dragging = true;
+		$("body").addClass("tree-dragging");
+	}
+
+	on_drag_move(evt) {
+		// a branch cannot be dropped inside itself
+		if (evt.dragged && evt.to && evt.dragged.contains(evt.to)) return false;
+
+		this.tree.wrapper.find(".tree-drop-target").removeClass("tree-drop-target");
+		$(evt.to).addClass("tree-drop-target");
+
+		this.queue_hover_expand(evt.related);
+		return true;
+	}
+
+	on_drag_end(evt) {
+		this.dragging = false;
+		this.tree.suppress_click_until = Date.now() + CLICK_GUARD_MS;
+		$("body").removeClass("tree-dragging");
+		this.tree.wrapper.find(".tree-drop-target").removeClass("tree-drop-target");
+		this.cancel_hover_expand();
+
+		if (!this.active) return this.undo_drop(evt);
+
+		const node = this.node_for_item(evt.item);
+		const from_node = this.node_for_list(evt.from);
+		const to_node = this.node_for_list(evt.to);
+		if (!node || !from_node || !to_node) return;
+
+		if (evt.from === evt.to) {
+			// Children are listed by name, so a drop that only changes the
+			// position among siblings has nothing to save. Put the row back
+			// rather than leave an order that will not survive a reload.
+			if (evt.oldIndex !== evt.newIndex) {
+				frappe.show_alert({
+					message: __(
+						"Records are listed by name, so the order of siblings cannot be changed."
+					),
+					indicator: "orange",
+				});
+				this.undo_drop(evt);
+			}
+			return;
+		}
+
+		this.record(this.doc_name(node), this.parent_value(to_node), this.parent_value(from_node));
+	}
+
+	undo_drop(evt) {
+		const sibling = evt.from.children[evt.oldIndex];
+		sibling ? evt.from.insertBefore(evt.item, sibling) : evt.from.appendChild(evt.item);
+	}
+
+	queue_hover_expand(related) {
+		const item = $(related).closest("li.tree-node").get(0);
+		if (item === this.hover_item) return;
+
+		this.cancel_hover_expand();
+		this.hover_item = item;
+		if (!item) return;
+
+		const node = this.node_for_item(item);
+		if (!node || !node.expandable || node.expanded) return;
+
+		this.hover_timer = setTimeout(() => {
+			if (this.dragging) this.tree.expand_node(node, false);
+		}, HOVER_EXPAND_MS);
+	}
+
+	cancel_hover_expand() {
+		clearTimeout(this.hover_timer);
+		this.hover_timer = null;
+		this.hover_item = null;
+	}
+
+	// --- reading the rendered tree ------------------------------------------
+
+	doc_name(node) {
+		return node && (node.data?.value || node.label);
+	}
+
+	/** What to store in the parent field for a node's children. */
+	parent_value(node) {
+		return node.is_root && !this.root_is_doc ? "" : this.doc_name(node);
+	}
+
+	/** The node whose children live in the given <ul>, or the root node. */
+	node_for_list(list) {
+		const $li = $(list).closest("li.tree-node");
+		return $li.length ? this.node_for_item($li.get(0)) : this.tree.root_node;
+	}
+
+	node_for_item(item) {
+		return $(item).children(".tree-link").data("node");
+	}
+
+	// --- editing one record in place ----------------------------------------
+
+	quick_edit(node) {
+		const name = this.doc_name(node);
+		if (!name) return;
+
+		frappe.model.with_doctype(this.doctype, () => {
+			frappe.db.get_doc(this.doctype, name).then((doc) => this.show_edit_dialog(node, doc));
+		});
+	}
+
+	show_edit_dialog(node, doc) {
+		const editable = frappe.model.can_write(this.doctype);
+		const fields = this.get_dialog_fields(editable);
+
+		// nothing this dialog can usefully show, so fall back to the form
+		if (!fields.some((df) => !LAYOUT_FIELDTYPES.has(df.fieldtype))) {
+			frappe.set_route("Form", this.doctype, doc.name);
+			return;
+		}
+
+		const dialog = new frappe.ui.Dialog({
+			title: editable ? __("Edit {0}", [doc.name]) : doc.name,
+			size: "large",
+			fields,
+		});
+
+		this.bind_doc(dialog, doc);
+		dialog.set_values(this.values_for(doc, fields));
+
+		if (editable) {
+			dialog.set_primary_action(__("Save"), () => this.save_from_dialog(node, doc, dialog));
+		}
+
+		dialog.set_secondary_action_label(__("Open Full Form"));
+		dialog.set_secondary_action(() => {
+			dialog.hide();
+			frappe.set_route("Form", this.doctype, doc.name);
+		});
+
+		dialog.show();
+	}
+
+	/**
+	 * depends_on and friends are evaluated against `dialog.doc`. Left alone
+	 * that is only the fields the dialog renders, so a rule reading a field
+	 * left out of it would silently evaluate false. Expose the stored
+	 * document merged with whatever the controls currently hold.
+	 */
+	bind_doc(dialog, doc) {
+		let stored = Object.assign({}, doc);
+
+		Object.defineProperty(dialog, "doc", {
+			configurable: true,
+			get: () => Object.assign({}, stored, this.control_values(dialog)),
+			set: (value) => {
+				stored = Object.assign({}, value);
+			},
+		});
+	}
+
+	control_values(dialog) {
+		const values = {};
+
+		for (const key in dialog.fields_dict) {
+			const field = dialog.fields_dict[key];
+			if (field?.df && field.get_value) values[field.df.fieldname] = field.get_value();
+		}
+
+		return values;
+	}
+
+	get_dialog_fields(editable) {
+		const meta = frappe.get_meta(this.doctype);
+		if (!meta) return [];
+
+		const fields = [];
+
+		for (const df of meta.fields || []) {
+			// a dialog reads better as one scrolling column than as tabs
+			if (df.fieldtype === "Tab Break") {
+				fields.push({
+					fieldtype: "Section Break",
+					fieldname: `tree_tab_${df.fieldname}`,
+					label: df.label,
+				});
+				continue;
+			}
+
+			if (LAYOUT_FIELDTYPES.has(df.fieldtype)) {
+				fields.push(Object.assign({}, df));
+				continue;
+			}
+
+			if (SKIP_FIELDTYPES.has(df.fieldtype)) continue;
+			if (df.hidden || df.read_only || df.is_virtual) continue;
+			if (df.permlevel && !frappe.perm.has_perm(this.doctype, df.permlevel, "write"))
+				continue;
+
+			const copy = Object.assign({}, df);
+
+			// set_only_once fields can no longer be changed on a saved record
+			copy.read_only = editable && !df.set_only_once ? 0 : 1;
+
+			// A fetch_from field makes the link it reads from build a fetch map,
+			// and that path calls layout.set_value unbound and then reaches for
+			// a frm a dialog does not have. The stored value still shows, and
+			// the server applies its own fetch on save.
+			delete copy.fetch_from;
+			delete copy.fetch_if_empty;
+
+			fields.push(copy);
+		}
+
+		return this.prune_layout(fields);
+	}
+
+	/**
+	 * Leaving out read-only and table fields strands section and column
+	 * breaks with nothing under them, which render as empty gaps. Keep only
+	 * the breaks that still have a field to introduce.
+	 */
+	prune_layout(fields) {
+		const pruned = [];
+		let pending = [];
+
+		for (const df of fields) {
+			if (LAYOUT_FIELDTYPES.has(df.fieldtype)) {
+				pending.push(df);
+				continue;
+			}
+
+			pruned.push(...this.collapse_breaks(pending, pruned.length === 0));
+			pending = [];
+			pruned.push(df);
+		}
+
+		return pruned;
+	}
+
+	collapse_breaks(pending, at_start) {
+		if (!pending.length) return [];
+
+		const sections = pending.filter((df) => df.fieldtype === "Section Break");
+		if (sections.length) {
+			const labelled = sections.filter((df) => df.label);
+			const keep = labelled.length ? labelled : sections;
+			return [keep[keep.length - 1]];
+		}
+
+		// only column breaks; one is enough, and one before the first field
+		// would leave the first column empty
+		return at_start ? [] : [pending[pending.length - 1]];
+	}
+
+	values_for(doc, fields) {
+		const values = {};
+
+		for (const df of fields) {
+			if (LAYOUT_FIELDTYPES.has(df.fieldtype)) continue;
+			if (df.fieldname in doc) values[df.fieldname] = doc[df.fieldname];
+		}
+
+		return values;
+	}
+
+	save_from_dialog(node, doc, dialog) {
+		// runs the dialog's own mandatory field checks
+		if (!dialog.get_values()) return;
+
+		const changed = this.changed_values(dialog, doc);
+		if (!Object.keys(changed).length) {
+			dialog.hide();
+			frappe.show_alert({ message: __("No changes to save"), indicator: "blue" });
+			return;
+		}
+
+		dialog.disable_primary_action();
+
+		return frappe
+			.xcall("frappe.client.set_value", {
+				doctype: this.doctype,
+				name: doc.name,
+				fieldname: changed,
+			})
+			.then((saved) => {
+				dialog.hide();
+				frappe.show_alert({ message: __("Saved"), indicator: "green" });
+				this.refresh_after_edit(node, saved);
+			})
+			.finally(() => dialog.enable_primary_action());
+	}
+
+	changed_values(dialog, doc) {
+		const changed = {};
+
+		for (const key in dialog.fields_dict) {
+			const field = dialog.fields_dict[key];
+			if (!field?.df || !field.get_value || field.df.read_only) continue;
+
+			const fieldname = field.df.fieldname;
+			// skips the synthetic section breaks standing in for tabs
+			if (!(fieldname in doc)) continue;
+
+			const value = field.get_value();
+			if (!this.same_value(value, doc[fieldname], field.df.fieldtype)) {
+				changed[fieldname] = value;
+			}
+		}
+
+		return changed;
+	}
+
+	same_value(a, b, fieldtype) {
+		if (["Check", "Int"].includes(fieldtype)) return cint(a) === cint(b);
+		if (["Float", "Currency", "Percent"].includes(fieldtype)) return flt(a) === flt(b);
+		return cstr(a) === cstr(b);
+	}
+
+	/**
+	 * Re-read the branch the edited node sits in. If the edit moved it to a
+	 * different parent, re-read that branch too so it turns up in its new home.
+	 */
+	refresh_after_edit(node, saved) {
+		if (!this.tree) return;
+
+		// re-reading now would wipe out rows dragged but not yet saved
+		if (this.active && this.count) {
+			frappe.show_alert({
+				message: __("Saved. The tree will catch up when you save your moves."),
+				indicator: "blue",
+			});
+			return;
+		}
+
+		if (node.is_root || !node.parent_node) return this.treeview.make_tree();
+
+		const labels = [node.parent_node.label];
+		const new_parent = this.parent_field && saved ? saved[this.parent_field] : null;
+
+		if (new_parent && new_parent !== node.parent_node.label && this.tree.nodes[new_parent]) {
+			labels.push(new_parent);
+		}
+
+		this.reload_branches(labels);
+	}
+
+	/**
+	 * Re-read the given branches in order. Nodes are looked up by label on
+	 * each step rather than held onto, because reloading one branch replaces
+	 * the node objects of anything rendered underneath it.
+	 */
+	reload_branches(labels) {
+		const pending = [...new Set(labels.filter(Boolean))];
+
+		return frappe.run_serially(
+			pending.map((label) => () => {
+				const node = this.tree.nodes && this.tree.nodes[label];
+				if (!node || !node.$ul || !document.body.contains(node.$ul.get(0))) return null;
+				return this.tree.load_children(node);
+			})
+		);
+	}
+};

--- a/frappe/public/js/list.bundle.js
+++ b/frappe/public/js/list.bundle.js
@@ -29,6 +29,7 @@ import "./frappe/views/kanban/kanban_view.js";
 import "./frappe/views/inbox/inbox_view.js";
 import "./frappe/views/file/file_view.js";
 
+import "./frappe/views/treeview_editor.js";
 import "./frappe/views/treeview.js";
 import "./frappe/views/interaction.js";
 

--- a/frappe/public/scss/desk/tree.scss
+++ b/frappe/public/scss/desk/tree.scss
@@ -171,3 +171,128 @@
 	background-color: var(--fg-hover-color);
 	border-radius: var(--radius);
 }
+
+// --- rearranging the tree -------------------------------------------------
+
+.tree-edit-banner {
+	display: flex;
+	align-items: center;
+	gap: var(--margin-sm);
+	margin-bottom: var(--margin-md);
+	padding: var(--padding-sm) var(--padding-md);
+	border: 1px dashed var(--orange-400);
+	border-radius: var(--radius);
+	background-color: var(--bg-orange);
+	color: var(--text-on-orange);
+	font-size: var(--text-sm);
+	font-weight: 500;
+
+	&::before {
+		content: "\271B";
+		font-size: var(--text-md);
+		line-height: 1;
+	}
+}
+
+// while a session is open the whole card reads as a work surface
+.tree-editing {
+	.layout-main-section.frappe-card,
+	.page-main-content .frappe-card {
+		outline: 1px dashed var(--orange-400);
+		outline-offset: 4px;
+	}
+
+	.tree.tree-draggable .tree-link {
+		cursor: grab;
+		border: 1px dashed transparent;
+		border-radius: var(--radius);
+
+		// a grip, so a row visibly announces that it can be picked up
+		&::before {
+			content: "\2807\2807";
+			margin-right: var(--margin-xs);
+			color: var(--text-muted);
+			font-size: var(--text-md);
+			line-height: 1.4em;
+		}
+
+		&:hover {
+			border-color: var(--gray-400);
+			background-color: var(--highlight-color);
+		}
+
+		&:active {
+			cursor: grabbing;
+		}
+
+		// moved, but not saved yet
+		&.tree-link-moved {
+			border-color: var(--orange-400);
+			border-style: solid;
+			background-color: var(--bg-orange);
+
+			&::before {
+				color: var(--text-on-orange);
+			}
+
+			.tree-label {
+				color: var(--text-on-orange);
+				font-weight: 600;
+			}
+		}
+	}
+}
+
+// the gap the dragged row leaves behind
+li.tree-node.tree-drag-ghost {
+	opacity: 0.4;
+
+	> .tree-link {
+		background-color: var(--highlight-color);
+		border-radius: var(--radius);
+	}
+}
+
+li.tree-node.tree-drag-chosen > .tree-link {
+	background-color: var(--control-bg);
+	border-radius: var(--radius);
+}
+
+// the row following the cursor
+li.tree-node.tree-drag-image {
+	background-color: var(--card-bg);
+	border-radius: var(--radius);
+	box-shadow: var(--shadow-base);
+	opacity: 0.9;
+
+	// only the row itself follows the cursor, not the branch under it
+	> ul.tree-children {
+		display: none !important;
+	}
+}
+
+// the children list the row would land in
+ul.tree-children.tree-drop-target {
+	background-color: var(--bg-orange);
+	border-radius: var(--radius);
+	outline: 1px dashed var(--orange-400);
+	outline-offset: 2px;
+}
+
+body.tree-dragging {
+	// a group with no children is still a valid destination, so give it
+	// enough of a target to aim at
+	ul.tree-children.tree-sortable:empty {
+		display: block !important;
+		min-height: 36px;
+		margin-right: var(--margin-md);
+		margin-bottom: var(--margin-xs);
+		border: 1px dashed var(--gray-400);
+		border-radius: var(--radius);
+		background-color: var(--highlight-color);
+	}
+
+	.tree-link {
+		cursor: grabbing;
+	}
+}


### PR DESCRIPTION
## Problem

Rearranging a hierarchy means opening each record and editing its parent field one at a time. On something like the Chart of Accounts, moving a handful of accounts is a handful of full page loads, and there is no way to see the shape you are producing while you produce it.

## What this adds

An editing session on the tree view, in the shape of the workspace editor:

1. **Edit Tree** in the page menu opens the session. The card outlines, rows grow a grip, and the primary action becomes **Save**, with **Discard** beside it.
2. Drag rows onto groups. Each move marks the row and bumps an "N unsaved" counter — **nothing is written yet**.
3. **Save** sends the whole set in one call that either lands completely or not at all. **Discard** throws it away.

The row's **Edit** button now opens the record in a dialog built from its own form layout instead of routing away, and re-reads the branch in place on save.

Deferring the write is the point: a drop that saved immediately would mean one stray drag over the Chart of Accounts could quietly re-parent an account.

## How it works

Nothing is hard-coded per DocType. The parent field is derived the way the framework already derives it — `nsm_parent_field`, else `parent_<scrubbed doctype>` — so a tree view gets this by having a parent field and a user with write permission.

Moves are applied by loading the document, setting its parent field and calling `save()`, so the DocType's own validations, permission checks and nested-set updates all still run. The parent fieldname is worked out on the server and never taken from the request, so `move_node`/`move_nodes` cannot be used to write other fields.

`frappe/public/js/frappe/ui/tree.js` gains only two optional hooks (`on_children_render`, `suppress_click_until`), so trees built outside `frappe.views.TreeView` — the setup wizard's chart preview and the CoA importer — are untouched.

## Edges, and what they do

- **Sibling order** — children are listed by name, so a drop that only reorders siblings is put back rather than pretending an order that will not survive a reload.
- **Synthetic roots** — trees that hang nodes under something that is not a record of the DocType (the Company in the Chart of Accounts) do not accept drops at root level, since that would mean a second root. Trees whose root is a real record (*All Item Groups*) do.
- **Reloading mid-session** — Expand All, Collapse All, Refresh, Rebuild Tree and Rename all re-read a branch, which would replace rows moved but not yet saved, so they ask the user to save or discard first.
- **Closing the tab** with unsaved moves prompts.
- **Opt out** per DocType with `frappe.treeview_settings["X"].disable_drag_drop = true`.

## Testing

Driven against a real ERPNext site (Frappe v16.31 / ERPNext v16.32) with headless Chrome, **79 checks, all passing**:

| Area | Checks |
|---|---|
| `move_node` / `move_nodes` — validation, nested-set integrity, atomic rollback of a bad batch | 23 |
| Session — gate before Edit, banner, counters, Save writes, Discard writes nothing | 27 |
| Quick edit dialog — opens in place, saves, no navigation, unchanged save skips the server | 16 |
| Second DocType (Item Group, whose root *is* a record) end to end | 13 |

Covered explicitly: dropping into a populated group and an empty one; refusing to drop a group into its own descendant; refusing root-level drops on a synthetic root; and that a drag before pressing Edit does nothing at all.

## One thing found on the way, worth its own fix

A field with `fetch_from` breaks inside any `frappe.ui.Dialog`. `Link` is in the "read only fieldtype" list in `setup_add_fetch`, so an ordinary Link field with `fetch_from` builds a fetch map; then `validate_link_and_fetch` calls `layout_set_value(...)` **unbound** (so `this` is undefined inside `FieldGroup.set_value` → *Cannot read properties of undefined (reading 'fields_dict')*), and `after_set_value()` does `this.frm.refresh_field(...)` with no `frm`. This affects **Quick Entry** too, not just this dialog.

I have worked around it here by dropping the rule from the dialog's copy of the docfield, and left a comment saying so. Happy to send the actual fix separately if you would like it.

cc @ejaaz @umairsy
