### PR TITLE
fix: truncate long error log titles

### DIFF
--- a/frappe/core/doctype/error_log/test_error_log.py
+++ b/frappe/core/doctype/error_log/test_error_log.py
@@ -15,7 +15,14 @@ class TestErrorLog(IntegrationTestCase):
 		doc = frappe.new_doc("Error Log")
 		error = doc.log_error("This is an error")
 		self.assertEqual(error.doctype, "Error Log")
-
+	def test_log_error_with_long_title(self):
+		title = "x" * 200
+		error_log = frappe.log_error(
+		title=title,
+		message="Test error",
+		defer_insert=True,
+		)
+		self.assertEqual(error_log.method, title[:140])
 	def test_error_fingerprint(self):
 		def boom(msg):
 			raise ValueError(msg)

--- a/frappe/utils/error.py
+++ b/frappe/utils/error.py
@@ -62,10 +62,10 @@ def log_error(
 
 	if not title:
 		if traceback:
-			title = traceback.splitlines()[-1][:140]
+			title = traceback.splitlines()[-1]
 		else:
 			title = "Error"
-
+	title = title[:140]
 	if not frappe.db:
 		print(f"Failed to log error in db: {title}")
 		return


### PR DESCRIPTION
## Summary

Error Log titles are stored in the `method` field, which has a maximum length of 140 characters. Passing a longer title to `frappe.log_error` could therefore cause validation or database issues.

This change truncates titles to 140 characters before creating the Error Log document and adds a regression test for long titles.

## Testing

- `bench --site frappe-test.local run-tests --module frappe.core.doctype.error_log.test_error_log`