### PR TITLE
fix: quote tabSingles during DocType rename

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -702,9 +702,9 @@ class DocType(Document):
 		`doctype` property for Single type."""
 
 		if self.issingle:
-			frappe.db.sql("""update tabSingles set doctype=%s where doctype=%s""", (new, old))
+			frappe.db.sql("""update `tabSingles` set doctype=%s where doctype=%s""", (new, old))
 			frappe.db.sql(
-				"""update tabSingles set value=%s
+				"""update `tabSingles` set value=%s
 				where doctype=%s and field='name' and value = %s""",
 				(new, new, old),
 			)

--- a/frappe/tests/test_rename_doc.py
+++ b/frappe/tests/test_rename_doc.py
@@ -37,6 +37,21 @@ def patch_db(endpoints: list[str] | None = None):
 		frappe.db.rollback(save_point=savepoint)
 
 
+class TestRenameSingleDocType(IntegrationTestCase):
+	def test_rename_single_doctype(self):
+		old_name = "Test Single Rename Old"
+		new_name = "Test Single Rename New"
+		new_doctype(old_name, issingle=1).insert()
+		single = frappe.get_single(old_name)
+		single.some_fieldname = "some value"
+		single.save()
+
+		self.assertEqual(new_name, frappe.rename_doc("DocType", old_name, new_name, force=True))
+		self.assertEqual(frappe.db.get_single_value(new_name, "some_fieldname"), "some value")
+		self.assertEqual(frappe.db.get_single_value(new_name, "name"), new_name)
+		self.assertEqual(frappe.db.count("Singles", {"doctype": old_name}), 0)
+
+
 class TestRenameDoc(IntegrationTestCase):
 	@classmethod
 	def setUpClass(self):


### PR DESCRIPTION
## Problem

PostgreSQL folds unquoted identifiers to lowercase. Frappe creates `tabSingles` with a quoted mixed-case identifier.

Renaming a Single DocType used unquoted identifiers. PostgreSQL could not find the resulting `tabsingles` relation.

## Change

- Quote `tabSingles` in both Single DocType rename updates.
- Add a regression test that checks the renamed values and removes old rows.

## Tests

- `frappe.tests.test_rename_doc`: 11 tests passed on PostgreSQL.
- All applicable pre-commit code checks passed.

Closes #42053
