### PR TITLE
fix(virtual): enforce permission checks on list and delete

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -91,7 +91,18 @@ def delete_doc(
 
 	for name in names or []:
 		if is_virtual:
-			frappe.get_doc(doctype, name).delete()
+			doc = frappe.get_doc(doctype, name)
+			update_flags(doc, flags, ignore_permissions)
+			check_permission_and_not_submitted(doc)
+
+			from frappe.model.document import Document
+
+			if type(doc).delete == Document.delete:
+				frappe.throw(
+					_("{0} is a Virtual DocType and must implement its own delete() method.").format(doctype)
+				)
+
+			doc.delete()
 			continue
 
 		# already deleted..?

--- a/frappe/model/qb_query.py
+++ b/frappe/model/qb_query.py
@@ -123,7 +123,7 @@ class DatabaseQuery:
 		# Handle virtual doctypes before any other processing
 		if is_virtual_doctype(self.doctype):
 			if not ignore_permissions:
-				ptype = "select" if frappe.only_has_select_perm(self.doctype) else "read"
+				ptype = "select" if frappe.only_has_select_perm(self.doctype, user=user) else "read"
 				frappe.has_permission(
 					self.doctype,
 					ptype=ptype,

--- a/frappe/model/qb_query.py
+++ b/frappe/model/qb_query.py
@@ -122,6 +122,16 @@ class DatabaseQuery:
 
 		# Handle virtual doctypes before any other processing
 		if is_virtual_doctype(self.doctype):
+			if not ignore_permissions:
+				ptype = "select" if frappe.only_has_select_perm(self.doctype) else "read"
+				frappe.has_permission(
+					self.doctype,
+					ptype=ptype,
+					parent_doctype=parent_doctype,
+					throw=True,
+					user=user,
+				)
+
 			return self._handle_virtual_doctype(
 				fields,
 				filters,

--- a/frappe/tests/test_virtual_doctype.py
+++ b/frappe/tests/test_virtual_doctype.py
@@ -174,3 +174,33 @@ class TestVirtualDoctypes(IntegrationTestCase):
 	def test_controller_validity(self):
 		validate_controller(TEST_DOCTYPE_NAME)
 		validate_controller(TEST_CHILD_DOCTYPE_NAME)
+
+	def test_guest_cannot_list_virtual_doctype(self):
+		frappe.get_doc(doctype=TEST_DOCTYPE_NAME).insert()
+
+		with self.set_user("Guest"):
+			self.assertRaises(frappe.PermissionError, frappe.get_list, TEST_DOCTYPE_NAME)
+
+	def test_authorized_user_can_list_virtual_doctype(self):
+		doc = frappe.get_doc(doctype=TEST_DOCTYPE_NAME).insert()
+
+		listed_docs = {d.name for d in frappe.get_list(TEST_DOCTYPE_NAME)}
+		self.assertIn(doc.name, listed_docs)
+
+	def test_guest_cannot_delete_virtual_doctype(self):
+		doc = frappe.get_doc(doctype=TEST_DOCTYPE_NAME).insert()
+
+		with self.set_user("Guest"):
+			self.assertRaises(frappe.PermissionError, frappe.delete_doc, doc.doctype, doc.name)
+
+		# document must survive the rejected delete attempt
+		listed_docs = {d.name for d in VirtualDoctypeTest.get_list()}
+		self.assertIn(doc.name, listed_docs)
+
+	def test_authorized_user_can_delete_virtual_doctype(self):
+		doc = frappe.get_doc(doctype=TEST_DOCTYPE_NAME).insert()
+
+		frappe.delete_doc(doc.doctype, doc.name)
+
+		listed_docs = {d.name for d in VirtualDoctypeTest.get_list()}
+		self.assertNotIn(doc.name, listed_docs)


### PR DESCRIPTION
This PR enforces permission checks on list and delete for virtual doctypes.

closes Ticket 75881