### PR TITLE
fix: prepared report automation flags the reference report instead of the custom report

### DIFF
--- a/frappe/core/doctype/prepared_report/prepared_report.py
+++ b/frappe/core/doctype/prepared_report/prepared_report.py
@@ -14,7 +14,7 @@ import frappe
 from frappe import _
 from frappe.database.utils import dangerously_reconnect_on_connection_abort
 from frappe.desk.form.load import get_attachments
-from frappe.desk.query_report import generate_report_result
+from frappe.desk.query_report import generate_report_result, get_reference_report
 from frappe.model.document import Document
 from frappe.monitor import add_data_to_monitor
 from frappe.utils import add_to_date, now
@@ -131,8 +131,7 @@ def generate_report(prepared_report):
 
 		if report.report_type == "Custom Report":
 			custom_report_doc = report
-			reference_report = custom_report_doc.reference_report
-			report = frappe.get_doc("Report", reference_report)
+			report = get_reference_report(custom_report_doc)
 			report.custom_report = instance.report_name
 			report.prepared_report = custom_report_doc.prepared_report
 			report.disable_prepared_report_automation = custom_report_doc.disable_prepared_report_automation

--- a/frappe/core/doctype/prepared_report/prepared_report.py
+++ b/frappe/core/doctype/prepared_report/prepared_report.py
@@ -133,6 +133,9 @@ def generate_report(prepared_report):
 			custom_report_doc = report
 			reference_report = custom_report_doc.reference_report
 			report = frappe.get_doc("Report", reference_report)
+			report.custom_report = instance.report_name
+			report.prepared_report = custom_report_doc.prepared_report
+			report.disable_prepared_report_automation = custom_report_doc.disable_prepared_report_automation
 			if custom_report_doc.json:
 				data = json.loads(custom_report_doc.json)
 				if data:

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -194,13 +194,15 @@ class Report(Document):
 		# save the timestamp to automatically set to prepared
 		threshold = 15
 
+		executed_report = self.get("custom_report") or self.name
+
 		start_time = datetime.datetime.now()
 		prepared_report_watcher = None
 		if not self.prepared_report and not self.disable_prepared_report_automation:
 			prepared_report_watcher = threading.Timer(
 				interval=threshold,
 				function=enable_prepared_report,
-				kwargs={"report": self.name, "site": frappe.local.site},
+				kwargs={"report": executed_report, "site": frappe.local.site},
 			)
 			prepared_report_watcher.start()
 
@@ -218,7 +220,7 @@ class Report(Document):
 
 		execution_time = (datetime.datetime.now() - start_time).total_seconds()
 
-		frappe.cache.hset("report_execution_time", self.name, execution_time)
+		frappe.cache.hset("report_execution_time", executed_report, execution_time)
 
 		return res
 

--- a/frappe/core/doctype/report/test_report.py
+++ b/frappe/core/doctype/report/test_report.py
@@ -391,6 +391,66 @@ result = [
 		# check values
 		self.assertTrue("System User" in [d.get("type") for d in data[1]])
 
+	def create_custom_report_pair(self, **custom_report_args):
+		"""A script report, and a custom report built on top of it."""
+		reference_report_name = "Test Prepared Report Automation"
+		custom_report_name = "Test Prepared Report Automation - Warehouse Wise"
+
+		for name in (custom_report_name, reference_report_name):
+			frappe.delete_doc("Report", name, force=True, ignore_permissions=True, ignore_missing=True)
+
+		frappe.cache.hdel("report_execution_time", [reference_report_name, custom_report_name])
+
+		reference_report = frappe.get_doc(
+			{
+				"doctype": "Report",
+				"ref_doctype": "User",
+				"report_name": reference_report_name,
+				"report_type": "Script Report",
+				"is_standard": "No",
+				"report_script": "result = []",
+			}
+		).insert(ignore_permissions=True)
+
+		custom_report = frappe.get_doc(
+			{
+				"doctype": "Report",
+				"ref_doctype": "User",
+				"report_name": custom_report_name,
+				"report_type": "Custom Report",
+				"reference_report": reference_report.name,
+				"is_standard": "No",
+				**custom_report_args,
+			}
+		).insert(ignore_permissions=True)
+
+		return reference_report.name, custom_report.name
+
+	def armed_watchdog_targets(self, report_name):
+		"""Reports the prepared report watchdog was armed for while running `report_name`."""
+		import threading
+		from unittest.mock import MagicMock, patch
+
+		timer = MagicMock()
+		with patch.object(threading, "Timer", timer):
+			run(report_name=report_name, filters={}, are_default_filters=False)
+
+		return [call.kwargs["kwargs"]["report"] for call in timer.call_args_list]
+
+	def test_prepared_report_automation_targets_the_report_that_ran(self):
+		"""A custom report auto-enables prepared report on itself, not on its reference report."""
+		reference_report, custom_report = self.create_custom_report_pair()
+
+		self.assertEqual(self.armed_watchdog_targets(custom_report), [custom_report])
+		self.assertIsNotNone(frappe.cache.hget("report_execution_time", custom_report))
+		self.assertIsNone(frappe.cache.hget("report_execution_time", reference_report))
+
+	def test_prepared_report_automation_honours_custom_report_opt_out(self):
+		"""A custom report opting out of automation is never auto-enabled."""
+		_, custom_report = self.create_custom_report_pair(disable_prepared_report_automation=1)
+
+		self.assertEqual(self.armed_watchdog_targets(custom_report), [])
+
 	def test_toggle_disabled(self):
 		"""Make sure that authorization is respected."""
 		# Assuming that there will be reports in the system.

--- a/frappe/core/doctype/report/test_report.py
+++ b/frappe/core/doctype/report/test_report.py
@@ -3,6 +3,8 @@
 
 import json
 import os
+import threading
+from unittest.mock import MagicMock, patch
 
 import frappe
 from frappe.core.doctype.user_permission.test_user_permission import create_user
@@ -391,65 +393,27 @@ result = [
 		# check values
 		self.assertTrue("System User" in [d.get("type") for d in data[1]])
 
-	def create_custom_report_pair(self, **custom_report_args):
-		"""A script report, and a custom report built on top of it."""
-		reference_report_name = "Test Prepared Report Automation"
-		custom_report_name = "Test Prepared Report Automation - Warehouse Wise"
-
-		for name in (custom_report_name, reference_report_name):
-			frappe.delete_doc("Report", name, force=True, ignore_permissions=True, ignore_missing=True)
-
-		frappe.cache.hdel("report_execution_time", [reference_report_name, custom_report_name])
-
-		reference_report = frappe.get_doc(
-			{
-				"doctype": "Report",
-				"ref_doctype": "User",
-				"report_name": reference_report_name,
-				"report_type": "Script Report",
-				"is_standard": "No",
-				"report_script": "result = []",
-			}
-		).insert(ignore_permissions=True)
-
-		custom_report = frappe.get_doc(
-			{
-				"doctype": "Report",
-				"ref_doctype": "User",
-				"report_name": custom_report_name,
-				"report_type": "Custom Report",
-				"reference_report": reference_report.name,
-				"is_standard": "No",
-				**custom_report_args,
-			}
-		).insert(ignore_permissions=True)
-
-		return reference_report.name, custom_report.name
-
-	def armed_watchdog_targets(self, report_name):
-		"""Reports the prepared report watchdog was armed for while running `report_name`."""
-		import threading
-		from unittest.mock import MagicMock, patch
-
-		timer = MagicMock()
-		with patch.object(threading, "Timer", timer):
-			run(report_name=report_name, filters={}, are_default_filters=False)
-
-		return [call.kwargs["kwargs"]["report"] for call in timer.call_args_list]
-
 	def test_prepared_report_automation_targets_the_report_that_ran(self):
 		"""A custom report auto-enables prepared report on itself, not on its reference report."""
-		reference_report, custom_report = self.create_custom_report_pair()
+		reference_report = "Permitted Documents For User"
+		filters = {"user": "Administrator", "doctype": "User"}
+		custom_report = save_report(
+			reference_report, "Permitted Documents For User Prepared", "[]", json.dumps(filters)
+		)
+		frappe.cache.hdel("report_execution_time", [reference_report, custom_report])
 
-		self.assertEqual(self.armed_watchdog_targets(custom_report), [custom_report])
+		def prepared_report_watcher_targets():
+			timer = MagicMock()
+			with patch.object(threading, "Timer", timer):
+				run(report_name=custom_report, filters=filters, are_default_filters=False)
+			return [call.kwargs["kwargs"]["report"] for call in timer.call_args_list]
+
+		self.assertEqual(prepared_report_watcher_targets(), [custom_report])
 		self.assertIsNotNone(frappe.cache.hget("report_execution_time", custom_report))
 		self.assertIsNone(frappe.cache.hget("report_execution_time", reference_report))
 
-	def test_prepared_report_automation_honours_custom_report_opt_out(self):
-		"""A custom report opting out of automation is never auto-enabled."""
-		_, custom_report = self.create_custom_report_pair(disable_prepared_report_automation=1)
-
-		self.assertEqual(self.armed_watchdog_targets(custom_report), [])
+		frappe.db.set_value("Report", custom_report, "disable_prepared_report_automation", 1)
+		self.assertEqual(prepared_report_watcher_targets(), [])
 
 	def test_toggle_disabled(self):
 		"""Make sure that authorization is respected."""

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -40,8 +40,9 @@ def get_report_doc(report_name):
 				doc.custom_filters = data.get("filters")
 		doc.is_custom_report = True
 
-		# Follow whatever the custom report has set for prepared report field
+		# Follow whatever the custom report has set for prepared report fields
 		doc.prepared_report = custom_report_doc.prepared_report
+		doc.disable_prepared_report_automation = custom_report_doc.disable_prepared_report_automation
 
 	if not doc.is_permitted():
 		frappe.throw(
@@ -132,6 +133,8 @@ def generate_report_result(
 	if isinstance(filters, dict) and filters.get("translate_data"):
 		result = translate_report_data(result, has_total_row)
 
+	execution_time = frappe.cache.hget("report_execution_time", report.get("custom_report") or report.name)
+
 	return_dict = {
 		"result": result,
 		"columns": columns,
@@ -140,7 +143,7 @@ def generate_report_result(
 		"report_summary": report_summary,
 		"skip_total_row": skip_total_row or 0,
 		"status": None,
-		"execution_time": frappe.cache.hget("report_execution_time", report.name) or 0,
+		"execution_time": execution_time or 0,
 	}
 
 	if report.snapshot_report and report.doctype_to_sync:


### PR DESCRIPTION
## Description

Custom reports were enabling `prepared_report` on their reference report instead of on the custom report itself.

This happened because `get_report_doc` loaded the reference report and copied the custom report's `prepared_report` value onto it. As a result, the watchdog read the custom report but updated the reference report. The custom report never got enabled and kept restarting the timer. `report_execution_time` was also stored under the wrong report, so custom reports always showed `0`.

This could cause the base report to use cached results while the custom report continued running inline, leading to slow requests and gateway timeouts.

## Fix

Resolve the target report once from the custom report and use it for both `prepared_report` and `report_execution_time`.

Also:

* Pass `disable_prepared_report_automation` along with `prepared_report`.
* Update `generate_report` to handle custom reports the same way as `get_report_doc`.

This ensures the prepared report settings and cache are always updated on the correct report.

---

Ref: https://support.frappe.io/helpdesk/tickets/76258?view=VIEW-HD+Ticket-1252