### PR TITLE
fix(ui): align the timeline gutter line with the icon axis

### DIFF
--- a/ui/src/components/ActivityTimeline/ActivityTimeline.vue
+++ b/ui/src/components/ActivityTimeline/ActivityTimeline.vue
@@ -33,7 +33,7 @@
 					<div class="grid w-full grid-cols-[30px_minmax(0,_1fr)] gap-2 px-6 md:px-0">
 						<!-- gutter column: vertical connector line + icon/avatar -->
 						<div
-							class="relative flex justify-center after:absolute after:start-[50%] after:z-0 after:border-s after:border-outline-elevation-2"
+							class="relative flex justify-center after:absolute after:start-[calc(50%-0.5px)] after:z-0 after:border-s after:border-outline-elevation-2"
 							:class="
 								activity.type === 'load_more'
 									? 'after:-top-2 after:h-[calc(100%+1rem)]'

--- a/ui/src/components/ActivityTimeline/DotIcon.vue
+++ b/ui/src/components/ActivityTimeline/DotIcon.vue
@@ -11,7 +11,7 @@
 	/>
 	<template v-else>
 		<!-- email + comment: author avatar on the axis + channel badge (mail/comment) -->
-		<div v-if="activity.type === 'email' || activity.type === 'comment'" class="relative">
+		<div v-if="activity.type === 'email' || activity.type === 'comment'" class="relative flex">
 			<Avatar size="lg" :label="activity.author.fullname" :image="activity.author.image" />
 			<span
 				class="absolute -bottom-0.5 -end-1.5 flex size-4.5 items-center justify-center rounded-full bg-surface-base text-ink-gray-5"


### PR DESCRIPTION
The gutter icon was not centered on the timeline line, and the white space above and below the comment and email avatar was uneven.

### Icon centering

| Before | After |
| --- | --- |
| <img width="220" alt="before-dot" src="https://github.com/user-attachments/assets/d2148b8b-2d3e-454f-a97f-10fcab36ce2a" /> | <img width="220" alt="after-dot" src="https://github.com/user-attachments/assets/64dd6eaa-909c-47ad-8556-0c0d0c0da9aa" /> |

### White space around the avatar

| Before | After |
| --- | --- |
| <img width="220" alt="before-avatar" src="https://github.com/user-attachments/assets/116cb4ad-9162-4cee-bffc-9a3ab82deb16" /> | <img width="220" alt="after-avatar" src="https://github.com/user-attachments/assets/d04792b7-212d-4662-9886-ad7406c22f67" /> |
