### PR TITLE
fix: email dialog ignores document's print language

### DIFF
--- a/cypress/integration/email_composer.js
+++ b/cypress/integration/email_composer.js
@@ -1,0 +1,30 @@
+context("Email Composer", () => {
+	const test_user = "test_email_composer@example.com";
+
+	before(() => {
+		cy.login();
+		cy.visit("/desk/user");
+		cy.insert_doc(
+			"User",
+			{
+				email: test_user,
+				first_name: "Test Email Composer",
+				language: "de",
+				send_welcome_email: 0,
+			},
+			true
+		);
+	});
+
+	it("picks print language from the document, not the system language", () => {
+		cy.visit(`/desk/user/${test_user}`);
+		cy.window().its("cur_frm.doc.language").should("eq", "de");
+
+		cy.window().then((win) => {
+			new win.frappe.views.CommunicationComposer({ frm: win.cur_frm, doc: win.cur_frm.doc });
+		});
+
+		cy.get_open_dialog().should("be.visible");
+		cy.window().its("cur_dialog").invoke("get_value", "print_language").should("eq", "de");
+	});
+});

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -204,7 +204,6 @@ frappe.views.CommunicationComposer = class {
 				fieldtype: "Link",
 				options: "Language",
 				fieldname: "print_language",
-				default: frappe.boot.lang,
 				depends_on: "attach_document_print",
 			},
 			{ fieldtype: "Column Break" },


### PR DESCRIPTION
## Description

The Print Language field in the email dialog always defaulted to the system language, causing PDFs to be sent in the wrong language unless the user changed it manually.

`guess_language()` already picks the correct language, but the field also had `default: frappe.boot.lang`. Because defaults are applied asynchronously, they overwrote the value set by `guess_language()`.

This fix removes the field default so `guess_language()` is the only source for the Print Language value.

---

Ref: https://support.frappe.io/helpdesk/tickets/76590?view=VIEW-HD+Ticket-1252