### PR TITLE
fix: allow null filters in custom html block link query

### DIFF
--- a/frappe/desk/doctype/custom_html_block/custom_html_block.py
+++ b/frappe/desk/doctype/custom_html_block/custom_html_block.py
@@ -36,7 +36,12 @@ class CustomHTMLBlock(Document):
 
 @frappe.whitelist()
 def get_custom_blocks_for_user(
-	doctype: str, txt: str, searchfield: str, start: int, page_len: int, filters: dict | str | list
+	doctype: str,
+	txt: str,
+	searchfield: str,
+	start: int,
+	page_len: int,
+	filters: dict | str | list | None = None,
 ):
 	# return logged in users private blocks and all public blocks
 	customHTMLBlock = DocType("Custom HTML Block")

--- a/frappe/desk/doctype/custom_html_block/test_custom_html_block.py
+++ b/frappe/desk/doctype/custom_html_block/test_custom_html_block.py
@@ -1,9 +1,11 @@
 # Copyright (c) 2023, Frappe Technologies and Contributors
 # See license.txt
 
-# import frappe
+from frappe.desk.doctype.custom_html_block.custom_html_block import get_custom_blocks_for_user
 from frappe.tests import IntegrationTestCase
 
 
 class TestCustomHTMLBlock(IntegrationTestCase):
-	pass
+	def test_query_allows_null_filters(self):
+		result = get_custom_blocks_for_user("Custom HTML Block", "", "name", 0, 20, None)
+		self.assertIsInstance(result, list | tuple)


### PR DESCRIPTION
- Allow `filters` to be `None` in `get_custom_blocks_for_user` (the link query behind the Workspace "Custom Block" picker).

Why: link search calls it with `filters=None`, but the param was typed `dict | str | list` with no default, so the whitelist type check raised `FrappeTypeError: Argument 'filters' should be of type 'dict | str | list' but got 'NoneType'` and the dropdown never loaded. `filters` is unused here, so accepting `None` is safe and matches the standard link-query signature in `desk/search.py`.