### PR TITLE
refactor!: allowing page_length argument for controlling amount of fetched linked items.

### DIFF
--- a/frappe/public/js/frappe/db.js
+++ b/frappe/public/js/frappe/db.js
@@ -142,7 +142,7 @@ frappe.db = {
 					doctype,
 					txt,
 					filters,
-					page_length, // NOTE: 0 as page_length, would correspond to no LIMIT clause in the final SQL QUERY. Reference `get_query` in `query.py` module.
+					page_length,
 				},
 				callback(r) {
 					resolve(r.message);

--- a/frappe/public/js/frappe/db.js
+++ b/frappe/public/js/frappe/db.js
@@ -133,7 +133,7 @@ frappe.db = {
 			{ cache }
 		);
 	},
-	get_link_options(doctype, txt = "", filters = {}) {
+	get_link_options(doctype, txt = "", filters = {}, page_length = 0) {
 		return new Promise((resolve) => {
 			frappe.call({
 				type: "GET",
@@ -142,6 +142,7 @@ frappe.db = {
 					doctype,
 					txt,
 					filters,
+					page_length, // NOTE: 0 as page_length, would correspond to no LIMIT clause in the final SQL QUERY. Reference `get_query` in `query.py` module.
 				},
 				callback(r) {
 					resolve(r.message);


### PR DESCRIPTION
We introduce a default `page_length` argument with value 0 (aka all linked records)  for `frappe.db.get_link_options` . Almost all fetching of such linked records is triggered on click or some event (aka conditionally) and also cached on the backend for some time.
This will still introduce a minor breaking change.