### PR TITLE
feat(list): open documents in a resizable quick view panel

### DIFF
--- a/cypress/integration/list_view.js
+++ b/cypress/integration/list_view.js
@@ -224,4 +224,23 @@ context("List View", () => {
 				});
 		}
 	);
+
+	it(
+		"opens a document in the quick view panel without navigating away",
+		{ scrollBehavior: false },
+		() => {
+			cy.go_to_list("ToDo");
+			cy.clear_filters();
+
+			cy.get(".list-row-container .list-subject a").first().click();
+
+			cy.get(".list-quick-view").should("be.visible");
+			cy.get(".list-quick-view .list-quick-view-body .form-layout").should("exist");
+			cy.location("pathname").should("eq", "/desk/todo");
+
+			cy.get(".list-quick-view .list-quick-view-close").click();
+			cy.get(".list-quick-view").should("have.class", "hidden");
+			cy.location("pathname").should("eq", "/desk/todo");
+		}
+	);
 });

--- a/cypress/integration/list_view.js
+++ b/cypress/integration/list_view.js
@@ -243,4 +243,21 @@ context("List View", () => {
 			cy.location("pathname").should("eq", "/desk/todo");
 		}
 	);
+
+	it(
+		"navigates to the form instead of the quick view on narrow screens",
+		{ scrollBehavior: false },
+		() => {
+			cy.viewport(768, 1024);
+			cy.go_to_list("ToDo");
+			cy.clear_filters();
+
+			cy.get(".list-row-container .list-subject a").first().click();
+
+			cy.location("pathname").should("match", /^\/desk\/todo\/.+/);
+			cy.get(".list-quick-view").should("not.exist");
+
+			cy.viewport(Cypress.config("viewportWidth"), Cypress.config("viewportHeight"));
+		}
+	);
 });

--- a/frappe/public/js/frappe/list/list_quick_view.js
+++ b/frappe/public/js/frappe/list/list_quick_view.js
@@ -1,0 +1,251 @@
+// Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+// MIT License. See license.txt
+
+frappe.provide("frappe.views");
+
+/**
+ * Opens a document's real form in a resizable side panel next to the list, without
+ * navigating away -- the same split-layout mechanism the attachment previewer already
+ * uses on the form sidebar (a sibling panel next to .layout-main-section-wrapper,
+ * driven by a --*-width custom property and a drag handle), not an overlay.
+ */
+frappe.views.ListQuickView = class ListQuickView {
+	constructor(list_view) {
+		this.list_view = list_view;
+		this.width_key = "list_view_quick_view_width";
+		this.width = this.get_stored_width();
+
+		// the container hides the outgoing page (and fires "hide" on it) when routing
+		// away; that already hides this panel along with it (it's nested inside the
+		// page), but reset cur_frm/keyboard state the same way an explicit close does.
+		$(this.list_view.page.wrapper).on("hide", () => this.hide());
+	}
+
+	show(docname) {
+		if (!docname) return;
+
+		this.setup_panel();
+		this.current_docname = docname;
+		this.set_width(this.width);
+		this.$panel.removeClass("hidden");
+		this.refresh_list_layout();
+		this.load_and_render(docname);
+		this.bind_escape();
+	}
+
+	hide() {
+		if (!this.$panel) return;
+
+		this.$panel.addClass("hidden");
+		this.current_docname = null;
+
+		if (typeof cur_frm !== "undefined" && cur_frm === this.frm) {
+			cur_frm = null;
+		}
+
+		$(document).off("keydown.list_quick_view");
+		this.refresh_list_layout();
+	}
+
+	setup_panel() {
+		if (this.$panel) return;
+
+		this.$panel = $(`<div class="list-quick-view hidden">
+				<div class="list-quick-view-resize-handle"></div>
+				<div class="list-quick-view-body"></div>
+			</div>`).appendTo(this.list_view.page.main.closest(".layout-main"));
+
+		this.$body = this.$panel.find(".list-quick-view-body");
+
+		this.$panel.find(".list-quick-view-resize-handle").on("mousedown", (event) => {
+			if (event.target !== event.currentTarget) return;
+			this.start_resize(event);
+		});
+	}
+
+	load_and_render(docname) {
+		let doctype = this.list_view.doctype;
+		let doc = frappe.get_doc(doctype, docname);
+		let is_fresh =
+			doc &&
+			frappe.model.get_docinfo(doctype, docname) &&
+			(doc.__islocal || frappe.model.is_fresh(doc));
+
+		if (is_fresh) {
+			this.render_form(docname);
+			return;
+		}
+
+		frappe.model.with_doc(
+			doctype,
+			docname,
+			(name, r) => {
+				// the panel may have moved on to a different row while this was in flight
+				if (this.current_docname !== docname) return;
+				if (r && r["403"]) return;
+
+				if (!(locals[doctype] && locals[doctype][name])) {
+					this.render_not_found(docname);
+					return;
+				}
+
+				this.render_form(name);
+			},
+			// any error_callback (even a no-op) makes with_doc() skip its cache and
+			// recheck with the server -- list rows only carry the columns shown,
+			// not the full document.
+			() => {}
+		);
+	}
+
+	render_form(docname) {
+		if (!this.frm) {
+			this.frm = new frappe.ui.form.Form(this.list_view.doctype, this.$body.get(0), true, null);
+			this.add_panel_actions(this.frm);
+		}
+
+		this.with_route_state_preserved(() => this.frm.refresh(docname));
+	}
+
+	// Standard page actions (same frappe.ui.Page API every toolbar icon uses) instead
+	// of a bespoke header bar -- the form already renders its own title/breadcrumb/
+	// toolbar, so a second header here would just duplicate it.
+	add_panel_actions(frm) {
+		frm.page.add_action_icon(
+			"arrow-up-right",
+			() => {
+				let docname = this.current_docname;
+				this.hide();
+				frappe.set_route("Form", this.list_view.doctype, docname);
+			},
+			"list-quick-view-open-link",
+			__("Open in full page")
+		);
+		frm.page.add_action_icon("x", () => this.hide(), "list-quick-view-close", __("Close"));
+	}
+
+	render_not_found(docname) {
+		this.$body.html(`<div class="list-quick-view-unavailable">
+			<div class="text-muted">${__("{0} {1} not found", [
+				__(this.list_view.doctype),
+				frappe.utils.escape_html(docname),
+			])}</div>
+		</div>`);
+	}
+
+	/**
+	 * The list decides once at render time -- based on the width available then --
+	 * whether each row needs horizontal scrolling and hides the row divider when it
+	 * doesn't (see update_listview_classes()). Opening or resizing this panel changes
+	 * that available width after the fact, so ask the list to re-derive those classes
+	 * against the new width, the same way it already does on window resize.
+	 */
+	refresh_list_layout() {
+		if (!this.list_view.update_listview_classes) return;
+		let { has_assignto, assign_to_count } = this.list_view.get_assignment_stats();
+		this.list_view.update_listview_classes(has_assignto, assign_to_count);
+	}
+
+	/**
+	 * frm.refresh() assumes it owns the current route and mutates several route-keyed
+	 * globals to match it: the page registered for this route, the browser tab title,
+	 * and the breadcrumb trail. The quick view keeps the list on screen and the route
+	 * unchanged, so those mutations are wrong for as long as they last -- undo them
+	 * right after the call.
+	 */
+	with_route_state_preserved(fn) {
+		let route_str = frappe.get_route_str();
+		let sub_path = frappe.router.get_sub_path();
+		let existing_page = frappe.ui.pages[route_str];
+		let existing_title = document.title;
+		let existing_original_title = frappe._original_title;
+		let existing_route_title = frappe.route_titles[sub_path];
+		let crumb = frappe.breadcrumbs.all[route_str];
+		let existing_layout_name = crumb?.layout_name;
+
+		fn();
+
+		frappe.ui.pages[route_str] = existing_page;
+		document.title = existing_title;
+		frappe._original_title = existing_original_title;
+		frappe.route_titles[sub_path] = existing_route_title;
+		if (crumb) {
+			crumb.layout_name = existing_layout_name;
+			frappe.breadcrumbs.update();
+		}
+	}
+
+	bind_escape() {
+		$(document)
+			.off("keydown.list_quick_view")
+			.on("keydown.list_quick_view", (event) => {
+				if (event.key !== "Escape") return;
+				if (!this.$panel || !document.body.contains(this.$panel[0])) {
+					$(document).off("keydown.list_quick_view");
+					return;
+				}
+				this.hide();
+			});
+	}
+
+	start_resize(event) {
+		event.preventDefault();
+		this.is_resizing = true;
+		this.list_view.page.wrapper.addClass("list-quick-view-resizing");
+
+		$(document)
+			.on("mousemove.list_quick_view_resize", (event) => this.resize(event))
+			.on("mouseup.list_quick_view_resize", () => this.stop_resize());
+	}
+
+	resize(event) {
+		if (!this.is_resizing) return;
+
+		let layout = this.list_view.page.wrapper.find(".layout-main").get(0);
+		if (!layout) return;
+
+		let layout_rect = layout.getBoundingClientRect();
+		let width = ((layout_rect.right - event.clientX) / layout_rect.width) * 100;
+		this.set_width(width);
+	}
+
+	stop_resize() {
+		if (!this.is_resizing) return;
+
+		this.is_resizing = false;
+		this.list_view.page.wrapper.removeClass("list-quick-view-resizing");
+		$(document).off(".list_quick_view_resize");
+		this.save_width();
+		this.refresh_list_layout();
+	}
+
+	set_width(width) {
+		this.width = this.clamp_width(width);
+		this.list_view.page.wrapper
+			.get(0)
+			?.style.setProperty("--list-quick-view-width", `${this.width}%`);
+	}
+
+	clamp_width(width) {
+		let min_width = 25;
+		let max_width = 60;
+		return Math.min(Math.max(width, min_width), max_width);
+	}
+
+	get_stored_width() {
+		try {
+			let stored = Number(localStorage.getItem(this.width_key));
+			return this.clamp_width(stored || 40);
+		} catch {
+			return 40;
+		}
+	}
+
+	save_width() {
+		try {
+			localStorage.setItem(this.width_key, this.width);
+		} catch {
+			// localStorage can be unavailable in restricted browser contexts.
+		}
+	}
+};

--- a/frappe/public/js/frappe/list/list_quick_view.js
+++ b/frappe/public/js/frappe/list/list_quick_view.js
@@ -28,6 +28,7 @@ frappe.views.ListQuickView = class ListQuickView {
 		this.current_docname = docname;
 		this.set_width(this.width);
 		this.$panel.removeClass("hidden");
+		this.render_header(docname);
 		this.refresh_list_layout();
 		this.load_and_render(docname);
 		this.bind_escape();
@@ -52,15 +53,55 @@ frappe.views.ListQuickView = class ListQuickView {
 
 		this.$panel = $(`<div class="list-quick-view hidden">
 				<div class="list-quick-view-resize-handle"></div>
+				<div class="list-quick-view-header">
+					<div class="list-quick-view-title ellipsis"></div>
+					<div class="list-quick-view-actions">
+						<a class="es-button list-quick-view-open-link"
+							data-variant="ghost" data-icon-button="true"
+							title="${__("Open in full page")}"
+							aria-label="${__("Open in full page")}"
+						>
+							${frappe.utils.icon("arrow-up-right", "sm", "", "", "", true)}
+						</a>
+						${frappe.ui.button.html({
+							icon: "x",
+							variant: "ghost",
+							title: __("Close"),
+							css_class: "list-quick-view-close",
+						})}
+					</div>
+				</div>
 				<div class="list-quick-view-body"></div>
 			</div>`).appendTo(this.list_view.page.main.closest(".layout-main"));
 
+		this.$header_title = this.$panel.find(".list-quick-view-title");
 		this.$body = this.$panel.find(".list-quick-view-body");
+
+		this.$panel.find(".list-quick-view-open-link").on("click", (event) => {
+			if (event.ctrlKey || event.metaKey) return; // let the browser open a new tab
+			event.preventDefault();
+			let docname = this.current_docname;
+			this.hide();
+			frappe.set_route("Form", this.list_view.doctype, docname);
+		});
+
+		this.$panel.find(".list-quick-view-close").on("click", () => this.hide());
 
 		this.$panel.find(".list-quick-view-resize-handle").on("mousedown", (event) => {
 			if (event.target !== event.currentTarget) return;
 			this.start_resize(event);
 		});
+	}
+
+	render_header(docname) {
+		let title_field = this.list_view.meta?.title_field;
+		let row = title_field && (this.list_view.data || []).find((d) => d.name === docname);
+		let title = (row && row[title_field]) || docname;
+
+		this.$header_title.text(title).attr("title", title);
+		this.$panel
+			.find(".list-quick-view-open-link")
+			.attr("href", this.list_view.get_form_link({ name: docname }));
 	}
 
 	load_and_render(docname) {
@@ -101,27 +142,9 @@ frappe.views.ListQuickView = class ListQuickView {
 	render_form(docname) {
 		if (!this.frm) {
 			this.frm = new frappe.ui.form.Form(this.list_view.doctype, this.$body.get(0), true, null);
-			this.add_panel_actions(this.frm);
 		}
 
 		this.with_route_state_preserved(() => this.frm.refresh(docname));
-	}
-
-	// Standard page actions (same frappe.ui.Page API every toolbar icon uses) instead
-	// of a bespoke header bar -- the form already renders its own title/breadcrumb/
-	// toolbar, so a second header here would just duplicate it.
-	add_panel_actions(frm) {
-		frm.page.add_action_icon(
-			"arrow-up-right",
-			() => {
-				let docname = this.current_docname;
-				this.hide();
-				frappe.set_route("Form", this.list_view.doctype, docname);
-			},
-			"list-quick-view-open-link",
-			__("Open in full page")
-		);
-		frm.page.add_action_icon("x", () => this.hide(), "list-quick-view-close", __("Close"));
 	}
 
 	render_not_found(docname) {

--- a/frappe/public/js/frappe/list/list_quick_view.js
+++ b/frappe/public/js/frappe/list/list_quick_view.js
@@ -9,6 +9,11 @@ frappe.provide("frappe.views");
  * uses on the form sidebar (a sibling panel next to .layout-main-section-wrapper,
  * driven by a --*-width custom property and a drag handle), not an overlay.
  */
+// Below this, there just isn't a sensible width left over for the list once the
+// panel takes its minimum share -- phones and small tablets get the plain
+// navigate-to-form behavior instead, same as before this existed.
+const MIN_SCREEN_WIDTH_FOR_QUICK_VIEW = 1024;
+
 frappe.views.ListQuickView = class ListQuickView {
 	constructor(list_view) {
 		this.list_view = list_view;
@@ -21,8 +26,12 @@ frappe.views.ListQuickView = class ListQuickView {
 		$(this.list_view.page.wrapper).on("hide", () => this.hide());
 	}
 
+	get is_available() {
+		return window.innerWidth >= MIN_SCREEN_WIDTH_FOR_QUICK_VIEW;
+	}
+
 	show(docname) {
-		if (!docname) return;
+		if (!docname || !this.is_available) return;
 
 		this.setup_panel();
 		this.current_docname = docname;
@@ -141,7 +150,12 @@ frappe.views.ListQuickView = class ListQuickView {
 
 	render_form(docname) {
 		if (!this.frm) {
-			this.frm = new frappe.ui.form.Form(this.list_view.doctype, this.$body.get(0), true, null);
+			this.frm = new frappe.ui.form.Form(
+				this.list_view.doctype,
+				this.$body.get(0),
+				true,
+				null
+			);
 		}
 
 		this.with_route_state_preserved(() => this.frm.refresh(docname));

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1,5 +1,6 @@
 import BulkOperations from "./bulk_operations";
 import ListSettings from "./list_settings";
+import "./list_quick_view";
 
 frappe.provide("frappe.views");
 
@@ -183,6 +184,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	setup_page() {
 		this.parent.list_view = this;
 		super.setup_page();
+		this.quick_view = new frappe.views.ListQuickView(this);
 	}
 
 	setup_paging_area() {
@@ -2080,16 +2082,26 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 				return;
 			}
 
-			// link, let the event be handled via set_route
-			if ($target.is("a")) return;
+			// ctrl/cmd+click on the link: let the browser open it in a new tab as usual
+			if ($target.is("a")) {
+				if (e.ctrlKey || e.metaKey || !this.quick_view) return;
+				e.preventDefault();
+				this.quick_view.show($target.attr("data-name"));
+				return false;
+			}
 
-			// clicked on the row, open form
+			// clicked on the row, open the quick view (or the form, without one)
 			const $row = $(e.currentTarget);
 			const link = $row.find(".list-subject a").get(0);
-			if (link) {
+			if (!link) return;
+
+			if (!this.quick_view) {
 				frappe.set_route(link.pathname);
 				return false;
 			}
+
+			this.quick_view.show(link.dataset.name);
+			return false;
 		});
 	}
 

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -2084,18 +2084,19 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 			// ctrl/cmd+click on the link: let the browser open it in a new tab as usual
 			if ($target.is("a")) {
-				if (e.ctrlKey || e.metaKey || !this.quick_view) return;
+				if (e.ctrlKey || e.metaKey || !this.quick_view?.is_available) return;
 				e.preventDefault();
 				this.quick_view.show($target.attr("data-name"));
 				return false;
 			}
 
-			// clicked on the row, open the quick view (or the form, without one)
+			// clicked on the row, open the quick view where there's room for one,
+			// otherwise navigate to the form as before (phones, small tablets)
 			const $row = $(e.currentTarget);
 			const link = $row.find(".list-subject a").get(0);
 			if (!link) return;
 
-			if (!this.quick_view) {
+			if (!this.quick_view?.is_available) {
 				frappe.set_route(link.pathname);
 				return false;
 			}

--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -651,6 +651,52 @@ body.full-width {
 	}
 }
 
+// Below, the mobile.scss/desktop.scss breakpoints above only respond to the
+// browser viewport -- fine for a full-page form, but a form rendered inside
+// a narrower container (the list view's quick view panel) can be squeezed
+// well past those breakpoints while the viewport itself stays desktop-sized.
+// Establish a size container on the form's own page wrapper so its layout
+// can respond to how much room it actually has, not the browser window.
+body[data-route^="Form"] .page-container,
+.list-quick-view-body {
+	container-type: inline-size;
+	container-name: frappe-page;
+}
+
+@container frappe-page (max-width: 560px) {
+	// two-column (and wider) sections don't have room to stay side by side;
+	// let flex-wrap on .section-body stack them the way a mobile-width form
+	// already does via .form-column.col-sm-12 rules elsewhere.
+	.form-column {
+		flex: 1 1 100% !important;
+		max-width: 100% !important;
+	}
+}
+
+@container frappe-page (max-width: 575.98px) {
+	// same icon-only collapse .page-actions already gets below the "sm"
+	// viewport breakpoint (see media-breakpoint-down(sm) above in page.scss),
+	// triggered by the container's width instead. primary/secondary action
+	// are excluded -- unlike View/Actions/Duplicate/etc. they're plain text
+	// buttons with no icon of their own, so hiding their label would leave
+	// an empty square instead of something recognizable.
+	.page-actions {
+		.es-button:not(.primary-action):not(.secondary-action) {
+			.es-button__label {
+				display: none !important;
+			}
+
+			padding-inline: 0;
+			width: var(--es-bt-h);
+			min-width: 0;
+		}
+	}
+
+	.title-area {
+		min-width: 0;
+	}
+}
+
 .popover-header {
 	background: var(--bg-color);
 	color: var(--ink-gray-9);

--- a/frappe/public/scss/desk/index.scss
+++ b/frappe/public/scss/desk/index.scss
@@ -38,6 +38,7 @@
 @import "form_sidebar";
 @import "filters";
 @import "list";
+@import "list_quick_view";
 @import "global_search";
 @import "report";
 @import "file_view";

--- a/frappe/public/scss/desk/list_quick_view.scss
+++ b/frappe/public/scss/desk/list_quick_view.scss
@@ -1,0 +1,64 @@
+body[data-route^="List"] {
+	.layout-main:has(> .list-quick-view:not(.hidden)) {
+		.layout-main-section-wrapper {
+			flex: 1 1 calc(100% - var(--list-quick-view-width));
+			width: calc(100% - var(--list-quick-view-width));
+			// list rows size their columns in fixed pixels and pin their meta
+			// info (like/count) to the row's right edge with position: sticky;
+			// squeezed past this floor that sticky content starts landing on
+			// top of column text instead of scrolling past it with the row.
+			min-width: 480px;
+		}
+	}
+
+	.list-quick-view-resizing {
+		cursor: col-resize;
+	}
+}
+
+.list-quick-view {
+	position: sticky;
+	top: var(--page-head-height);
+	overflow: hidden;
+	display: flex;
+	flex-direction: column;
+	flex: 0 0 var(--list-quick-view-width);
+	width: var(--list-quick-view-width);
+	min-width: var(--list-quick-view-width);
+	height: calc(100vh - var(--page-head-height));
+	background-color: var(--fg-color);
+	border-left: 1px solid var(--border-color);
+	outline: none;
+
+	.list-quick-view-body {
+		position: relative;
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+	}
+
+	.list-quick-view-unavailable {
+		padding: var(--padding-md);
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: var(--margin-sm);
+		text-align: center;
+	}
+
+	.list-quick-view-resize-handle {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 3px;
+		height: 100%;
+		cursor: col-resize;
+		z-index: 1;
+		background-color: var(--border-color);
+		transition: background-color 120ms ease;
+
+		&:hover {
+			background-color: var(--gray-400);
+		}
+	}
+}

--- a/frappe/public/scss/desk/list_quick_view.scss
+++ b/frappe/public/scss/desk/list_quick_view.scss
@@ -1,6 +1,11 @@
 body[data-route^="List"] {
 	.layout-main:has(> .list-quick-view:not(.hidden)) {
-		.layout-main-section-wrapper {
+		// direct-child combinator: the embedded form inside .list-quick-view
+		// builds an identical .layout-main > .layout-main-section-wrapper
+		// structure of its own, nested arbitrarily deep -- a descendant
+		// selector here would also floor *that* wrapper's width, which is
+		// exactly the bug this rule is meant to prevent, just one level in.
+		> .layout-main-section-wrapper {
 			flex: 1 1 calc(100% - var(--list-quick-view-width));
 			width: calc(100% - var(--list-quick-view-width));
 			// list rows size their columns in fixed pixels and pin their meta
@@ -30,6 +35,33 @@ body[data-route^="List"] {
 	border-left: 1px solid var(--border-color);
 	outline: none;
 
+	.list-quick-view-header {
+		flex-shrink: 0;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 8px;
+		padding: 0 8px 0 12px;
+		height: 40px;
+		background-color: var(--subtle-fg);
+		border-bottom: 1px solid var(--border-color);
+	}
+
+	.list-quick-view-title {
+		flex: 1;
+		min-width: 0;
+		font-size: var(--text-sm);
+		font-weight: 500;
+		color: var(--text-color);
+	}
+
+	.list-quick-view-actions {
+		display: flex;
+		align-items: center;
+		gap: 2px;
+		flex-shrink: 0;
+	}
+
 	.list-quick-view-body {
 		position: relative;
 		flex: 1;
@@ -46,18 +78,29 @@ body[data-route^="List"] {
 		text-align: center;
 	}
 
+	// the visible line is 3px, centered inside a wider invisible hit area --
+	// a 3px target is unreliable to grab with a mouse.
 	.list-quick-view-resize-handle {
 		position: absolute;
 		top: 0;
-		left: 0;
-		width: 3px;
+		left: -4px;
+		width: 9px;
 		height: 100%;
 		cursor: col-resize;
 		z-index: 1;
-		background-color: var(--border-color);
-		transition: background-color 120ms ease;
+		background-color: transparent;
 
-		&:hover {
+		&::after {
+			content: "";
+			display: block;
+			margin: 0 auto;
+			width: 3px;
+			height: 100%;
+			background-color: var(--border-color);
+			transition: background-color 120ms ease;
+		}
+
+		&:hover::after {
 			background-color: var(--gray-400);
 		}
 	}


### PR DESCRIPTION
## Summary

Clicking a document's link in List View now opens its form in a resizable side panel next to the list, instead of navigating away — the same split-layout mechanism the attachment previewer already uses on the form sidebar (a sibling panel next to `.layout-main-section-wrapper`, driven by a `--*-width` custom property and a drag handle). Ctrl/Cmd+click still opens the document in a new tab as before.

The panel embeds a real `frappe.ui.form.Form` instance (lazily created, reused across rows of the same list) so the document is fully interactive: fields, save, workflow, and its own standard title/toolbar/sidebar all work exactly as they do on the full form page. "Open in full page" and "Close" live in a compact header, mirroring the attachment previewer's own header.

Only available at ≥1024px viewport width — below that there isn't a sensible width left over for the list once the panel takes its minimum share, so phones and small tablets keep the plain navigate-to-form behavior.

## Details

- `frm.refresh()` assumes it owns the current route and mutates a few route-keyed globals to match (the page registered for this route in `frappe.ui.pages`, the browser tab title, and the breadcrumb trail). Since the quick view keeps the list on screen and the route unchanged, those mutations are undone right after each refresh.
- List rows already refresh via the existing realtime `list_update` subscription when a document is saved, so no extra refresh wiring was needed.
- Two-column form sections and the page toolbar now respond to their own rendered width via a CSS size container (`container-type: inline-size`), not just the browser viewport — needed because the panel can be narrower than any existing viewport breakpoint while the browser window itself stays desktop-sized. Verified full-page forms at desktop width are unaffected.
- A `min-width` floor on the list's own wrapper keeps its columns from being squeezed into the zone where the row's sticky like/count indicator starts overlapping column text.

## Testing

Verified live against a running bench at multiple panel widths (25%–60%), at the 1024px viewport boundary (1023px navigates, 1024px opens the panel), and on a 375px mobile viewport (navigates as before). Added Cypress coverage for both the quick view flow and the narrow-screen fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)