### PR TITLE
fix: render website analytics group by column as text

### DIFF
--- a/cypress/integration/website_analytics_source_escaping.js
+++ b/cypress/integration/website_analytics_source_escaping.js
@@ -1,0 +1,48 @@
+context("Website Analytics", () => {
+	const linked_source = "Web Page <b>newsletter</b>";
+	const plain_source = "newsletter <b";
+	const campaign = "spring sale <b";
+
+	before(() => {
+		cy.login();
+		cy.visit("/desk/website");
+		cy.insert_doc(
+			"Web Page View",
+			{ path: "blog/introducing-frappe-framework-v16", source: linked_source },
+			true
+		);
+		cy.insert_doc(
+			"Web Page View",
+			{ path: "blog/scaling-frappe-in-production", source: plain_source },
+			true
+		);
+		cy.insert_doc(
+			"Web Page View",
+			{ path: "blog/whats-new-in-erpnext", campaign: campaign },
+			true
+		);
+	});
+
+	function group_by(label) {
+		cy.visit("/desk/query-report/Website Analytics");
+		cy.get(".datatable", { timeout: 60000 }).should("exist");
+		cy.get('#page-query-report select[data-fieldname="group_by"]').select(label, {
+			force: true,
+		});
+	}
+
+	it("renders the source column as text", () => {
+		group_by("Source");
+
+		cy.contains(".dt-cell__content", linked_source).should("exist");
+		cy.contains(".dt-cell__content", plain_source).should("exist");
+		cy.get(".datatable .dt-cell__content").find("b").should("not.exist");
+	});
+
+	it("renders the campaign column as text", () => {
+		group_by("Campaign");
+
+		cy.contains(".dt-cell__content", campaign).should("exist");
+		cy.get(".datatable .dt-cell__content").find("b").should("not.exist");
+	});
+});

--- a/frappe/website/report/website_analytics/website_analytics.js
+++ b/frappe/website/report/website_analytics/website_analytics.js
@@ -7,13 +7,13 @@ frappe.query_reports["Website Analytics"] = {
 			fieldname: "from_date",
 			label: __("From Date"),
 			fieldtype: "Date",
-			default: frappe.datetime.add_days(frappe.datetime.now_date(true), -100),
+			default: frappe.datetime.add_days(frappe.datetime.now_date(), -100),
 		},
 		{
 			fieldname: "to_date",
 			label: __("To Date"),
 			fieldtype: "Date",
-			default: frappe.datetime.now_date(true),
+			default: frappe.datetime.now_date(),
 		},
 		{
 			fieldname: "range",

--- a/frappe/website/report/website_analytics/website_analytics.js
+++ b/frappe/website/report/website_analytics/website_analytics.js
@@ -44,22 +44,32 @@ frappe.query_reports["Website Analytics"] = {
 		},
 	],
 	formatter: function (value, row, column, data, default_formatter) {
-		if (
-			frappe.query_report.get_filter_value("group_by") === "source" &&
-			column.id === "source"
-		) {
-			if (value) {
-				try {
-					let doctype = value.split(">")[0].trim();
-					let name = value.split(">")[1].trim();
-					return frappe.utils.get_form_link(doctype, name, true, value);
-				} catch (e) {
-					// skip and return with default formatter
-				}
-			} else {
-				return `<i>${__("Unknown")}</i>`;
+		const group_by = frappe.query_report.get_filter_value("group_by");
+
+		if (column.id !== group_by) {
+			return default_formatter(value, row, column, data);
+		}
+
+		if (!value) {
+			return group_by === "source"
+				? `<i>${__("Unknown")}</i>`
+				: default_formatter(value, row, column, data);
+		}
+
+		const escaped_value = frappe.utils.escape_html(value);
+
+		if (group_by === "source") {
+			const [doctype, name] = String(value).split(">");
+			if (doctype && name) {
+				return frappe.utils.get_form_link(
+					doctype.trim(),
+					name.trim(),
+					true,
+					escaped_value
+				);
 			}
 		}
-		return default_formatter(value, row, column, data);
+
+		return default_formatter(escaped_value, row, column, data);
 	},
 };


### PR DESCRIPTION
## Description

The report formatter was rendering grouped field values as HTML instead of plain text. This affected all Group By options, not just `source`.

The formatter now escapes the value once and uses the escaped value on every return path. The escaping is done here instead of inside `get_form_link`, since other callers intentionally pass HTML as display text.

The `source` handling was also simplified to avoid using an exception to detect missing separators.

Both shots group by Source over three `Web Page View` rows whose `source` values are `Web Page <b>newsletter</b>`, `newsletter <b`, and empty. Before, the first value renders bold with its tags gone and the half tag in the second one swallows that row's count cells; after, every value prints as stored.

### Before

![before.png](https://github.com/user-attachments/assets/bcf80308-f898-4919-a500-20e8de2a3d55)

### After

![after.png](https://github.com/user-attachments/assets/956d8e31-63c7-4a99-bb06-c527b32fd291)

### Other Fix

Fixed the date filter defaults. They were passing a moment object instead of a string, causing `value.match is not a function` and preventing the report from loading.

A Cypress test was added for grouped value rendering. It fails on `develop` and passes with this change.
