### PR TITLE
  chore: bump jquery, moment and sortablejs

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "frappe-quill-image-resize": "^3.0.9",
     "highlight.js": "^10.4.1",
     "html5-qrcode": "^2.3.8",
-    "jquery": "3.7.0",
+    "jquery": "3.7.1",
     "js-sha256": "^0.9.0",
     "jsbarcode": "^3.11.0",
     "launch-editor": "^2.14.1",
@@ -89,6 +89,7 @@
     "utf-8-validate": "^6.0.3"
   },
   "resolutions": {
-    "esbuild-plugin-vue3/esbuild": "^0.28.0"
+    "esbuild-plugin-vue3/esbuild": "^0.28.0",
+    "sortablejs": "^1.15.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1331,12 +1331,7 @@ is-what@^4.1.8:
   resolved "https://registry.yarnpkg.com/is-what/-/is-what-4.1.16.tgz#1ad860a19da8b4895ad5495da3182ce2acdd7a6f"
   integrity sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==
 
-jquery@3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.7.0.tgz#fe2c01a05da500709006d8790fe21c8a39d75612"
-  integrity sha512-umpJ0/k8X0MvD1ds0P9SfowREz2LenHsQaxSohMZ5OMNEU2r0tf8pdeEFTHMFxWVxKNyU9rTtK3CWzUCTKJUeQ==
-
-"jquery@>=2.0.0 <4.0.0":
+jquery@3.7.1, "jquery@>=2.0.0 <4.0.0":
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.7.1.tgz#083ef98927c9a6a74d05a6af02806566d16274de"
   integrity sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==
@@ -1478,9 +1473,9 @@ moment-timezone@^0.5.35:
     moment "^2.29.4"
 
 moment@^2.29.4:
-  version "2.29.4"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
-  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
+  version "2.30.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
+  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
 
 ms@2.0.0:
   version "2.0.0"
@@ -1998,15 +1993,10 @@ socket.io@^4.7.1:
     socket.io-adapter "~2.5.2"
     socket.io-parser "~4.2.4"
 
-sortablejs@1.14.0:
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.14.0.tgz#6d2e17ccbdb25f464734df621d4f35d4ab35b3d8"
-  integrity sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w==
-
-sortablejs@^1.15.0, sortablejs@^1.7.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.15.0.tgz#53230b8aa3502bb77a29e2005808ffdb4a5f7e2a"
-  integrity sha512-bv9qgVMjUMf89wAvM6AxVvS/4MX3sPeN0+agqShejLU5z5GX4C75ow1O2e5k4L6XItUyAK3gH6AxSbXrOM5e8w==
+sortablejs@1.14.0, sortablejs@^1.15.0, sortablejs@^1.15.7, sortablejs@^1.7.0:
+  version "1.15.7"
+  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.15.7.tgz#83a0bddc472117ee328dea20b2e6f490fed20f86"
+  integrity sha512-Kk8wLQPlS+yi1ZEf48a4+fzHa4yxjC30M/Sr2AnQu+f/MPwvvX9XjZ6OWejiz8crBsLwSq8GHqaxaET7u6ux0A==
 
 "source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.0.2, source-map-js@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
## Description

Bumps:

* `jquery` → `3.7.1`
* `moment` → `2.30.1`
* `sortablejs` → `1.15.7`

The `sortablejs` resolution ensures all dependencies use a single version instead of bundling older copies.

Verified on a production build: old versions are no longer bundled, and Desk, Report View, and Form Builder work as expected.

Ref: https://support.frappe.io/helpdesk/tickets/76721
