### PR TITLE
perf(search): skip `_relevance` when search text is empty

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -261,7 +261,12 @@ def search_widget(
 	# `idx` is number of times a document is referred, check link_count.py
 	order_by = f"idx desc, {order_by_based_on_meta}"
 
-	if not for_link_validation and not meta.translated_doctype:
+	# With an empty `txt`, LOCATE always returns 1, so `_relevance` is the same constant for
+	# every row. The sort key then changes no ordering, but is still evaluated per row and
+	# still forces a filesort. Skip it: link fields search with an empty `txt` on every focus.
+	add_relevance = bool(txt) and not for_link_validation and not meta.translated_doctype
+
+	if add_relevance:
 		_txt = frappe.db.escape((txt or "").replace("%", "").replace("@", ""))
 		# locate returns 0 if string is not found, convert 0 to null and then sort null to end in order by
 		_relevance_expr = {"DIV": [1, {"NULLIF": [{"LOCATE": [_txt, "name"]}, 0]}]}
@@ -303,7 +308,7 @@ def search_widget(
 		values = sorted(values, key=lambda x: relevance_sorter(x, txt, as_dict))
 
 		# remove _relevance from results
-		if not meta.translated_doctype:
+		if add_relevance:
 			if as_dict:
 				for r in values:
 					r.pop("_relevance", None)

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -180,6 +180,32 @@ class TestSearch(IntegrationTestCase):
 		frappe.db.set_value("Language", "es", "idx", 10)
 		self.assertEqual("es", search(txt="es")[0]["value"])
 
+	def test_relevance_skipped_without_txt(self):
+		"""`_relevance` is a constant when txt is empty, so it must not be selected or sorted on."""
+
+		def search_and_capture(txt):
+			captured = []
+			orig_sql = frappe.db.__class__.sql
+
+			def _capture(*args, **kwargs):
+				result = orig_sql(*args, **kwargs)
+				captured.append(str(args[0].last_query))
+				return result
+
+			with patch.object(frappe.db.__class__, "sql", _capture):
+				values = search_widget(doctype="Language", txt=txt, page_length=5)
+
+			return values, "\n".join(captured)
+
+		empty, empty_sql = search_and_capture("")
+		typed, typed_sql = search_and_capture("e")
+
+		self.assertNotIn("_relevance", empty_sql)
+		self.assertIn("_relevance", typed_sql)
+
+		# the result shape must not change: a mismatched strip would drop a real column
+		self.assertEqual(len(empty[0]), len(typed[0]))
+
 	def test_search_with_paren(self):
 		search = partial(search_link, doctype="Language", filters=None, page_length=10)
 		result = search(txt="(txt)")

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -206,6 +206,13 @@ class TestSearch(IntegrationTestCase):
 		# the result shape must not change: a mismatched strip would drop a real column
 		self.assertEqual(len(empty[0]), len(typed[0]))
 
+	def test_empty_search_still_orders_by_idx(self):
+		"""Dropping the constant relevance key must not change the order of an empty search."""
+		frappe.db.set_value("Language", "es", {"enabled": 1, "idx": 500})
+
+		# page_length=1 leaves the python relevance_sorter no second row to reorder
+		self.assertEqual("es", search_link("Language", "", page_length=1)[0]["value"])
+
 	def test_search_with_paren(self):
 		search = partial(search_link, doctype="Language", filters=None, page_length=10)
 		result = search(txt="(txt)")


### PR DESCRIPTION
Reported in: https://support.frappe.io/helpdesk/tickets/76758

## Problem

A Link field searches with an empty `txt` each time it gets focus:

https://github.com/frappe/frappe/blob/develop/frappe/public/js/frappe/form/controls/link.js#L35-L39

```js
this.$input.on("focus", function () {
	if (!me.$input.val()) {
		me.$input.val("").trigger("input");
	}
```

One pass through a form with 6 empty Link fields makes 6 of these requests.

On this path `_relevance` does nothing. `LOCATE('', name)` returns 1 for every row, so the value is the same constant everywhere. It changes no ordering. But the database still evaluates it for each row, and still stays on a filesort:

```sql
SELECT ..., (? / nullif(locate(?, `tabCustomer`.`name`), ?)) AS `_relevance`
FROM `tabCustomer`
WHERE `tabCustomer`.`customer_group` IN (...) AND `tabCustomer`.`disabled` != ?
  AND ( ( ( ( COALESCE(`tabCustomer`.`customer_group`, ?) = ?
              OR `tabCustomer`.`customer_group` IN (...) ) ) ) )
ORDER BY COALESCE(`_relevance`, ?) DESC,
         `tabCustomer`.`idx` DESC,
         `tabCustomer`.`modified` DESC
LIMIT ? OFFSET ?
```

Note: this query has no `LIKE` at all. It is the empty-text shape.

## Fix

Do not build `_relevance` when there is no search text.

The order becomes `idx desc, <meta order>`. The constant leading key gave that same order before, so **the results do not change**.

The same flag guards the block that removes `_relevance` from the results. A guard on the first block alone makes that block remove a real column. Therefore both blocks change together.

## Impact

Found on a v15 site with the Frappe Cloud Database Analyzer. The two `search_link` shapes on one doctype were the top two rows under Time Consuming Queries:

| # | % of DB time | Calls | Avg time |
|---|---|---|---|
| 1 | 36% | 1,212,821 | 2.3 s |
| 2 | 14% | 528,383 | 2.1 s |

Row 2 is the empty-text shape that this PR corrects. Together the two rows were 50% of database time.

This PR does not remove the rest of the cost. The typed shape still scans on `LIKE '%txt%'`, which needs an index or a custom link query per site. This PR removes one expression per row and one dead sort key from the shape with the highest volume.

## Test

Two tests, both run on a local `develop` bench against `test.localhost`.

`test_relevance_skipped_without_txt` makes sure that an empty search generates no `_relevance`, and that a typed search still generates it. It also compares the column count of the two results.

`test_empty_search_still_orders_by_idx` makes sure that an empty search still returns the row with the highest `idx` first.

Results:

| Code under test | `frappe.tests.test_search` |
|---|---|
| With this change | 16 tests, all pass |
| Without this change | `test_relevance_skipped_without_txt` fails |
| First guard only, strip block left behind | the same test fails with `2 != 3` |

The second row shows that the change happens. The third row shows that the two guards cannot drift apart without a test failure. `test_empty_search_still_orders_by_idx` passes in all three states, which is the point: the order does not change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
