### PR TITLE
fix: escape docname used as default link text in get_form_link

### DIFF
--- a/cypress/integration/utils.js
+++ b/cypress/integration/utils.js
@@ -69,6 +69,21 @@ context("Utils", () => {
 		});
 	});
 
+	it("should escape the docname when it is used as the link text", () => {
+		run_util("get_form_link", "ToDo", "<img src=x onerror=alert(1)>", true).then((link) => {
+			expect(link).to.equal(
+				'<a href="/desk/todo/%3Cimg%20src%3Dx%20onerror%3Dalert(1)%3E">' +
+					"&lt;img src&#x3D;x onerror&#x3D;alert(1)&gt;</a>"
+			);
+		});
+	});
+
+	it("should not escape display text passed by the caller", () => {
+		run_util("get_form_link", "ToDo", "TODO-0001", true, "<b>Open item</b>").then((link) => {
+			expect(link).to.equal('<a href="/desk/todo/TODO-0001"><b>Open item</b></a>');
+		});
+	});
+
 	it("should parse days, hours, minutes and seconds", () => {
 		run_util("seconds_to_duration", 60 * 60 * 24 + 60 * 60 + 60 + 1).then((duration) => {
 			expect(duration).to.deep.equal({

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1000,7 +1000,7 @@ Object.assign(frappe.utils, {
 		display_text = null,
 		query_params_obj = null
 	) {
-		display_text = display_text || name;
+		display_text = display_text || frappe.utils.escape_html(name);
 		name = encodeURIComponent(name);
 		let route = `/desk/${encodeURIComponent(
 			doctype.toLowerCase().replace(/ /g, "-")


### PR DESCRIPTION
## Description

`get_form_link` used the raw docname as link text when no display text was provided. While the URL is already encoded, the link text was not.

This is not currently exploitable because document names reject `<` and `>`. However, escaping the fallback removes the dependency on that validation.

Only the default docname is escaped. Callers that intentionally pass HTML as display text are unchanged.
