### PR TITLE
refactor(perf): speeding up permission level maps generation.

### DIFF
--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -744,12 +744,11 @@ class Meta(Document):
 		return permitted_fieldnames
 
 	def get_permlevel_access(self, permission_type="read", parenttype=None, *, user=None):
-		has_access_to = []
+		has_access_to = set()
 		roles = set(frappe.get_roles(user))
 		for perm in self.get_permissions(parenttype):
 			if perm.role in roles and perm.get(permission_type):
-				if perm.permlevel not in has_access_to:
-					has_access_to.append(perm.permlevel)
+				has_access_to.add(perm.permlevel)
 
 		return has_access_to
 


### PR DESCRIPTION
Using `set` while generating permission level maps , current `get_permlevel_access` does redundant work by using `list` and then preventing duplicates .
Though now `get_permlevel_access`  returns a `set` instead of `list`, it is safe and much faster downstream, as at some places we regenerate a `set` type from such returned `lists` anyway, all returned values from `get_permlevel_access` are queried using `in` or `not in` which `set` types also support. 