### PR TITLE
fix: log lock path on filelock timeout

### DIFF
--- a/frappe/utils/synchronization.py
+++ b/frappe/utils/synchronization.py
@@ -40,7 +40,7 @@ def filelock(lock_name: str, *, timeout=30, is_global=False):
 		with _StrongFileLock(lock_path, timeout=timeout):
 			yield
 	except Timeout as e:
-		frappe.log_error("Filelock: Failed to aquire {lock_path}")
+		frappe.log_error(f"Filelock: Failed to aquire {lock_path}")
 
 		raise LockTimeoutError(
 			_("Failed to aquire lock: {}. Lock may be held by another process.").format(lock_name)


### PR DESCRIPTION
The diagnostic log in `filelock()` uses a plain string, so a lock timeout writes the literal `Filelock: Failed to aquire {lock_path}` to the error log instead of the path that was contended. Every v15 lock timeout, on restore, migrate, build or install-app, loses the one detail the log exists to capture.

develop and version-16-hotfix already carry the `f` prefix; this brings version-15-hotfix in line. The file is now byte-identical to version-16-hotfix.
