### PR TITLE
fix(file): Give parent docs identity to link child table with attach field

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -378,19 +378,47 @@ class File(Document):
 		):
 			return
 
-		if frappe.get_meta(self.attached_to_doctype).issingle:
+		parent_meta = frappe.get_meta(self.attached_to_doctype)
+
+		if parent_meta.issingle:
 			frappe.db.set_single_value(
 				self.attached_to_doctype,
 				self.attached_to_field,
 				self.file_url,
 			)
-		else:
+			return
+		if parent_meta.has_field(self.attached_to_field) and frappe.db.exists(
+			self.attached_to_doctype,
+			{"name": self.attached_to_name, self.attached_to_field: old_file_url},
+		):
 			frappe.db.set_value(
 				self.attached_to_doctype,
 				self.attached_to_name,
 				self.attached_to_field,
 				self.file_url,
 			)
+
+		for table_df in parent_meta.get_table_fields():
+			child_meta = frappe.get_meta(table_df.options)
+			if not child_meta.has_field(self.attached_to_field):
+				continue
+
+			match_filters = {
+				"parent": self.attached_to_name,
+				"parentfield": table_df.fieldname,
+				self.attached_to_field: old_file_url,
+			}
+			if not frappe.db.exists(table_df.options, match_filters):
+				continue
+
+			child_table = frappe.qb.DocType(table_df.options)
+			(
+				frappe.qb.update(child_table)
+				.set(child_table[self.attached_to_field], self.file_url)
+				.where(child_table.parent == self.attached_to_name)
+				.where(child_table.parentfield == table_df.fieldname)
+				.where(child_table[self.attached_to_field] == old_file_url)
+			).run()
 
 	def fetch_attached_to_field(self, old_file_url):
 		if self.attached_to_field:

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -408,17 +408,13 @@ class File(Document):
 				"parentfield": table_df.fieldname,
 				self.attached_to_field: old_file_url,
 			}
-			if not frappe.db.exists(table_df.options, match_filters):
+			matching_rows = frappe.get_all(table_df.options, filters=match_filters, pluck="name")
+			if not matching_rows:
+				continue
+			if len(matching_rows) > 1:
 				continue
 
-			child_table = frappe.qb.DocType(table_df.options)
-			(
-				frappe.qb.update(child_table)
-				.set(child_table[self.attached_to_field], self.file_url)
-				.where(child_table.parent == self.attached_to_name)
-				.where(child_table.parentfield == table_df.fieldname)
-				.where(child_table[self.attached_to_field] == old_file_url)
-			).run()
+			frappe.db.set_value(table_df.options, matching_rows[0], self.attached_to_field, self.file_url)
 
 	def fetch_attached_to_field(self, old_file_url):
 		if self.attached_to_field:

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -1473,6 +1473,47 @@ class TestChildTableAttachments(IntegrationTestCase):
 		self.assertEqual(untouched_cards_file.file_url, cards_old_url)
 		self.assertEqual(untouched_cards_file.is_private, 1)
 
+	def test_toggle_is_private_fails_closed_when_two_rows_share_the_same_url(self):
+		# row A and row B, same table, both holding the identical file_url string -- but
+		# attached via two *separate* File records, since attached_to_field alone can't tell
+		# rows apart. Only file_a is toggled; row B's own File (file_b) never changes.
+		file_a = self.make_unattached_file(b"row-a-bytes", is_private=1)
+		doc = self.make_parent_doc(cards=[{"image": file_a.file_url}])
+		doc.append("cards", {"image": file_a.file_url})
+		doc.save(ignore_permissions=True)
+
+		shared_url = file_a.file_url
+		file_b = frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_name": f"row_b_{frappe.generate_hash(length=6)}.png",
+				"file_url": shared_url,
+				"content_hash": file_a.content_hash,
+				"file_size": file_a.file_size,
+				"is_private": 1,
+				"attached_to_doctype": self.parent_doctype,
+				"attached_to_name": doc.name,
+				"attached_to_field": "image",
+			}
+		)
+		file_b.flags.copy_from_existing_file = True
+		file_b.insert(ignore_permissions=True)
+
+		attached_file_a = frappe.get_doc("File", file_a.name)
+		attached_file_a.is_private = 0
+		attached_file_a.save(ignore_permissions=True)
+
+		reloaded_file_a = frappe.get_doc("File", file_a.name)
+		self.assertNotEqual(reloaded_file_a.file_url, shared_url)
+
+		reloaded_doc = frappe.get_doc(self.parent_doctype, doc.name)
+		self.assertEqual(reloaded_doc.cards[0].image, shared_url)
+		self.assertEqual(reloaded_doc.cards[1].image, shared_url)
+
+		reloaded_file_b = frappe.get_doc("File", file_b.name)
+		self.assertEqual(reloaded_file_b.file_url, shared_url)
+		self.assertEqual(reloaded_file_b.is_private, 1)
+
 	def test_toggle_is_private_does_not_let_parent_field_capture_child_update(self):
 		file = self.make_unattached_file(b"collision-bytes", is_private=1)
 		old_url = file.file_url

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -1278,6 +1278,273 @@ class TestCopyAttachmentsFromAmendedFrom(IntegrationTestCase):
 		self.assertEqual(copied_files[0].folder, custom_folder.name)
 
 
+class TestChildTableAttachments(IntegrationTestCase):
+	"""A file uploaded without doctype/docname (the SPA "upload
+	first" pattern), then set into an Attach/Attach Image field nested inside a
+	child table, must end up attached to the PARENT document -- same as a
+	top-level Attach field -- instead of staying permanently unattached and
+	private to only its uploader.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		from frappe.core.doctype.doctype.test_doctype import new_doctype
+
+		cls.child_doctype = "Test Attachment Child"
+		new_doctype(
+			cls.child_doctype,
+			istable=1,
+			fields=[
+				{"label": "Image", "fieldname": "image", "fieldtype": "Attach Image"},
+			],
+		).insert(ignore_if_duplicate=True)
+
+		cls.second_child_doctype = "Test Attachment Child 2"
+		new_doctype(
+			cls.second_child_doctype,
+			istable=1,
+			fields=[
+				{"label": "Image", "fieldname": "image", "fieldtype": "Attach Image"},
+			],
+		).insert(ignore_if_duplicate=True)
+
+		cls.parent_doctype = "Test Attachment Parent"
+		new_doctype(
+			cls.parent_doctype,
+			fields=[
+				{"label": "Title", "fieldname": "title", "fieldtype": "Data"},
+				{"label": "Image", "fieldname": "parent_image", "fieldtype": "Attach Image"},
+				{
+					"label": "Cards",
+					"fieldname": "cards",
+					"fieldtype": "Table",
+					"options": cls.child_doctype,
+				},
+				{
+					"label": "Photos",
+					"fieldname": "photos",
+					"fieldtype": "Table",
+					"options": cls.second_child_doctype,
+				},
+			],
+			permissions=[
+				{"role": "System Manager", "read": 1, "write": 1, "create": 1, "delete": 1},
+				{"role": "All", "read": 1},
+			],
+		).insert(ignore_if_duplicate=True)
+
+		cls.collision_parent_doctype = "Test Attachment Parent Collision"
+		new_doctype(
+			cls.collision_parent_doctype,
+			fields=[
+				{"label": "Title", "fieldname": "title", "fieldtype": "Data"},
+				{"label": "Image", "fieldname": "image", "fieldtype": "Attach Image"},
+				{
+					"label": "Cards",
+					"fieldname": "cards",
+					"fieldtype": "Table",
+					"options": cls.child_doctype,
+				},
+			],
+			permissions=[
+				{"role": "System Manager", "read": 1, "write": 1, "create": 1, "delete": 1},
+				{"role": "All", "read": 1},
+			],
+		).insert(ignore_if_duplicate=True)
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.db.rollback()
+		frappe.delete_doc_if_exists("DocType", cls.parent_doctype)
+		frappe.delete_doc_if_exists("DocType", cls.collision_parent_doctype)
+		frappe.delete_doc_if_exists("DocType", cls.child_doctype)
+		frappe.delete_doc_if_exists("DocType", cls.second_child_doctype)
+		super().tearDownClass()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	def make_unattached_file(self, content: bytes, is_private: int = 1):
+		return frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_name": f"child_attach_{frappe.generate_hash(length=8)}.png",
+				"content": content,
+				"is_private": is_private,
+			}
+		).insert(ignore_permissions=True)
+
+	def make_parent_doc(self, **kwargs):
+		return frappe.get_doc({"doctype": self.parent_doctype, "title": "Test", **kwargs}).insert(
+			ignore_permissions=True
+		)
+
+	def test_child_table_attach_field_is_linked_to_parent(self):
+		file = self.make_unattached_file(b"child-link-bytes")
+		self.assertIsNone(file.attached_to_doctype)
+
+		doc = self.make_parent_doc(cards=[{"image": file.file_url}])
+
+		reloaded = frappe.get_doc("File", file.name)
+		self.assertEqual(reloaded.attached_to_doctype, self.parent_doctype)
+		self.assertEqual(reloaded.attached_to_name, doc.name)
+		self.assertEqual(reloaded.attached_to_field, "image")
+
+	def test_child_table_file_permission_follows_parent_permission(self):
+		file = self.make_unattached_file(b"child-perm-bytes")
+		doc = self.make_parent_doc(cards=[{"image": file.file_url}])
+		reloaded = frappe.get_doc("File", file.name)
+
+		frappe.set_user("test4@example.com")
+		self.assertTrue(frappe.has_permission(self.parent_doctype, doc=doc, ptype="read"))
+		self.assertTrue(frappe.has_permission("File", doc=reloaded, ptype="read"))
+
+	def test_batched_attach_does_not_duplicate_already_attached_files(self):
+		file = self.make_unattached_file(b"child-resave-bytes")
+		doc = self.make_parent_doc(cards=[{"image": file.file_url}])
+
+		before_count = frappe.db.count("File", {"file_url": file.file_url})
+		doc.title = "Updated Title"
+		doc.save(ignore_permissions=True)
+		after_count = frappe.db.count("File", {"file_url": file.file_url})
+
+		self.assertEqual(before_count, after_count)
+		reloaded = frappe.get_doc("File", file.name)
+		self.assertEqual(reloaded.attached_to_name, doc.name)
+
+	def test_toggle_is_private_to_public_updates_child_row_not_parent_column(self):
+		file = self.make_unattached_file(b"child-toggle-bytes", is_private=1)
+		doc = self.make_parent_doc(cards=[{"image": file.file_url}])
+
+		attached = frappe.get_doc("File", file.name)
+		old_url = attached.file_url
+
+		attached.is_private = 0
+		attached.save(ignore_permissions=True)
+
+		reloaded_doc = frappe.get_doc(self.parent_doctype, doc.name)
+		reloaded_file = frappe.get_doc("File", file.name)
+		self.assertNotEqual(reloaded_file.file_url, old_url)
+		self.assertEqual(reloaded_doc.cards[0].image, reloaded_file.file_url)
+
+	def test_toggle_public_to_is_private_updates_child_row_not_parent_column(self):
+		file = self.make_unattached_file(b"child-toggle-bytes-reverse", is_private=0)
+		doc = self.make_parent_doc(cards=[{"image": file.file_url}])
+
+		attached = frappe.get_doc("File", file.name)
+		old_url = attached.file_url
+
+		attached.is_private = 1
+		attached.save(ignore_permissions=True)
+
+		reloaded_doc = frappe.get_doc(self.parent_doctype, doc.name)
+		reloaded_file = frappe.get_doc("File", file.name)
+		self.assertNotEqual(reloaded_file.file_url, old_url)
+		self.assertEqual(reloaded_doc.cards[0].image, reloaded_file.file_url)
+
+	def test_toggle_is_private_disambiguates_between_child_tables_sharing_a_fieldname(self):
+		cards_file = self.make_unattached_file(b"cards-image-bytes", is_private=1)
+		photos_file = self.make_unattached_file(b"photos-image-bytes", is_private=1)
+
+		doc = self.make_parent_doc(
+			cards=[{"image": cards_file.file_url}],
+			photos=[{"image": photos_file.file_url}],
+		)
+
+		cards_old_url = cards_file.file_url
+		photos_old_url = photos_file.file_url
+
+		attached_photos_file = frappe.get_doc("File", photos_file.name)
+		attached_photos_file.is_private = 0
+		attached_photos_file.save(ignore_permissions=True)
+
+		reloaded_doc = frappe.get_doc(self.parent_doctype, doc.name)
+		reloaded_photos_file = frappe.get_doc("File", photos_file.name)
+
+		# the toggled file's own row was updated to its new URL ...
+		self.assertNotEqual(reloaded_photos_file.file_url, photos_old_url)
+		self.assertEqual(reloaded_doc.photos[0].image, reloaded_photos_file.file_url)
+
+		# ... and the unrelated "cards" row -- same fieldname, different
+		# table, never toggled -- was left completely untouched.
+		self.assertEqual(reloaded_doc.cards[0].image, cards_old_url)
+		untouched_cards_file = frappe.get_doc("File", cards_file.name)
+		self.assertEqual(untouched_cards_file.file_url, cards_old_url)
+		self.assertEqual(untouched_cards_file.is_private, 1)
+
+	def test_toggle_is_private_does_not_let_parent_field_capture_child_update(self):
+		file = self.make_unattached_file(b"collision-bytes", is_private=1)
+		old_url = file.file_url
+
+		doc = frappe.get_doc(
+			{
+				"doctype": self.collision_parent_doctype,
+				"title": "Collision Test",
+				"cards": [{"image": file.file_url}],
+			}
+		).insert(ignore_permissions=True)
+
+		attached = frappe.get_doc("File", file.name)
+		self.assertEqual(attached.attached_to_doctype, self.collision_parent_doctype)
+		self.assertEqual(attached.attached_to_field, "image")
+		self.assertIsNone(doc.image)
+
+		attached.is_private = 0
+		attached.save(ignore_permissions=True)
+
+		reloaded_doc = frappe.get_doc(self.collision_parent_doctype, doc.name)
+		reloaded_file = frappe.get_doc("File", file.name)
+
+		self.assertNotEqual(reloaded_file.file_url, old_url)
+		self.assertEqual(reloaded_doc.cards[0].image, reloaded_file.file_url)
+
+		self.assertIsNone(reloaded_doc.image)
+
+	def test_toggle_is_private_updates_both_parent_and_child_when_url_is_shared(self):
+		file = self.make_unattached_file(b"shared-bytes", is_private=1)
+		old_url = file.file_url
+
+		doc = frappe.get_doc(
+			{
+				"doctype": self.collision_parent_doctype,
+				"title": "Shared URL Test",
+				"image": file.file_url,
+				"cards": [{"image": file.file_url}],
+			}
+		).insert(ignore_permissions=True)
+
+		self.assertEqual(doc.image, old_url)
+		self.assertEqual(doc.cards[0].image, old_url)
+
+		attached = frappe.get_doc("File", file.name)
+		attached.is_private = 0
+		attached.save(ignore_permissions=True)
+
+		reloaded_doc = frappe.get_doc(self.collision_parent_doctype, doc.name)
+		reloaded_file = frappe.get_doc("File", file.name)
+
+		self.assertNotEqual(reloaded_file.file_url, old_url)
+		self.assertEqual(reloaded_doc.image, reloaded_file.file_url)
+		self.assertEqual(reloaded_doc.cards[0].image, reloaded_file.file_url)
+
+	def test_top_level_attach_field_still_works(self):
+		file = self.make_unattached_file(b"parent-level-bytes")
+		doc = self.make_parent_doc(parent_image=file.file_url)
+
+		reloaded = frappe.get_doc("File", file.name)
+		self.assertEqual(reloaded.attached_to_doctype, self.parent_doctype)
+		self.assertEqual(reloaded.attached_to_name, doc.name)
+		self.assertEqual(reloaded.attached_to_field, "parent_image")
+
+		reloaded.is_private = 0
+		reloaded.save(ignore_permissions=True)
+
+		doc_reloaded = frappe.get_doc(self.parent_doctype, doc.name)
+		file_reloaded = frappe.get_doc("File", file.name)
+		self.assertEqual(doc_reloaded.parent_image, file_reloaded.file_url)
+
+
 class TestAttachmentsAccess(IntegrationTestCase):
 	def setUp(self) -> None:
 		frappe.db.delete("File", {"is_folder": 0})

--- a/frappe/core/doctype/file/utils.py
+++ b/frappe/core/doctype/file/utils.py
@@ -4,7 +4,7 @@ import os
 import re
 from binascii import Error as BinasciiError
 from io import BytesIO
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 from urllib.parse import unquote, urljoin
 
 import filetype
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 	from PIL.ImageFile import ImageFile
 	from requests.models import Response
 
+	from frappe.core.doctype.docfield.docfield import DocField
 	from frappe.model.document import Document
 
 	from .file import File
@@ -357,41 +358,79 @@ def attach_files_to_document(doc: "Document", event) -> None:
 	the file to the document if not already attached. If no file is found, a new file
 	is created.
 	"""
+	candidates: list[tuple["DocField", Any]] = []
 
+	# this method runs in on_update hook of all documents
+	# we dont want the update to fail if file cannot be attached for some reason
 	attach_fields = doc.meta.get("fields", {"fieldtype": ["in", ["Attach", "Attach Image"]]})
-
 	for df in attach_fields:
-		# this method runs in on_update hook of all documents
-		# we dont want the update to fail if file cannot be attached for some reason
-		value = doc.get(df.fieldname)
-		if not (value or "").startswith(("/files", "/private/files", "http://", "https://")):
+		candidates.append((df, doc.get(df.fieldname)))
+
+	table_fields = doc.meta.get("fields", {"fieldtype": "Table"})
+	for table_df in table_fields:
+		child_rows = doc.get(table_df.fieldname) or []
+		if not child_rows:
 			continue
 
-		if frappe.db.exists(
+		child_meta = frappe.get_meta(table_df.options)
+		child_attach_fields = child_meta.get("fields", {"fieldtype": ["in", ["Attach", "Attach Image"]]})
+		if not child_attach_fields:
+			continue
+
+		for child_row in child_rows:
+			for child_df in child_attach_fields:
+				candidates.append((child_df, child_row.get(child_df.fieldname)))
+
+	_attach_field_values(doc, candidates)
+
+
+def _attach_field_values(doc: "Document", candidates: list[tuple["DocField", Any]]) -> None:
+	valid = [
+		(df, value)
+		for df, value in candidates
+		if (value or "").startswith(("/files", "/private/files", "http://", "https://"))
+	]
+	if not valid:
+		return
+
+	values = list({value for _, value in valid})
+	already_attached = {
+		(row.file_url, row.attached_to_field)
+		for row in frappe.get_all(
 			"File",
-			{
-				"file_url": value,
-				"attached_to_name": doc.name,
+			filters={
 				"attached_to_doctype": doc.doctype,
-				"attached_to_field": df.fieldname,
+				"attached_to_name": doc.name,
+				"file_url": ["in", values],
 			},
-		):
-			continue
-
-		unattached_file = frappe.db.exists(
-			"File",
-			{
-				"file_url": value,
-				"attached_to_name": None,
-				"attached_to_doctype": None,
-				"attached_to_field": None,
-			},
+			fields=["file_url", "attached_to_field"],
 		)
+	}
 
-		if unattached_file:
+	remaining = [(df, value) for df, value in valid if (value, df.fieldname) not in already_attached]
+	if not remaining:
+		return
+
+	remaining_values = list({value for _, value in remaining})
+	orphan_by_url = {
+		row.file_url: row.name
+		for row in frappe.get_all(
+			"File",
+			filters={
+				"attached_to_doctype": ["is", "not set"],
+				"attached_to_name": ["is", "not set"],
+				"attached_to_field": ["is", "not set"],
+				"file_url": ["in", remaining_values],
+			},
+			fields=["name", "file_url"],
+		)
+	}
+
+	for df, value in remaining:
+		if orphan_name := orphan_by_url.get(value):
 			frappe.db.set_value(
 				"File",
-				unattached_file,
+				orphan_name,
 				field={
 					"attached_to_name": doc.name,
 					"attached_to_doctype": doc.doctype,


### PR DESCRIPTION
fixes: #41662 

In this PR, fixed only the code bug that will reflect for newer docs. But for the existing docs with this issue it has to be patched for this fix to work on them.