### PR TITLE
fix: don't advise deleting the lock file on lock timeout

### DIFF
--- a/frappe/utils/synchronization.py
+++ b/frappe/utils/synchronization.py
@@ -45,5 +45,5 @@ def filelock(lock_name: str, *, timeout=30, is_global=False):
 		raise LockTimeoutError(
 			_("Failed to aquire lock: {}. Lock may be held by another process.").format(lock_name)
 			+ "<br>"
-			+ _("Wait for that process to finish. Removing the lock file won't help: {}").format(lock_path)
+			+ _("Wait for it to finish. Deleting the lock file {} will not release the lock.").format(lock_path)
 		) from e

--- a/frappe/utils/synchronization.py
+++ b/frappe/utils/synchronization.py
@@ -45,5 +45,7 @@ def filelock(lock_name: str, *, timeout=30, is_global=False):
 		raise LockTimeoutError(
 			_("Failed to aquire lock: {}. Lock may be held by another process.").format(lock_name)
 			+ "<br>"
-			+ _("Wait for it to finish. Deleting the lock file {} will not release the lock.").format(lock_path)
+			+ _("Wait for it to finish. Deleting the lock file {} will not release the lock.").format(
+				lock_path
+			)
 		) from e

--- a/frappe/utils/synchronization.py
+++ b/frappe/utils/synchronization.py
@@ -45,5 +45,5 @@ def filelock(lock_name: str, *, timeout=30, is_global=False):
 		raise LockTimeoutError(
 			_("Failed to aquire lock: {}. Lock may be held by another process.").format(lock_name)
 			+ "<br>"
-			+ _("You can manually remove the lock if you think it's safe: {}").format(lock_path)
+			+ _("Wait for that process to finish. Removing the lock file won't help: {}").format(lock_path)
 		) from e


### PR DESCRIPTION
## Description

The lock timeout message incorrectly told users to delete the lock file.

`filelock.FileLock` uses `fcntl.flock` on Linux, so the lock is released automatically when the holding process exits. A leftover lock file does not block anything; a timeout means another process is still holding the lock.

Deleting the file while it is held can allow another `bench restore` or `bench migrate` to start at the same time, causing concurrent database operations.

The error message now tells users to wait for the process holding the lock instead.
