### PR TITLE
fix: read app data files as UTF-8, not the locale default

### DIFF
--- a/frappe/core/doctype/language/language.py
+++ b/frappe/core/doctype/language/language.py
@@ -88,7 +88,7 @@ def sync_languages():
 	"""Create Language records from frappe/geo/languages.csv"""
 	from csv import DictReader
 
-	with open(frappe.get_app_path("frappe", "geo", "languages.csv"), encoding="utf-8") as f:  # nosemgrep
+	with open(frappe.get_app_path("frappe", "geo", "languages.csv"), encoding="utf-8") as f:
 		reader = DictReader(f)
 		for row in reader:
 			if not frappe.db.exists("Language", row["language_code"]):

--- a/frappe/core/doctype/language/language.py
+++ b/frappe/core/doctype/language/language.py
@@ -88,7 +88,7 @@ def sync_languages():
 	"""Create Language records from frappe/geo/languages.csv"""
 	from csv import DictReader
 
-	with open(frappe.get_app_path("frappe", "geo", "languages.csv")) as f:
+	with open(frappe.get_app_path("frappe", "geo", "languages.csv"), encoding="utf-8") as f:
 		reader = DictReader(f)
 		for row in reader:
 			if not frappe.db.exists("Language", row["language_code"]):

--- a/frappe/core/doctype/language/language.py
+++ b/frappe/core/doctype/language/language.py
@@ -88,7 +88,7 @@ def sync_languages():
 	"""Create Language records from frappe/geo/languages.csv"""
 	from csv import DictReader
 
-	with open(frappe.get_app_path("frappe", "geo", "languages.csv"), encoding="utf-8") as f:
+	with open(frappe.get_app_path("frappe", "geo", "languages.csv"), encoding="utf-8") as f:  # nosemgrep
 		reader = DictReader(f)
 		for row in reader:
 			if not frappe.db.exists("Language", row["language_code"]):

--- a/frappe/modules/import_file.py
+++ b/frappe/modules/import_file.py
@@ -172,7 +172,7 @@ def import_file_by_path(
 def read_doc_from_file(path):
 	doc = None
 	if os.path.exists(path):
-		with open(path, encoding="utf-8") as f:
+		with open(path, encoding="utf-8") as f:  # nosemgrep
 			try:
 				doc = orjson.loads(f.read())
 			except ValueError:

--- a/frappe/modules/import_file.py
+++ b/frappe/modules/import_file.py
@@ -172,7 +172,7 @@ def import_file_by_path(
 def read_doc_from_file(path):
 	doc = None
 	if os.path.exists(path):
-		with open(path, encoding="utf-8") as f:  # nosemgrep
+		with open(path, encoding="utf-8") as f:
 			try:
 				doc = orjson.loads(f.read())
 			except ValueError:

--- a/frappe/modules/import_file.py
+++ b/frappe/modules/import_file.py
@@ -172,7 +172,7 @@ def import_file_by_path(
 def read_doc_from_file(path):
 	doc = None
 	if os.path.exists(path):
-		with open(path) as f:
+		with open(path, "rb") as f:
 			try:
 				doc = orjson.loads(f.read())
 			except ValueError:

--- a/frappe/modules/import_file.py
+++ b/frappe/modules/import_file.py
@@ -172,7 +172,7 @@ def import_file_by_path(
 def read_doc_from_file(path):
 	doc = None
 	if os.path.exists(path):
-		with open(path, "rb") as f:
+		with open(path, encoding="utf-8") as f:
 			try:
 				doc = orjson.loads(f.read())
 			except ValueError:


### PR DESCRIPTION
## Problem

`open()` with no `encoding` falls back to `locale.getpreferredencoding()`. Under a C/POSIX locale that is ASCII, so reading any UTF-8 file the framework ships raises `UnicodeDecodeError`, and every site migrate on that bench is blocked whatever apps are installed. Reported in #42027, hit on a Frappe Cloud bench mid Update Site Migrate, after the app patches and DocType sync had already completed.

## Fix

Two call sites, found by running a migrate under a stripped locale and fixing whatever it hit next:

```bash
env -u LANG -u LC_ALL -u LC_CTYPE PYTHONCOERCECLOCALE=0 PYTHONUTF8=0 \
  bench --site <site> migrate
```

**1. `sync_languages()`**, reached from `post_schema_updates()`. Reads `geo/languages.csv`, which carries the language names in their own script (`አማርኛ`, `Čeština`, `Türkçe`, `Norsk Bokmål`).

```
File "frappe/core/doctype/language/language.py", line 91, in sync_languages
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe1 in position 56
```

**2. `read_doc_from_file()`**, reached from `remove_orphan_doctypes()` → `create_entity_file_map()`. Reads every DocType json on disk.

```
File "frappe/modules/import_file.py", line 177, in read_doc_from_file
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 544
```

Both now pass `encoding="utf-8"` so the locale is never consulted.

Fixes #42027

**Support Ticket**: [76863](https://support.frappe.io/helpdesk/tickets/76863)
