### PR TITLE
fix: translate field labels in bulk edit dialog

### DIFF
--- a/cypress/integration/list_view.js
+++ b/cypress/integration/list_view.js
@@ -109,6 +109,39 @@ context("List View", () => {
 		});
 	});
 
+	it("translates field labels in the bulk edit dialog", { scrollBehavior: false }, () => {
+		const translations = {
+			Route: "Routen-Pfad",
+			"Web Page": "Webseite",
+			"CSS Class": "CSS-Klasse",
+			"Page Building Blocks": "Seitenbausteine",
+		};
+
+		cy.insert_doc(
+			"Web Page",
+			{ title: "Impressum", route: "impressum", content_type: "Rich Text" },
+			true
+		);
+		cy.go_to_list("Web Page");
+		cy.clear_filters();
+		cy.get(".list-header-subject .list-subject .list-check-all").click();
+
+		cy.window().then((win) => Object.assign(win.frappe._messages, translations));
+		cy.click_action_button("Edit");
+
+		cy.get_open_dialog().find('input[data-fieldname="field"]').clear().type("Routen-Pfad");
+		cy.get(".awesomplete li:visible").should("contain.text", "Routen-Pfad (Webseite)");
+
+		cy.get_open_dialog().find('input[data-fieldname="field"]').clear().type("CSS-Klasse");
+		cy.get(".awesomplete li:visible").should("contain.text", "CSS-Klasse (Seitenbausteine)");
+
+		cy.hide_dialog();
+		cy.window().then((win) => {
+			Object.keys(translations).forEach((key) => delete win.frappe._messages[key]);
+		});
+		cy.remove_doc("Web Page", "impressum");
+	});
+
 	it("keeps selected rows checked after a list rerender", { scrollBehavior: false }, () => {
 		cy.go_to_list("ToDo");
 		cy.clear_filters();

--- a/frappe/public/js/frappe/list/bulk_operations.js
+++ b/frappe/public/js/frappe/list/bulk_operations.js
@@ -321,14 +321,12 @@ export default class BulkOperations {
 
 	edit(docnames, field_mappings, done) {
 		const field_options = Object.keys(field_mappings).sort(function (a, b) {
-			return __(cstr(field_mappings[a].label)).localeCompare(
-				cstr(__(field_mappings[b].label))
+			return field_mappings[a].translated_label.localeCompare(
+				field_mappings[b].translated_label
 			);
 		});
-		// Same strings as legacy Select (`options`: sorted mapping keys)—parent `Label (Doctype)`,
-		// child `Child Label (Table column)`, so labels stay distinguishable after Autocomplete swap.
 		const field_autocomplete_options = field_options.map((key) => ({
-			label: __(cstr(key)),
+			label: field_mappings[key].translated_label,
 			value: key,
 		}));
 		const status_regex = /status/i;

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -2948,6 +2948,9 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 							const field_key = `${field_doc.label} (${doctype})`;
 							field_mappings[field_key] = Object.assign({}, field_doc, {
 								is_child_field: false,
+								translated_label: `${__(field_doc.label, null, doctype)} (${__(
+									doctype
+								)})`,
 							});
 						}
 
@@ -2963,6 +2966,11 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 										is_child_field: true,
 										child_doctype: child_doctype,
 										parent_table_field: field_doc.fieldname,
+										translated_label: `${__(
+											child_field.label,
+											null,
+											child_doctype
+										)} (${__(field_doc.label, null, doctype)})`,
 									});
 								}
 							});


### PR DESCRIPTION
## Description

The Field dropdown in the Bulk Edit dialog showed English labels even when the user’s language was German.

The issue was caused by translating the full `Label (Parent)` string instead of translating each part separately. The translation lookup could not find the combined string.

The label is now built from translated values, with the doctype used as translation context. The option value remains unchanged, so field lookup and update behavior are unaffected.

## Before/After

<img width="1400" height="900" alt="before" src="https://github.com/user-attachments/assets/c5fd6107-5caf-4682-8eb6-af4986f553dc" />
<img width="1400" height="900" alt="after" src="https://github.com/user-attachments/assets/d1b28419-4c88-4053-b7bf-d4d975412ae5" />


---

Ref: https://support.frappe.io/helpdesk/tickets/76545?view=VIEW-HD+Ticket-1252