### PR TITLE
feat(desk-v2): run contributed record customizations through the engine

### DIFF
--- a/frontend/src/contributions/registry.ts
+++ b/frontend/src/contributions/registry.ts
@@ -5,32 +5,17 @@
 // in plugin/contributions.js, at build time, where it costs nothing at runtime.
 
 import contributions from 'virtual:frappe/contributions'
-import type {
-  DoctypeContribution,
-  ListHandlers,
-  PageContribution,
-  RecordHandlers,
-} from './types'
+import { registerRecordPage, withRegisteringSource } from '@/recordPage'
+import type { DoctypeContribution, ListHandlers, PageContribution } from './types'
 
 export const pages: PageContribution[] = contributions.pages
 
 /** List customizations, indexed by doctype. No registrar exists for these in
- *  `@framework/ui` yet, so the shell holds them rather than growing that package. */
+ *  the record-page engine yet, so the shell's own index holds them. */
 const listHandlers = new Map<string, { app: string; handlers: ListHandlers }[]>()
-
-/** Record customizations, indexed by doctype, in the run order `ordered` decided.
- *
- *  Held rather than run: this PR proves a contribution is *discovered* and *ordered*.
- *  Making one actually run is the record-page engine's job, and it arrives with the
- *  engine — at which point this map is what it registers from. */
-const recordHandlers = new Map<string, { app: string; handlers: RecordHandlers }[]>()
 
 export function listHandlersFor(doctype: string) {
   return listHandlers.get(doctype) ?? []
-}
-
-export function recordHandlersFor(doctype: string) {
-  return recordHandlers.get(doctype) ?? []
 }
 
 /**
@@ -84,10 +69,10 @@ export async function registerContributions(appOrder: string[]) {
       }
 
       // Tagged with the contributing app, so a later `unregisterSource` can drop
-      // exactly one app's handlers once the engine is doing the registering.
-      const own = recordHandlers.get(doctype) ?? []
-      own.push({ app: contribution.app, handlers: contribution.handlers })
-      recordHandlers.set(doctype, own)
+      // exactly one app's handlers.
+      await withRegisteringSource(contribution.app, async () =>
+        registerRecordPage(doctype, contribution.handlers),
+      )
     }
   }
 }

--- a/frontend/src/pages/Record.vue
+++ b/frontend/src/pages/Record.vue
@@ -2,10 +2,11 @@
   The generated record page: what every app gets at /apps/<prefix>/<slug>/<name> with
   no declaration at all. Charter item 2's "default first" made literal.
 
-  Deliberately a MINIMAL host: no form layout, no tabs, no panel. What it proves here is
-  that the generated route resolves, the doctype de-slugs through boot, and the record
-  loads. Making a contributed `record.js` actually *run* rather than merely be discovered
-  is the record-page engine's job and arrives with it.
+  It hosts the REAL record-page engine (`@/recordPage`), which is what makes a
+  contributed `record.js` run rather than merely be discovered. Deliberately a MINIMAL
+  host: no form layout, no tabs, no panel. `RecordPageHost` documents `formLayout` and
+  friends as "absent for a host that renders no form", so this is a supported shape
+  rather than a fork of the engine.
 
   What it is NOT is a port of `crm/frontend2`'s record page. That is 1,962 lines across
   a dozen components plus a 400-line composable, and migrating it wholesale is a later
@@ -21,8 +22,19 @@
 			<header class="flex items-center gap-3">
 				<h1 class="text-lg font-semibold">{{ route.params.name }}</h1>
 				<span class="text-sm text-ink-gray-5">{{ doctype }}</span>
+
+				<!-- Contributed quick actions, in the run order the registry decided. -->
+				<div class="ml-auto flex gap-2">
+					<Button
+						v-for="action in quickActions"
+						:key="action.name"
+						:label="action.label"
+						@click="runAction(action)"
+					/>
+				</div>
 			</header>
 
+			<p v-if="actionError" class="mt-4 text-sm text-ink-red-4">{{ actionError }}</p>
 			<p v-if="error" class="mt-4 text-sm text-ink-red-4">{{ error }}</p>
 
 			<dl v-else class="mt-6 grid max-w-2xl grid-cols-[12rem_1fr] gap-y-1.5 text-sm">
@@ -36,19 +48,30 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject, ref, watch } from "vue";
-import { useRoute } from "vue-router";
+import { computed, inject, ref, shallowRef, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { Button } from "frappe-ui";
+import { createRecordPage, type RecordPageController } from "@/recordPage";
 import type { Boot } from "@/boot";
 import { resolveDoctype } from "@/router";
 
 const boot = inject<Boot>("boot")!;
 const route = useRoute();
+const router = useRouter();
 
 const doc = ref<Record<string, any>>({});
+const saved = ref<Record<string, any>>({});
+const meta = ref<any>(null);
 const error = ref("");
+// Kept apart from `error`: a failed ACTION must not blank the record the reader is
+// looking at, which sharing one ref would do (the field list renders in its v-else).
+const actionError = ref("");
+const controller = shallowRef<RecordPageController | null>(null);
+const actionsVersion = ref(0);
 
 // Which load is current. Navigating A -> B leaves A's fetch in flight, and without
-// this the slower response wins: `doc` would hold A while the URL says B.
+// this the slower response wins: `doc` would hold A while the URL says B, and `save()`
+// would then POST A's fields -- writing the record the user is not looking at.
 let generation = 0;
 
 const doctype = computed(() => resolveDoctype(boot, String(route.params.doctype)));
@@ -60,6 +83,11 @@ const fields = computed(() =>
 		.slice(0, 25)
 );
 
+const quickActions = computed(() => {
+	actionsVersion.value; // re-read after each replay
+	return controller.value?.quickActions.visible() ?? [];
+});
+
 async function call(method: string, params: Record<string, string>) {
 	const res = await fetch(`/api/method/${method}?${new URLSearchParams(params)}`);
 	if (!res.ok) throw new Error(String(res.status));
@@ -69,20 +97,86 @@ async function call(method: string, params: Record<string, string>) {
 async function load() {
 	if (!doctype.value) return;
 	const mine = ++generation;
+	const target = { doctype: doctype.value, name: docname.value };
 	error.value = "";
+	const carriedActionError = actionError.value;
 	try {
-		const document = await call("frappe.client.get", {
-			doctype: doctype.value,
-			name: docname.value,
-		});
+		const [document, metadata] = await Promise.all([
+			call("frappe.client.get", { doctype: doctype.value, name: docname.value }),
+			call("frappe.desk.form.load.getdoctype", { doctype: doctype.value, with_parent: "1" }),
+		]);
 		if (mine !== generation) return;
-		doc.value = document;
+		saved.value = { ...document };
+		doc.value = JSON.parse(JSON.stringify(document));
+		meta.value =
+			(metadata?.docs ?? []).find((entry: any) => entry.name === target.doctype) ?? null;
 	} catch (e) {
 		if (mine !== generation) return;
 		error.value =
 			String(e) === "Error: 403"
 				? "You do not have permission to read this record."
 				: "Not found.";
+		return;
+	}
+
+	controller.value = createRecordPage({
+		doctype: target.doctype,
+		docname: target.name,
+		doc,
+		saved,
+		meta,
+		perms: () => ({}),
+		isDirty: () => JSON.stringify(doc.value) !== JSON.stringify(saved.value),
+		// No strip on this page, so the reader is never on a tab and activation is a
+		// no-op. The engine already refuses to activate a tab it cannot see.
+		activeTab: () => "",
+		activateTab: () => {},
+		save,
+		reload: load,
+		router,
+	});
+
+	await controller.value.refresh();
+	if (mine !== generation) return;
+	// A reload triggered by a failed action must not wipe the message explaining it.
+	actionError.value = carriedActionError;
+	actionsVersion.value++;
+}
+
+async function save() {
+	// Refuse rather than write the wrong record: if the route moved while an action was
+	// running, the draft in `doc` no longer belongs to what the URL addresses.
+	if (doc.value.name !== docname.value || doctype.value === null) {
+		throw new Error("The record changed while saving; nothing was written.");
+	}
+
+	const mine = generation;
+	const res = await fetch("/api/method/frappe.client.save", {
+		method: "POST",
+		headers: { "Content-Type": "application/json", "X-Frappe-CSRF-Token": boot.csrf_token },
+		body: JSON.stringify({ doc: { ...doc.value, doctype: doctype.value } }),
+	});
+	if (!res.ok) throw new Error(`Save failed with ${res.status}`);
+
+	const document = (await res.json()).message;
+	if (mine !== generation) return;
+	saved.value = { ...document };
+	doc.value = JSON.parse(JSON.stringify(document));
+	await controller.value?.refresh();
+	actionsVersion.value++;
+}
+
+async function runAction(action: { run: (page: unknown) => unknown }) {
+	// Awaited and caught. Neither, and a failing action leaves the draft mutated on
+	// screen with no error at all -- CRM's `markWon` sets status to Won *before*
+	// awaiting save(), so a user without write permission would watch the record flip
+	// to Won and nothing else happen. Reloading discards the rejected draft.
+	actionError.value = "";
+	try {
+		await action.run(controller.value?.page);
+	} catch (e) {
+		actionError.value = String((e as Error)?.message ?? e);
+		await load();
 	}
 }
 

--- a/frontend/src/recordPage/context.ts
+++ b/frontend/src/recordPage/context.ts
@@ -1,0 +1,33 @@
+// Which source is speaking right now: registration attributes new handlers,
+// running attributes surface ops. "host" is the app's own bundled code.
+export const HOST_SOURCE = "host";
+
+let registering = HOST_SOURCE;
+let running = HOST_SOURCE;
+
+export function registeringSource() {
+	return registering;
+}
+
+export function runningSource() {
+	return running;
+}
+
+export async function withRegisteringSource(source: string, work: () => Promise<any>) {
+	registering = source;
+	try {
+		await work();
+	} finally {
+		registering = HOST_SOURCE;
+	}
+}
+
+export async function withRunningSource(source: string, work: () => Promise<any>) {
+	const previous = running;
+	running = source;
+	try {
+		await work();
+	} finally {
+		running = previous;
+	}
+}

--- a/frontend/src/recordPage/createRecordPage.ts
+++ b/frontend/src/recordPage/createRecordPage.ts
@@ -1,0 +1,587 @@
+// Builds the curated `page` and the controller that fires events into it.
+// Handlers run serially in run order, each in its own try/catch: a thrower is
+// skipped half-applied, never taking the page or another source down with it.
+// The one exception is `beforeSave`, the veto point: its throw aborts the save.
+import { computed, ref, type ComputedRef, type Ref } from "vue";
+import type { Router } from "vue-router";
+import { call, toast } from "frappe-ui";
+import { withRunningSource } from "./context";
+import { createPageDialogs, type PageDialogEntry } from "./dialog";
+import type { Decorator } from "@framework/ui/components/FormLayout/buildLayoutFromMeta";
+import type {
+  FormLayoutSchema,
+  RawMetaField,
+} from "@framework/ui/components/FormLayout/types";
+import { holdsChildRows } from "@framework/ui/components/Fields/rowIdentity";
+import type { RowAddress } from "@framework/ui/components/Fields/types";
+import { FieldsSurface, LAYOUT_BREAKS } from "./fields";
+import { FormTabsSurface } from "./formTabs";
+import { HeaderActionsSurface } from "./headerRenderings";
+import { ROW_EVENTS } from "./flattenHandlers";
+import { withRemovals } from "./pageCompatibility";
+import { createPagePermissions } from "./pagePermissions";
+import { readOnly, type ReadOnlyAdvice } from "./readOnly";
+import { registrationsFor } from "./registry";
+import { reportCustomizationError } from "./reportError";
+import { createRows, warnRowIssue } from "./rows";
+import { Surface } from "./surface";
+import type {
+  PanelSectionItem,
+  QuickAction,
+  RecordPageApi,
+  TabItem,
+  TabsApi,
+} from "./types";
+
+/** The closed event vocabulary (wayfinder ticket 14); every other key is a fieldname. */
+export const RECORD_PAGE_EVENTS = [
+  "onRefresh",
+  "beforeSave",
+  "afterSave",
+  "onTabChange",
+  "onFormTabChange",
+];
+
+// Everything `page` hands back is read-only (ticket 47), and each member names
+// the verb that does support what the write was reaching for — a refusal that
+// names nothing is a removal wearing a Proxy.
+const META_IS_READ_ONLY: ReadOnlyAdvice = {
+  path: "page.meta",
+  instead: "page.fields.update('qty', { hidden: 1 })",
+};
+
+const PERMS_ARE_READ_ONLY: ReadOnlyAdvice = {
+  path: "page.perms",
+  instead: "a copy: { ...page.perms }, since rights come from the server",
+};
+
+const ROLES_ARE_READ_ONLY: ReadOnlyAdvice = {
+  path: "page.roles",
+  instead:
+    "a copy: [...page.roles], since roles belong to the session, not the page",
+};
+
+// The two differ by one letter and hold structurally identical objects, so
+// `page.saved.qty = 5` is a plausible typo for `page.doc.qty = 5` — and it would
+// otherwise silently rewrite the baseline `isDirty`, the layout conditions and
+// the conflict path all read.
+const SAVED_IS_READ_ONLY: ReadOnlyAdvice = {
+  path: "page.saved",
+  instead: "page.doc, which is the draft this is the saved counterpart of",
+};
+
+/** The two tab strips, by the member each is reached through. */
+type TabStrip = "tabs" | "formTabs";
+
+const STRIPS: Record<TabStrip, { other: string; sibling: TabStrip }> = {
+  tabs: { other: "form's", sibling: "formTabs" },
+  formTabs: { other: "record's", sibling: "tabs" },
+};
+
+export interface RecordPageHost {
+  doctype: string;
+  docname: string;
+  doc: Ref<Record<string, any>>;
+  /** The document as the server last showed it; the draft's baseline. */
+  saved: Ref<Record<string, any>>;
+  meta: Ref<any>;
+  /** `docinfo.permissions` as `getdoc` gave it; the engine curates it. */
+  perms: () => Record<string, any>;
+  isDirty: () => boolean;
+  /** The name of the tab the reader is on, as the host's strip resolves it. */
+  activeTab: () => string;
+  /**
+   * Move the reader to a named tab of the record's strip — `activeTab`'s
+   * symmetric partner, and the host's half of `page.tabs.activate`. The engine
+   * has already resolved the name against the strip, so this is handed only
+   * tabs that are there and on screen; how a strip *records* where the reader is
+   * — a URL query here, a ref elsewhere — stays the host's business, which is
+   * what keeps activation from having to be spelled as a `page.router` edit.
+   */
+  activateTab: (name: string) => void;
+  /**
+   * The record's Details layout, which is the strip `page.formTabs` addresses.
+   * Absent for a host that renders no form.
+   */
+  formLayout?: () => FormLayoutSchema | undefined;
+  /**
+   * The **identity** of the Form Layout tab the reader is on, as `FormLayout`
+   * resolves it and the host's strip reports it, or `''` when the reader is not
+   * looking at the form.
+   */
+  activeFormTab?: () => string;
+  /**
+   * Move the reader to a tab of the form, by identity. Optional on the same
+   * terms as `activeFormTab`: a host that renders no form has no strip to move,
+   * and one absent here simply never receives an activation, because the
+   * identity will have missed against an empty layout first.
+   */
+  activateFormTab?: (identity: string) => void;
+  save: () => Promise<void>;
+  reload: () => Promise<void>;
+  router: Router;
+  /**
+   * The per-field UI overlay hook the host also passes its layout source. Only
+   * `page.fields.get` reads it here, and only so its answer cannot disagree
+   * with what the host actually renders.
+   */
+  decorate?: Decorator;
+  /**
+   * A child doctype's meta fields, by doctype name — what makes the row half of
+   * the event vocabulary knowable. Absent while the metas load, and for a host
+   * that has none: the tables then speak `.onAdd` / `.onRemove` only, which is
+   * what the vocabulary check assumes rather than warns about.
+   */
+  childFields?: (doctype: string) => RawMetaField[] | undefined;
+  /** Resolves when sources that register after mount (Page Scripts) are in. */
+  sourcesReady?: () => Promise<void>;
+}
+
+export interface RecordPageController {
+  page: RecordPageApi;
+  quickActions: Surface<QuickAction>;
+  headerActions: HeaderActionsSurface;
+  tabs: Surface<TabItem>;
+  panelSections: Surface<PanelSectionItem>;
+  /** Field property overrides; the host feeds `resolve()` to its layout source. */
+  fields: FieldsSurface;
+  /** Form Layout tab overrides; fed to the same layout source alongside them. */
+  formTabs: FormTabsSurface;
+  /** The replay: clears every surface, then runs every source's `refresh` in run order. */
+  refresh: () => Promise<void>;
+  /** `row` addresses the child row a dotted event happened to; see `Handler`. */
+  fireEvent: (event: string, row?: RowAddress) => Promise<void>;
+  /** True once the first replay has run — before it, surfaces are only built-ins. */
+  ready: Ref<boolean>;
+  /**
+   * True while a replay is staging. Reactive because a host that announces a
+   * *settled* strip has to wait for the commit, and the commit is the moment
+   * this goes false.
+   */
+  isReplaying: ComputedRef<boolean>;
+  /** The `open`/`form` dialogs on screen, for the host's `<PageDialogs>`. */
+  dialogs: Ref<PageDialogEntry[]>;
+  /** Closes them newest-first, each promise resolving `null`. */
+  closeDialogs: () => void;
+}
+
+export function createRecordPage(host: RecordPageHost): RecordPageController {
+  const quickActions = new Surface<QuickAction>();
+  const headerActions = new HeaderActionsSurface();
+  const tabs = new Surface<TabItem>();
+  const panelSections = new Surface<PanelSectionItem>();
+  const permissions = createPagePermissions(host);
+  const fields = new FieldsSurface({
+    fields: () => host.meta.value?.fields,
+    doc: () => host.doc.value,
+    fieldAccess: (fieldname) => permissions.fieldAccess(fieldname),
+    decorate: host.decorate,
+  });
+  const formTabs = new FormTabsSurface({
+    tabs: () => host.formLayout?.(),
+    doc: () => host.doc.value,
+  });
+  const rows = createRows({
+    doc: () => host.doc.value,
+    fields: () => host.meta.value?.fields,
+    childFields: host.childFields,
+    dispatch: (event, row) => fireEvent(event, row),
+  });
+  // Every overlay a replay stages. `fields` and `formTabs` are not `Surface`s —
+  // they override properties rather than arranging items — but they stage here.
+  const surfaces: { beginReplay: () => void; commitReplay: () => void }[] = [
+    quickActions,
+    headerActions,
+    tabs,
+    panelSections,
+    fields,
+    formTabs,
+  ];
+
+  Object.defineProperty(tabs, "active", { get: () => host.activeTab() });
+  // The same shape as the record strip's: `active` is stored nowhere here
+  // either, it is a read into whichever strip the host is drawing.
+  Object.defineProperty(formTabs, "active", {
+    get: () => host.activeFormTab?.() ?? "",
+  });
+
+  const ready = ref(false);
+  let vocabularyChecked = false;
+  const replaying = ref(0);
+  const isReplaying = computed(() => replaying.value > 0);
+
+  // An activation made while a replay is in flight, held until it commits — one
+  // name per strip, so a second call replaces the first the way the reader's own
+  // last move would. This is not the queueing `activate` refuses: the name is
+  // resolved at the moment of the call, against the strip the caller can see
+  // (`isVisible` reads the staged ops, as `has` does). Only the *delivery*
+  // waits, because until the commit the host is still rendering last replay's
+  // strip, and moving the reader to a tab that is not on it yet would show them
+  // the fallback for a tick — the replay's middle, leaking through the one
+  // channel ticket 71's staging does not cover. That is true of any activation
+  // made in the window, not only the ones the replay's own handlers make, which
+  // is why the gate is `isReplaying` and not "am I inside `onRefresh`".
+  const heldActivations = new Map<TabStrip, string>();
+
+  Object.defineProperty(tabs, "activate", {
+    value: (name: string) => activate("tabs", name),
+  });
+  Object.defineProperty(formTabs, "activate", {
+    value: (identity: string) => activate("formTabs", identity),
+  });
+
+  const dialogs = createPageDialogs({ isReplaying: () => isReplaying.value });
+
+  const capabilities: RecordPageApi = {
+    doctype: host.doctype,
+    docname: host.docname,
+    // Exempt from the read-only rule below, and deliberately: mutating the
+    // document *is* the API. Do not "fix" this.
+    get doc() {
+      return host.doc.value;
+    },
+    get saved() {
+      return readOnly(host.saved.value, SAVED_IS_READ_ONLY);
+    },
+    get meta() {
+      return readOnly(host.meta.value, META_IS_READ_ONLY);
+    },
+    // Read-only goes outermost, so a write is refused before the DEV-only
+    // unknown-right advisory inside `permissions.perms()` gets to fire.
+    get perms() {
+      return readOnly(permissions.perms(), PERMS_ARE_READ_ONLY);
+    },
+    get roles() {
+      return readOnly(permissions.roles(), ROLES_ARE_READ_ONLY);
+    },
+    fieldAccess: (fieldname) => permissions.fieldAccess(fieldname),
+    get isDirty() {
+      return host.isDirty();
+    },
+    quickActions,
+    headerActions,
+    tabs: tabs as unknown as TabsApi,
+    panelSections,
+    fields,
+    formTabs,
+    rows: rows.rows,
+    save: () => host.save(),
+    reload: () => host.reload(),
+    refresh: () => refresh(),
+    toast: {
+      success: (message) => toast.success(message),
+      error: (message) => toast.error(message),
+    },
+    dialog: dialogs.api,
+    call: (method, params) => call(method, params),
+    // The one member handed straight through: it is vue-router's object, not
+    // ours, so neither the inbound nor the outbound rule catches it. That is a
+    // real cost, not a technicality, and COMPATIBILITY.md's "The one
+    // hand-through" section now states it and the two rules that bound it —
+    // chiefly that no capability may *require* the router. Do not "fix" this
+    // by deleting the member, and do not hand a second one through on its
+    // precedent.
+    router: host.router,
+  };
+
+  // Nothing has been removed yet, so this hands the same object straight back:
+  // the guard, and its cost on every member read in every handler, exists only
+  // once the removals list has something to say (ticket 20 §4).
+  const page = withRemovals(capabilities);
+
+  async function refresh() {
+    await Promise.all([host.sourcesReady?.(), permissions.ready()]);
+    warnUnknownHandlers();
+    // Counted, not a boolean: a script's own `page.refresh()` re-enters this.
+    replaying.value += 1;
+    // Staged, not cleared: clearing here and re-adding one microtask later is
+    // what tore the rendered strip down between the two, taking the reader's
+    // place in it with them (ticket 70). The surfaces publish on commit, in one
+    // flush, so the host only ever sees a replay's result.
+    for (const surface of surfaces) surface.beginReplay();
+    try {
+      await fireEvent("onRefresh");
+    } finally {
+      // In `finally` so a throwing handler cannot leave the page staged, which
+      // would freeze the overlay on the previous replay for good.
+      for (const surface of surfaces) surface.commitReplay();
+      replaying.value -= 1;
+      // After the commit, so the strip the reader is being moved onto is the one
+      // on screen; and inside the same `finally`, so a throwing handler cannot
+      // strand a move that had already been decided.
+      if (!isReplaying.value) releaseActivations();
+    }
+    ready.value = true;
+  }
+
+  function releaseActivations() {
+    const held = [...heldActivations];
+    heldActivations.clear();
+    for (const [strip, name] of held) {
+      // Re-read, not replayed. The strip a held move was decided against is not
+      // the one that necessarily settled: a later source can hide the tab an
+      // earlier one activated, and delivering that move would land the reader on
+      // the strip's fallback — the very outcome a miss exists to prevent. A tab
+      // that left before the strip settled is a miss like any other.
+      if (!surfaceFor(strip).isVisible(name)) {
+        warnActivate(strip, name, "it left the strip before the replay settled");
+        continue;
+      }
+      move(strip, name);
+    }
+  }
+
+  function surfaceFor(strip: TabStrip) {
+    return strip === "tabs" ? tabs : formTabs;
+  }
+
+  /**
+   * `page.tabs.activate` and `page.formTabs.activate`, both of them, because the
+   * interesting miss is the one that names the *other* strip: the two are not
+   * interchangeable, an author will mix them up, and only a caller holding both
+   * can say which one they wanted. The engine resolves the name and the host
+   * moves the reader — activation never reaches for `page.router`.
+   */
+  function activate(strip: TabStrip, name: string) {
+    if (!canReach(strip, name)) return;
+    if (isReplaying.value) heldActivations.set(strip, name);
+    else move(strip, name);
+  }
+
+  function canReach(strip: TabStrip, name: string) {
+    // The Details layout can land after the first replay has run, and until it
+    // does, "the administrator never authored this" and "it is not here yet"
+    // are the same answer — which is why `FormTabsSurface.warnIfAbsent` holds
+    // its tongue in the same window. The move is dropped either way: an
+    // activation is resolved at the moment of the call and is not queued.
+    if (strip === "formTabs" && !host.formLayout?.()?.length) return false;
+    const here = surfaceFor(strip);
+    const there = surfaceFor(strip === "tabs" ? "formTabs" : "tabs");
+    if (!here.has(name)) {
+      warnActivate(
+        strip,
+        name,
+        there.has(name)
+          ? `it is on the ${STRIPS[strip].other} strip — page.${STRIPS[strip].sibling}.activate("${name}")`
+          : "no such tab",
+      );
+      return false;
+    }
+    // Hidden is a miss and not an invitation: `show()` is the verb that reveals
+    // a tab, and one call should not quietly perform two.
+    if (!here.isVisible(name)) {
+      warnActivate(strip, name, "it is hidden — show() reveals a tab");
+      return false;
+    }
+    return true;
+  }
+
+  /** The host's half, and the only place the engine hands a strip a name. */
+  function move(strip: TabStrip, name: string) {
+    // A host that draws the form's strip but cannot move it would otherwise
+    // swallow an activation that passed every check — the one silent failure
+    // this verb exists to abolish.
+    if (strip === "formTabs" && !host.activateFormTab) {
+      warnActivate(strip, name, "this host cannot move the reader on that strip");
+      return;
+    }
+    try {
+      if (strip === "tabs") host.activateTab(name);
+      else host.activateFormTab?.(name);
+    } catch (error) {
+      // Reported, never rethrown: a released move runs inside `refresh`'s
+      // `finally`, so a throwing host hook would take the rest of the release
+      // with it and leave `ready` false — a page stuck on its skeleton because
+      // a router guard said no.
+      console.error(
+        `[record-page] page.${strip}.activate("${name}") — the host threw`,
+        error,
+      );
+    }
+  }
+
+  /**
+   * Said every time, not once: a miss here is an act the script just performed —
+   * the reader was not moved — rather than a standing fault in its text, and the
+   * second failed move is not the first one repeated.
+   */
+  function warnActivate(strip: TabStrip, name: string, because: string) {
+    if (!import.meta.env.DEV) return;
+    console.warn(
+      `[record-page] page.${strip}.activate("${name}") — ${because}; the reader was not moved.`,
+    );
+  }
+
+  async function fireEvent(event: string, row?: RowAddress) {
+    // One handle for the whole dispatch, and the same object `page.rows()` hands
+    // back: it is an address, so every source is looking at the same live row.
+    const handle = row ? rows.handle(row) : undefined;
+    for (const { source, handlers } of registrationsFor(host.doctype)) {
+      const handler = handlers[event];
+      if (!handler) continue;
+      await withRunningSource(source, async () => {
+        try {
+          await handler(page, handle);
+        } catch (error) {
+          // `beforeSave` rethrows to abort the save, and is the one catch site
+          // that does not report: the user is looking straight at a failed save,
+          // so logging it would file a working veto as an error.
+          if (event === "beforeSave") throw error;
+          console.error(
+            `[record-page] ${source}.${event} on ${host.doctype} threw`,
+            error,
+          );
+          // No `route`: the reporter reads `location`, which is the URL an admin
+          // can paste. `router.fullPath` drops the app's base and would make this
+          // one site disagree with the other three.
+          reportCustomizationError(error, {
+            source,
+            event,
+            doctype: host.doctype,
+            record: host.docname,
+          });
+        }
+      });
+    }
+  }
+
+  // Meta can lag the first paint, so the check waits for a replay that has fields.
+  function warnUnknownHandlers() {
+    if (!import.meta.env.DEV) return;
+    const fields = host.meta.value?.fields;
+    if (!fields) return;
+    const registrations = registrationsFor(host.doctype);
+    // Nothing to shadow and no keys to check when no source is registered — and
+    // saying so anyway would fire the warning on every record a plain app opens.
+    if (!registrations.length) return;
+    // Deliberately *not* behind the latch below: this one reads the **child**
+    // meta, which can land after the parent's — `handlerVocabulary`'s
+    // `unresolved` list exists for exactly that window — so latching on the
+    // parent alone would drop the collision warning for the whole session.
+    // Re-attempting it costs a loop over the tables, and `warnRowIssue`
+    // remembers what it has already said.
+    warnShadowedChildFields(fields);
+    if (vocabularyChecked) return;
+    vocabularyChecked = true;
+    const known = handlerVocabulary(fields, host.childFields);
+    const said = new Set<string>();
+    for (const { source, handlers } of registrations)
+      for (const key of Object.keys(handlers)) {
+        if (known.has(key)) continue;
+        // A whole block written under a fieldname that holds no rows is one
+        // mistake, not one per handler in it — so it is named by its table.
+        const [table] = key.split(".");
+        const nested = key.includes(".") && !known.isTable(table);
+        const message = nested
+          ? `${source}.${table} on ${host.doctype} is not a child table — nothing nested under it will fire`
+          : `${source}.${key} on ${host.doctype} is neither an event nor a fieldname — it will never fire`;
+        if (said.has(message)) continue;
+        said.add(message);
+        console.warn(`[record-page] ${message}`);
+      }
+  }
+
+  /**
+   * The three child fieldnames the table vocabulary occupies, named at load
+   * because the engine knows the child's fields where v1 could only warn on
+   * every access. Frappe reserves none of them (`RESERVED_KEYWORDS` is five
+   * names plus the cached properties), so a child doctype may legitimately
+   * carry any — and ticket 54 traded a guarantee for this warning knowingly.
+   *
+   * 54 called the result "an announced capability hole, never a misfire", and
+   * for `trigger` that is exact. For the two lifecycle names it is not: a child
+   * field named `onAdd` commits as `<table>.onAdd`, which is the *same string*
+   * the row-added event dispatches, so the author's `onAdd` handler runs — with
+   * a live row — on that field being edited. The hole is announced, but it is a
+   * misfire, and the warning says so rather than the comfortable thing.
+   */
+  function warnShadowedChildFields(fields: RawMetaField[]) {
+    for (const field of fields) {
+      if (!holdsChildRows(field.fieldtype) || !field.options) continue;
+      const child = host.childFields?.(field.options);
+      if (!child) continue;
+      const has = (fieldname: string) =>
+        child.some((one) => one.fieldname === fieldname);
+      // The verb wins and the field stays reachable through `page.doc`.
+      if (has("trigger"))
+        // Warned per child doctype for the session, not per controller: the same
+        // shadow is the same fact on every record of the doctype, and navigating
+        // between them must not restate it.
+        warnRowIssue(
+          `${field.options}.trigger is shadowed by the row handle's own trigger() — read it from page.doc.${field.fieldname} instead`,
+        );
+      // One string cannot be two events, and the field's commit is the one that
+      // arrives unannounced — so the warning names the direction that bites.
+      for (const lifecycle of Object.values(ROW_EVENTS))
+        if (has(lifecycle))
+          warnRowIssue(
+            `${field.options}.${lifecycle} collides with the table's ${lifecycle} handler — editing that field on a row fires ${field.fieldname}.${lifecycle} as though a row had been ${lifecycle === ROW_EVENTS.add ? "added" : "removed"}. Rename the field, or handle it from page.doc.${field.fieldname}`,
+          );
+    }
+  }
+
+  return {
+    page,
+    quickActions,
+    headerActions,
+    tabs,
+    panelSections,
+    fields,
+    formTabs,
+    refresh,
+    fireEvent,
+    ready,
+    isReplaying,
+    dialogs: dialogs.entries,
+    closeDialogs: dialogs.closeAll,
+  };
+}
+
+/**
+ * The whole vocabulary a handler key may be drawn from (tickets 44, 45): the
+ * four events, every parent fieldname, and — for a child table — the dotted
+ * family and nothing else.
+ *
+ * A Table fieldtype's **bare** fieldname is deliberately not here. It was only
+ * ever firable because the deleted deep watch could not tell one row's edit from
+ * another's, so a table has no control that commits under its own name; leaving
+ * it in would accept `products() {}` silently and never fire it.
+ */
+function handlerVocabulary(
+  fields: RawMetaField[],
+  childFields?: (doctype: string) => RawMetaField[] | undefined,
+) {
+  const known = new Set(RECORD_PAGE_EVENTS);
+  // Every child table on the doctype, so a nested block written under something
+  // that is not one can be named as that rather than as a generic typo.
+  const tables = new Set<string>();
+  // Tables whose child doctype we cannot see. A host with no `childFields`, or
+  // one whose child meta has not landed, must not accuse a correct key of being
+  // a typo — so those tables are answered by prefix instead.
+  const unresolved: string[] = [];
+  for (const field of fields) {
+    if (!holdsChildRows(field.fieldtype)) {
+      known.add(field.fieldname);
+      continue;
+    }
+    tables.add(field.fieldname);
+    known.add(`${field.fieldname}.${ROW_EVENTS.add}`);
+    known.add(`${field.fieldname}.${ROW_EVENTS.remove}`);
+    // A Table MultiSelect has no per-cell editing, so its vocabulary is add and
+    // remove alone — an honest gap rather than keys that would never fire.
+    if (field.fieldtype !== "Table") continue;
+    const child = field.options && childFields?.(field.options);
+    if (!child) unresolved.push(field.fieldname);
+    // A layout break has no value and so no commit; `page.fields` excludes them
+    // for the same reason, and accepting one here would be a key that never fires.
+    else
+      for (const one of child)
+        if (!LAYOUT_BREAKS.has(one.fieldtype))
+          known.add(`${field.fieldname}.${one.fieldname}`);
+  }
+  return {
+    has: (key: string) =>
+      known.has(key) || unresolved.some((table) => key.startsWith(`${table}.`)),
+    isTable: (fieldname: string) => tables.has(fieldname),
+  };
+}

--- a/frontend/src/recordPage/dialog.ts
+++ b/frontend/src/recordPage/dialog.ts
@@ -1,0 +1,276 @@
+// `page.dialog` — the one dialog surface scripts are taught. `confirm` and
+// `danger` are frappe-ui's own imperative dialogs, narrowed; `open` and `form`
+// render on this page's own stack, which `<PageDialogs>` mounts.
+//
+// What the facade buys over importing frappe-ui's `dialog` directly:
+//   - every verb is a promise, `null` meaning dismissed, so `if (!result) return`
+//   - the page owns the stack, so navigating off the record cannot strand an
+//     awaiting script behind a dialog the reader can no longer see
+//   - opens are tagged with the running source, so a stuck dialog has a name
+//   - nothing an author writes is forwarded to frappe-ui unnamed, so an option
+//     whose meaning frappe-ui changes cannot change what a stored script does
+import { shallowRef, type Component, type Ref } from "vue";
+import { dialog as frappeDialog } from "frappe-ui";
+import { runningSource } from "./context";
+import type {
+  PageDialog,
+  PageDialogConfirmAction,
+  PageDialogConfirmOptions,
+  PageDialogControl,
+  PageDialogFormOptions,
+  PageDialogOpenOptions,
+} from "./types";
+
+/** One dialog this page is rendering. */
+export interface PageDialogEntry {
+  id: number;
+  /** The script that opened it — who a failure or a stuck dialog is named after. */
+  source: string;
+  kind: "component" | "form";
+  /** `open`: what renders inside the host dialog, and its chrome. */
+  component?: Component;
+  props: Record<string, any>;
+  options: PageDialogOpenOptions;
+  /** `form`: what the form host renders. */
+  form?: PageDialogFormOptions;
+  /**
+   * Resolves the opener's promise. Idempotent, and deliberately separate from
+   * `dismiss`: the promise settles the moment the answer is known, not when the
+   * leave transition ends, so a page that unmounts mid-transition cannot turn a
+   * submitted dialog into a cancelled one.
+   */
+  settle: (result?: any) => void;
+  /** Takes the dialog off the stack — the host calls it after the leave transition. */
+  dismiss: () => void;
+  /** Set by the host component so navigating away still runs the author's `onCancel`. */
+  onDismissed?: () => void;
+}
+
+export interface PageDialogHost {
+  /**
+   * True while a replay is running. A dialog opened from `refresh` re-opens on
+   * every replay, so dev builds name the source rather than block the call —
+   * a deliberate on-load gate stays possible.
+   */
+  isReplaying: () => boolean;
+}
+
+export interface PageDialogs {
+  api: PageDialog;
+  /** The renderable stack, oldest first. */
+  entries: Ref<PageDialogEntry[]>;
+  /**
+   * The page is gone: close every open dialog newest-first, each promise
+   * resolving `null`, and refuse every later open — with nothing left to render
+   * them, a script awaiting one would wait forever.
+   */
+  closeAll: () => void;
+}
+
+// frappe-ui's `ConfirmArgs`, named key by key: `page` forwards an option it names
+// and drops one it does not (COMPATIBILITY.md, ticket 20 §2).
+const CONFIRM_OPTIONS = [
+  "title",
+  "message",
+  "confirmLabel",
+  "cancelLabel",
+  "theme",
+  "icon",
+  "size",
+  "dismissible",
+  "onConfirm",
+  "onCancel",
+  "actions",
+];
+
+// `DangerArgs` is `Omit<ConfirmArgs, 'theme' | 'icon'>` — frappe-ui forces red and
+// its own icon — so passing either here is the mistake the warning exists for.
+const DANGER_OPTIONS = CONFIRM_OPTIONS.filter(
+  (option) => option !== "theme" && option !== "icon",
+);
+
+// frappe-ui's `DialogAction` is `Omit<ButtonProps, 'onClick' | 'loading'>`: a whole
+// component's prop surface, moving on frappe-ui's cadence. These five are the ones
+// `page` means by an action.
+const ACTION_OPTIONS = ["label", "variant", "theme", "icon", "onClick"];
+
+let nextId = 0;
+
+export function createPageDialogs(host: PageDialogHost): PageDialogs {
+  const entries = shallowRef<PageDialogEntry[]>([]);
+  // Every open dialog's dismisser, in open order — including the `confirm` and
+  // `danger` ones frappe-ui renders, which never reach `entries`.
+  const openDialogs: Array<() => void> = [];
+  let detached = false;
+
+  function track(dismiss: () => void) {
+    openDialogs.push(dismiss);
+    return () => {
+      const index = openDialogs.indexOf(dismiss);
+      if (index >= 0) openDialogs.splice(index, 1);
+    };
+  }
+
+  function warn(verb: string, reason: string) {
+    if (!import.meta.env.DEV) return;
+    console.warn(
+      `[record-page] ${runningSource()} called page.dialog.${verb} ${reason}`,
+    );
+  }
+
+  /** Nothing renders a dialog opened after the page went away. */
+  function refused(verb: string) {
+    warn(verb, "after leaving the record — it resolves null unopened");
+    return Promise.resolve(null);
+  }
+
+  function warnOnReplay(verb: string) {
+    if (!host.isReplaying()) return;
+    warn(
+      verb,
+      "during a replay — it will re-open on every refresh. Dialogs belong in `run` and event handlers, not `refresh`.",
+    );
+  }
+
+  /** Keeps the named keys and drops the rest, saying which it dropped. */
+  function pick(
+    verb: string,
+    from: Record<string, any>,
+    named: string[],
+    where = "",
+  ) {
+    const kept: Record<string, any> = {};
+    for (const [key, value] of Object.entries(from)) {
+      if (named.includes(key)) kept[key] = value;
+      else
+        warn(
+          verb,
+          `with '${key}'${where}, which it does not forward — dropped. See COMPATIBILITY.md.`,
+        );
+    }
+    return kept;
+  }
+
+  function mount(
+    verb: "open" | "form",
+    build: () => {
+      kind: PageDialogEntry["kind"];
+      component?: Component;
+      props?: Record<string, any>;
+      options?: PageDialogOpenOptions;
+      form?: PageDialogFormOptions;
+    },
+  ): Promise<any> {
+    if (detached) return refused(verb);
+    warnOnReplay(verb);
+    const source = runningSource();
+    return new Promise((resolve) => {
+      const id = nextId++;
+      let settled = false;
+      const settle = (result: any = null) => {
+        if (settled) return;
+        settled = true;
+        untrack();
+        resolve(result ?? null);
+      };
+      const dismiss = () => {
+        entries.value = entries.value.filter((entry) => entry.id !== id);
+      };
+      const untrack = track(() => {
+        entry.onDismissed?.();
+        settle(null);
+        dismiss();
+      });
+      const entry: PageDialogEntry = {
+        id,
+        source,
+        props: {},
+        options: {},
+        ...build(),
+        settle,
+        dismiss,
+      };
+      entries.value = [...entries.value, entry];
+    });
+  }
+
+  // `confirm`/`danger` are curated three layers deep — the options, the nested
+  // actions, and the object each callback receives — so that no part of what an
+  // author writes reaches frappe-ui, or comes back from it, unnamed by `page`.
+  function native(
+    verb: "confirm" | "danger",
+    args: PageDialogConfirmOptions,
+  ): Promise<true | null> {
+    if (detached) return refused(verb) as Promise<null>;
+    warnOnReplay(verb);
+    const options = pick(
+      verb,
+      args,
+      verb === "danger" ? DANGER_OPTIONS : CONFIRM_OPTIONS,
+    );
+    return new Promise((resolve) => {
+      let handle: { close: () => void } | null = null;
+      let settled = false;
+      const settle = (result: true | null) => {
+        if (settled) return;
+        settled = true;
+        untrack();
+        resolve(result);
+      };
+      // Navigating away closes the dialog without frappe-ui firing `onCancel`,
+      // so the promise is settled here rather than left to that callback.
+      const untrack = track(() => {
+        handle?.close();
+        settle(null);
+      });
+      handle = frappeDialog[verb]({
+        ...options,
+        actions: args.actions?.map((action: PageDialogConfirmAction) => ({
+          ...pick(verb, action, ACTION_OPTIONS, ` on action '${action.label}'`),
+          onClick: async (control: any) => {
+            // An action with no `onClick` is frappe-ui's plain dismiss button;
+            // answering `true` for it would read as a confirmation.
+            if (!action.onClick) return settle(null);
+            await action.onClick(controlFor(control));
+            settle(true);
+          },
+        })),
+        onConfirm: async (control: any) => {
+          await args.onConfirm?.(controlFor(control));
+          settle(true);
+        },
+        onCancel: () => {
+          args.onCancel?.();
+          settle(null);
+        },
+      } as any);
+    });
+  }
+
+  const api: PageDialog = {
+    open: (component, props = {}, options = {}) =>
+      mount("open", () => ({ kind: "component", component, props, options })),
+    form: (options) => mount("form", () => ({ kind: "form", form: options })),
+    confirm: (args) => native("confirm", args ?? {}),
+    danger: (args) => native("danger", args ?? {}),
+  };
+
+  return {
+    api,
+    entries,
+    closeAll: () => {
+      detached = true;
+      for (const dismiss of [...openDialogs].reverse()) dismiss();
+    },
+  };
+}
+
+// The engine's own object rather than frappe-ui's `DialogControl` — the subtlest
+// of the three layers, and the one that matters most to a stored script: a rename
+// under us must not change what the script does on an upgrade nobody reviewed.
+function controlFor(control: any): PageDialogControl {
+  return {
+    close: () => control?.close?.(),
+    setError: (message) => control?.setError?.(message),
+  };
+}

--- a/frontend/src/recordPage/evaluatePageScript.ts
+++ b/frontend/src/recordPage/evaluatePageScript.ts
@@ -1,0 +1,33 @@
+// A stored script is literally a file script: it is evaluated as a real ES module
+// through a blob URL, so `export default {…}` is the same text in both places and
+// bare imports resolve through the page's import map — the four shared deps and
+// nothing else.
+import type { PageScriptRow } from "./pageScriptTypes";
+import type { AuthoredHandlers } from "./types";
+
+export async function evaluatePageScript(
+  row: PageScriptRow,
+): Promise<AuthoredHandlers> {
+  const url = URL.createObjectURL(
+    new Blob([named(row)], { type: "text/javascript" }),
+  );
+  try {
+    const module = await import(/* @vite-ignore */ url);
+    return handlersOf(module.default);
+  } finally {
+    // Safe once the import has settled: the module map holds the evaluated
+    // module, not the URL.
+    URL.revokeObjectURL(url);
+  }
+}
+
+/** Names the module so stack traces and devtools show the script, not a blob id. */
+function named(row: PageScriptRow) {
+  return `${row.script}\n//# sourceURL=page-script/${row.name}.js\n`;
+}
+
+function handlersOf(handlers: unknown): AuthoredHandlers {
+  if (!handlers || typeof handlers !== "object")
+    throw new Error("default export is not a handlers object");
+  return handlers as AuthoredHandlers;
+}

--- a/frontend/src/recordPage/fields.ts
+++ b/frontend/src/recordPage/fields.ts
@@ -1,0 +1,304 @@
+// The fields surface (wayfinder ticket 42) — clause 2 of the v1-parity map.
+//
+// Not a `Surface`. The four list surfaces arrange items a script may also
+// create; fields are a set authored elsewhere whose *properties* a script
+// overrides, so the verbs are a strict subset and the key is a fieldname
+// rather than an item name.
+//
+// Ops are recorded, not applied: `resolve()` folds them into one patch per
+// field, which the host hands to `useFormLayout` as plain data. That keeps the
+// override a render-time overlay — nothing is written into the layout, the Form
+// Layout row or the doctype meta — and makes `reset()` the whole of the replay
+// clear, so an authored script is a plain `if` with no `else`.
+import { markRaw, shallowReactive } from "vue";
+import { mapField } from "@framework/ui/components/FormLayout/buildLayoutFromMeta";
+import type { Decorator } from "@framework/ui/components/FormLayout/buildLayoutFromMeta";
+import { resolveFieldConditionals } from "@framework/ui/components/FormLayout/resolveLayout";
+import type { RawMetaField } from "@framework/ui/components/FormLayout/types";
+import type { FieldAccess } from "@framework/ui/composables/useDocPermissions";
+import { withAccess } from "./formLayoutSource/fieldAccess";
+import { applyFieldPatch, type FieldPatch } from "./formLayoutSource/fieldPatch";
+import { readOnly, type ReadOnlyAdvice } from "./readOnly";
+import type { PageField, PageFieldPatch, PageFields } from "./types";
+
+const SNAPSHOT_IS_READ_ONLY: ReadOnlyAdvice = {
+  path: "page.fields.get()",
+  instead: "page.fields.update(fieldname, { … }), which is the writable half",
+};
+
+/** What `joinLayout` drops before any patch could apply. */
+export const LAYOUT_BREAKS = new Set([
+  "Tab Break",
+  "Section Break",
+  "Column Break",
+]);
+
+type Slot = "meta" | "override" | "ui";
+
+interface Landing {
+  /** Which half of the `FieldPatch` this key lands on. */
+  on: Slot;
+  /** Its name there — the pipeline is camelCase, the script vocabulary is not. */
+  as: string;
+  coerce?: (value: any) => any;
+  /**
+   * A reference rather than data, so it is handed back as itself: comparing and
+   * re-feeding it is the point, and a read-only view of a component's options
+   * breaks both. `markRaw` is how that is said to the rest of Vue.
+   */
+  opaque?: boolean;
+}
+
+const asBoolean = (value: any) => !!value;
+
+/** Meta writes `precision` as a number; a script may reasonably say `"2"`. */
+function asPrecision(value: any): number | undefined {
+  if (value == null || value === "") return undefined;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+/**
+ * The enumerated vocabulary and where each key goes: v1's ten minus
+ * `button_color` (nothing renders it), plus `component`/`props`, which
+ * `FieldUI` already carries through the render path.
+ *
+ * The split is not cosmetic. `hidden`/`read_only`/`reqd` are recomputed on
+ * every keystroke from the `depends_on` family, so they ride the carrier
+ * `resolveFieldConditionals` applies last; the rest are computed once when the
+ * node is built, so they are merged there.
+ */
+const PATCH_KEYS: Record<string, Landing> = {
+  hidden: { on: "override", as: "hidden", coerce: asBoolean },
+  read_only: { on: "override", as: "readOnly", coerce: asBoolean },
+  reqd: { on: "override", as: "reqd", coerce: asBoolean },
+  label: { on: "meta", as: "label" },
+  placeholder: { on: "meta", as: "placeholder" },
+  description: { on: "meta", as: "description" },
+  options: { on: "meta", as: "options" },
+  link_filters: { on: "meta", as: "filters" },
+  precision: { on: "meta", as: "precision", coerce: asPrecision },
+  // Belt and braces beside `shallowReactive` — and the stamp is also what tells
+  // the outbound read-only wrapper to leave the component alone.
+  component: { on: "ui", as: "component", coerce: markRaw, opaque: true },
+  props: { on: "ui", as: "props" },
+};
+
+/**
+ * The reader's key list, derived from the writer's rather than written twice —
+ * and carrying each key's whole landing, so a key added above is read back from
+ * the right slot without anyone remembering to come here.
+ */
+const SNAPSHOT_KEYS = Object.entries(PATCH_KEYS);
+
+export interface FieldsSurfaceHost {
+  /** The doctype's flat meta `fields`; absent until the meta lands. */
+  fields: () => RawMetaField[] | undefined;
+  /** The draft document conditional expressions resolve against. */
+  doc: () => Record<string, any>;
+  fieldAccess: (fieldname: string) => FieldAccess;
+  /**
+   * The same per-field UI overlay hook the host passes its layout source. `get`
+   * needs it or it would report `component`/`props` the renderer disagrees
+   * with, which is the asymmetry `get` exists to abolish.
+   */
+  decorate?: Decorator;
+}
+
+type Op =
+  | { verb: "hide" | "show"; fieldname: string }
+  | { verb: "update"; fieldname: string; patch: FieldPatch };
+
+export class FieldsSurface implements PageFields {
+  // Reactive so the host's layout re-joins when a replay changes the overlay,
+  // exactly as the four list surfaces re-resolve. *Shallow*: a deep proxy would
+  // reach inside a patch's `props` and hand `v-bind` a Proxy of whatever a
+  // script put there — a nested component, a `Date`, a class instance — which
+  // is the internal-slots hazard `readOnly.ts` documents for its own wrapper.
+  private ops: Op[] = shallowReactive([]);
+  // The replay's ops until it commits, so the host's overlay never carries a
+  // half-applied replay — which is what made a script-hidden field flash into
+  // view for a tick on every save. Non-null only inside a replay; see
+  // `Surface.beginReplay`, which this mirrors.
+  private pending: Op[] | null = null;
+  private replaying = 0;
+
+  constructor(private host: FieldsSurfaceHost) {}
+
+  hide(fieldname: string) {
+    this.record({ verb: "hide", fieldname });
+    this.warnIfAbsent(fieldname, "hide");
+  }
+
+  show(fieldname: string) {
+    this.record({ verb: "show", fieldname });
+    this.warnIfAbsent(fieldname, "show");
+  }
+
+  update(fieldname: string, patch: PageFieldPatch) {
+    // Named before the keys are read, so an author who mistyped the fieldname
+    // hears that first rather than after a list of keys it would never reach.
+    this.warnIfAbsent(fieldname, "update");
+    this.record({ verb: "update", fieldname, patch: translate(fieldname, patch) });
+  }
+
+  has(fieldname: string) {
+    return !!this.raw(fieldname);
+  }
+
+  get(fieldname: string): PageField | null {
+    const raw = this.raw(fieldname);
+    if (!raw) {
+      this.warnIfAbsent(fieldname, "get");
+      return null;
+    }
+    // The same three calls the join makes for one field, in the same order, so
+    // the reader cannot drift from what the renderer decided.
+    const node = mapField(
+      withAccess(raw, (field) => this.host.fieldAccess(field.fieldname)),
+      {},
+      this.host.decorate,
+    );
+    // Over the replay in flight when there is one, the same way `Surface.has`
+    // reads: a source that hides a field and then reads it back inside its own
+    // `refresh` handler is told about its own work, not about last replay's.
+    const patched = applyFieldPatch(node, this.fold(this.pending ?? this.ops)[fieldname]);
+    const resolved = resolveFieldConditionals(patched, this.host.doc());
+    return readOnly(snapshot(resolved), SNAPSHOT_IS_READ_ONLY);
+  }
+
+  // Host side, below: not part of what a script may call.
+
+  /**
+   * Open a replay: ops recorded from here are staged, not applied. The clear is
+   * the replay clear `reset()` used to be — the next commit starts from the
+   * authored layout alone. Counted, so a nested `page.refresh()` re-enters
+   * without publishing a half-built overlay.
+   */
+  beginReplay() {
+    this.pending = [];
+    this.replaying += 1;
+  }
+
+  /** Close a replay: the outermost one publishes the staged ops in one flush. */
+  commitReplay() {
+    if (this.replaying === 0) return;
+    this.replaying -= 1;
+    if (this.replaying > 0) return;
+    const staged = this.pending ?? [];
+    this.pending = null;
+    this.ops.splice(0, this.ops.length, ...staged);
+  }
+
+  /** The applied overlay: committed ops only, never a replay in flight. */
+  resolve(): Record<string, FieldPatch> {
+    return this.fold(this.ops);
+  }
+
+  private record(op: Op) {
+    (this.pending ?? this.ops).push(op);
+  }
+
+  /**
+   * One patch per field, in op order — later verbs win, key by key.
+   *
+   * Folded in a `Map`, not an object literal: a fieldname is a string a script
+   * chooses, and `patches["__proto__"] ??= {}` would leave `into` pointing at
+   * `Object.prototype`, so the next `override.hidden` would be inherited by
+   * every field object in the application for the rest of the session.
+   */
+  private fold(ops: Op[]): Record<string, FieldPatch> {
+    const patches = new Map<string, FieldPatch>();
+    for (const op of ops) {
+      let into = patches.get(op.fieldname);
+      if (!into) patches.set(op.fieldname, (into = {}));
+      if (op.verb === "update") mergeInto(into, op.patch);
+      else (into.override ??= {}).hidden = op.verb === "hide";
+    }
+    return Object.fromEntries(patches);
+  }
+
+  /**
+   * Layout breaks are excluded: `joinLayout` drops them before any patch is
+   * applied, so an override on one could never render, and sections and tabs
+   * have their own surfaces anyway.
+   */
+  private raw(fieldname: string): RawMetaField | undefined {
+    const field = this.host
+      .fields()
+      ?.find((one) => one.fieldname === fieldname);
+    return field && !LAYOUT_BREAKS.has(field.fieldtype) ? field : undefined;
+  }
+
+  /**
+   * The op is recorded either way — a patch keyed by a fieldname the layout
+   * does not carry is simply never applied, and dropping it here would lose it
+   * for good in the window before the meta lands, when "absent" and "not here
+   * yet" are indistinguishable. This only says so when it can tell.
+   */
+  private warnIfAbsent(fieldname: string, verb: string) {
+    const fields = this.host.fields();
+    if (!fields || this.raw(fieldname)) return;
+    warnOnce(`page.fields.${verb}("${fieldname}") — no such field.`);
+  }
+}
+
+/** Translate the script's vocabulary into the pipeline's, dropping the rest. */
+function translate(fieldname: string, patch: PageFieldPatch): FieldPatch {
+  const translated: FieldPatch = {};
+  for (const [key, value] of Object.entries(patch)) {
+    // `hasOwn`, or `toString` and `constructor` would each resolve to a truthy
+    // `Object.prototype` member and slip through the enumeration unwarned.
+    const landing = Object.hasOwn(PATCH_KEYS, key) ? PATCH_KEYS[key] : undefined;
+    if (!landing) {
+      warnOnce(
+        `page.fields.update("${fieldname}", { ${key} }) — not a field property a script may set; dropped.`,
+      );
+      continue;
+    }
+    const slot = (translated[landing.on] ??= {}) as Record<string, any>;
+    slot[landing.as] = landing.coerce ? landing.coerce(value) : value;
+  }
+  return translated;
+}
+
+/** Shallow per half: two patches for one field merge key by key, last wins. */
+function mergeInto(into: FieldPatch, from: FieldPatch) {
+  if (from.meta) into.meta = { ...into.meta, ...from.meta };
+  if (from.override) into.override = { ...into.override, ...from.override };
+  if (from.ui) into.ui = { ...into.ui, ...from.ui };
+}
+
+/**
+ * Read a resolved node back out in the vocabulary `update` writes. Curated the
+ * same way, and for the same reason: the internal node also carries the child
+ * doctype's whole layout, the raw conditional expressions and the permission
+ * bookkeeping, none of which is a field property a script asked about.
+ */
+function snapshot(resolved: Record<string, any>): PageField {
+  const field: PageField = {
+    fieldname: resolved.fieldname,
+    fieldtype: resolved.fieldtype,
+  };
+  for (const [key, { on, as, opaque }] of SNAPSHOT_KEYS) {
+    const value = on === "ui" ? resolved.ui?.[as] : resolved[as];
+    if (value === undefined) continue;
+    // A decorator's component arrives unstamped, unlike one a script passed
+    // through `update` — stamp it here so the wrapper below leaves it alone.
+    (field as Record<string, any>)[key] = opaque ? markRaw(value) : value;
+  }
+  return field;
+}
+
+const warned = new Set<string>();
+
+function warnOnce(message: string) {
+  if (!import.meta.env.DEV || warned.has(message)) return;
+  warned.add(message);
+  console.warn(`[record-page] ${message}`);
+}
+
+/** Test seam: the warn-once memory is module state. */
+export function resetFieldWarnings(): void {
+  warned.clear();
+}

--- a/frontend/src/recordPage/flattenHandlers.ts
+++ b/frontend/src/recordPage/flattenHandlers.ts
@@ -1,0 +1,98 @@
+// A table's handlers nest under its fieldname (ticket 54), and the engine
+// dispatches against one flat keyspace — so the authored shape is flattened
+// here, once, at the choke point every script passes through.
+//
+//   products: { onAdd, onRemove, qty }  →  'products.onAdd', 'products.onRemove',
+//                                          'products.qty'
+//
+// The lifecycle events are spelled `onAdd` / `onRemove` rather than `add` /
+// `remove` because `add` is a legal, unreserved fieldname: `products.add` is the
+// same string as the commit event of a child field called `add`, which is the
+// collision ticket 45 rejected the underscore spelling for and then shipped one
+// level down. `on`-prefixing moves the lifecycle keys out of the fieldname
+// namespace, and the two child fields that could still collide are warned about
+// by name at load (`createRecordPage`) — an announced capability hole rather
+// than a silent misfire.
+import type { AuthoredHandlers, Handler, RecordPageHandlers } from "./types";
+
+/** The lifecycle half of a table's vocabulary, in the one spelling used end to end. */
+export const ROW_EVENTS = { add: "onAdd", remove: "onRemove" } as const;
+
+export function flattenHandlers(
+  authored: AuthoredHandlers,
+  source: string,
+  doctype: string,
+): RecordPageHandlers {
+  // Null-prototype, so `handlers[event]` can only answer with what the author
+  // wrote: a doctype may have a field called `constructor` or `toString`, and
+  // an inherited hit there would dispatch an event to `Object.prototype`.
+  const flat: RecordPageHandlers = Object.create(null);
+  const said = (key: string, message: string) =>
+    warn(`${source}.${key} on ${doctype} ${message}`);
+
+  const put = (key: string, handler: Handler) => {
+    // Both spellings are accepted, so one can quietly land on the other. Last
+    // wins, as it would anywhere else — but not in silence, in a module that
+    // names every other authoring mistake.
+    if (key in flat) said(key, "is written twice — the later one wins");
+    flat[key] = handler;
+  };
+
+  for (const [key, value] of Object.entries(authored)) {
+    if (typeof value === "function") {
+      warnRetiredSpelling(key, said);
+      put(key, value);
+      continue;
+    }
+    if (!isHandlerBlock(value)) {
+      said(key, "is neither a handler nor a block of them — ignored");
+      continue;
+    }
+    const nested = Object.entries(value);
+    // Vacuously a block of functions, and the one authoring mistake this would
+    // otherwise wave through.
+    if (!nested.length) said(key, "is an empty block — it registers nothing");
+    for (const [child, handler] of nested) put(`${key}.${child}`, handler);
+  }
+  return flat;
+}
+
+/**
+ * The spelling this replaced, named at the one moment the engine can say what to
+ * write instead. It is a *legal* key — a child field may genuinely be called
+ * `add`, which is the whole reason the lifecycle names moved — so this is advice
+ * rather than a refusal, and it belongs here rather than in the vocabulary
+ * check, which has no reason to doubt a key it can resolve.
+ *
+ * The underscore spelling is deliberately not named here: `<parent>_add` is an
+ * ordinary parent fieldname, and accusing one would be a warning that lies. The
+ * vocabulary check already names it if it is not a fieldname at all.
+ */
+function warnRetiredSpelling(
+  key: string,
+  said: (key: string, message: string) => void,
+) {
+  const dotted = /^(.+)\.(add|remove)$/.exec(key);
+  if (!dotted) return;
+  const [, table, change] = dotted;
+  said(
+    key,
+    `no longer fires on a row being ${change === "add" ? "added" : "removed"} — write ${table}: { ${ROW_EVENTS[change as "add" | "remove"]}() {} }`,
+  );
+}
+
+/**
+ * A plain object of functions and nothing else. Anything else nested under a
+ * fieldname is a mistake the author wants named rather than a shape to guess
+ * at — and a non-function value would flatten to a key that could never fire.
+ */
+function isHandlerBlock(value: unknown): value is Record<string, Handler> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  if (proto !== Object.prototype && proto !== null) return false;
+  return Object.values(value).every((one) => typeof one === "function");
+}
+
+function warn(message: string) {
+  if (import.meta.env.DEV) console.warn(`[record-page] ${message}`);
+}

--- a/frontend/src/recordPage/formLayoutSource/fieldAccess.ts
+++ b/frontend/src/recordPage/formLayoutSource/fieldAccess.ts
@@ -1,0 +1,30 @@
+import type { RawMetaField } from "@framework/ui/components/FormLayout/types";
+import type { FieldAccess } from "@framework/ui/composables/useDocPermissions";
+
+/**
+ * Bake a permlevel decision into a raw meta field: `read` demotes it to
+ * read-only, `none` hides it. Applied *before* `mapField`, in DocField
+ * vocabulary, so both layout sources hand the same shape forward.
+ *
+ * The denial is expressed as a plain `hidden` / `read_only` flag — which reads
+ * exactly like a meta-hidden or meta-read-only field — so it is also stamped
+ * `perm_denied`. That stamp, not the `permlevel`, is what
+ * `resolveFieldConditionals` treats as a floor an override may not lift: a
+ * reader who *has* the level leaves here untouched, and so must stay
+ * overridable.
+ *
+ * Note this is fail-open while permissions load: `useDocPermissions.fieldAccess`
+ * deliberately answers `"write"` until the roles land (better a field the server
+ * refuses to save than a form that flashes empty), so during that window nothing
+ * is stamped and nothing is floored. It re-joins when they arrive.
+ */
+export function withAccess(
+	field: RawMetaField,
+	fieldAccess?: (field: RawMetaField) => FieldAccess
+): RawMetaField {
+	const access = fieldAccess?.(field);
+	if (!access || access === "write") return field;
+	return access === "read"
+		? { ...field, read_only: 1, perm_denied: 1 }
+		: { ...field, hidden: 1, perm_denied: 1 };
+}

--- a/frontend/src/recordPage/formLayoutSource/fieldPatch.ts
+++ b/frontend/src/recordPage/formLayoutSource/fieldPatch.ts
@@ -1,0 +1,56 @@
+// One field's per-render property override, and the three places it lands.
+//
+// Ticket 48 built the carrier for the three properties the render path
+// *recomputes* (`FieldOverride`). The other properties an app may override are
+// computed once, when `mapField` builds the node, and never touched again — so
+// they are applied there instead, and a single carrier would have hidden that
+// difference behind one flat object that half worked.
+import type {
+	FieldMeta,
+	FieldNode,
+	FieldOverride,
+	FieldUI,
+} from "@framework/ui/components/FormLayout/types";
+
+/**
+ * The build-time half: properties `mapField` sets once and nothing recomputes,
+ * so overriding them is a plain merge onto the built node.
+ *
+ * `options` is the one with a caveat — on a `Table` it names the child doctype,
+ * and the node's `childFields`/`childLayout` were already resolved from the
+ * original. Overriding a `Link`'s target or a `Select`'s choices (what v1's
+ * `options` is for) is unaffected.
+ */
+export type FieldMetaPatch = Pick<
+	FieldMeta,
+	"label" | "options" | "placeholder" | "description" | "precision" | "filters"
+>;
+
+/**
+ * Everything an app may override on one field, split by *when* it applies.
+ * Plain data throughout: `FormLayout` reads the result off the schema and knows
+ * nothing about who wrote it.
+ */
+export interface FieldPatch {
+	/** Merged onto the built node (see `FieldMetaPatch`). */
+	meta?: FieldMetaPatch;
+	/** The three the render path recomputes; applied last, after `depends_on`. */
+	override?: FieldOverride;
+	/** Presentation overlay, merged over whatever `decorate` contributed. */
+	ui?: FieldUI;
+}
+
+/** Apply a patch to a freshly built node, returning a new node. */
+export function applyFieldPatch(
+	node: FieldNode,
+	patch: FieldPatch | undefined
+): FieldNode {
+	if (!patch) return node;
+	const patched: FieldNode = { ...node, ...patch.meta };
+	// Both halves merge rather than replace: nothing upstream writes `override`
+	// today, but a patch that names one key should not silently drop another.
+	if (patch.override)
+		patched.override = { ...node.override, ...patch.override };
+	if (patch.ui) patched.ui = { ...node.ui, ...patch.ui };
+	return patched;
+}

--- a/frontend/src/recordPage/formTabs.ts
+++ b/frontend/src/recordPage/formTabs.ts
@@ -1,0 +1,244 @@
+// The Form Layout tabs surface (wayfinder ticket 73) — the second tab strip,
+// the one inside the record's Details form.
+//
+// Not a `Surface`, and modelled on `FieldsSurface` instead: these tabs are
+// authored elsewhere, in a Form Layout an administrator edits, so a script only
+// overrides their properties. That makes the verbs a strict subset — no `add`,
+// `move` or `order`, since a tab here is a container of *fields* and inventing
+// fields is `page.dialog`'s job — and the key an identity rather than a name.
+//
+// Ops are recorded, not applied: `resolve()` folds them into one override per
+// tab, which the host hands to its layout source as plain data. Nothing is
+// written into the Form Layout row or the doctype meta, and the replay clear is
+// the whole of the undo, so an authored script is a plain `if` with no `else`.
+import { shallowReactive } from "vue";
+import {
+  applyTabOverride,
+  resolveTabConditionals,
+} from "@framework/ui/components/FormLayout/resolveLayout";
+import {
+  identifyTabs,
+  tabStripLabel,
+} from "@framework/ui/components/FormLayout/tabIdentity";
+import type {
+  FormLayoutSchema,
+  Tab,
+  TabOverride,
+} from "@framework/ui/components/FormLayout/types";
+import { readOnly, type ReadOnlyAdvice } from "./readOnly";
+import type { PageFormTab, PageFormTabPatch, PageFormTabs } from "./types";
+
+const SNAPSHOT_IS_READ_ONLY: ReadOnlyAdvice = {
+  path: "page.formTabs.get()",
+  instead:
+    "page.formTabs.hide(identity) / .show(identity) / .update(identity, { label })",
+};
+
+export interface FormTabsSurfaceHost {
+  /**
+   * The record's Details layout, as joined and before this surface's ops — the
+   * whole authored strip, hidden tabs included, so `has()` answers "did the
+   * administrator author this" rather than "is it on screen".
+   */
+  tabs: () => FormLayoutSchema | undefined;
+  /** The draft document conditional expressions resolve against. */
+  doc: () => Record<string, any>;
+}
+
+type Op =
+  | { verb: "hide" | "show"; identity: string }
+  | { verb: "update"; identity: string; patch: TabOverride };
+
+export class FormTabsSurface implements PageFormTabs {
+  // Reactive so the host's layout re-joins when a replay changes the overlay,
+  // shallow for the reason `FieldsSurface` gives.
+  private ops: Op[] = shallowReactive([]);
+  // The replay's ops until it commits, so the host never renders a replay's
+  // middle — which on this surface would tear the strip down and take the
+  // reader's place in it with them (ticket 70).
+  private pending: Op[] | null = null;
+  private replaying = 0;
+
+  /** Installed by `createRecordPage`, which reads it from the host's strip. */
+  declare readonly active: string;
+  /** Installed there too: a miss on one strip wants to name the other, and
+   *  `createRecordPage` is the one place that holds both. */
+  declare activate: (identity: string) => void;
+
+  constructor(private host: FormTabsSurfaceHost) {}
+
+  hide(identity: string) {
+    this.record({ verb: "hide", identity });
+    this.warnIfAbsent(identity, "hide");
+  }
+
+  show(identity: string) {
+    this.record({ verb: "show", identity });
+    this.warnIfAbsent(identity, "show");
+  }
+
+  update(identity: string, patch: PageFormTabPatch) {
+    // Named before the keys are read, so an author who mistyped the identity
+    // hears that first rather than after a list of keys it would never reach.
+    this.warnIfAbsent(identity, "update");
+    this.record({ verb: "update", identity, patch: translate(identity, patch) });
+  }
+
+  has(identity: string) {
+    return !!this.raw(identity);
+  }
+
+  get(identity: string): PageFormTab | null {
+    // Every tab, not just the one asked for: the strip's label fallback depends
+    // on how many tabs are visible beside it, and a `get` that reported a label
+    // the button does not carry is the asymmetry `get` exists to abolish.
+    const strip = this.resolved();
+    const tab = strip.find((one) => one.identity === identity);
+    if (!tab) {
+      this.warnIfAbsent(identity, "get");
+      return null;
+    }
+    const multipleTabs = strip.filter((one) => !one.hidden).length > 1;
+    return readOnly(
+      {
+        name: tab.name,
+        identity,
+        label: tabStripLabel(tab.label, multipleTabs),
+        hidden: tab.hidden,
+      },
+      SNAPSHOT_IS_READ_ONLY,
+    );
+  }
+
+  // Host side, below: not part of what a script may call.
+
+  /**
+   * Whether the tab is on the strip right now — `depends_on` and this surface's
+   * ops both folded in, the replay in flight included. What `activate` asks to
+   * tell a hidden tab from one the administrator never authored.
+   */
+  isVisible(identity: string) {
+    const tab = this.resolved().find((one) => one.identity === identity);
+    return !!tab && !tab.hidden;
+  }
+
+  /** Open a replay: ops recorded from here are staged, not applied. */
+  beginReplay() {
+    this.pending = [];
+    this.replaying += 1;
+  }
+
+  /** Close a replay: the outermost one publishes the staged ops in one flush. */
+  commitReplay() {
+    if (this.replaying === 0) return;
+    this.replaying -= 1;
+    if (this.replaying > 0) return;
+    const staged = this.pending ?? [];
+    this.pending = null;
+    this.ops.splice(0, this.ops.length, ...staged);
+  }
+
+  /** The applied overlay: committed ops only, never a replay in flight. */
+  resolve(): Record<string, TabOverride> {
+    return this.fold(this.ops);
+  }
+
+  private record(op: Op) {
+    (this.pending ?? this.ops).push(op);
+  }
+
+  /**
+   * One override per tab, in op order — later verbs win, key by key. Folded in
+   * a `Map` for the reason `FieldsSurface.fold` gives: an identity is a string
+   * a script chooses, and `"__proto__"` would otherwise be written onto
+   * `Object.prototype`.
+   */
+  private fold(ops: Op[]): Record<string, TabOverride> {
+    const overrides = new Map<string, TabOverride>();
+    for (const op of ops) {
+      let into = overrides.get(op.identity);
+      if (!into) overrides.set(op.identity, (into = {}));
+      if (op.verb === "update") Object.assign(into, op.patch);
+      else into.hidden = op.verb === "hide";
+    }
+    return Object.fromEntries(overrides);
+  }
+
+  private raw(identity: string): (Tab & { identity: string }) | undefined {
+    return this.identified().find((tab) => tab.identity === identity);
+  }
+
+  /**
+   * The strip as it stands: `depends_on` baked against the doc, then the ops
+   * over the replay in flight when there is one — the same way `Surface.has`
+   * reads, so a source that hides a tab and reads it back inside its own
+   * `onRefresh` handler is told about its own work, not about last replay's.
+   */
+  private resolved() {
+    const overrides = this.fold(this.pending ?? this.ops);
+    const doc = this.host.doc();
+    return this.identified().map((tab) => {
+      const conditional = resolveTabConditionals(
+        { ...tab, override: overrides[tab.identity] },
+        doc,
+      );
+      return { ...conditional, ...applyTabOverride(conditional) };
+    });
+  }
+
+  /**
+   * The same identities `FormLayout` resolves: the join leaves every tab's
+   * `name` and authored `label` alone, and this reads the layout the form is
+   * handed, so the two cannot disagree about what a script's address means.
+   */
+  private identified() {
+    return identifyTabs(this.host.tabs() ?? []);
+  }
+
+  /**
+   * The op is recorded either way — an override keyed by a tab the layout does
+   * not carry is simply never applied, and dropping it here would lose it for
+   * good in the window before the layout lands, when "absent" and "not here
+   * yet" are indistinguishable. This only says so when it can tell.
+   */
+  private warnIfAbsent(identity: string, verb: string) {
+    const tabs = this.host.tabs();
+    if (!tabs?.length || this.raw(identity)) return;
+    warnOnce(`page.formTabs.${verb}("${identity}") — no such tab.`);
+  }
+}
+
+/**
+ * `label` and nothing else. `hidden` is `hide`/`show`'s, and `dependsOn` is
+ * deliberately not patchable: rewriting the administrator's expression *string*
+ * is the two-authorities objection in its one genuinely bad form, and a script
+ * wanting conditional visibility already has a real `if` in `onRefresh`.
+ */
+function translate(identity: string, patch: PageFormTabPatch): TabOverride {
+  const translated: TabOverride = {};
+  for (const [key, value] of Object.entries(patch)) {
+    if (key === "label") {
+      translated.label = value as string;
+      continue;
+    }
+    warnOnce(
+      key === "hidden"
+        ? `page.formTabs.update("${identity}", { hidden }) — use hide()/show(); dropped.`
+        : `page.formTabs.update("${identity}", { ${key} }) — not a tab property a script may set; dropped.`,
+    );
+  }
+  return translated;
+}
+
+const warned = new Set<string>();
+
+function warnOnce(message: string) {
+  if (!import.meta.env.DEV || warned.has(message)) return;
+  warned.add(message);
+  console.warn(`[record-page] ${message}`);
+}
+
+/** Test seam: the warn-once memory is module state. */
+export function resetFormTabWarnings(): void {
+  warned.clear();
+}

--- a/frontend/src/recordPage/headerRenderings.ts
+++ b/frontend/src/recordPage/headerRenderings.ts
@@ -1,0 +1,466 @@
+// How the header's one flat list becomes its renderings (tickets 65 and 77),
+// and what happens when it asks for more top-level controls than fit (66).
+import { Surface, type ResolvedItem } from "./surface";
+import type { HeaderAction, Position } from "./types";
+
+/** The displays that hold other items, as against `button` and the default. */
+export type ContainerDisplay = "dropdown" | "section";
+
+/**
+ * How many containers may be stacked (ticket 76 §3). Ours to choose, but half
+ * of it is forced: `MenuGroupOption.options` is `MenuOption[]` and `MenuOption`
+ * excludes `MenuGroupOption`, so a section inside a band cannot keep its title
+ * at any depth. A *submenu* could nest further — `MenuSubmenuOption.submenu` is
+ * `MenuOptions`, which does admit groups — and is capped anyway, so `order` and
+ * the overflow projection stay unambiguous.
+ */
+export const MAX_CONTAINER_DEPTH = 2;
+
+/**
+ * One row of a rendered list: an action, or a container holding more rows.
+ *
+ * The *authored* vocabulary stays flat — every item is still addressable by its
+ * one name — and the nesting appears only here, where the rendering is decided
+ * (ticket 77 §3).
+ */
+export interface HeaderNode {
+  item: HeaderAction;
+  /** Set when this row holds others; absent on a plain action row. */
+  container?: ContainerDisplay;
+  /**
+   * Set when this container could not render where it was declared. It is then
+   * a band of the `⋯` menu and never a top-level control, so a `group` cycle
+   * cannot win a slot in the header row (ticket 77 §3).
+   */
+  clamped?: boolean;
+  members: HeaderNode[];
+}
+
+/** A control the host draws in the header itself, left of `⋯ │ Save`. */
+export type HeaderControl =
+  | { kind: "button"; item: HeaderAction }
+  | { kind: "dropdown"; item: HeaderAction; members: HeaderNode[] };
+
+/**
+ * One band of the `⋯` menu. A band shows a heading iff its container was
+ * declared — a `section` the author wrote, or a dropdown that did not fit and
+ * collapsed whole (ticket 77 §7, restating 66 §4).
+ */
+export interface HeaderBand {
+  group: string;
+  label?: string;
+  items: HeaderNode[];
+}
+
+export interface HeaderProjection {
+  controls: HeaderControl[];
+  bands: HeaderBand[];
+}
+
+/**
+ * Project the resolved items into the header's controls and the `⋯` menu's
+ * bands, given how many top-level controls the host has room for.
+ *
+ * Takes the resolved list rather than the visible one because a **hidden
+ * container takes its members with it**, however deep: it is a floor above them,
+ * as a hidden `panelSection` is above its fields, and `hide('telephony')` is how
+ * a script removes the whole control (tickets 66 §5 and 77).
+ *
+ * Overflow is host-side and unobservable: a script cannot read back that its
+ * button was demoted, so nothing here writes to the surface.
+ */
+export function projectHeaderActions(
+  resolved: ResolvedItem<HeaderAction>[],
+  budget: number
+): HeaderProjection {
+  if (import.meta.env.DEV) for (const entry of resolved) warnItem(entry.item);
+  const items = surviving(resolved);
+  const containers = containersOf(items);
+  const tree = prune(build(items, containers));
+  // An empty dropdown is a button that opens nothing, so it is dropped before
+  // the budget applies and its slot passes to the next control in order.
+  const controls = tree
+    .filter(isControl)
+    .map(asControl)
+    .filter((control) => control.kind === "button" || control.members.length);
+  const kept = Math.max(budget, 0);
+  return {
+    controls: controls.slice(0, kept),
+    bands: [...demotedBands(controls.slice(kept)), ...menuBands(tree)],
+  };
+}
+
+function containerDisplay(item: HeaderAction): ContainerDisplay | undefined {
+  if (item.display === "dropdown" || item.display === "section")
+    return item.display;
+  return undefined;
+}
+
+function containersOf(items: HeaderAction[]) {
+  const containers = new Map<string, HeaderAction>();
+  for (const item of items)
+    if (containerDisplay(item)) containers.set(item.name, item);
+  return containers;
+}
+
+/**
+ * The items a hidden container has not taken with it.
+ *
+ * Only a *container* is a floor: a `group` naming a plain item names no
+ * container at all, which is the undeclared branch, so that item's own
+ * visibility says nothing about the band.
+ */
+function surviving(resolved: ResolvedItem<HeaderAction>[]): HeaderAction[] {
+  const containers = containersOf(resolved.map((entry) => entry.item));
+  const hidden = new Set(
+    resolved.filter((entry) => entry.hidden).map((entry) => entry.item.name)
+  );
+  const buried = (item: HeaderAction) => {
+    const seen = new Set<string>();
+    let group = item.group;
+    while (group && containers.has(group) && !seen.has(group)) {
+      if (hidden.has(group)) return true;
+      seen.add(group);
+      group = containers.get(group)!.group;
+    }
+    return false;
+  };
+  return resolved
+    .filter((entry) => !hidden.has(entry.item.name) && !buried(entry.item))
+    .map((entry) => entry.item);
+}
+
+/**
+ * How many containers deep a container sits, counting itself. `Infinity` when
+ * its `group` chain cycles, which has no depth at all.
+ */
+function depthOf(name: string, containers: Map<string, HeaderAction>): number {
+  const seen = new Set<string>([name]);
+  let depth = 1;
+  let group = containers.get(name)!.group;
+  while (group && containers.has(group)) {
+    if (seen.has(group)) return Infinity;
+    seen.add(group);
+    depth += 1;
+    group = containers.get(group)!.group;
+  }
+  return depth;
+}
+
+/**
+ * Where a container actually renders. One that nests too deep is **clamped to
+ * the deepest level it can reach, never ignored**: ignoring its `group` would
+ * promote it to a top-level control, where it would eat a budget slot and
+ * compete with the record's title (ticket 77 §3). A cycle reaches no level at
+ * all, so it lands in `⋯` as a band of its own — reachable, titled, and costing
+ * nothing.
+ */
+function placeContainer(
+  item: HeaderAction,
+  containers: Map<string, HeaderAction>
+) {
+  const depth = depthOf(item.name, containers);
+  if (depth <= MAX_CONTAINER_DEPTH) {
+    const group = declaredGroup(item, containers);
+    // Legal depth, but a band cannot hold a band, so this one renders with its
+    // title dropped. Said out loud because it is the author's own declaration
+    // losing, not the viewport taking it (which is demotion, and silent).
+    if (group && containerDisplay(item) === "section")
+      if (containers.get(group)!.display === "section")
+        warnOnce(
+          `headerActions: the section '${item.name}' is inside the section ` +
+            `'${group}', which cannot hold a titled band — its members render ` +
+            `under '${group}' and its own title is dropped.`
+        );
+    return { group, clamped: false };
+  }
+  warnClamp(item, depth);
+  if (depth === Infinity) return { group: undefined, clamped: true };
+  let group = declaredGroup(item, containers);
+  while (group && depthOf(group, containers) > 1)
+    group = declaredGroup(containers.get(group)!, containers);
+  return { group, clamped: true };
+}
+
+/** The container an item's `group` names, if one was declared. */
+function declaredGroup(
+  item: HeaderAction,
+  containers: Map<string, HeaderAction>
+) {
+  return item.group && containers.has(item.group) ? item.group : undefined;
+}
+
+/**
+ * The one rule, with its default: `group: 'x'` puts an item inside the item
+ * named `x`; an undeclared `x` synthesises an anonymous, untitled container,
+ * which is the adjacency band a script has always got (ticket 77 §2).
+ */
+function build(items: HeaderAction[], containers: Map<string, HeaderAction>) {
+  const nodes = new Map<string, HeaderNode>();
+  const top: HeaderNode[] = [];
+  const parents: (string | undefined)[] = [];
+  for (const item of items) {
+    const node: HeaderNode = {
+      item,
+      container: containerDisplay(item),
+      members: [],
+    };
+    nodes.set(item.name, node);
+    if (!node.container) {
+      parents.push(declaredGroup(item, containers));
+      continue;
+    }
+    const placed = placeContainer(item, containers);
+    if (placed.clamped) node.clamped = true;
+    parents.push(placed.group);
+  }
+  // A member joins its container wherever the container sits: a container is
+  // placed by its own item, never by its first member (ticket 65).
+  items.forEach((item, index) => {
+    const node = nodes.get(item.name)!;
+    const parent = parents[index];
+    if (parent) nodes.get(parent)!.members.push(node);
+    else top.push(node);
+  });
+  return top;
+}
+
+/**
+ * Drop every dropdown left with nothing in it, at any depth: it is a trigger
+ * that opens nothing, which is 66 §5's rule about a top-level control applied
+ * where clamping actually produces the case — a container whose only member was
+ * lifted out from under it. A *section* needs no such rule; an empty group is
+ * dropped by frappe-ui's own normalization.
+ */
+function prune(nodes: HeaderNode[]): HeaderNode[] {
+  return nodes.flatMap((node) => {
+    if (!node.container) return [node];
+    node.members = prune(node.members);
+    if (node.container === "dropdown" && !node.members.length) return [];
+    return [node];
+  });
+}
+
+/** A top-level control: a bare button, or a dropdown that renders as one. */
+function isControl(node: HeaderNode) {
+  if (node.clamped) return false;
+  return node.item.display === "button" || node.container === "dropdown";
+}
+
+function asControl(node: HeaderNode): HeaderControl {
+  return node.container === "dropdown"
+    ? { kind: "dropdown", item: node.item, members: node.members }
+    : { kind: "button", item: node.item };
+}
+
+// A demoted control keeps a band of its own, ahead of the built-ins and in
+// top-level order, with no signal that it wanted to be a button (ticket 66 §4).
+// Banding by its own name, not by its `group`, is what keeps a demoted button
+// from reading as a member of a dropdown that was demoted beside it.
+function demotedBands(controls: HeaderControl[]): HeaderBand[] {
+  return controls.map((control) =>
+    control.kind === "button"
+      ? { group: control.item.name, items: [row(control.item)] }
+      : {
+          group: control.item.name,
+          label: control.item.label,
+          items: bandRows(control.members),
+        }
+  );
+}
+
+function row(item: HeaderAction): HeaderNode {
+  return { item, members: [] };
+}
+
+/**
+ * A band's rows. A submenu survives here — `MenuSubmenuOption` is a legal
+ * `MenuOption` — but a section cannot keep its title inside a band, so it
+ * flattens and its members are spliced in where it sat (ticket 77 §4). That is
+ * demotion being lossy, silent and unobservable, as 66 already had it.
+ */
+function bandRows(nodes: HeaderNode[]): HeaderNode[] {
+  return nodes.flatMap((node) =>
+    node.container === "section" ? bandRows(node.members) : [node]
+  );
+}
+
+// Bands are derived from the one flat list by adjacency, except where an author
+// declared a container: a top-level `section` titles a band and consumes no
+// budget slot, since it is not a control (ticket 77 §2).
+function menuBands(top: HeaderNode[]): HeaderBand[] {
+  const bands: HeaderBand[] = [];
+  for (const node of top) {
+    if (isControl(node)) continue;
+    if (node.container) {
+      if (node.members.length)
+        bands.push({
+          group: node.item.name,
+          label: node.item.label,
+          items: bandRows(node.members),
+        });
+      continue;
+    }
+    const group = node.item.group ?? "actions";
+    const last = bands[bands.length - 1];
+    if (last?.group === group && last.label === undefined)
+      last.items.push(node);
+    else bands.push({ group, items: [node] });
+  }
+  return bands;
+}
+
+/**
+ * Which list an item is ordered within, as a comparable key. Read off the
+ * **declared** `display` and never off the effective one, so nothing computed
+ * from it can become width-dependent (ticket 66 §5): a demoted control is still
+ * `row` here, because demotion is the host's answer to a width, not the
+ * author's to a question.
+ */
+export function renderingOf(item: HeaderAction, items: HeaderAction[]): string {
+  const containers = containersOf(items);
+  const group = declaredGroup(item, containers);
+  if (group) return `container:${group}`;
+  if (item.display === "button" || item.display === "dropdown") return "row";
+  return "menu";
+}
+
+type AnchorClaim = { verb: string; name: string; anchor: string };
+
+/**
+ * The header's surface, which is an ordinary `Surface` plus one warning: an
+ * anchor naming an item in a different rendering still splices where it always
+ * did, and says so (ticket 65).
+ *
+ * The check runs over the *resolved* list rather than at call time, because a
+ * member can be added before the container that decides its rendering.
+ */
+export class HeaderActionsSurface extends Surface<HeaderAction> {
+  private claims: AnchorClaim[] = [];
+  private said = new Set<string>();
+
+  // One claim per **block**, not per item: a block splices as a unit, so only
+  // its head is anchored where the caller asked. Claiming the rest would
+  // report an anchor they were never given.
+  add(item: HeaderAction | HeaderAction[], position?: Position) {
+    const block = Array.isArray(item) ? item : [item];
+    if (block.length) this.claim("add", block[0].name, position);
+    super.add(item, position);
+  }
+
+  move(name: string, position: Position) {
+    this.claim("move", name, position);
+    super.move(name, position);
+  }
+
+  // Claims are staged with the ops they belong to: a replay rebuilds the list
+  // from built-ins, so the claims that produced the old one go with it.
+  beginReplay() {
+    this.claims = [];
+    super.beginReplay();
+  }
+
+  resolve() {
+    const resolved = super.resolve();
+    if (import.meta.env.DEV)
+      this.warnCrossRendering(resolved.map((e) => e.item));
+    return resolved;
+  }
+
+  private claim(verb: string, name: string, position?: Position) {
+    const anchor = position?.before ?? position?.after;
+    if (anchor) this.claims.push({ verb, name, anchor });
+  }
+
+  private warnCrossRendering(items: HeaderAction[]) {
+    for (const claim of this.claims) {
+      const item = items.find((one) => one.name === claim.name);
+      const anchor = items.find((one) => one.name === claim.anchor);
+      if (!item || !anchor) continue;
+      if (renderingOf(item, items) === renderingOf(anchor, items)) continue;
+      // Anchoring a member at its own container is how an author says "first
+      // in this dropdown", and it does exactly that. The two sit in different
+      // lists, but one of them *is* the other's list.
+      if (renderingOf(item, items) === `container:${claim.anchor}`) continue;
+      if (renderingOf(anchor, items) === `container:${claim.name}`) continue;
+      const message =
+        `[record-page] headerActions.${claim.verb}('${claim.name}'): anchor ` +
+        `'${claim.anchor}' renders as ${describe(anchor, items)}, but ` +
+        `'${claim.name}' renders as ${describe(
+          item,
+          items
+        )} — position orders ` +
+        `items only within one rendering.`;
+      if (this.said.has(message)) continue;
+      this.said.add(message);
+      console.warn(message);
+    }
+  }
+}
+
+function describe(item: HeaderAction, items: HeaderAction[]) {
+  const containers = containersOf(items);
+  const group = declaredGroup(item, containers);
+  if (group) {
+    const container = containers.get(group)!;
+    const kind = container.display === "section" ? "section" : "dropdown";
+    return `an entry in the “${container.label}” ${kind}`;
+  }
+  if (item.display === "button") return "a top-level button";
+  if (item.display === "dropdown") return `the “${item.label}” dropdown button`;
+  return "an entry in the ⋯ menu";
+}
+
+// Said once per message, for the same reason the anchor warning is: a
+// projection runs on every render, and a warning that repeats with the frame
+// rate is a warning nobody reads.
+const warned = new Set<string>();
+
+function warnOnce(message: string) {
+  if (!import.meta.env.DEV || warned.has(message)) return;
+  warned.add(message);
+  console.warn(`[record-page] ${message}`);
+}
+
+/** Test seam: the warn-once memory is module state. */
+export function resetHeaderWarnings(): void {
+  warned.clear();
+}
+
+function warnClamp(item: HeaderAction, depth: number) {
+  const where =
+    depth === Infinity
+      ? "sits in a `group` cycle, which reaches no level at all"
+      : `nests ${depth} containers deep, and only ${MAX_CONTAINER_DEPTH} render`;
+  warnOnce(
+    `headerActions: '${item.name}' ${where} — ` +
+      `rendered at the deepest level it can reach.`
+  );
+}
+
+// What an item declared about itself, checked before anything is placed —
+// including for a hidden item, since these are complaints about the
+// declaration and not about the rendering. `display` type-checks whatever it is
+// given (`SurfaceItem` carries an index signature), so an unknown value is
+// silently the default: 65's trap a second time, and worth a word.
+function warnItem(item: HeaderAction) {
+  const display = item.display;
+  if (display && !containerDisplay(item) && display !== "button")
+    warnOnce(
+      `headerActions: '${item.name}' has display: '${display}' — expected ` +
+        `'button', 'dropdown' or 'section'; rendered as an entry in the ⋯ menu.`
+    );
+  if (item.run && containerDisplay(item))
+    warnOnce(
+      `headerActions: '${item.name}' is a ${display}, a container, so its ` +
+        `\`run\` never fires; the items inside it run.`
+    );
+  // `group` decides *where* an item goes and `display` only decides what it
+  // looks like once it is there, so a button inside a container is an ordinary
+  // row. Two declarations that disagree should not be settled in silence.
+  if (display === "button" && item.group)
+    warnOnce(
+      `headerActions: '${item.name}' is a button inside '${item.group}', and a ` +
+        `container holds rows, not buttons — if it should stand on its own, drop its \`group\`.`
+    );
+}

--- a/frontend/src/recordPage/iconClasses.ts
+++ b/frontend/src/recordPage/iconClasses.ts
@@ -1,0 +1,80 @@
+// Script-named icons, bridged to CSS classes at runtime.
+//
+// The host renders an item's `icon` as a `lucide-*` class, and those classes are
+// generated at build time by frappe-ui's `iconPackPlugin` — so only the icons the
+// host bundle already mentions exist. A third-party app can ship CSS for the rest,
+// but a Page Script is a string in a table and can never ship a file: unbridged,
+// `icon: 'lucide-flag'` renders a silent blank box. So we generate the missing rule
+// from the lucide sprite frappe-ui's `spritePlugin` already put in the DOM, in
+// exactly the shape `iconPackPlugin` emits.
+import type { SurfaceItem } from "./types";
+
+const PREFIX = "lucide-";
+const SPRITE_ID = "lucide-sprite";
+const STYLE_ID = "record-page-icon-classes";
+/** `lucideIconsPlugin`'s normalization; lucide itself ships 2. */
+const STROKE_WIDTH = 1.5;
+
+const bridged = new Set<string>();
+let warnedMissingSprite = false;
+
+/** Every icon an item can name: its own, plus a tab's create-action icon. */
+export function ensureIcons(item: Partial<SurfaceItem>) {
+	ensureIconClass(item.icon);
+	ensureIconClass(item.create?.icon);
+}
+
+/** Guarantees the class `icon` names exists. Idempotent, and safe to over-call. */
+export function ensureIconClass(icon?: string) {
+	// No document in the engine's node tests; built-in icons are in the bundle already.
+	if (typeof document === "undefined") return;
+	if (!icon?.startsWith(PREFIX) || bridged.has(icon)) return;
+	bridged.add(icon);
+	const geometry = symbolGeometry(icon.slice(PREFIX.length));
+	if (geometry) addRule(icon, dataUri(geometry));
+}
+
+function symbolGeometry(name: string) {
+	const sprite = document.getElementById(SPRITE_ID);
+	if (!sprite) {
+		// Once per session, not once per icon: absent sprite means every icon is absent.
+		if (!warnedMissingSprite)
+			console.warn("[record-page] lucide sprite missing; script-named icons will not render");
+		warnedMissingSprite = true;
+		return null;
+	}
+	// Scoped to the sprite: symbol ids are bare words like 'flag' that collide readily.
+	const symbol = sprite.querySelector(`#${CSS.escape(name)}`);
+	if (!symbol) console.warn(`[record-page] unknown lucide icon '${PREFIX}${name}'`);
+	return symbol?.innerHTML ?? null;
+}
+
+// The sprite's symbols carry geometry only, so rebuild the wrapper Icon.vue draws.
+function dataUri(geometry: string) {
+	const svg =
+		`<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" ` +
+		`fill="none" stroke="currentColor" stroke-width="${STROKE_WIDTH}" ` +
+		`stroke-linecap="round" stroke-linejoin="round">${geometry}</svg>`;
+	return `data:image/svg+xml;utf8,${encodeURIComponent(svg.replace(/\s+/g, " "))}`;
+}
+
+function addRule(className: string, uri: string) {
+	styleElement().textContent +=
+		`.${className}{display:block;width:1em;height:1em;background-color:currentColor;` +
+		`-webkit-mask-image:url("${uri}");mask-image:url("${uri}");` +
+		`-webkit-mask-repeat:no-repeat;mask-repeat:no-repeat;` +
+		`-webkit-mask-position:center;mask-position:center;` +
+		`-webkit-mask-size:contain;mask-size:contain;flex-shrink:0}`;
+}
+
+function styleElement() {
+	const existing = document.getElementById(STYLE_ID);
+	if (existing) return existing;
+	const style = document.createElement("style");
+	style.id = STYLE_ID;
+	// Prepended so utilities loaded later — `size-4` at the call site — still beat the
+	// `width: 1em` here, the same way Tailwind's utilities layer beats its components
+	// layer for the build-time classes this mirrors.
+	document.head.prepend(style);
+	return style;
+}

--- a/frontend/src/recordPage/index.ts
+++ b/frontend/src/recordPage/index.ts
@@ -1,0 +1,32 @@
+// The record-page engine's one entry, so a call site imports from `@/recordPage` and
+// nothing deeper.
+//
+// The engine lives in the shell rather than in `@framework/ui` because it is desk
+// layer, not generic layer: `@framework/ui` holds self-contained components an app may
+// use however it likes, while this is one opinionated record-page runtime that speaks
+// doctype, `page.save()` and Page Script. It CONSUMES the generic layer -- FormLayout,
+// Fields, useDocPermissions -- which is what places it on this side of the boundary.
+//
+// A contributed `record.js` imports nothing at all: its default export IS the
+// registration, and the shell's contribution registry is what reaches this file.
+export {
+  ALL_DOCTYPES,
+  registerRecordPage,
+  registrationsFor,
+  resetRegistry,
+  unregisterSource,
+} from "./registry";
+export type { Registration } from "./registry";
+
+export {
+  HOST_SOURCE,
+  registeringSource,
+  runningSource,
+  withRegisteringSource,
+  withRunningSource,
+} from "./context";
+
+export { createRecordPage } from "./createRecordPage";
+export type { RecordPageController } from "./createRecordPage";
+
+export type { AuthoredHandlers, Handler, RecordPageHandlers } from "./types";

--- a/frontend/src/recordPage/pageCompatibility.ts
+++ b/frontend/src/recordPage/pageCompatibility.ts
@@ -1,0 +1,127 @@
+// What happens to a script that reaches for a name we removed (wayfinder ticket
+// 20 §4, §5). Two nets over one list: a removal still inside its tombstone major
+// stays on `page` as a function that throws, naming the removal and what replaced
+// it; a removal past that is gone, and reading the name is all there is left to
+// catch.
+//
+// The list is empty — nothing has been removed yet — and an empty list installs no
+// Proxy at all, so the mechanism costs the replay nothing until it has something
+// to say. That is also why the warning is narrowed to this list rather than firing
+// on any unknown key: `if (page.dialog.prompt)` is the feature detection
+// COMPATIBILITY.md tells authors to write, and it must stay silent.
+import { runningSource } from "./context";
+import { toastScriptError } from "./pageScripts";
+import { reportCustomizationError } from "./reportError";
+
+export interface Removal {
+  /** Dotted path from `page`: `"reload"`, `"dialog.prompt"`. */
+  path: string;
+  /** The release it went in — half of every message this produces. */
+  removedIn: string;
+  /** What to write instead — the other half. */
+  instead: string;
+  /**
+   * `tombstone` while the name is still there as a thrower (one major), `gone`
+   * once it has been deleted and only the read can be seen.
+   */
+  stage: "tombstone" | "gone";
+}
+
+/** Every `page` member ever removed. Empty, and adding to it is the whole ritual. */
+export const REMOVALS: Removal[] = [];
+
+const throwers = new Map<Removal, () => never>();
+const warned = new Set<string>();
+
+/**
+ * Wraps `page` so the removals list is answered rather than read past. Returns
+ * the object itself when there is nothing to answer.
+ */
+export function withRemovals<Page extends object>(
+  page: Page,
+  removals: Removal[] = REMOVALS,
+): Page {
+  return removals.length ? (guard(page, "", removals) as Page) : page;
+}
+
+/** Test seam: the notices are once-per-session, and a session ends between tests. */
+export function resetRemovalNotices() {
+  warned.clear();
+  throwers.clear();
+}
+
+// One Proxy per object that owns a removed name, built from the top down: the
+// nested ones are installed on the way in, so `page.dialog` is a guarded object
+// before anything reads a member off it.
+function guard(target: any, prefix: string, removals: Removal[]): any {
+  const here = new Map<string, Removal>();
+  const below = new Map<string, Removal[]>();
+  for (const removal of removals) {
+    const [key, ...rest] = removal.path.slice(prefix.length).split(".");
+    if (rest.length) below.set(key, [...(below.get(key) ?? []), removal]);
+    else here.set(key, removal);
+  }
+
+  for (const [key, deeper] of below) {
+    const child = target[key];
+    if (child && typeof child === "object")
+      target[key] = guard(child, `${prefix}${key}.`, deeper);
+  }
+
+  if (!here.size) return target;
+  return new Proxy(target, {
+    get(owner, key, receiver) {
+      const removal = typeof key === "string" ? here.get(key) : undefined;
+      if (!removal) return Reflect.get(owner, key, receiver);
+      if (removal.stage === "gone") {
+        warnRemoved(removal);
+        return undefined;
+      }
+      return tombstone(removal);
+    },
+  });
+}
+
+// Memoized so a tombstone is the same function every read: a script that stashes
+// `const open = page.dialog.prompt` must not get a different one each replay.
+function tombstone(removal: Removal) {
+  const existing = throwers.get(removal);
+  if (existing) return existing;
+  const thrower = () => reportAndThrow(removal);
+  throwers.set(removal, thrower);
+  return thrower;
+}
+
+// Not dev-gated, deliberately (20 §5): a removal firing is an upgrade breaking a
+// customer's customization on a site no developer is watching, and no production
+// site runs a dev build.
+function reportAndThrow(removal: Removal): never {
+  const source = runningSource();
+  const error = new Error(`page.${removal.path} was ${detail(removal)}`);
+  console.error(
+    `[record-page] ${source} called page.${removal.path}, ${detail(removal)}`,
+  );
+  reportCustomizationError(error, {
+    source,
+    event: `removed:${removal.path}`,
+  });
+  toastScriptError(
+    `removed:${source}:${removal.path}`,
+    `${source} uses page.${removal.path}, ${detail(removal)}`,
+  );
+  throw error;
+}
+
+// Console only, always on: probing is legitimate, so this has to be cheap enough
+// to be wrong about — an Error Log row per probe is not.
+function warnRemoved(removal: Removal) {
+  const source = runningSource();
+  const message = `[record-page] ${source} read page.${removal.path}, ${detail(removal)}`;
+  if (warned.has(message)) return;
+  warned.add(message);
+  console.warn(message);
+}
+
+function detail(removal: Removal) {
+  return `removed in ${removal.removedIn} — use ${removal.instead}`;
+}

--- a/frontend/src/recordPage/pagePermissions.ts
+++ b/frontend/src/recordPage/pagePermissions.ts
@@ -1,0 +1,103 @@
+// What a script may ask about permissions (wayfinder ticket 18): the rights
+// dict, the session's roles, and a field's access — one vocabulary with the
+// host, since both sides come from `useDocPermissions`.
+import { watch, type ComputedRef, type Ref } from "vue";
+import {
+  useDocPermissions,
+  type FieldAccess,
+} from "@framework/ui/composables/useDocPermissions";
+import { useUserRoles } from "@framework/ui/composables/useUserRoles";
+
+/** Enforcement bookkeeping `getdoc` ships beside the rights. Closed list: the
+ *  right set is open-ended (custom `Permission Type` rows), so never allowlist. */
+const NON_RIGHTS = ["if_owner", "has_if_owner_enabled"];
+
+export interface PagePermissionsHost {
+  doctype: string;
+  meta: Ref<any>;
+  perms: () => Record<string, any>;
+}
+
+export interface PagePermissions {
+  /** Every right frappe would check for this doctype, values `0` or `1`. */
+  perms: () => Record<string, any>;
+  roles: () => string[];
+  fieldAccess: (fieldname: string) => FieldAccess;
+  /** Resolves once roles and meta are in, so `page.roles` is never seen empty. */
+  ready: () => Promise<void>;
+}
+
+export function createPagePermissions(
+  host: PagePermissionsHost,
+): PagePermissions {
+  const { fieldAccess, loading } = useDocPermissions(() => host.doctype);
+  const { roles } = useUserRoles();
+  const warned = new Set<string>();
+  let rights: { from: Record<string, any>; view: Record<string, any> } | null =
+    null;
+  // One promise for every replay: `refresh` runs on each paint and each save.
+  let loaded: Promise<void> | null = null;
+
+  return {
+    perms: () => {
+      const from = host.perms();
+      if (rights?.from !== from) rights = { from, view: rightsView(from) };
+      return rights.view;
+    },
+    roles: () => roles.value ?? [],
+    fieldAccess: (fieldname) => accessTo(fieldname),
+    ready: () => (loaded ??= whenLoaded(loading)),
+  };
+
+  function rightsView(from: Record<string, any>) {
+    const view: Record<string, any> = {};
+    for (const [right, value] of Object.entries(from))
+      if (!NON_RIGHTS.includes(right)) view[right] = value;
+    return import.meta.env.DEV ? warnOnUnknownRight(view) : view;
+  }
+
+  // `get_rights` emits every right as a key, so a key that is absent from a
+  // populated dict is a typo, not a right the user lacks.
+  function warnOnUnknownRight(view: Record<string, any>) {
+    return new Proxy(view, {
+      get(target, key, receiver) {
+        if (typeof key === "string" && !(key in target) && hasRights(target))
+          warn(`page.perms.${key} is not a right on ${host.doctype}.`);
+        return Reflect.get(target, key, receiver);
+      },
+    });
+  }
+
+  function hasRights(view: Record<string, any>) {
+    return Object.keys(view).length > 0;
+  }
+
+  function accessTo(fieldname: string): FieldAccess {
+    const fields = host.meta.value?.fields;
+    if (!fields) return "write";
+    const field = fields.find((one: any) => one.fieldname === fieldname);
+    if (field) return fieldAccess(field);
+    warn(
+      `page.fieldAccess("${fieldname}") — no such field on ${host.doctype}.`,
+    );
+    return "none";
+  }
+
+  function warn(message: string) {
+    if (!import.meta.env.DEV || warned.has(message)) return;
+    warned.add(message);
+    console.warn(`[record-page] ${message}`);
+  }
+}
+
+/** Resolves the first time `loading` is false, then disposes its watcher. */
+export function whenLoaded(loading: ComputedRef<boolean>): Promise<void> {
+  if (!loading.value) return Promise.resolve();
+  return new Promise((resolve) => {
+    const stop = watch(loading, (still) => {
+      if (still) return;
+      stop();
+      resolve();
+    });
+  });
+}

--- a/frontend/src/recordPage/pageScriptTypes.ts
+++ b/frontend/src/recordPage/pageScriptTypes.ts
@@ -1,0 +1,15 @@
+/** One Page Script row as `get_page_scripts` returns it. */
+export interface PageScriptRow {
+  name: string;
+  script: string;
+}
+
+export interface PageScriptsResponse {
+  scripts: PageScriptRow[];
+  /** Whether this user may write Page Scripts — the gate on failure toasts. */
+  can_write: boolean;
+}
+
+export const PAGE_SCRIPT_CHANGED = "page_script_changed";
+export const GET_PAGE_SCRIPTS =
+  "frappe.desk.doctype.page_script.page_script.get_page_scripts";

--- a/frontend/src/recordPage/pageScripts.ts
+++ b/frontend/src/recordPage/pageScripts.ts
@@ -1,0 +1,145 @@
+// The Page Script tier: the doctype's stored scripts, fetched once per doctype,
+// evaluated as modules and registered as sources in creation order — after the
+// host's file scripts and app extensions, because this runs at page mount.
+import { readonly, ref } from "vue";
+import { call, toast } from "frappe-ui";
+import { withRegisteringSource } from "./context";
+import { evaluatePageScript } from "./evaluatePageScript";
+import { GET_PAGE_SCRIPTS } from "./pageScriptTypes";
+import type { PageScriptRow, PageScriptsResponse } from "./pageScriptTypes";
+import { registerRecordPage, unregisterSource } from "./registry";
+import {
+  reportCustomizationError,
+  resetCustomizationErrorReports,
+} from "./reportError";
+
+// The tier's own fetch has no script to blame, so it reports under its own name.
+const TIER_SOURCE = "page-scripts";
+
+const tiers = new Map<string, Promise<void>>();
+const sources = new Map<string, string[]>();
+const toasted = new Set<string>();
+// 08 §6's toast as a shared channel: the compatibility layer reports a
+// removal hit through it, keyed by source and removed name.
+const notified = new Set<string>();
+// Two saves in quick succession overlap: the later build must win, and the
+// earlier one must not register its now-stale scripts behind it.
+const builds = new Map<string, number>();
+// Whether this session may write Page Scripts — the permission is on the
+// doctype, so it is one answer for every doctype, and the tier's fetch already
+// carries it. Gates the failure toast below and the editor's entry affordance.
+const writable = ref(false);
+
+export const canWritePageScripts = readonly(writable);
+
+/**
+ * Tells a script author, and only a script author, about a customization failure
+ * — once per key per page session. A reader who cannot edit Page Scripts is being
+ * told about somebody else's bug, so they are not told at all.
+ */
+export function toastScriptError(key: string, message: string) {
+  if (!writable.value || notified.has(key)) return;
+  notified.add(key);
+  toast.error(message);
+}
+
+/** Resolves when the doctype's tier has registered; one fetch per doctype. */
+export function loadPageScripts(doctype: string): Promise<void> {
+  const loading = tiers.get(doctype) ?? buildTier(doctype);
+  tiers.set(doctype, loading);
+  return loading;
+}
+
+/** Drops the cached tier and builds it again — a saved or deleted script. */
+export function reloadPageScripts(doctype: string): Promise<void> {
+  tiers.delete(doctype);
+  return loadPageScripts(doctype);
+}
+
+export function resetPageScripts() {
+  for (const doctype of sources.keys()) clearTier(doctype);
+  tiers.clear();
+  builds.clear();
+  toasted.clear();
+  notified.clear();
+  resetCustomizationErrorReports();
+  writable.value = false;
+}
+
+async function buildTier(doctype: string) {
+  const build = (builds.get(doctype) ?? 0) + 1;
+  builds.set(doctype, build);
+  clearTier(doctype);
+
+  const response = await fetchScripts(doctype);
+  if (builds.get(doctype) !== build) return;
+  // Only an answer the server actually gave: a failed fetch must not read as
+  // "no permission" and retract the editor's entry point.
+  if (response) writable.value = response.can_write;
+  for (const row of response?.scripts ?? []) {
+    if (builds.get(doctype) !== build) return;
+    await addScript(doctype, row, response!.can_write);
+  }
+}
+
+/** Null when the tier could not be fetched — distinct from an empty tier. */
+async function fetchScripts(
+  doctype: string,
+): Promise<PageScriptsResponse | null> {
+  try {
+    return await call(GET_PAGE_SCRIPTS, { dt: doctype, view: "Record" });
+  } catch (error) {
+    console.error(`[page-script] could not load scripts for ${doctype}`, error);
+    reportCustomizationError(error, {
+      source: TIER_SOURCE,
+      tier: "page_script",
+      event: "load",
+      doctype,
+    });
+    return null;
+  }
+}
+
+// A script that fails to load is skipped whole; the rest of the tier still runs.
+async function addScript(
+  doctype: string,
+  row: PageScriptRow,
+  canWrite: boolean,
+) {
+  const source = sourceName(row.name);
+  try {
+    const handlers = await evaluatePageScript(row);
+    await withRegisteringSource(source, async () =>
+      registerRecordPage(doctype, handlers),
+    );
+    sources.get(doctype)?.push(source);
+  } catch (error) {
+    reportFailure(doctype, row.name, error, canWrite);
+  }
+}
+
+function reportFailure(
+  doctype: string,
+  name: string,
+  error: unknown,
+  canWrite: boolean,
+) {
+  console.error(`[page-script] ${name} failed to load, skipped`, error);
+  reportCustomizationError(error, {
+    source: sourceName(name),
+    event: "load",
+    doctype,
+  });
+  if (!canWrite || toasted.has(name)) return;
+  toasted.add(name);
+  toast.error(`Page Script '${name}' failed to load`);
+}
+
+function clearTier(doctype: string) {
+  for (const source of sources.get(doctype) ?? []) unregisterSource(source);
+  sources.set(doctype, []);
+}
+
+function sourceName(name: string) {
+  return `page-script:${name}`;
+}

--- a/frontend/src/recordPage/readOnly.ts
+++ b/frontend/src/recordPage/readOnly.ts
@@ -90,6 +90,18 @@ function wrap(value: unknown, path: string, member: ReadOnlyAdvice): unknown {
     deleteProperty(_owner, key) {
       return refuse(refusal(key));
     },
+    // The other two mutating operations. They take no key, so they are not
+    // reachable through `set` — and an operation with no trap forwards to the
+    // target, so without these `Object.setPrototypeOf(page.roles, ...)` swaps
+    // the prototype of the shared array (every later `roles.includes` answers
+    // the script) and `Object.freeze(page.meta)` locks shared cached state.
+    // Same hole as `page.roles.push`, reached by a door `set` does not watch.
+    setPrototypeOf() {
+      return refuse({ path: `${path}'s prototype`, member });
+    },
+    preventExtensions() {
+      return refuse({ path: `${path}'s extensibility`, member });
+    },
   });
 
   wrappers.set(target, wrapper);

--- a/frontend/src/recordPage/readOnly.ts
+++ b/frontend/src/recordPage/readOnly.ts
@@ -1,0 +1,149 @@
+// The outbound half of the compatibility policy (wayfinder ticket 47): every
+// object `page` hands back is read-only. Ticket 20 curated what goes *in* to
+// `page`; nothing said what a script may do to what comes back out, and the
+// answer was "corrupt the application" — `page.roles` is a module-level array
+// shared by the whole session, `page.perms` a memoised view shared by every
+// source, `page.meta` a cached resource that outlives navigation to another
+// doctype.
+//
+// A write is refused, not softened: it reports on the tombstone channel and
+// throws, which aborts the rest of the handler. The engine already skips a
+// throwing handler half-applied and this is not the exception (47 §3) —
+// report-but-continue is the silent no-op wearing a report.
+//
+// Not deep-freeze. A frozen object is non-extensible, Vue 3's `getTargetType`
+// returns INVALID for a non-extensible target, and `reactive()` then hands the
+// raw object back — meta would stop being deeply reactive. That is a repo-wide
+// reactivity change, and it stays addable underneath this Proxy later.
+import { runningSource } from "./context";
+import { toastScriptError } from "./pageScripts";
+import { reportCustomizationError } from "./reportError";
+
+/**
+ * What to write instead, per wrapped member. A bare `TypeError` names nothing;
+ * the whole reason this is a redirect rather than a removal is that there is a
+ * supported verb to point at.
+ */
+export interface ReadOnlyAdvice {
+  /** Dotted path to the member: `"page.meta"`. Nested writes extend it. */
+  path: string;
+  /** The verb that does support this: `"page.fields.update(...)"`. */
+  instead: string;
+}
+
+// Raw object to wrapper. Mandatory, not an optimisation: without it every read
+// allocates a fresh Proxy, `page.meta.fields[0] !== page.meta.fields[0]`, and
+// `.indexOf()` / `.includes()` / any identity comparison quietly misbehaves.
+//
+// It also fixes the reported path to the one the object was *first* reached
+// through, when the same object is reachable two ways. That is the price of the
+// identity guarantee, and identity is the one that breaks working scripts.
+const wrappers = new WeakMap<object, any>();
+
+// Wrapping a wrapper would nest two Proxies and report the inner path twice.
+// Nothing does it today — every wrap starts from a raw host value — but this is
+// one lookup to make it impossible rather than a rule to remember.
+const wrapped = new WeakSet<object>();
+
+/**
+ * Wraps `value` so reads pass through and writes throw. Lazy and recursive: a
+ * nested object is wrapped when it is read, not walked up front, so an untouched
+ * meta costs nothing.
+ */
+export function readOnly<T>(value: T, advice: ReadOnlyAdvice): T {
+  return wrap(value, advice.path, advice) as T;
+}
+
+// `member` is the wrap's root, fixed for the whole descent: the message names
+// the full path, because the author has to find the line, but the report and the
+// toast are keyed on the member, so a script that walks an array writing to
+// every row of it files one row rather than one per row.
+function wrap(value: unknown, path: string, member: ReadOnlyAdvice): unknown {
+  if (!wrappable(value)) return value;
+  const target = value as object;
+  if (wrapped.has(target)) return target;
+  const existing = wrappers.get(target);
+  if (existing) return existing;
+
+  const refusal = (key: string | symbol) => ({
+    path: step(target, path, key),
+    member,
+  });
+
+  const wrapper = new Proxy(target, {
+    get(owner, key, receiver) {
+      const read = Reflect.get(owner, key, receiver);
+      // A Proxy must hand back a non-configurable, non-writable property
+      // exactly as the target holds it, or the engine throws on the read. That
+      // is not hypothetical here: deep-freezing meta at source stays on the
+      // table (ticket 47 §1), and the day it happens this would start throwing
+      // TypeErrors on every read instead of quietly staying correct.
+      if (fixed(owner, key)) return read;
+      return wrap(read, step(owner, path, key), member);
+    },
+    set(_owner, key) {
+      return refuse(refusal(key));
+    },
+    defineProperty(_owner, key) {
+      return refuse(refusal(key));
+    },
+    deleteProperty(_owner, key) {
+      return refuse(refusal(key));
+    },
+  });
+
+  wrappers.set(target, wrapper);
+  wrapped.add(wrapper);
+  return wrapper;
+}
+
+function fixed(target: object, key: string | symbol) {
+  const descriptor = Object.getOwnPropertyDescriptor(target, key);
+  return !!descriptor && !descriptor.configurable && !descriptor.writable;
+}
+
+// Arrays and plain objects only. A `Date`, a `Map` or any class instance keeps
+// its internal slots, which a Proxy receiver breaks the moment a method is
+// called on it — and nothing `page` hands back is one of those. Functions pass
+// through as themselves: `roles.push` is reached as a function and called on the
+// wrapper, so its writes land in the `set` trap anyway. That is the whole of the
+// `page.roles.push('System Manager')` fix — no array special case exists.
+function wrappable(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  // `markRaw`'s stamp. A component's options object is a plain object, so it
+  // would otherwise be descended into: identity would stop holding
+  // (`get('x').component === MyComponent` false), and Vue's own render-time
+  // caches onto those options (`__vccOpts`, normalized props) would start
+  // throwing from inside a render effect.
+  //
+  // Asked as an own-property question, not a read: `page.perms` is itself a
+  // Proxy that warns about any key it does not recognise, and probing it for
+  // `__v_skip` would file that probe as the author's typo.
+  if (Object.hasOwn(value, "__v_skip")) return false;
+  if (Array.isArray(value)) return true;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+// `page.meta.fields[3].hidden`, not `page.meta` — the author has to be able to
+// find the line.
+function step(target: object, path: string, key: string | symbol) {
+  const name = String(key);
+  return Array.isArray(target) ? `${path}[${name}]` : `${path}.${name}`;
+}
+
+// Not dev-gated, for the reason `pageCompatibility.ts` gives and this inherits
+// unchanged: no production site runs a dev build, and this fires on a site no
+// developer is watching.
+function refuse(refusal: { path: string; member: ReadOnlyAdvice }): never {
+  const { path, member } = refusal;
+  const source = runningSource();
+  // The thrown message stands alone — it is what a `catch` and the Error Log row
+  // carry. The console line and the toast add the attribution around it.
+  const error = new Error(`${path} is read-only — use ${member.instead}`);
+  const sentence = `${source} wrote to ${path}, which is read-only — use ${member.instead}`;
+  console.error(`[record-page] ${sentence}`);
+  reportCustomizationError(error, { source, event: `readonly:${member.path}` });
+  toastScriptError(`readonly:${source}:${member.path}`, sentence);
+  throw error;
+}

--- a/frontend/src/recordPage/registry.ts
+++ b/frontend/src/recordPage/registry.ts
@@ -1,0 +1,62 @@
+// Where every script lands, whatever delivered it: file scripts at bundle
+// evaluation, extensions as the loader imports them. Run order is precedence.
+import { registeringSource } from "./context";
+import { flattenHandlers } from "./flattenHandlers";
+import type { AuthoredHandlers, RecordPageHandlers } from "./types";
+
+export const ALL_DOCTYPES = "*";
+
+export interface Registration {
+  source: string;
+  doctype: string;
+  handlers: RecordPageHandlers;
+}
+
+const registrations: Registration[] = [];
+
+export function registerRecordPage(
+  doctype: string,
+  handlers: AuthoredHandlers,
+) {
+  const source = registeringSource();
+  // The one place a nested table block is flattened: file scripts and stored
+  // scripts both land here, so neither the loader nor the evaluator has to know
+  // the authored shape from the dispatched one.
+  registrations.push({
+    source,
+    doctype,
+    handlers: flattenHandlers(handlers, source, doctype),
+  });
+}
+
+/** Sources in registration order; within one, `*` handlers before the doctype's own. */
+export function registrationsFor(doctype: string): Registration[] {
+  const bySource = new Map<string, Registration[]>();
+  for (const registration of registrations) {
+    if (
+      registration.doctype !== doctype &&
+      registration.doctype !== ALL_DOCTYPES
+    )
+      continue;
+    const own = bySource.get(registration.source) ?? [];
+    own.push(registration);
+    bySource.set(registration.source, own);
+  }
+  return [...bySource.values()].flatMap((own) =>
+    own.sort((a, b) => specificity(a) - specificity(b)),
+  );
+}
+
+/** Drops a source's handlers, so a re-registered tier lands in creation order again. */
+export function unregisterSource(source: string) {
+  for (let index = registrations.length - 1; index >= 0; index--)
+    if (registrations[index].source === source) registrations.splice(index, 1);
+}
+
+function specificity(registration: Registration) {
+  return registration.doctype === ALL_DOCTYPES ? 0 : 1;
+}
+
+export function resetRegistry() {
+  registrations.length = 0;
+}

--- a/frontend/src/recordPage/reportError.ts
+++ b/frontend/src/recordPage/reportError.ts
@@ -1,0 +1,92 @@
+// The third destination for a customization failure (ticket 19): console always,
+// toast for script editors, and — from here — one Error Log row an admin can read
+// without being in the room. Fire-and-forget in every direction: a failed report
+// never toasts, never logs, never retries, because an error channel that can
+// itself error is a loop.
+import { call } from "frappe-ui";
+import { HOST_SOURCE } from "./context";
+
+const REPORT_METHOD =
+  "frappe.desk.customization_error.report_customization_error";
+
+const MESSAGE_LIMIT = 1000;
+const STACK_LIMIT = 4000;
+
+export type CustomizationTier = "page_script" | "extension" | "file_script";
+
+// One report per (source, event) per page session. This is the layer that kills
+// the replay storm before a request is made, and still yields one row per user
+// per visit — "50 people hit this today" at a volume the log can hold.
+const reported = new Set<string>();
+// An error already filed where more was known about it — a tombstone hit names
+// the removal and its replacement — must not be filed a second time by the
+// handler catch that sees it on the way out.
+const filed = new WeakSet<object>();
+
+export interface CustomizationErrorContext {
+  /** `page-script:<name>`, an app name, or `host` — the attribution already carried. */
+  source: string;
+  /** A handler key, or `load` for a failure to arrive at all. */
+  event: string;
+  /** Overrides the tier the source implies: the tier's own fetch has no script. */
+  tier?: CustomizationTier;
+  doctype?: string;
+  record?: string;
+  route?: string;
+}
+
+/** `host` is the app's own bundled code; everything else unprefixed is an app. */
+export function tierOf(source: string): CustomizationTier {
+  if (source.startsWith("page-script:")) return "page_script";
+  return source === HOST_SOURCE ? "file_script" : "extension";
+}
+
+export function reportCustomizationError(
+  error: unknown,
+  context: CustomizationErrorContext,
+) {
+  if (typeof error === "object" && error !== null) {
+    if (filed.has(error)) return;
+    filed.add(error);
+  }
+  const key = `${context.source} ${context.event}`;
+  if (reported.has(key)) return;
+  reported.add(key);
+  // Every call site is already inside a catch, so a throw from here would escape
+  // as the failure of whatever it was reporting. `call` is guarded both ways:
+  // synchronously, and for whatever it hands back.
+  try {
+    const sent = call(REPORT_METHOD, {
+      source: context.source,
+      tier: context.tier ?? tierOf(context.source),
+      event: context.event,
+      doctype: context.doctype ?? "",
+      message: messageOf(error).slice(0, MESSAGE_LIMIT),
+      stack: stackOf(error).slice(0, STACK_LIMIT),
+      record: context.record ?? "",
+      route: context.route ?? currentRoute(),
+    });
+    void Promise.resolve(sent).catch(() => {});
+  } catch {
+    // An error channel that can itself error is a loop.
+  }
+}
+
+/** Cleared alongside `toasted`, so a new page session reports afresh. */
+export function resetCustomizationErrorReports() {
+  reported.clear();
+}
+
+function messageOf(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function stackOf(error: unknown) {
+  return error instanceof Error ? (error.stack ?? "") : "";
+}
+
+function currentRoute() {
+  return typeof location === "undefined"
+    ? ""
+    : `${location.pathname}${location.hash}`;
+}

--- a/frontend/src/recordPage/rows.ts
+++ b/frontend/src/recordPage/rows.ts
@@ -1,0 +1,300 @@
+// How a script addresses a child row (wayfinder ticket 43) — `page.rows('products')`
+// and the handle it hands back.
+//
+// A handle holds `(parentfield, key)` and **re-finds its row on every access**.
+// Nothing about a row's position is ever captured, which is the whole of the
+// staleness answer: a script that captures a row, `await`s a server call and then
+// writes to it is doing the dangerous thing the ported script actually does, and
+// v1 loses those writes silently by wrapping the row object. Here a removed row
+// throws, attributed, aborting the handler — 47's precedent, for 47's reason.
+//
+// Fields are read and written bare (`row.amount = row.qty * row.rate`), and there
+// is exactly one engine member, `trigger`, spelled as v1 spells it. That set is
+// deliberately one: 43 designed a `$` prefix to keep engine members out of the
+// fieldname namespace and then retired it by cutting the members it protected, and
+// recorded that adding a second bare member is the moment to reopen it.
+import { runningSource } from "./context";
+import {
+  holdsChildRows,
+  identify,
+  ROW_ID,
+  rowKey,
+} from "@framework/ui/components/Fields/rowIdentity";
+import type { RawMetaField } from "@framework/ui/components/FormLayout/types";
+import type { RowAddress } from "@framework/ui/components/Fields/types";
+import { ROW_EVENTS } from "./flattenHandlers";
+import { readOnly, type ReadOnlyAdvice } from "./readOnly";
+import { toastScriptError } from "./pageScripts";
+import { reportCustomizationError } from "./reportError";
+import type { PageRow } from "./types";
+
+const ROWS_ARE_READ_ONLY: ReadOnlyAdvice = {
+  path: "page.rows()",
+  instead: "page.doc[parentfield], which is the table itself",
+};
+
+/** The one engine member on a handle; everything else is a child fieldname. */
+const TRIGGER = "trigger";
+
+// `markRaw`'s stamp, answered by the traps below rather than stored on the target.
+// It is what tells both Vue's reactivity and the outbound read-only guard that a
+// handle is not data to descend into — the guard wraps every object it hands back,
+// and a read-only handle would refuse the writes that are the whole point of one.
+const RAW = "__v_skip";
+
+/**
+ * What `trigger` will not dispatch: the structural half of the vocabulary. Note
+ * these are the `on`-prefixed spellings (ticket 54) — a child field genuinely
+ * called `add` is triggerable like any other, which is the whole reason the
+ * lifecycle keys left the fieldname namespace.
+ */
+const STRUCTURAL: string[] = Object.values(ROW_EVENTS);
+
+export interface RowsHost {
+  /** The draft document; rows are re-found in it on every access. */
+  doc: () => Record<string, any>;
+  /** The parent doctype's flat meta `fields`; absent until the meta lands. */
+  fields: () => RawMetaField[] | undefined;
+  /** The child doctype's fields, for telling a typo'd `trigger` from a real one. */
+  childFields?: (doctype: string) => RawMetaField[] | undefined;
+  /** Fires a row-keyed event across every source; `trigger`'s whole body. */
+  dispatch: (event: string, row: RowAddress) => Promise<void>;
+}
+
+export interface Rows {
+  /** `page.rows` — the table's handles, in array order. */
+  rows: (parentfield: string) => PageRow[];
+  /** The handle a row-keyed event hands its handler. */
+  handle: (address: RowAddress) => PageRow;
+}
+
+export function createRows(host: RowsHost): Rows {
+  // One handle per address, for the page's life. Not an optimisation and not
+  // optional: without it `page.rows('products')[0] !== page.rows('products')[0]`,
+  // so `indexOf`, `includes`, `filter(r => r !== row)` and every `===` a script
+  // writes are quietly wrong — and a handler comparing the row it was handed
+  // against the table would find it nowhere. `readOnly.ts` keeps its own wrappers
+  // for exactly this reason; a handle is the same kind of object.
+  const handles = new Map<string, PageRow>();
+
+  function rows(parentfield: string): PageRow[] {
+    const table = holdsRows(parentfield) ? host.doc()?.[parentfield] : undefined;
+    if (!Array.isArray(table)) return readOnly([], ROWS_ARE_READ_ONLY);
+    const keys = keysOf(table);
+    return readOnly(
+      table.map((_row, index) => handle({ parentfield, key: keys[index] })),
+      ROWS_ARE_READ_ONLY,
+    );
+  }
+
+  /**
+   * Every row's key, minted here as well as at the two mutation sites so a row a
+   * script pushed onto `page.doc.products` itself is still addressable. A read
+   * that writes, and safe because a painted document carries a server `name` on
+   * every row: nothing is minted unless a script added the row.
+   *
+   * Two rows sharing a key would read as one — the grid selects and deletes them
+   * together, and a handle would write into whichever comes first, silently.
+   * A server name is unique by construction, so the only way it happens is a
+   * script copying a row (`{ ...products[0] }`), which copies the `__row_id`
+   * with it; that copy is re-minted rather than left aliasing the original.
+   */
+  function keysOf(table: Record<string, any>[]): string[] {
+    const seen = new Set<string>();
+    return table.map((row) => {
+      const key = rowKey(identify(row))!;
+      if (!seen.has(key)) return seen.add(key), key;
+      if (row.name) {
+        warnOnce(`Two rows share the child docname ${row.name} — addressing the first.`);
+        return key;
+      }
+      delete row[ROW_ID];
+      const minted = rowKey(identify(row))!;
+      seen.add(minted);
+      return minted;
+    });
+  }
+
+  function handle(address: RowAddress): PageRow {
+    const cached = handles.get(`${address.parentfield}\0${address.key}`);
+    if (cached) return cached;
+    const made = build(address);
+    handles.set(`${address.parentfield}\0${address.key}`, made);
+    return made;
+  }
+
+  function build({ parentfield, key }: RowAddress): PageRow {
+    /** The row as it is *now*, or the throw. Every field trap starts here. */
+    function required(prop: string | symbol): Record<string | symbol, any> {
+      const row = resolve();
+      if (!row) refuseRemovedRow(parentfield, prop);
+      return row;
+    }
+
+    // Keyed by symbol as well as fieldname: the traps below answer probes too.
+    function resolve(): Record<string | symbol, any> | undefined {
+      const table = host.doc()?.[parentfield];
+      return Array.isArray(table)
+        ? table.find((row) => rowKey(row) === key)
+        : undefined;
+    }
+
+    // A bare child fieldname, because the handle already knows its table and
+    // forms the dotted key itself: the author spells the table once, when they
+    // acquire the row (ticket 45 §3).
+    const trigger = (fieldname: string) => {
+      required(TRIGGER);
+      if (!triggerable(parentfield, fieldname)) return Promise.resolve();
+      return host.dispatch(`${parentfield}.${fieldname}`, { parentfield, key });
+    };
+
+    // The target is an empty object rather than the row: a Proxy may only lie
+    // about a target's properties while the target is extensible and owns none,
+    // and the row it would otherwise wrap is a different object on every access.
+    return new Proxy({} as PageRow, {
+      get(_target, prop) {
+        if (prop === TRIGGER) return trigger;
+        if (prop === RAW) return true;
+        if (probe(prop)) return resolve()?.[prop];
+        return required(prop)[prop];
+      },
+      set(_target, prop, value) {
+        required(prop)[prop] = value;
+        return true;
+      },
+      deleteProperty(_target, prop) {
+        return Reflect.deleteProperty(required(prop), prop);
+      },
+      has(_target, prop) {
+        if (prop === TRIGGER || prop === RAW) return true;
+        if (probe(prop)) return !!resolve() && prop in resolve()!;
+        return prop in required(prop);
+      },
+      // `{ ...row }` and `Object.keys(row)` answer with the row's own fields:
+      // `trigger` and the stamp are not among them, so a spread copies data.
+      // A removed row throws here rather than spreading to `{}` — silently
+      // copying nothing is the v1 failure this whole handle exists to end.
+      // `*` rather than a fieldname: enumerating asks about the whole row, and
+      // naming a field the doctype does not have would be a worse message.
+      ownKeys() {
+        return Reflect.ownKeys(required("*"));
+      },
+      getOwnPropertyDescriptor(_target, prop) {
+        if (prop === RAW) return RAW_DESCRIPTOR;
+        const row = probe(prop) ? resolve() : required(prop);
+        const descriptor = row && Object.getOwnPropertyDescriptor(row, prop);
+        // Configurable, always: the target does not own the property, and a
+        // Proxy may not report a non-configurable one it cannot produce.
+        return descriptor ? { ...descriptor, configurable: true } : undefined;
+      },
+    });
+  }
+
+  /**
+   * Only the meta can say a fieldname is not a child table, and it lands after
+   * the first paint — so this stays quiet until it can tell, exactly as
+   * `page.fields` does about a fieldname it cannot find yet.
+   */
+  function holdsRows(parentfield: string): boolean {
+    const field = tableField(parentfield);
+    if (!host.fields() || field) return true;
+    warnOnce(`page.rows("${parentfield}") — not a child table; no rows to address.`);
+    return false;
+  }
+
+  /**
+   * `trigger` dispatches a *field* event, so it refuses the structural keys —
+   * `'products.onAdd'` fired from here would hand a live row to a handler 45 §3
+   * gives none, and `'products.onRemove'` would announce a removal that did not
+   * happen. It also refuses a dotted argument, since the handle spells the
+   * table itself, and warns about a fieldname the child doctype does not have:
+   * the same typo written as a handler key is already named at load.
+   */
+  function triggerable(parentfield: string, fieldname: string): boolean {
+    const said = `row.trigger("${fieldname}") on ${parentfield}`;
+    if (STRUCTURAL.includes(fieldname))
+      return refuseTrigger(
+        `${said} — ${STRUCTURAL.join(" and ")} fire at the mutation site.`,
+      );
+    if (fieldname.includes("."))
+      return refuseTrigger(`${said} — pass a bare child fieldname; the row knows its table.`);
+    const child = childFieldsOf(parentfield);
+    if (child && !child.some((one) => one.fieldname === fieldname))
+      return refuseTrigger(`${said} — no such field on the child doctype.`);
+    return true;
+  }
+
+  function childFieldsOf(parentfield: string): RawMetaField[] | undefined {
+    const options = tableField(parentfield)?.options;
+    return options ? host.childFields?.(options) : undefined;
+  }
+
+  function tableField(parentfield: string): RawMetaField | undefined {
+    const field = host
+      .fields()
+      ?.find((one) => one.fieldname === parentfield);
+    return field && holdsChildRows(field.fieldtype) ? field : undefined;
+  }
+
+  return { rows, handle };
+}
+
+// Vue's reactivity flags are plain strings, not symbols (`__v_isRef`, `__v_raw`,
+// …), so the symbol test alone would let a `ref(row)` or an `isRef` in a template
+// throw from inside a render effect. Neither kind is a fieldname a script wrote,
+// and answering a probe with a throw makes a removed row blow up on being *looked
+// at* rather than on being used.
+function probe(prop: string | symbol): boolean {
+  return typeof prop === "symbol" || prop.startsWith("__v_");
+}
+
+const RAW_DESCRIPTOR: PropertyDescriptor = {
+  value: true,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+};
+
+/**
+ * The tombstone channel, as [47] fixed its shape: the thrown `Error` carries the
+ * standalone sentence, the console line and the toast add the attribution, and
+ * the throw aborts the rest of the handler — report-but-continue is the silent
+ * no-op wearing a report, which is the one thing v1 does here.
+ */
+function refuseRemovedRow(parentfield: string, prop: string | symbol): never {
+  const path = `${parentfield}.${String(prop)}`;
+  const advice = `re-acquire it with page.rows("${parentfield}")`;
+  const source = runningSource();
+  const error = new Error(
+    `${path} — this row is no longer in the document; ${advice}`,
+  );
+  const sentence = `${source} reached ${path} on a row that has been removed — ${advice}`;
+  console.error(`[record-page] ${sentence}`);
+  reportCustomizationError(error, { source, event: `removed-row:${parentfield}` });
+  toastScriptError(`removed-row:${parentfield}:${source}`, sentence);
+  throw error;
+}
+
+/** A refused `trigger` is a dev warning and a no-op, not a throw: the row is
+ *  fine, the argument is wrong, and the rest of the handler is still worth
+ *  running — unlike a write that has nowhere to land. */
+function refuseTrigger(message: string): false {
+  warnOnce(message);
+  return false;
+}
+
+const warned = new Set<string>();
+
+function warnOnce(message: string) {
+  if (!import.meta.env.DEV || warned.has(message)) return;
+  warned.add(message);
+  console.warn(`[record-page] ${message}`);
+}
+
+/** Test seam: the warn-once memory is module state. */
+export function resetRowWarnings(): void {
+  warned.clear();
+}
+
+/** The same once-per-session warning, for the row facts the controller knows. */
+export { warnOnce as warnRowIssue };

--- a/frontend/src/recordPage/surface.ts
+++ b/frontend/src/recordPage/surface.ts
@@ -1,0 +1,222 @@
+// One customizable region of a Record page. Verbs record ops; the rendered list
+// is those ops replayed over the host's built-ins, so a refresh replay and a
+// built-in that changed underneath both resolve to the same answer.
+import { markRaw, reactive } from "vue";
+import { runningSource } from "./context";
+import { ensureIcons } from "./iconClasses";
+import type { Position, SurfaceItem, SurfaceVerbs } from "./types";
+
+export interface ResolvedItem<Item extends SurfaceItem = SurfaceItem> {
+	item: Item;
+	source: string;
+	hidden: boolean;
+}
+
+type Op<Item extends SurfaceItem> =
+	| { verb: "add"; source: string; item: Item; position?: Position }
+	| { verb: "hide" | "show"; source: string; name: string }
+	| { verb: "update"; source: string; name: string; patch: Partial<Item> }
+	| { verb: "move"; source: string; name: string; position: Position }
+	| { verb: "order"; source: string; names: string[] };
+
+export const BUILTIN = "builtin";
+
+export class Surface<Item extends SurfaceItem = SurfaceItem> implements SurfaceVerbs<Item> {
+	private ops: Op<Item>[] = reactive([]);
+	// Where a replay's ops accumulate until it commits. Non-null only inside a
+	// replay: ops recorded anywhere else -- a `run` handler, `onTabChange`, a
+	// quick-action callback -- go straight to `ops` and render immediately, as
+	// they always have. Staging is a property of the replay, not of the surface.
+	private pending: Op<Item>[] | null = null;
+	private replaying = 0;
+	private builtins: () => Item[] = () => [];
+
+	// A block splices as a unit at the anchor, in list order: the first item
+	// takes the caller's position and each one after it follows the one before,
+	// so `add([a, b, c], { before: 'delete' })` reads in the list the way it
+	// reads in the call (ticket 77 §5). No new op: an array is the sugar, the
+	// flat namespace underneath is unchanged.
+	add(item: Item | Item[], position?: Position) {
+		let anchor = position;
+		for (const one of Array.isArray(item) ? item : [item]) {
+			ensureIcons(one);
+			keepComponentRaw(one);
+			this.record({ verb: "add", source: runningSource(), item: one, position: anchor });
+			anchor = { after: one.name };
+		}
+	}
+
+	hide(name: string) {
+		this.record({ verb: "hide", source: runningSource(), name });
+	}
+
+	show(name: string) {
+		this.record({ verb: "show", source: runningSource(), name });
+	}
+
+	update(name: string, patch: Partial<Item>) {
+		ensureIcons(patch);
+		keepComponentRaw(patch);
+		this.record({ verb: "update", source: runningSource(), name, patch });
+	}
+
+	move(name: string, position: Position) {
+		this.record({ verb: "move", source: runningSource(), name, position });
+	}
+
+	order(names: string[]) {
+		this.record({ verb: "order", source: runningSource(), names });
+	}
+
+	// The one read a script makes, and the one that resolves over the replay in
+	// flight: a source that calls `add('x')` and then `has('x')` in its own
+	// `refresh` handler is told the truth about its own work. Outside a replay
+	// there is no pending list and this is the committed answer.
+	has(name: string) {
+		return this.fold(this.pending ?? this.ops).some((entry) => entry.item.name === name);
+	}
+
+	// Host side, but reading the way `has` reads and for its reason: `activate`
+	// asks this to tell a hidden tab from an absent one, and a source that adds a
+	// tab and activates it in its own replay must be answered about its own work.
+	isVisible(name: string) {
+		return this.fold(this.pending ?? this.ops).some(
+			(entry) => entry.item.name === name && !entry.hidden,
+		);
+	}
+
+	// Host side, below: not part of what a script may call.
+
+	provideBuiltins(get: () => Item[]) {
+		this.builtins = get;
+	}
+
+	/**
+	 * Open a replay: from here until the matching commit, ops are staged instead
+	 * of rendered.
+	 *
+	 * Emptying the staged list is the replay clear that `reset()` used to be --
+	 * a replay rebuilds from built-ins alone. A nested replay (a script calling
+	 * `page.refresh()` from a `refresh` handler) clears it the same way, but
+	 * only the outermost commit publishes, so an inner one cannot put a
+	 * half-built outer list on screen.
+	 */
+	beginReplay() {
+		this.pending = [];
+		this.replaying += 1;
+	}
+
+	/** Close a replay: the outermost one publishes the staged ops in one flush. */
+	commitReplay() {
+		if (this.replaying === 0) return;
+		this.replaying -= 1;
+		if (this.replaying > 0) return;
+		const staged = this.pending ?? [];
+		this.pending = null;
+		// One splice, not a clear and a refill: `ops` is reactive and this is
+		// the whole point of staging -- the host renders the replay's result
+		// without ever rendering its middle.
+		this.ops.splice(0, this.ops.length, ...staged);
+	}
+
+	/** The rendered arrangement: committed ops only, never a replay in flight. */
+	resolve(): ResolvedItem<Item>[] {
+		return this.fold(this.ops);
+	}
+
+	visible(): Item[] {
+		return this.resolve()
+			.filter((entry) => !entry.hidden)
+			.map((entry) => entry.item);
+	}
+
+	private record(op: Op<Item>) {
+		(this.pending ?? this.ops).push(op);
+	}
+
+	private fold(ops: Op<Item>[]): ResolvedItem<Item>[] {
+		const items = this.builtins().map((item) => ({
+			item: { ...item },
+			source: BUILTIN,
+			hidden: false,
+		}));
+		for (const op of ops) apply(items, op);
+		return items;
+	}
+}
+
+// `ops` is reactive, so a component stored on an item would be deep-reactified
+// on its way in -- which Vue warns about, and pays for proxying a whole render
+// function. The item's own keys stay reactive; only the component opts out.
+function keepComponentRaw<Item extends SurfaceItem>(item: Partial<Item>) {
+	if (item.component) item.component = markRaw(item.component);
+}
+
+function apply<Item extends SurfaceItem>(items: ResolvedItem<Item>[], op: Op<Item>) {
+	if (op.verb === "add") return add(items, op);
+	if (op.verb === "order") return order(items, op.names);
+	const found = items.find((entry) => entry.item.name === op.name);
+	if (!found) return;
+	if (op.verb === "hide") found.hidden = true;
+	if (op.verb === "show") found.hidden = false;
+	if (op.verb === "update") Object.assign(found.item, op.patch);
+	if (op.verb === "move") reposition(items, found, op.position);
+}
+
+// A name collision replaces in place and transfers ownership; the earlier item
+// keeps its slot unless the writer also asked for a position.
+function add<Item extends SurfaceItem>(
+	items: ResolvedItem<Item>[],
+	op: { source: string; item: Item; position?: Position },
+) {
+	const entry = { item: { ...op.item }, source: op.source, hidden: false };
+	const existing = items.find((candidate) => candidate.item.name === op.item.name);
+	if (existing) {
+		warnCollision(existing, op);
+		items[items.indexOf(existing)] = entry;
+		if (op.position) reposition(items, entry, op.position);
+		return;
+	}
+	items.splice(anchorIndex(items, op.position), 0, entry);
+}
+
+function reposition<Item extends SurfaceItem>(
+	items: ResolvedItem<Item>[],
+	entry: ResolvedItem<Item>,
+	position: Position,
+) {
+	items.splice(items.indexOf(entry), 1);
+	items.splice(anchorIndex(items, position), 0, entry);
+}
+
+// An absent anchor degrades to append, so a guest never fails on an unknown name.
+function anchorIndex<Item extends SurfaceItem>(items: ResolvedItem<Item>[], position?: Position) {
+	if (!position) return items.length;
+	const target = items.findIndex(
+		(entry) => entry.item.name === (position.before ?? position.after),
+	);
+	if (target === -1) return items.length;
+	return position.before ? target : target + 1;
+}
+
+// Listed-and-present names to the front in the given sequence; unlisted items
+// follow in their prior relative order; unknown names are skipped.
+function order<Item extends SurfaceItem>(items: ResolvedItem<Item>[], names: string[]) {
+	const rank = (entry: ResolvedItem<Item>) => {
+		const claimed = names.indexOf(entry.item.name);
+		return claimed === -1 ? names.length : claimed;
+	};
+	const arranged = items
+		.map((entry, position) => ({ entry, position }))
+		.sort((a, b) => rank(a.entry) - rank(b.entry) || a.position - b.position)
+		.map(({ entry }) => entry);
+	items.splice(0, items.length, ...arranged);
+}
+
+function warnCollision(existing: ResolvedItem<any>, op: { source: string; item: SurfaceItem }) {
+	if (!import.meta.env.DEV) return;
+	if (existing.source === op.source) return;
+	console.warn(
+		`[record-page] '${op.item.name}' from ${existing.source} overwritten by ${op.source}`,
+	);
+}

--- a/frontend/src/recordPage/tests/compatibility.test.ts
+++ b/frontend/src/recordPage/tests/compatibility.test.ts
@@ -1,0 +1,155 @@
+// The compatibility mechanisms (wayfinder ticket 20 §4, §5) as executable claims:
+// a name we removed is answered by name, and a name that never existed is left
+// alone — because probing for one is the feature detection the policy recommends.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { call, toast } = vi.hoisted(() => ({
+  call: vi.fn(),
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("frappe-ui", () => ({
+  call,
+  toast,
+  dialog: { confirm: vi.fn(), danger: vi.fn() },
+}));
+
+import {
+  resetRemovalNotices,
+  withRemovals,
+  type Removal,
+} from "../pageCompatibility";
+import { loadPageScripts, resetPageScripts } from "../pageScripts";
+import { resetCustomizationErrorReports } from "../reportError";
+
+const REPORT_METHOD =
+  "frappe.desk.customization_error.report_customization_error";
+
+const tombstoned: Removal = {
+  path: "dialog.prompt",
+  removedIn: "0.3.0",
+  instead: "page.dialog.form",
+  stage: "tombstone",
+};
+
+const gone: Removal = {
+  path: "refreshAll",
+  removedIn: "0.2.0",
+  instead: "page.refresh",
+  stage: "gone",
+};
+
+function makePage() {
+  return {
+    doctype: "CRM Deal",
+    refresh: () => "refreshed",
+    dialog: { form: () => "form" },
+  } as any;
+}
+
+/** The tier's fetch is what carries whether this session may write scripts. */
+async function withEditorPermission(canWrite: boolean) {
+  call.mockResolvedValue({ scripts: [], can_write: canWrite });
+  await loadPageScripts("CRM Deal");
+  call.mockClear();
+}
+
+describe("removals", () => {
+  beforeEach(() => {
+    resetRemovalNotices();
+    resetPageScripts();
+    resetCustomizationErrorReports();
+    call.mockReset();
+    call.mockResolvedValue({});
+    toast.error.mockReset();
+  });
+
+  it("installs nothing at all while nothing has been removed", () => {
+    const page = makePage();
+    expect(withRemovals(page, [])).toBe(page);
+  });
+
+  it("keeps a removed verb as a thrower naming the removal and its replacement", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const page = withRemovals(makePage(), [tombstoned]);
+
+    expect(typeof page.dialog.prompt).toBe("function");
+    expect(() => page.dialog.prompt()).toThrow(
+      "page.dialog.prompt was removed in 0.3.0 — use page.dialog.form",
+    );
+  });
+
+  it("hands the same function back on every read", () => {
+    const page = withRemovals(makePage(), [tombstoned]);
+    expect(page.dialog.prompt).toBe(page.dialog.prompt);
+  });
+
+  it("leaves every other member of a guarded object alone", () => {
+    const page = withRemovals(makePage(), [tombstoned]);
+
+    expect(page.doctype).toBe("CRM Deal");
+    expect(page.refresh()).toBe("refreshed");
+    expect(page.dialog.form()).toBe("form");
+  });
+
+  it("files an Error Log row for a hit, and toasts an author who can edit scripts", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    await withEditorPermission(true);
+    const page = withRemovals(makePage(), [tombstoned]);
+
+    expect(() => page.dialog.prompt()).toThrow();
+
+    expect(call).toHaveBeenCalledWith(REPORT_METHOD, expect.anything());
+    expect(call.mock.calls[0][1].event).toBe("removed:dialog.prompt");
+    expect(toast.error).toHaveBeenCalledWith(
+      expect.stringContaining("removed in 0.3.0"),
+    );
+  });
+
+  it("still files the row for a reader who cannot edit scripts, but does not toast them", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    await withEditorPermission(false);
+    const page = withRemovals(makePage(), [tombstoned]);
+
+    expect(() => page.dialog.prompt()).toThrow();
+
+    expect(call).toHaveBeenCalledWith(REPORT_METHOD, expect.anything());
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("toasts once per script per session, however often the verb is reached for", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    await withEditorPermission(true);
+    const page = withRemovals(makePage(), [tombstoned]);
+
+    for (let attempt = 0; attempt < 3; attempt++)
+      expect(() => page.dialog.prompt()).toThrow();
+
+    expect(toast.error).toHaveBeenCalledTimes(1);
+  });
+
+  it("warns once and reads undefined for a removal past its tombstone", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const page = withRemovals(makePage(), [gone]);
+
+    expect(page.refreshAll).toBeUndefined();
+    expect(page.refreshAll).toBeUndefined();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("page.refreshAll, removed in 0.2.0"),
+    );
+    warn.mockRestore();
+  });
+
+  it("says nothing about a name that never existed — that probe is the documented idiom", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const page = withRemovals(makePage(), [tombstoned, gone]);
+
+    expect(page.neverWasAVerb).toBeUndefined();
+    expect(page.dialog.neverWasAVerb).toBeUndefined();
+
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/frontend/src/recordPage/tests/events.test.ts
+++ b/frontend/src/recordPage/tests/events.test.ts
@@ -1,0 +1,436 @@
+// The event vocabulary's firing semantics (wayfinder ticket 14) as executable claims.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+
+// The page only borrows `call` and `toast`; the real barrel drags icon plugins in.
+vi.mock("frappe-ui", () => ({
+  call: vi.fn(),
+  toast: { success: vi.fn(), error: vi.fn() },
+  createResource: () => ({
+    data: null,
+    loading: false,
+    fetch() {},
+    reload() {},
+  }),
+  frappeRequest: vi.fn(),
+}));
+
+import { createRecordPage, type RecordPageHost } from "../createRecordPage";
+import { registerRecordPage, resetRegistry } from "../registry";
+import { withRegisteringSource } from "../context";
+import { resetCustomizationErrorReports } from "../reportError";
+import { resetRowWarnings } from "../rows";
+import { call as mockedCall } from "frappe-ui";
+
+function makeHost(overrides: Partial<RecordPageHost> = {}): RecordPageHost {
+  return {
+    doctype: "CRM Deal",
+    docname: "CRM-DEAL-1",
+    doc: ref({ status: "Open" }),
+    saved: ref({ status: "Open" }),
+    meta: ref(null),
+    perms: () => ({}),
+    isDirty: () => false,
+    activeTab: () => "activity",
+    activateTab: () => {},
+    save: async () => {},
+    reload: async () => {},
+    router: {} as any,
+    ...overrides,
+  };
+}
+
+function reportedFailures() {
+  return (mockedCall as any).mock.calls
+    .filter(([method]: [string]) =>
+      method.includes("report_customization_error"),
+    )
+    .map(([, payload]: [string, any]) => `${payload.source}.${payload.event}`);
+}
+
+describe("fireEvent", () => {
+  beforeEach(() => {
+    resetRegistry();
+    resetCustomizationErrorReports();
+    (mockedCall as any).mockReset();
+  });
+
+  it("propagates a beforeSave throw so the host can abort the save", async () => {
+    registerRecordPage("CRM Deal", {
+      beforeSave: () => {
+        throw new Error("Amount required");
+      },
+    });
+    const controller = createRecordPage(makeHost());
+    await expect(controller.fireEvent("beforeSave")).rejects.toThrow(
+      "Amount required",
+    );
+  });
+
+  it("stops later beforeSave handlers once one vetoes", async () => {
+    const ran: string[] = [];
+    await withRegisteringSource("first", async () => {
+      registerRecordPage("CRM Deal", {
+        beforeSave: () => {
+          ran.push("first");
+          throw new Error("veto");
+        },
+      });
+    });
+    await withRegisteringSource("second", async () => {
+      registerRecordPage("CRM Deal", { beforeSave: () => ran.push("second") });
+    });
+    const controller = createRecordPage(makeHost());
+    await expect(controller.fireEvent("beforeSave")).rejects.toThrow("veto");
+    expect(ran).toEqual(["first"]);
+  });
+
+  it("isolates a throw from every other event", async () => {
+    const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+    const ran: string[] = [];
+    await withRegisteringSource("first", async () => {
+      registerRecordPage("CRM Deal", {
+        onRefresh: () => {
+          throw new Error("broken script");
+        },
+      });
+    });
+    await withRegisteringSource("second", async () => {
+      registerRecordPage("CRM Deal", { onRefresh: () => ran.push("second") });
+    });
+    const controller = createRecordPage(makeHost());
+    await controller.refresh();
+    expect(ran).toEqual(["second"]);
+    expect(errors).toHaveBeenCalled();
+    errors.mockRestore();
+  });
+});
+
+// Ticket 74 respelled the four top-level keys to camelCase, a hard break with no
+// dual-accept: the old spellings are legal *fieldnames*, which is the collision the
+// rename exists to remove. Both halves are claims, not conventions.
+describe("the event vocabulary is camelCase (ticket 74)", () => {
+  beforeEach(() => resetRegistry());
+
+  it("never fires a handler under one of the retired snake_case keys", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const ran: string[] = [];
+    registerRecordPage("CRM Deal", {
+      refresh: () => ran.push("refresh"),
+      before_save: () => ran.push("before_save"),
+      after_save: () => ran.push("after_save"),
+      on_tab_change: () => ran.push("on_tab_change"),
+    });
+    const controller = createRecordPage(makeHost());
+
+    await controller.refresh();
+    for (const event of ["beforeSave", "afterSave", "onTabChange"])
+      await controller.fireEvent(event);
+
+    expect(ran).toEqual([]);
+  });
+
+  // `page.refresh()` is a different symbol from the `onRefresh` key and did not
+  // move: it is the imperative verb a handler calls to force its own replay.
+  it("keeps page.refresh() as the verb that re-fires onRefresh", async () => {
+    let fired = 0;
+    registerRecordPage("CRM Deal", { onRefresh: () => (fired += 1) });
+    const controller = createRecordPage(makeHost());
+    await controller.refresh();
+    expect(fired).toBe(1);
+
+    await controller.page.refresh();
+    expect(fired).toBe(2);
+  });
+});
+
+describe("page.tabs.active", () => {
+  it("reads the tab the host's strip resolves", () => {
+    resetRegistry();
+    const controller = createRecordPage(
+      makeHost({ activeTab: () => "audit_log" }),
+    );
+    expect(controller.page.tabs.active).toBe("audit_log");
+  });
+});
+
+describe("unknown handler keys", () => {
+  beforeEach(() => resetRegistry());
+
+  const fields = [
+    { fieldname: "status", fieldtype: "Select" },
+    { fieldname: "items", fieldtype: "Table", options: "Deal Item" },
+  ];
+
+  const childFields = [
+    { fieldname: "qty", fieldtype: "Int" },
+    { fieldname: "rate", fieldtype: "Currency" },
+  ];
+
+  it("warns once, after meta arrives, for a key that will never fire", async () => {
+    const warnings = vi.spyOn(console, "warn").mockImplementation(() => {});
+    registerRecordPage("CRM Deal", { after_svae: () => {} });
+    const meta = ref<any>(null);
+    const controller = createRecordPage(makeHost({ meta }));
+    await controller.refresh();
+    meta.value = { fields };
+    await controller.refresh();
+    await controller.refresh();
+    const typoWarnings = warnings.mock.calls.filter((call) =>
+      String(call[0]).includes("after_svae"),
+    );
+    expect(typoWarnings).toHaveLength(1);
+    warnings.mockRestore();
+  });
+
+  it("accepts events, fieldnames and a table's nested block", async () => {
+    const warnings = vi.spyOn(console, "warn").mockImplementation(() => {});
+    registerRecordPage("CRM Deal", {
+      onRefresh: () => {},
+      beforeSave: () => {},
+      afterSave: () => {},
+      onTabChange: () => {},
+      status: () => {},
+      items: {
+        onAdd: () => {},
+        onRemove: () => {},
+        qty: () => {},
+      },
+    });
+    const controller = createRecordPage(
+      makeHost({ meta: ref({ fields }), childFields: () => childFields }),
+    );
+    await controller.refresh();
+    expect(warnings).not.toHaveBeenCalled();
+    warnings.mockRestore();
+  });
+
+  // 45 §5: only reachable because the deleted deep watch could not tell one
+  // row's edit from another's, and retiring it is what makes the warning useful.
+  it("rejects a Table fieldname, its underscore keys, and an unknown child field", async () => {
+    const warnings = vi.spyOn(console, "warn").mockImplementation(() => {});
+    registerRecordPage("CRM Deal", {
+      items: () => {},
+      items_add: () => {},
+      "items.nope": () => {},
+    });
+    const controller = createRecordPage(
+      makeHost({ meta: ref({ fields }), childFields: () => childFields }),
+    );
+    await controller.refresh();
+    const rejected = warnings.mock.calls.map((call) => String(call[0]));
+    expect(rejected.filter((line) => line.includes("never fire"))).toHaveLength(3);
+    warnings.mockRestore();
+  });
+
+  // 45 §7: a Table MultiSelect has no per-cell editing, so a child-field key on
+  // one could never fire — and naming that is what the warning is for.
+  it("gives a Table MultiSelect add and remove only", async () => {
+    const warnings = vi.spyOn(console, "warn").mockImplementation(() => {});
+    registerRecordPage("CRM Deal", {
+      labels: {
+        onAdd: () => {},
+        onRemove: () => {},
+        label: () => {},
+      },
+    });
+    const controller = createRecordPage(
+      makeHost({
+        meta: ref({
+          fields: [
+            { fieldname: "labels", fieldtype: "Table MultiSelect", options: "Tag Link" },
+          ],
+        }),
+        childFields: () => [{ fieldname: "label", fieldtype: "Link" }],
+      }),
+    );
+    await controller.refresh();
+    const rejected = warnings.mock.calls.map((call) => String(call[0]));
+    expect(rejected.filter((line) => line.includes("never fire"))).toHaveLength(1);
+    expect(rejected[0]).toContain("labels.label");
+    warnings.mockRestore();
+  });
+
+  // The child meta lands with the parent's, but a host that has none must not
+  // accuse a correct key of being a typo.
+  it("stays quiet about a table whose child fields it cannot see", async () => {
+    const warnings = vi.spyOn(console, "warn").mockImplementation(() => {});
+    registerRecordPage("CRM Deal", { "items.anything": () => {} });
+    const controller = createRecordPage(makeHost({ meta: ref({ fields }) }));
+    await controller.refresh();
+    expect(warnings).not.toHaveBeenCalled();
+    warnings.mockRestore();
+  });
+
+  // Once per child doctype for the session, not once per controller: navigating
+  // between records of the same doctype must not restate the same fact.
+  it("warns once when a child doctype has a field named trigger (ticket 43 §3)", async () => {
+    const warnings = vi.spyOn(console, "warn").mockImplementation(() => {});
+    resetRowWarnings();
+    registerRecordPage("CRM Deal", { onRefresh: () => {} });
+    const controller = createRecordPage(
+      makeHost({
+        meta: ref({ fields }),
+        childFields: () => [
+          ...childFields,
+          { fieldname: "trigger", fieldtype: "Data" },
+        ],
+      }),
+    );
+    await controller.refresh();
+    await createRecordPage({
+      ...makeHost({
+        meta: ref({ fields }),
+        childFields: () => [
+          ...childFields,
+          { fieldname: "trigger", fieldtype: "Data" },
+        ],
+      }),
+    }).refresh();
+    const shadowed = warnings.mock.calls.filter((call) =>
+      String(call[0]).includes("shadowed by the row handle"),
+    );
+    expect(shadowed).toHaveLength(1);
+    warnings.mockRestore();
+  });
+
+  // 54 §3: the convention is not a construction, so the two fieldnames that can
+  // still collide are named at load — an announced hole, not a silent misfire.
+  it("warns when a child doctype has a field named onAdd or onRemove (ticket 54)", async () => {
+    const warnings = vi.spyOn(console, "warn").mockImplementation(() => {});
+    resetRowWarnings();
+    registerRecordPage("CRM Deal", { onRefresh: () => {} });
+    await createRecordPage(
+      makeHost({
+        meta: ref({ fields }),
+        childFields: () => [
+          ...childFields,
+          { fieldname: "onAdd", fieldtype: "Check" },
+          { fieldname: "onRemove", fieldtype: "Check" },
+        ],
+      }),
+    ).refresh();
+    const collisions = warnings.mock.calls
+      .map((call) => String(call[0]))
+      .filter((line) => line.includes("collides with the table's"));
+    expect(collisions).toHaveLength(2);
+    expect(collisions[0]).toContain("Deal Item.onAdd");
+    warnings.mockRestore();
+  });
+
+  // The collision is a *misfire*, not an inert gap — the thing the warning has
+  // to say, and the reason it says it. Editing the child field commits under
+  // the same string the row-added event dispatches.
+  it("routes a colliding child field's commit into the table's lifecycle handler", async () => {
+    const fired: string[] = [];
+    registerRecordPage("CRM Deal", { items: { onAdd: () => fired.push("onAdd") } });
+    const controller = createRecordPage(
+      makeHost({ meta: ref({ fields }), childFields: () => childFields }),
+    );
+    await controller.fireEvent("items.onAdd", { parentfield: "items", key: "name:a" });
+    expect(fired).toEqual(["onAdd"]);
+  });
+
+  // 48/50's lesson in its own shape: the shadow check reads the *child* meta,
+  // which can land after the parent's, so latching on the parent alone dropped
+  // the warning for the session.
+  it("still warns when the child meta lands after the parent's", async () => {
+    const warnings = vi.spyOn(console, "warn").mockImplementation(() => {});
+    resetRowWarnings();
+    registerRecordPage("CRM Deal", { onRefresh: () => {} });
+    let child: any[] | undefined = undefined;
+    const controller = createRecordPage(
+      makeHost({ meta: ref({ fields }), childFields: () => child }),
+    );
+    await controller.refresh();
+    child = [...childFields, { fieldname: "onAdd", fieldtype: "Check" }];
+    await controller.refresh();
+    const collisions = warnings.mock.calls
+      .map((call) => String(call[0]))
+      .filter((line) => line.includes("collides with the table's"));
+    expect(collisions).toHaveLength(1);
+    warnings.mockRestore();
+  });
+
+  // A block under something that holds no rows is one mistake, not one per
+  // handler in it — and naming the table beats naming each dead key.
+  it("names the table once when a nested block is not on a child table", async () => {
+    const warnings = vi.spyOn(console, "warn").mockImplementation(() => {});
+    registerRecordPage("CRM Deal", {
+      status: { onAdd: () => {}, qty: () => {} },
+    });
+    await createRecordPage(
+      makeHost({ meta: ref({ fields }), childFields: () => childFields }),
+    ).refresh();
+    const rejected = warnings.mock.calls
+      .map((call) => String(call[0]))
+      .filter((line) => line.includes("not a child table"));
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0]).toContain("status");
+    warnings.mockRestore();
+  });
+
+  it("reports a handler throw, but never a beforeSave veto (ticket 19 §1)", async () => {
+    withRegisteringSource("page-script:A", async () =>
+      registerRecordPage("CRM Deal", {
+        onRefresh: () => {
+          throw new Error("boom");
+        },
+        beforeSave: () => {
+          throw new Error("veto");
+        },
+      }),
+    );
+    const controller = createRecordPage(makeHost());
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await controller.fireEvent("onRefresh");
+    await expect(controller.fireEvent("beforeSave")).rejects.toThrow("veto");
+
+    expect(reportedFailures()).toContain("page-script:A.onRefresh");
+    expect(reportedFailures()).not.toContain("page-script:A.beforeSave");
+  });
+});
+
+describe("the replay clears the field overlay too (ticket 42)", () => {
+  it("drops every override before re-firing, so a condition is a plain if", async () => {
+    let stage = "Open";
+    registerRecordPage("CRM Deal", {
+      // No `else` branch anywhere: the overlay is gone before every re-fire.
+      onRefresh: (page) => {
+        if (stage === "Won") page.fields.hide("discount");
+      },
+    });
+    const controller = createRecordPage(makeHost());
+
+    stage = "Won";
+    await controller.refresh();
+    expect(controller.fields.resolve()).toEqual({
+      discount: { override: { hidden: true } },
+    });
+
+    stage = "Open";
+    await controller.refresh();
+    expect(controller.fields.resolve()).toEqual({});
+  });
+
+  // Ticket 71: the replay stages its ops now, so the commit has to happen on
+  // the way out of a failed replay too — otherwise the overlay would be frozen
+  // on the previous replay for the rest of the session.
+  it("commits what a failed replay managed to record", async () => {
+    registerRecordPage("CRM Deal", {
+      onRefresh: (page) => {
+        page.fields.hide("discount");
+        throw new Error("boom");
+      },
+    });
+    const controller = createRecordPage(makeHost());
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await controller.refresh();
+
+    expect(controller.fields.resolve()).toEqual({
+      discount: { override: { hidden: true } },
+    });
+  });
+});

--- a/frontend/src/recordPage/tests/fields.test.ts
+++ b/frontend/src/recordPage/tests/fields.test.ts
@@ -1,0 +1,281 @@
+// The fields surface (wayfinder ticket 42) as executable claims: an enumerated
+// snake_case patch, a render-time overlay cleared by the replay, a reader that
+// speaks the writer's vocabulary, and a permlevel floor an override cannot lift.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("frappe-ui", () => ({
+  call: vi.fn(),
+  toast: { success: vi.fn(), error: vi.fn() },
+  frappeRequest: vi.fn(),
+  createResource: () => ({ data: null, loading: false, fetch() {}, reload() {} }),
+}));
+
+import { markRaw } from "vue";
+import { FieldsSurface, resetFieldWarnings } from "../fields";
+import type { FieldsSurfaceHost } from "../fields";
+import type { RawMetaField } from "@framework/ui/components/FormLayout/types";
+import type { FieldAccess } from "@framework/ui/composables/useDocPermissions";
+
+const FIELDS: RawMetaField[] = [
+  { fieldname: "status", fieldtype: "Select", options: "Open\nWon" },
+  { fieldname: "qty", fieldtype: "Int" },
+  { fieldname: "rate", fieldtype: "Currency", depends_on: "eval:doc.qty > 0" },
+  { fieldname: "secret", fieldtype: "Data", permlevel: 1 },
+];
+
+function makeSurface(
+  host: Partial<FieldsSurfaceHost> = {},
+): FieldsSurface {
+  return new FieldsSurface({
+    fields: () => FIELDS,
+    doc: () => ({ qty: 0 }),
+    fieldAccess: (): FieldAccess => "write",
+    ...host,
+  });
+}
+
+beforeEach(() => {
+  resetFieldWarnings();
+  vi.restoreAllMocks();
+});
+
+describe("the patch vocabulary", () => {
+  it("splits a patch across the three points it is applied at", () => {
+    const fields = makeSurface();
+    fields.update("status", {
+      read_only: true,
+      label: "Stage",
+      link_filters: { company: "Frappe" },
+      props: { variant: "subtle" },
+    });
+    expect(fields.resolve().status).toEqual({
+      override: { readOnly: true },
+      meta: { label: "Stage", filters: { company: "Frappe" } },
+      ui: { props: { variant: "subtle" } },
+    });
+  });
+
+  it("takes `precision` as a number or the string a script may reach for", () => {
+    const fields = makeSurface();
+    fields.update("qty", { precision: "2" });
+    expect(fields.resolve().qty.meta).toEqual({ precision: 2 });
+  });
+
+  it("carries a patch's payload through by identity, not deep-proxied", () => {
+    // Anything a script puts in `props` reaches `v-bind`; a deep reactive
+    // wrapper there breaks a nested component's internal slots.
+    const props = { icon: markRaw({ name: "Icon" }) };
+    const fields = makeSurface();
+    fields.update("qty", { props });
+    expect(fields.resolve().qty.ui?.props).toBe(props);
+  });
+
+  it("drops a key that is not a field property a script may set", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fields = makeSurface();
+    fields.update("status", { hidden: true, fieldtype: "Data" } as any);
+    expect(fields.resolve().status).toEqual({ override: { hidden: true } });
+    expect(warn.mock.calls[0][0]).toContain("fieldtype");
+  });
+
+  it("names a field the doctype does not have, and still records nothing that renders", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    makeSurface().hide("nope");
+    expect(warn.mock.calls[0][0]).toContain('page.fields.hide("nope")');
+  });
+
+  it("stays quiet while the meta is still loading", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fields = makeSurface({ fields: () => undefined });
+    fields.hide("status");
+    expect(warn).not.toHaveBeenCalled();
+    // Recorded anyway: the meta lands later and the join applies it then.
+    expect(fields.resolve().status).toEqual({ override: { hidden: true } });
+  });
+});
+
+// A fieldname and a patch key are both strings a script chooses, and both were
+// indexed into object literals — where four of them are inherited members.
+describe("names that are not names", () => {
+  it("keeps a `__proto__` fieldname out of Object.prototype", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fields = makeSurface();
+    fields.hide("__proto__");
+    const patches = fields.resolve();
+
+    // The damage this avoids: `resolveFieldConditionals` reads `override` off
+    // the prototype chain, so one such write would hide a field in every form
+    // in the application for the rest of the session.
+    expect(({} as any).override).toBeUndefined();
+    // Recorded as an ordinary own key instead — inert, since no field can be
+    // named this, and attributable rather than invisible.
+    expect(Object.hasOwn(patches, "__proto__")).toBe(true);
+    expect(Object.getPrototypeOf(patches)).toBe(Object.prototype);
+  });
+
+  it("drops an inherited patch key instead of letting it through unwarned", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fields = makeSurface();
+    fields.update("qty", { toString: "hi", constructor: 1 } as any);
+
+    expect(fields.resolve().qty).toEqual({});
+    expect(warn.mock.calls.map((call) => call[0]).join()).toContain("toString");
+  });
+
+  it("does not address a layout break, which never reaches the renderer", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fields = makeSurface({
+      fields: () => [
+        ...FIELDS,
+        { fieldname: "sb_1", fieldtype: "Section Break" },
+      ],
+    });
+    expect(fields.has("sb_1")).toBe(false);
+    expect(fields.get("sb_1")).toBeNull();
+  });
+});
+
+describe("the verbs", () => {
+  it("reads `hide` and `show` as the same override, last one winning", () => {
+    const fields = makeSurface();
+    fields.hide("status");
+    fields.show("status");
+    expect(fields.resolve().status).toEqual({ override: { hidden: false } });
+  });
+
+  it("merges two patches for one field key by key", () => {
+    const fields = makeSurface();
+    fields.update("status", { label: "Stage", read_only: true });
+    fields.update("status", { label: "Phase" });
+    expect(fields.resolve().status).toEqual({
+      meta: { label: "Phase" },
+      override: { readOnly: true },
+    });
+  });
+
+  it("answers `has` from the doctype's fields", () => {
+    const fields = makeSurface();
+    expect(fields.has("qty")).toBe(true);
+    expect(fields.has("nope")).toBe(false);
+  });
+
+  it("clears every override on replay — and why a script needs no else", () => {
+    const fields = makeSurface();
+    fields.hide("status");
+    fields.update("qty", { label: "Quantity" });
+    fields.beginReplay();
+    fields.commitReplay();
+    expect(fields.resolve()).toEqual({});
+  });
+
+  // Ticket 71: the overlay used to empty on `reset()` and refill a microtask
+  // later, which is the `page.fields` flash — a script-hidden field visible for
+  // a tick on every save.
+  it("keeps the applied overlay whole while a replay is in flight", () => {
+    const fields = makeSurface();
+    fields.hide("status");
+    fields.beginReplay();
+    expect(fields.resolve().status).toEqual({ override: { hidden: true } });
+    fields.hide("status");
+    expect(fields.resolve().status).toEqual({ override: { hidden: true } });
+    fields.commitReplay();
+    expect(fields.resolve().status).toEqual({ override: { hidden: true } });
+  });
+
+  it("publishes only on the outermost commit of a nested replay", () => {
+    const fields = makeSurface();
+    fields.beginReplay();
+    fields.update("qty", { label: "Quantity" });
+    fields.beginReplay();
+    fields.update("qty", { label: "Nested" });
+    fields.commitReplay();
+    expect(fields.resolve()).toEqual({});
+    fields.commitReplay();
+    expect(fields.resolve().qty).toEqual({ meta: { label: "Nested" } });
+  });
+});
+
+describe("get — the reader", () => {
+  it("speaks the vocabulary the writer speaks, not the pipeline's", () => {
+    const fields = makeSurface();
+    fields.update("status", { read_only: true, label: "Stage" });
+    expect(fields.get("status")).toMatchObject({
+      fieldname: "status",
+      fieldtype: "Select",
+      label: "Stage",
+      read_only: true,
+      options: "Open\nWon",
+    });
+  });
+
+  // The other half of ticket 71's read split: the host renders the committed
+  // overlay, but a source reading its own work back mid-replay must see it.
+  it("reads the replay in flight, not the overlay the host is still rendering", () => {
+    const fields = makeSurface();
+    fields.update("status", { label: "Stage" });
+    fields.beginReplay();
+    fields.update("status", { label: "Rebuilt" });
+    expect(fields.get("status")).toMatchObject({ label: "Rebuilt" });
+    expect(fields.resolve().status).toEqual({ meta: { label: "Stage" } });
+  });
+
+  it("reads back what the setter wrote — the v1 asymmetry this exists to avoid", () => {
+    const fields = makeSurface();
+    expect(fields.get("qty")?.hidden).toBe(false);
+    fields.hide("qty");
+    expect(fields.get("qty")?.hidden).toBe(true);
+  });
+
+  it("resolves `depends_on`, and lets the override beat it", () => {
+    const fields = makeSurface();
+    // `qty` is 0, so `rate`'s condition is false and the field is hidden.
+    expect(fields.get("rate")?.hidden).toBe(true);
+    fields.show("rate");
+    expect(fields.get("rate")?.hidden).toBe(false);
+  });
+
+  it("refuses to lift a permlevel denial", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fields = makeSurface({
+      fieldAccess: (fieldname) => (fieldname === "secret" ? "none" : "write"),
+    });
+    fields.show("secret");
+    expect(fields.get("secret")?.hidden).toBe(true);
+  });
+
+  it("hands back a read-only snapshot", () => {
+    const snapshot = makeSurface().get("status")!;
+    expect(() => {
+      (snapshot as any).label = "Stage";
+    }).toThrow("is read-only");
+  });
+
+  it("reports the component the host's decorator mounts, not a plain node", () => {
+    const Button = { name: "Button" };
+    const fields = makeSurface({
+      decorate: (field) =>
+        field.fieldname === "qty" ? { component: Button } : undefined,
+    });
+    // Without the decorator the reader would answer `undefined` while the
+    // renderer mounts a component — the asymmetry `get` exists to abolish.
+    expect(fields.get("qty")?.component).toBe(Button);
+  });
+
+  it("hands a component back by identity, not wrapped in the read-only proxy", () => {
+    const Button = markRaw({ name: "Button" });
+    const fields = makeSurface();
+    fields.update("qty", { component: Button });
+    expect(fields.get("qty")?.component).toBe(Button);
+  });
+
+  it("is null for a field the doctype does not have", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(makeSurface().get("nope")).toBeNull();
+  });
+
+  it("carries none of the pipeline's internals", () => {
+    const snapshot = makeSurface().get("rate")! as Record<string, unknown>;
+    for (const internal of ["dependsOn", "permDenied", "override", "readOnly"])
+      expect(snapshot[internal]).toBeUndefined();
+  });
+});

--- a/frontend/src/recordPage/tests/flattenHandlers.test.ts
+++ b/frontend/src/recordPage/tests/flattenHandlers.test.ts
@@ -1,0 +1,126 @@
+// The authored shape (ticket 54) against the flat keyspace the engine dispatches
+// on: what a script writes, and what `registerRecordPage` stores.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { flattenHandlers } from "../flattenHandlers";
+import { registerRecordPage, registrationsFor, resetRegistry } from "../registry";
+
+const noop = () => {};
+
+describe("flattenHandlers", () => {
+  it("flattens a table's block onto dotted keys", () => {
+    const qty = () => {};
+    const flat = flattenHandlers(
+      { onRefresh: noop, products: { onAdd: noop, qty } },
+      "host",
+      "CRM Deal",
+    );
+    expect(Object.keys(flat)).toEqual([
+      "onRefresh",
+      "products.onAdd",
+      "products.qty",
+    ]);
+    // The author's function, not a wrapper: the dispatch path is unchanged.
+    expect(flat["products.qty"]).toBe(qty);
+  });
+
+  // Nothing about `page.rows`, the handle or the arguments rule changed with the
+  // spelling, so a script written against the merged dotted keys still runs.
+  it("passes a flat dotted key straight through", () => {
+    const flat = flattenHandlers({ "products.qty": noop }, "host", "CRM Deal");
+    expect(Object.keys(flat)).toEqual(["products.qty"]);
+  });
+
+  it("names a nested value that is not a block of handlers", () => {
+    const warnings = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const flat = flattenHandlers(
+      { products: { qty: 3 } as any, totals: "yes" as any },
+      "page-script:A",
+      "CRM Deal",
+    );
+    expect(Object.keys(flat)).toEqual([]);
+    expect(warnings).toHaveBeenCalledTimes(2);
+    expect(String(warnings.mock.calls[0][0])).toContain(
+      "page-script:A.products on CRM Deal",
+    );
+    warnings.mockRestore();
+  });
+
+  // Vacuously a block of functions, and so the one authoring mistake the check
+  // would otherwise wave through.
+  it("names an empty block", () => {
+    const warnings = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(Object.keys(flattenHandlers({ products: {} }, "host", "CRM Deal"))).toEqual([]);
+    expect(String(warnings.mock.calls[0][0])).toContain("empty block");
+    warnings.mockRestore();
+  });
+
+  // Both spellings are accepted, so one can land on the other — last wins, but
+  // not in silence.
+  it("names a key written twice", () => {
+    const warnings = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const nested = () => {};
+    const flat = flattenHandlers(
+      { "products.qty": noop, products: { qty: nested } },
+      "host",
+      "CRM Deal",
+    );
+    expect(flat["products.qty"]).toBe(nested);
+    expect(String(warnings.mock.calls[0][0])).toContain("written twice");
+    warnings.mockRestore();
+  });
+
+  // The one moment the engine can say what to write instead. Advice, not a
+  // refusal: `add` is a legal child fieldname, which is the whole point.
+  it("names the retired dotted spelling", () => {
+    const warnings = vi.spyOn(console, "warn").mockImplementation(() => {});
+    flattenHandlers({ "products.add": noop }, "host", "CRM Deal");
+    expect(String(warnings.mock.calls[0][0])).toContain(
+      "products: { onAdd() {} }",
+    );
+    warnings.mockRestore();
+  });
+
+  // `<parent>_add` is an ordinary parent fieldname; accusing one would be a
+  // warning that lies.
+  it("does not accuse an underscore fieldname", () => {
+    const warnings = vi.spyOn(console, "warn").mockImplementation(() => {});
+    flattenHandlers({ products_add: noop }, "host", "CRM Deal");
+    expect(warnings).not.toHaveBeenCalled();
+    warnings.mockRestore();
+  });
+
+  // 51's lesson, one level down: a keyspace argument about fieldnames says
+  // nothing about strings that were never fieldnames.
+  it("cannot be made to write onto Object.prototype", () => {
+    const flat = flattenHandlers(
+      { ["__proto__"]: noop, evil: { ["__proto__"]: noop } } as any,
+      "host",
+      "CRM Deal",
+    );
+    expect(Object.getPrototypeOf(flat)).toBe(null);
+    expect(Object.getPrototypeOf({})).toBe(Object.prototype);
+    expect(flat["__proto__"]).toBe(noop);
+    expect(flat["evil.__proto__"]).toBe(noop);
+  });
+
+  // A doctype may have a field called `constructor`, and an inherited hit would
+  // dispatch that field's commit to `Object.prototype`.
+  it("answers only with what the author wrote", () => {
+    const flat = flattenHandlers({ onRefresh: noop }, "host", "CRM Deal");
+    expect(flat["constructor"]).toBeUndefined();
+    expect(flat["toString"]).toBeUndefined();
+  });
+});
+
+describe("registerRecordPage", () => {
+  beforeEach(() => resetRegistry());
+
+  // The one choke point both file scripts and stored scripts pass through.
+  it("stores the flattened keys", () => {
+    registerRecordPage("CRM Deal", { products: { onAdd: noop } });
+    expect(Object.keys(registrationsFor("CRM Deal")[0].handlers)).toEqual([
+      "products.onAdd",
+    ]);
+  });
+});

--- a/frontend/src/recordPage/tests/formTabs.test.ts
+++ b/frontend/src/recordPage/tests/formTabs.test.ts
@@ -1,0 +1,230 @@
+// The Form Layout tabs surface (wayfinder ticket 73) as executable claims: a
+// tab addressed by identity, an overlay that beats `depends_on` in both
+// directions, a reader that resolves both, and a replay that stages.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("frappe-ui", () => ({
+  call: vi.fn(),
+  toast: { success: vi.fn(), error: vi.fn() },
+  frappeRequest: vi.fn(),
+  createResource: () => ({ data: null, loading: false, fetch() {}, reload() {} }),
+}));
+
+import { FormTabsSurface, resetFormTabWarnings } from "../formTabs";
+import type { FormTabsSurfaceHost } from "../formTabs";
+import type { FormLayoutSchema } from "@framework/ui/components/FormLayout/types";
+
+/** Three tabs: one named, one conditional, one with nothing but a label. */
+const LAYOUT: FormLayoutSchema = [
+  { name: "lead_details", label: "Lead Details", sections: [] },
+  {
+    name: "products",
+    label: "Products",
+    dependsOn: "eval:doc.with_products",
+    sections: [],
+  },
+  { label: "Contacts & More", sections: [] },
+];
+
+function makeSurface(host: Partial<FormTabsSurfaceHost> = {}) {
+  return new FormTabsSurface({
+    tabs: () => LAYOUT,
+    doc: () => ({ with_products: 0 }),
+    ...host,
+  });
+}
+
+beforeEach(() => {
+  resetFormTabWarnings();
+  vi.restoreAllMocks();
+});
+
+describe("addressing a tab", () => {
+  it("takes the author's name, and the label slugified when there is none", () => {
+    const formTabs = makeSurface();
+
+    expect(formTabs.has("lead_details")).toBe(true);
+    expect(formTabs.has("contacts-more")).toBe(true);
+    expect(formTabs.has("Contacts & More")).toBe(false);
+  });
+
+  it("sees a tab the layout hides, because `has` asks who authored it", () => {
+    // `products` is off under this doc; a surface that could not see it would
+    // leave a script unable to `show()` the very tab it wants.
+    const formTabs = makeSurface();
+
+    expect(formTabs.has("products")).toBe(true);
+    expect(formTabs.get("products")?.hidden).toBe(true);
+  });
+
+  it("says nothing while the layout is still loading", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const formTabs = makeSurface({ tabs: () => [] });
+
+    formTabs.hide("lead_details");
+
+    expect(warn).not.toHaveBeenCalled();
+    // Recorded anyway: the op must survive the window it was written in.
+    expect(formTabs.resolve()).toEqual({ lead_details: { hidden: true } });
+  });
+
+  it("names a tab the layout does not carry, once", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const formTabs = makeSurface();
+
+    formTabs.hide("nope");
+    formTabs.hide("nope");
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('page.formTabs.hide("nope")');
+  });
+});
+
+describe("the overlay", () => {
+  it("folds an identity's ops into one override, later winning", () => {
+    const formTabs = makeSurface();
+
+    formTabs.hide("lead_details");
+    formTabs.update("lead_details", { label: "Lead" });
+    formTabs.show("lead_details");
+
+    expect(formTabs.resolve()).toEqual({
+      lead_details: { hidden: false, label: "Lead" },
+    });
+  });
+
+  it("takes `label` and drops every other key, naming it", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const formTabs = makeSurface();
+
+    formTabs.update("products", { label: "Items", dependsOn: "eval:1" } as any);
+
+    expect(formTabs.resolve().products).toEqual({ label: "Items" });
+    expect(warn.mock.calls[0][0]).toContain("{ dependsOn }");
+  });
+
+  it("points `update({ hidden })` at the verbs that mean it", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const formTabs = makeSurface();
+
+    formTabs.update("products", { hidden: true } as any);
+
+    expect(formTabs.resolve().products).toEqual({});
+    expect(warn.mock.calls[0][0]).toContain("use hide()/show()");
+  });
+
+  it("keeps `__proto__` off `Object.prototype`", () => {
+    const formTabs = makeSurface();
+    formTabs.hide("__proto__");
+
+    expect(formTabs.resolve()["__proto__"]).toEqual({ hidden: true });
+    expect(({} as any).hidden).toBeUndefined();
+  });
+});
+
+describe("reading a tab back", () => {
+  it("resolves `hidden` from the doc, with the override the last word", () => {
+    const doc = { with_products: 0 };
+    const formTabs = makeSurface({ doc: () => doc });
+
+    expect(formTabs.get("products")?.hidden).toBe(true);
+    formTabs.show("products");
+    expect(formTabs.get("products")?.hidden).toBe(false);
+
+    // And in the other direction, over a `depends_on` that now says yes.
+    doc.with_products = 1;
+    formTabs.hide("products");
+    expect(formTabs.get("products")?.hidden).toBe(true);
+  });
+
+  it("hands back the label a script wrote, beside the address it wrote it at", () => {
+    const formTabs = makeSurface();
+    formTabs.update("contacts-more", { label: "People" });
+
+    expect(formTabs.get("contacts-more")).toEqual({
+      name: undefined,
+      identity: "contacts-more",
+      label: "People",
+      hidden: false,
+    });
+  });
+
+  it("reports the label the strip actually draws", () => {
+    // An unlabelled tab renders as "Details" once the strip is on screen, so a
+    // `get` that answered `''` would disagree with the button beside it.
+    const formTabs = makeSurface({
+      tabs: () => [
+        { name: "first", sections: [] },
+        { name: "second", label: "Second", sections: [] },
+      ],
+    });
+
+    expect(formTabs.get("first")?.label).toBe("Details");
+  });
+
+  it("drops that fallback when it is the only tab left", () => {
+    // One tab draws no strip at all, so there is no blank button to fill in.
+    const formTabs = makeSurface({
+      tabs: () => [
+        { name: "first", sections: [] },
+        { name: "second", label: "Second", sections: [] },
+      ],
+    });
+    formTabs.hide("second");
+
+    expect(formTabs.get("first")?.label).toBe("");
+  });
+
+  it("refuses a write through the snapshot", () => {
+    const formTabs = makeSurface();
+    const tab = formTabs.get("lead_details")!;
+
+    expect(() => {
+      (tab as any).hidden = true;
+    }).toThrow(/page\.formTabs/);
+  });
+
+  it("answers null for a tab that is not there", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(makeSurface().get("nope")).toBeNull();
+  });
+});
+
+describe("the replay", () => {
+  it("publishes a replay's ops in one flush, at the commit", () => {
+    const formTabs = makeSurface();
+    formTabs.hide("products");
+
+    formTabs.beginReplay();
+    formTabs.hide("lead_details");
+    // Mid-replay the host still sees last replay's overlay, never a half-built
+    // one — the strip would otherwise be torn down and rebuilt between them.
+    expect(formTabs.resolve()).toEqual({ products: { hidden: true } });
+
+    formTabs.commitReplay();
+    expect(formTabs.resolve()).toEqual({ lead_details: { hidden: true } });
+  });
+
+  it("tells a source about its own work inside its own handler", () => {
+    const formTabs = makeSurface();
+
+    formTabs.beginReplay();
+    formTabs.hide("lead_details");
+
+    expect(formTabs.get("lead_details")?.hidden).toBe(true);
+  });
+
+  it("publishes only on the outermost commit", () => {
+    // A script's own `page.refresh()` re-enters the replay.
+    const formTabs = makeSurface();
+
+    formTabs.beginReplay();
+    formTabs.beginReplay();
+    formTabs.hide("products");
+    formTabs.commitReplay();
+    expect(formTabs.resolve()).toEqual({});
+
+    formTabs.commitReplay();
+    expect(formTabs.resolve()).toEqual({ products: { hidden: true } });
+  });
+});

--- a/frontend/src/recordPage/tests/headerRenderings.test.ts
+++ b/frontend/src/recordPage/tests/headerRenderings.test.ts
@@ -1,0 +1,747 @@
+// The three renderings (ticket 65) and the fitting rule (ticket 66) as
+// executable claims.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  HeaderActionsSurface,
+  projectHeaderActions,
+  renderingOf,
+  resetHeaderWarnings,
+  type HeaderNode,
+} from "../headerRenderings";
+import type { HeaderAction } from "../types";
+
+const BUDGET = 2;
+
+// A failing assertion never reaches its own `mockRestore`, and a console spy
+// left installed collects the next test's warnings as if they were its own.
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// The warn-once memory is module state, so without this a case that reuses
+// another's message reads an empty `mock.calls` and passes for the wrong reason.
+beforeEach(() => {
+  resetHeaderWarnings();
+});
+
+function action(name: string, extra: Partial<HeaderAction> = {}): HeaderAction {
+  return { name, label: name, ...extra };
+}
+
+const button = (name: string, extra: Partial<HeaderAction> = {}) =>
+  action(name, { display: "button", ...extra });
+
+const dropdown = (name: string, extra: Partial<HeaderAction> = {}) =>
+  action(name, { display: "dropdown", ...extra });
+
+/** The surface's own shape: what `resolve()` hands the host. */
+function resolved(items: HeaderAction[], ...hidden: string[]) {
+  return items.map((item) => ({
+    item,
+    source: "test",
+    hidden: hidden.includes(item.name),
+  }));
+}
+
+function project(items: HeaderAction[], budget = BUDGET) {
+  return projectHeaderActions(resolved(items), budget);
+}
+
+function controlNames(items: HeaderAction[], budget = BUDGET) {
+  return project(items, budget).controls.map(
+    (control) => `${control.kind}:${control.item.name}`
+  );
+}
+
+function bandNames(items: HeaderAction[], budget = BUDGET) {
+  return project(items, budget).bands.map(
+    (band) => `${band.group}[${band.items.map(rendered).join(",")}]`
+  );
+}
+
+/** A band's rows as one string, so nesting is visible in the expectation. */
+function rendered(node: HeaderNode): string {
+  if (!node.container) return node.item.name;
+  return `${node.item.name}{${node.members.map(rendered).join(",")}}`;
+}
+
+describe("the three renderings", () => {
+  it("gives a bare button, a dropdown of its own, and the shared menu", () => {
+    const items = [
+      button("refresh_quote"),
+      dropdown("telephony"),
+      action("call", { group: "telephony" }),
+      action("sms", { group: "telephony" }),
+      action("audit"),
+    ];
+    expect(controlNames(items)).toEqual([
+      "button:refresh_quote",
+      "dropdown:telephony",
+    ]);
+    expect(bandNames(items)).toEqual(["actions[audit]"]);
+  });
+
+  it("collects a dropdown's members wherever they sit in the flat list", () => {
+    const items = [
+      action("call", { group: "telephony" }),
+      button("refresh_quote"),
+      dropdown("telephony"),
+      action("sms", { group: "telephony" }),
+    ];
+    const { controls } = project(items);
+    const telephony = controls[1];
+    expect(telephony.kind).toBe("dropdown");
+    expect(
+      telephony.kind === "dropdown" && telephony.members.map(rendered)
+    ).toEqual(["call", "sms"]);
+  });
+
+  // A member never relocates the button it hangs off: the container's own
+  // position places it (ticket 65).
+  it("places a dropdown by its own item, not by its first member", () => {
+    const items = [
+      action("sms", { group: "telephony" }),
+      button("refresh_quote"),
+      dropdown("telephony"),
+    ];
+    expect(controlNames(items)).toEqual([
+      "button:refresh_quote",
+      "dropdown:telephony",
+    ]);
+  });
+
+  it("keeps the adjacency banding for everything that stays in the menu", () => {
+    const items = [
+      action("favourite", { group: "favourite" }),
+      action("copy_url"),
+      action("copy_id"),
+      action("delete", { group: "delete" }),
+    ];
+    expect(bandNames(items)).toEqual([
+      "favourite[favourite]",
+      "actions[copy_url,copy_id]",
+      "delete[delete]",
+    ]);
+  });
+
+  it("keeps a dropdown's members out of the menu bands", () => {
+    const items = [
+      action("copy_url"),
+      dropdown("telephony"),
+      action("call", { group: "telephony" }),
+      action("copy_id"),
+    ];
+    expect(bandNames(items)).toEqual(["actions[copy_url,copy_id]"]);
+  });
+});
+
+describe("the fitting rule", () => {
+  it("keeps the leading controls and demotes from the right", () => {
+    const items = [button("one"), button("two"), button("three")];
+    expect(controlNames(items)).toEqual(["button:one", "button:two"]);
+    expect(bandNames(items)).toEqual(["three[three]"]);
+  });
+
+  it("demotes everything at budget 0, which is the mobile rule", () => {
+    const items = [
+      button("one"),
+      dropdown("two"),
+      action("call", { group: "two" }),
+    ];
+    expect(controlNames(items, 0)).toEqual([]);
+    expect(bandNames(items, 0)).toEqual(["one[one]", "two[call]"]);
+  });
+
+  it("collapses a demoted dropdown whole, under its own label as a heading", () => {
+    const items = [
+      button("one"),
+      button("two"),
+      dropdown("telephony", { label: "Telephony" }),
+      action("call", { group: "telephony" }),
+      action("sms", { group: "telephony" }),
+    ];
+    const { bands } = project(items);
+    expect(bands[0]).toMatchObject({ group: "telephony", label: "Telephony" });
+    expect(bands[0].items.map(rendered)).toEqual(["call", "sms"]);
+  });
+
+  // The only band that carries a heading is a collapsed dropdown's.
+  it("gives a demoted bare button a band with no heading", () => {
+    const items = [
+      button("one"),
+      button("two"),
+      button("three"),
+      action("audit"),
+    ];
+    const { bands } = project(items);
+    expect(bands[0]).toEqual({
+      group: "three",
+      items: [{ item: items[2], members: [] }],
+    });
+  });
+
+  it("demotes several controls in their top-level order, ahead of the built-ins", () => {
+    const items = [
+      button("one"),
+      button("two"),
+      button("three"),
+      button("four"),
+      action("copy_url"),
+    ];
+    expect(bandNames(items)).toEqual([
+      "three[three]",
+      "four[four]",
+      "actions[copy_url]",
+    ]);
+  });
+
+  // A promoted built-in overflows on the same rule and does not return to its
+  // home band: provenance orders nothing here (ticket 66 §4).
+  it("demotes a promoted built-in to the front, not back to its own band", () => {
+    const items = [
+      button("one"),
+      button("two"),
+      action("copy_url"),
+      button("delete", { group: "delete" }),
+    ];
+    expect(bandNames(items)).toEqual(["delete[delete]", "actions[copy_url]"]);
+  });
+
+  // An empty dropdown is a button that opens nothing (ticket 66 §5).
+  it("drops a dropdown with no visible members before the budget applies", () => {
+    const items = [dropdown("telephony"), button("one"), button("two")];
+    expect(controlNames(items)).toEqual(["button:one", "button:two"]);
+    expect(bandNames(items)).toEqual([]);
+  });
+
+  // The container is above its members, as a hidden panelSection is above its
+  // fields: hiding it removes the whole control, members and all.
+  it("takes a hidden dropdown's members with it", () => {
+    const items = [
+      dropdown("telephony"),
+      action("call", { group: "telephony" }),
+      action("sms", { group: "telephony" }),
+      action("copy_url"),
+    ];
+    const projection = projectHeaderActions(
+      resolved(items, "telephony"),
+      BUDGET
+    );
+    expect(projection.controls).toEqual([]);
+    expect(projection.bands.map((band) => band.group)).toEqual(["actions"]);
+  });
+
+  // ...but a group naming no dropdown at all is still an invented menu band,
+  // which is what a script writing `group: 'my_band'` has always got.
+  it("leaves a group that names no dropdown as a band of its own", () => {
+    const items = [
+      action("audit", { group: "audit_band" }),
+      action("copy_url"),
+    ];
+    expect(bandNames(items)).toEqual([
+      "audit_band[audit]",
+      "actions[copy_url]",
+    ]);
+  });
+});
+
+// Ticket 77 §1-§4: a section is a container spelled the way a dropdown is, a
+// submenu is a container inside a container, and both fall out of one rule.
+describe("sections and submenus", () => {
+  const section = (name: string, extra: Partial<HeaderAction> = {}) =>
+    action(name, { display: "section", ...extra });
+
+  it("titles a band with a top-level section, and charges it no budget", () => {
+    const items = [
+      button("one"),
+      button("two"),
+      section("danger", { label: "Danger" }),
+      action("delete", { group: "danger" }),
+      action("copy_url"),
+    ];
+    // Both buttons still fit: the section is not a control.
+    expect(controlNames(items)).toEqual(["button:one", "button:two"]);
+    const { bands } = project(items);
+    expect(bands.map((band) => [band.group, band.label])).toEqual([
+      ["danger", "Danger"],
+      ["actions", undefined],
+    ]);
+    expect(bands[0].items.map(rendered)).toEqual(["delete"]);
+  });
+
+  it("gives a top-level dropdown a titled section among its members", () => {
+    const items = [
+      dropdown("tools", { label: "Deal Tools" }),
+      action("snapshot", { group: "tools" }),
+      section("danger", { label: "Danger", group: "tools" }),
+      action("delete", { group: "danger" }),
+    ];
+    const { controls } = project(items);
+    expect(
+      controls[0].kind === "dropdown" && controls[0].members.map(rendered)
+    ).toEqual(["snapshot", "danger{delete}"]);
+  });
+
+  it("renders a container inside a container as a submenu", () => {
+    const items = [
+      dropdown("tools", { label: "Deal Tools" }),
+      dropdown("share", { label: "Share", group: "tools" }),
+      action("share_email", { group: "share" }),
+      action("share_link", { group: "share" }),
+    ];
+    const { controls } = project(items);
+    expect(
+      controls[0].kind === "dropdown" && controls[0].members.map(rendered)
+    ).toEqual(["share{share_email,share_link}"]);
+  });
+
+  // Ticket 77 §4: `MenuOption` excludes `MenuGroupOption`, so a band cannot hold
+  // a titled group — but `MenuSubmenuOption` is a legal `MenuOption`.
+  it("flattens a demoted dropdown's section and keeps its submenu", () => {
+    const items = [
+      button("one"),
+      button("two"),
+      dropdown("tools", { label: "Deal Tools" }),
+      dropdown("share", { label: "Share", group: "tools" }),
+      action("share_link", { group: "share" }),
+      section("danger", { label: "Danger", group: "tools" }),
+      action("delete", { group: "danger" }),
+    ];
+    const { bands } = project(items);
+    expect(bands[0]).toMatchObject({ group: "tools", label: "Deal Tools" });
+    expect(bands[0].items.map(rendered)).toEqual([
+      "share{share_link}",
+      "delete",
+    ]);
+  });
+
+  // The same fact one level up: a band is a band wherever it came from.
+  it("flattens a section inside a top-level section", () => {
+    const items = [
+      section("outer", { label: "Outer" }),
+      section("inner", { label: "Inner", group: "outer" }),
+      action("deep", { group: "inner" }),
+    ];
+    expect(bandNames(items)).toEqual(["outer[deep]"]);
+  });
+
+  it("takes a nested container and its members down with a hidden outer one", () => {
+    const items = [
+      dropdown("tools", { label: "Deal Tools" }),
+      section("danger", { label: "Danger", group: "tools" }),
+      action("delete", { group: "danger" }),
+      action("copy_url"),
+    ];
+    const projection = projectHeaderActions(resolved(items, "tools"), BUDGET);
+    expect(projection.controls).toEqual([]);
+    expect(projection.bands.map((band) => band.group)).toEqual(["actions"]);
+  });
+
+  it("drops a section that has nothing in it", () => {
+    const items = [section("danger", { label: "Danger" }), action("copy_url")];
+    expect(bandNames(items)).toEqual(["actions[copy_url]"]);
+  });
+
+  it("warns about an unknown display and renders it in the menu", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const items = [action("odd", { display: "flyout" as any })];
+    expect(bandNames(items)).toEqual(["actions[odd]"]);
+    expect(warn.mock.calls[0][0]).toContain("display: 'flyout'");
+    warn.mockRestore();
+  });
+
+  // Ticket 77 §6: `MenuSubmenuOption` forbids `onClick` outright, so what was
+  // incidental for a dropdown is now a rule in the dependency.
+  it("warns that a container's run never fires", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const items = [
+      dropdown("noisy", { label: "Noisy", run: () => {} }),
+      action("inside", { group: "noisy" }),
+    ];
+    project(items);
+    expect(warn.mock.calls[0][0]).toContain("its `run` never fires");
+    warn.mockRestore();
+  });
+});
+
+// Ticket 77 §3: clamped, never ignored — ignoring `group` would promote the
+// container to a top-level control, where it would eat a budget slot.
+describe("the depth cap", () => {
+  const section = (name: string, extra: Partial<HeaderAction> = {}) =>
+    action(name, { display: "section", ...extra });
+
+  it("moves a third-level container up to the deepest level it can reach", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const items = [
+      dropdown("d1", { label: "One" }),
+      dropdown("d2", { label: "Two", group: "d1" }),
+      dropdown("d3", { label: "Three", group: "d2" }),
+      action("deep", { group: "d3" }),
+    ];
+    const { controls } = project(items);
+    expect(controls.map((control) => control.item.name)).toEqual(["d1"]);
+    expect(
+      controls[0].kind === "dropdown" && controls[0].members.map(rendered)
+      // `d2` is not here: clamping emptied it, and an empty dropdown is a
+      // trigger that opens nothing.
+    ).toEqual(["d3{deep}"]);
+    expect(warn.mock.calls[0][0]).toContain("nests 3 containers deep");
+    warn.mockRestore();
+  });
+
+  // Clamping is what actually produces an empty container, and a dropdown with
+  // nothing in it is a trigger that opens nothing — 66 §5's rule, applied at
+  // every level and not only to a top-level control.
+  it("drops the dropdown clamping emptied, at any depth", () => {
+    const items = [
+      dropdown("e1", { label: "One" }),
+      dropdown("e2", { label: "Two", group: "e1" }),
+      dropdown("e3", { label: "Three", group: "e2" }),
+      action("leaf", { group: "e3" }),
+    ];
+    const { controls } = project(items);
+    expect(
+      controls[0].kind === "dropdown" && controls[0].members.map(rendered)
+    ).toEqual(["e3{leaf}"]);
+  });
+
+  it("puts a `group` cycle in the menu rather than in the header row", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const items = [
+      dropdown("ping", { label: "Ping", group: "pong" }),
+      dropdown("pong", { label: "Pong", group: "ping" }),
+      action("inside", { group: "ping" }),
+      action("other", { group: "pong" }),
+      button("real"),
+    ];
+    // The cycle wins no slot: the one real control is the only control.
+    expect(controlNames(items)).toEqual(["button:real"]);
+    const { bands } = project(items);
+    expect(bands.map((band) => [band.group, band.label])).toEqual([
+      ["ping", "Ping"],
+      ["pong", "Pong"],
+    ]);
+    expect(bands[0].items.map(rendered)).toEqual(["inside"]);
+    expect(warn.mock.calls[0][0]).toContain("`group` cycle");
+    warn.mockRestore();
+  });
+
+  // ...but an emptied *section* stays: frappe-ui drops a group with no options
+  // of its own, and a section is the one container that can be empty harmlessly.
+  it("clamps a section the same way, and leaves the emptied one standing", () => {
+    const items = [
+      dropdown("s1", { label: "One" }),
+      section("s2", { label: "Two", group: "s1" }),
+      section("s3", { label: "Three", group: "s2" }),
+      action("deep", { group: "s3" }),
+    ];
+    const { controls } = project(items);
+    expect(
+      controls[0].kind === "dropdown" && controls[0].members.map(rendered)
+    ).toEqual(["s2{}", "s3{deep}"]);
+  });
+});
+
+// Ticket 77 §5. `order(names[])` was the precedent; this is the same shape for
+// the verb that made a dropdown four calls.
+describe("add takes a block", () => {
+  it("splices the block as a unit at the anchor, in list order", () => {
+    const built = new HeaderActionsSurface();
+    built.provideBuiltins(() => [action("copy_url"), action("delete")]);
+    built.add(
+      [
+        dropdown("tools", { label: "Deal Tools" }),
+        action("snapshot", { group: "tools" }),
+        action("audit", { group: "tools" }),
+      ],
+      { before: "delete" }
+    );
+    expect(built.visible().map((item) => item.name)).toEqual([
+      "copy_url",
+      "tools",
+      "snapshot",
+      "audit",
+      "delete",
+    ]);
+  });
+
+  it("appends the block when the anchor names nothing", () => {
+    const built = new HeaderActionsSurface();
+    built.provideBuiltins(() => [action("copy_url")]);
+    built.add([action("a"), action("b")], { after: "nowhere" });
+    expect(built.visible().map((item) => item.name)).toEqual([
+      "copy_url",
+      "a",
+      "b",
+    ]);
+  });
+
+  // The block is spliced one item at a time, so an anchor naming an item the
+  // same block adds must still leave the block contiguous and in order.
+  it("stays contiguous when the anchor is inside the block", () => {
+    const built = new HeaderActionsSurface();
+    built.provideBuiltins(() => [action("copy_url"), action("delete")]);
+    built.add([action("a"), action("b"), action("c")], { before: "b" });
+    expect(built.visible().map((item) => item.name)).toEqual([
+      "copy_url",
+      "delete",
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+
+  // Ticket 77 §5: the icon bridge and the raw-component guard run per item, or
+  // only the head of a block gets them.
+  it("bridges every item's icon, not just the head's", () => {
+    const built = new HeaderActionsSurface();
+    built.provideBuiltins(() => []);
+    built.add([
+      action("a", { icon: "lucide-circle" }),
+      action("b", { icon: "lucide-square" }),
+    ]);
+    expect(built.visible().map((item) => item.icon)).toEqual([
+      "lucide-circle",
+      "lucide-square",
+    ]);
+  });
+
+  it("does nothing with an empty block", () => {
+    const built = new HeaderActionsSurface();
+    built.provideBuiltins(() => [action("copy_url")]);
+    built.add([]);
+    expect(built.visible().map((item) => item.name)).toEqual(["copy_url"]);
+  });
+
+  // The anchor belongs to the block, not to each item in it: claiming it for
+  // every item would report an anchor the tail was never given.
+  it("warns about the block's anchor once, for its head", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const built = new HeaderActionsSurface();
+    built.provideBuiltins(() => [button("refresh_quote"), action("delete")]);
+    built.add(
+      [
+        dropdown("tools", { label: "Deal Tools" }),
+        action("snapshot", { group: "tools" }),
+        action("audit", { group: "tools" }),
+      ],
+      { after: "delete" }
+    );
+    built.visible();
+    expect(warn.mock.calls.map((call) => call[0])).toEqual([
+      expect.stringContaining("headerActions.add('tools')"),
+    ]);
+    warn.mockRestore();
+  });
+
+  it("stages a block in a replay and swaps it in whole", () => {
+    const built = new HeaderActionsSurface();
+    built.provideBuiltins(() => [action("copy_url")]);
+    built.beginReplay();
+    built.add([action("a"), action("b")]);
+    // The self-read resolves over the replay in flight (ticket 70).
+    expect(built.has("b")).toBe(true);
+    built.commitReplay();
+    expect(built.visible().map((item) => item.name)).toEqual([
+      "copy_url",
+      "a",
+      "b",
+    ]);
+  });
+});
+
+// The one rule again, from the other end: `group` decides where an item goes,
+// and `display` only decides what it looks like once it is there.
+describe("group beats display", () => {
+  it("makes a button inside a dropdown an ordinary row, and says so", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    project([
+      dropdown("holder", { label: "Holder" }),
+      button("stray", { group: "holder" }),
+    ]);
+    expect(warn.mock.calls[0][0]).toContain("is a button inside 'holder'");
+    warn.mockRestore();
+  });
+
+  it("makes a button inside a dropdown an ordinary row", () => {
+    const items = [
+      dropdown("tools", { label: "Tools" }),
+      button("inside", { group: "tools" }),
+      button("outside"),
+    ];
+    expect(controlNames(items)).toEqual(["dropdown:tools", "button:outside"]);
+    const { controls } = project(items);
+    expect(
+      controls[0].kind === "dropdown" && controls[0].members.map(rendered)
+    ).toEqual(["inside"]);
+  });
+
+  it("buries a member two containers down with the outermost one", () => {
+    const items = [
+      dropdown("outer", { label: "Outer" }),
+      dropdown("middle", { label: "Middle", group: "outer" }),
+      action("leaf", { group: "middle" }),
+      action("copy_url"),
+    ];
+    const projection = projectHeaderActions(resolved(items, "outer"), BUDGET);
+    expect(projection.controls).toEqual([]);
+    expect(projection.bands.map((band) => band.group)).toEqual(["actions"]);
+  });
+});
+
+describe("the cross-rendering anchor warning", () => {
+  function surface(items: HeaderAction[]) {
+    const built = new HeaderActionsSurface();
+    built.provideBuiltins(() => items);
+    return built;
+  }
+
+  it("warns when an anchor renders somewhere else, and still splices", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const built = surface([button("refresh_quote"), action("delete")]);
+    built.add(action("escalate"), { after: "refresh_quote" });
+    expect(built.visible().map((item) => item.name)).toEqual([
+      "refresh_quote",
+      "escalate",
+      "delete",
+    ]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("a top-level button");
+    expect(warn.mock.calls[0][0]).toContain("an entry in the ⋯ menu");
+    warn.mockRestore();
+  });
+
+  it("says nothing when both items render the same way", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const built = surface([action("copy_url"), action("delete")]);
+    built.add(action("escalate"), { after: "copy_url" });
+    built.visible();
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  // Checked against the final list, not at call time: a member can be added
+  // before the container that decides its rendering.
+  it("resolves the rendering over the final list", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const built = surface([button("refresh_quote")]);
+    built.add(action("call", { group: "telephony" }), {
+      after: "refresh_quote",
+    });
+    built.add(dropdown("telephony", { label: "Telephony" }));
+    built.visible();
+    expect(warn.mock.calls[0][0]).toContain("“Telephony” dropdown");
+    warn.mockRestore();
+  });
+
+  // A container and its own members sit in different lists, but one of them
+  // *is* the other's list: anchoring a member at its container is how an author
+  // says "first in this dropdown", and it does exactly that.
+  it("says nothing when a member is anchored at its own container", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const built = surface([dropdown("telephony", { label: "Telephony" })]);
+    built.add(action("sms", { group: "telephony" }), { after: "telephony" });
+    built.visible();
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  // ...and the converse: a dropdown button and a bare button are ordered
+  // together by the fitting rule, so they are one rendering (ticket 77).
+  it("says nothing between a bare button and a dropdown button", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const built = surface([dropdown("telephony", { label: "Telephony" })]);
+    built.add(button("escalate"), { after: "telephony" });
+    built.visible();
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("warns once however often the list is resolved", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const built = surface([button("refresh_quote")]);
+    built.add(action("escalate"), { after: "refresh_quote" });
+    built.visible();
+    built.visible();
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it("drops the claims a replay rebuilt the list without", () => {
+    const built = surface([button("refresh_quote")]);
+    built.add(action("escalate"), { after: "refresh_quote" });
+    built.beginReplay();
+    built.commitReplay();
+    expect(built.visible().map((item) => item.name)).toEqual(["refresh_quote"]);
+  });
+});
+
+// Ticket 77 §2. `group: 'x'` now means "put me inside the item named `x`", and
+// an undeclared `x` synthesises an anonymous, untitled container. Every shipped
+// script points at a name it never declared, so it lands on that branch and must
+// render exactly as it did before sections existed: same bands, same order, no
+// headings anywhere.
+describe("the undeclared branch renders as it always did", () => {
+  const shipped = [
+    button("refresh_quote"),
+    dropdown("telephony", { label: "Telephony" }),
+    action("call", { group: "telephony" }),
+    action("sms", { group: "telephony" }),
+    action("favourite", { group: "favourite" }),
+    action("copy_url"),
+    action("copy_id"),
+    action("audit", { group: "audit_band" }),
+    action("delete", { group: "delete" }),
+  ];
+
+  it("bands by adjacency and titles nothing", () => {
+    const { controls, bands } = project(shipped);
+    expect(
+      controls.map((control) => `${control.kind}:${control.item.name}`)
+    ).toEqual(["button:refresh_quote", "dropdown:telephony"]);
+    expect(bandNames(shipped)).toEqual([
+      "favourite[favourite]",
+      "actions[copy_url,copy_id]",
+      "audit_band[audit]",
+      "delete[delete]",
+    ]);
+    expect(bands.every((band) => band.label === undefined)).toBe(true);
+  });
+
+  it("leaves every band flat, with no container among its rows", () => {
+    const { bands } = project(shipped);
+    const rows = bands.flatMap((band) => band.items);
+    expect(rows.every((node) => node.container === undefined)).toBe(true);
+    expect(rows.every((node) => node.members.length === 0)).toBe(true);
+  });
+
+  it("says nothing while doing it", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    project(shipped);
+    project(shipped, 0);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+describe("renderingOf", () => {
+  // Read off the declared display, never the effective one, so nothing
+  // computed from it can become width-dependent (ticket 66 §5).
+  it("answers from the declared display alone", () => {
+    const items = [button("one"), button("two"), button("three")];
+    expect(renderingOf(items[2], items)).toBe("row");
+  });
+
+  it("puts a member in its container's rendering", () => {
+    const items = [
+      dropdown("telephony"),
+      action("call", { group: "telephony" }),
+    ];
+    expect(renderingOf(items[1], items)).toBe("container:telephony");
+  });
+
+  it("leaves a group that names no dropdown in the menu", () => {
+    const items = [action("call", { group: "elsewhere" })];
+    expect(renderingOf(items[0], items)).toBe("menu");
+  });
+});

--- a/frontend/src/recordPage/tests/iconClasses.test.ts
+++ b/frontend/src/recordPage/tests/iconClasses.test.ts
@@ -1,0 +1,114 @@
+// The icon bridge (wayfinder ticket 21): a script may name any lucide icon, and
+// the class is generated from the sprite already in the page.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const STYLE_ID = "record-page-icon-classes";
+
+function installSprite(...names: string[]) {
+	const sprite = document.createElement("div");
+	sprite.id = "lucide-sprite";
+	sprite.innerHTML = names
+		.map((name) => `<symbol id="${name}" viewBox="0 0 24 24"><path d="M4 4h16" /></symbol>`)
+		.join("");
+	document.body.prepend(sprite);
+}
+
+function rules() {
+	return document.getElementById(STYLE_ID)?.textContent ?? "";
+}
+
+// The bridged-icon cache is module state, so each test needs a fresh module.
+async function freshModule() {
+	vi.resetModules();
+	return await import("../iconClasses");
+}
+
+beforeEach(() => {
+	document.head.innerHTML = "";
+	document.body.innerHTML = "";
+});
+
+describe("ensureIconClass", () => {
+	it("generates a masked rule from the sprite symbol", async () => {
+		installSprite("flag");
+		const { ensureIconClass } = await freshModule();
+
+		ensureIconClass("lucide-flag");
+
+		expect(rules()).toContain(".lucide-flag{");
+		expect(rules()).toContain('mask-image:url("data:image/svg+xml;utf8,');
+		// The symbol's geometry, wrapped in a stroke-normalized svg.
+		expect(decodeURIComponent(rules())).toContain('<path d="M4 4h16">');
+		expect(decodeURIComponent(rules())).toContain('stroke-width="1.5"');
+	});
+
+	it("emits a rule once however often an icon is named", async () => {
+		installSprite("flag");
+		const { ensureIconClass } = await freshModule();
+
+		ensureIconClass("lucide-flag");
+		ensureIconClass("lucide-flag");
+
+		expect(rules().match(/\.lucide-flag\{/g)).toHaveLength(1);
+	});
+
+	it("ignores icons the host already ships classes for", async () => {
+		installSprite("flag");
+		const { ensureIconClass } = await freshModule();
+
+		ensureIconClass(undefined);
+		ensureIconClass("space-dashboard"); // a non-lucide pack
+
+		expect(document.getElementById(STYLE_ID)).toBeNull();
+	});
+
+	it("warns and emits nothing for a name the sprite does not carry", async () => {
+		installSprite("flag");
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const { ensureIconClass } = await freshModule();
+
+		ensureIconClass("lucide-not-an-icon");
+
+		expect(document.getElementById(STYLE_ID)).toBeNull();
+		expect(warn).toHaveBeenCalledOnce();
+		warn.mockRestore();
+	});
+
+	it("warns once for a missing sprite, not once per icon", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const { ensureIconClass } = await freshModule();
+
+		ensureIconClass("lucide-flag");
+		ensureIconClass("lucide-scroll-text");
+
+		expect(warn).toHaveBeenCalledOnce();
+		warn.mockRestore();
+	});
+
+	// Prepended, so a `size-4` at the call site still beats the rule's own `width: 1em`.
+	it("puts its style ahead of the app's stylesheets", async () => {
+		installSprite("flag");
+		document.head.appendChild(document.createElement("link"));
+		const { ensureIconClass } = await freshModule();
+
+		ensureIconClass("lucide-flag");
+
+		expect(document.head.firstElementChild?.id).toBe(STYLE_ID);
+	});
+});
+
+describe("ensureIcons", () => {
+	it("bridges an item's own icon and a tab's create-action icon", async () => {
+		installSprite("scroll-text", "plus");
+		const { ensureIcons } = await freshModule();
+
+		ensureIcons({
+			name: "audit-log",
+			icon: "lucide-scroll-text",
+			create: { label: "New", icon: "lucide-plus", run: () => {} },
+		});
+
+		expect(rules()).toContain(".lucide-scroll-text{");
+		expect(rules()).toContain(".lucide-plus{");
+	});
+});

--- a/frontend/src/recordPage/tests/pageScripts.test.ts
+++ b/frontend/src/recordPage/tests/pageScripts.test.ts
@@ -1,0 +1,135 @@
+// The Page Script tier (wayfinder ticket 15) as executable claims.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { call, toast, evaluatePageScript } = vi.hoisted(() => ({
+  call: vi.fn(),
+  toast: { success: vi.fn(), error: vi.fn() },
+  // Blob-URL modules are the real mechanism, but node cannot import one; the
+  // evaluator's own contract is the browser verification's job.
+  evaluatePageScript: vi.fn(),
+}));
+
+vi.mock("frappe-ui", () => ({ call, toast }));
+vi.mock("../evaluatePageScript", () => ({ evaluatePageScript }));
+
+import {
+  canWritePageScripts,
+  loadPageScripts,
+  reloadPageScripts,
+  resetPageScripts,
+} from "../pageScripts";
+import { registrationsFor, resetRegistry } from "../registry";
+
+function respond(scripts: string[], canWrite = true) {
+  call.mockResolvedValue({
+    scripts: scripts.map((name) => ({ name, script: "export default {}" })),
+    can_write: canWrite,
+  });
+}
+
+function sources(doctype = "CRM Deal") {
+  return registrationsFor(doctype).map((registration) => registration.source);
+}
+
+describe("the Page Script tier", () => {
+  beforeEach(() => {
+    resetRegistry();
+    resetPageScripts();
+    call.mockReset();
+    toast.error.mockReset();
+    evaluatePageScript.mockReset();
+    evaluatePageScript.mockImplementation(async () => ({ onRefresh: () => {} }));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("registers the doctype's scripts as sources, in the order served", async () => {
+    respond(["oldest", "newest"]);
+    await loadPageScripts("CRM Deal");
+    expect(sources()).toEqual(["page-script:oldest", "page-script:newest"]);
+  });
+
+  it("fetches once per doctype", async () => {
+    respond(["only"]);
+    await loadPageScripts("CRM Deal");
+    await loadPageScripts("CRM Deal");
+    expect(call).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips a script that fails to load, keeping the rest of the tier", async () => {
+    respond(["broken", "fine"]);
+    evaluatePageScript.mockImplementation(async (row: { name: string }) => {
+      if (row.name === "broken") throw new SyntaxError("Unexpected token");
+      return { onRefresh: () => {} };
+    });
+    await loadPageScripts("CRM Deal");
+    expect(sources()).toEqual(["page-script:fine"]);
+  });
+
+  it("toasts a failure once per script, only for script editors", async () => {
+    respond(["broken"], false);
+    evaluatePageScript.mockRejectedValue(new SyntaxError("Unexpected token"));
+    await loadPageScripts("CRM Deal");
+    expect(toast.error).not.toHaveBeenCalled();
+
+    respond(["broken"], true);
+    await reloadPageScripts("CRM Deal");
+    await reloadPageScripts("CRM Deal");
+    expect(toast.error).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-registers the whole tier on reload, so creation order survives a save", async () => {
+    respond(["oldest", "newest"]);
+    await loadPageScripts("CRM Deal");
+    await reloadPageScripts("CRM Deal");
+    expect(sources()).toEqual(["page-script:oldest", "page-script:newest"]);
+  });
+
+  it("drops a deleted script's source on reload", async () => {
+    respond(["kept", "deleted"]);
+    await loadPageScripts("CRM Deal");
+    respond(["kept"]);
+    await reloadPageScripts("CRM Deal");
+    expect(sources()).toEqual(["page-script:kept"]);
+  });
+
+  it("lets the later of two overlapping reloads win, with no doubled source", async () => {
+    respond(["stale"]);
+    await loadPageScripts("CRM Deal");
+
+    let releaseStale = (_: unknown) => {};
+    call.mockReturnValueOnce(
+      new Promise((resolve) => (releaseStale = resolve)),
+    );
+    const slow = reloadPageScripts("CRM Deal");
+
+    respond(["fresh"]);
+    await reloadPageScripts("CRM Deal");
+    releaseStale({
+      scripts: [{ name: "stale", script: "export default {}" }],
+      can_write: true,
+    });
+    await slow;
+
+    expect(sources()).toEqual(["page-script:fresh"]);
+  });
+
+  // The editor's entry affordance is gated on this, and the tier's fetch is the
+  // only thing that asks the server the question (ticket 16).
+  it("publishes whether the session may write Page Scripts", async () => {
+    expect(canWritePageScripts.value).toBe(false);
+
+    respond(["one"], true);
+    await loadPageScripts("CRM Deal");
+    expect(canWritePageScripts.value).toBe(true);
+
+    respond(["one"], false);
+    await reloadPageScripts("CRM Deal");
+    expect(canWritePageScripts.value).toBe(false);
+  });
+
+  it("leaves the page scriptless when the fetch fails", async () => {
+    call.mockRejectedValue(new Error("offline"));
+    await loadPageScripts("CRM Deal");
+    expect(sources()).toEqual([]);
+  });
+});

--- a/frontend/src/recordPage/tests/permissions.test.ts
+++ b/frontend/src/recordPage/tests/permissions.test.ts
@@ -1,0 +1,203 @@
+// The script-side permission API (wayfinder ticket 18) as executable claims:
+// what `page.perms` holds, what `page.roles` answers, and how `fieldAccess`
+// treats a permlevel and a typo.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { computed, ref } from "vue";
+
+const state = vi.hoisted(() => ({
+  roles: null as string[] | null,
+  meta: null as any,
+}));
+
+// Both composables underneath fetch through `createResource`; here they read
+// whatever the test staged, so no request is made.
+vi.mock("frappe-ui", () => ({
+  call: vi.fn(),
+  toast: { success: vi.fn(), error: vi.fn() },
+  frappeRequest: vi.fn(),
+  createResource: (options: any) => ({
+    get data() {
+      return options.url.endsWith("get_current_user_roles")
+        ? state.roles
+        : state.meta && { docs: [state.meta] };
+    },
+    loading: false,
+    fetch() {},
+    reload() {},
+  }),
+}));
+
+import { createRecordPage, type RecordPageHost } from "../createRecordPage";
+import { whenLoaded } from "../pagePermissions";
+import { resetRegistry } from "../registry";
+import { resetDoctypeMeta } from "@framework/ui/composables/useDoctypeMeta";
+import { resetUserRoles } from "@framework/ui/composables/useUserRoles";
+
+const FIELDS = [
+  { fieldname: "status", fieldtype: "Select", permlevel: 0 },
+  { fieldname: "margin", fieldtype: "Currency", permlevel: 1 },
+  { fieldname: "secret", fieldtype: "Data", permlevel: 2 },
+];
+
+function makeHost(overrides: Partial<RecordPageHost> = {}): RecordPageHost {
+  return {
+    doctype: "CRM Deal",
+    docname: "CRM-DEAL-1",
+    doc: ref({ status: "Open" }),
+    saved: ref({ status: "Open" }),
+    meta: ref({ name: "CRM Deal", fields: FIELDS }),
+    perms: () => ({}),
+    isDirty: () => false,
+    activeTab: () => "activity",
+    activateTab: () => {},
+    save: async () => {},
+    reload: async () => {},
+    router: {} as any,
+    ...overrides,
+  };
+}
+
+describe("page.perms", () => {
+  beforeEach(reset);
+
+  it("keeps every right, including a doctype's custom Permission Type", () => {
+    const { page } = createRecordPage(
+      makeHost({ perms: () => ({ read: 1, write: 0, approve_invoice: 1 }) }),
+    );
+
+    expect(page.perms.read).toBe(1);
+    expect(page.perms.write).toBe(0);
+    expect(page.perms.approve_invoice).toBe(1);
+  });
+
+  it("drops the two bookkeeping keys that are not rights", () => {
+    const { page } = createRecordPage(
+      makeHost({
+        perms: () => ({ read: 1, if_owner: 1, has_if_owner_enabled: 1 }),
+      }),
+    );
+
+    expect(Object.keys(page.perms)).toEqual(["read"]);
+  });
+
+  it("warns once per typo'd right, naming the doctype", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { page } = createRecordPage(makeHost({ perms: () => ({ read: 1 }) }));
+
+    void page.perms.wrtie;
+    void page.perms.wrtie;
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain(
+      "page.perms.wrtie is not a right on CRM Deal.",
+    );
+  });
+
+  it("stays quiet before the rights have loaded", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { page } = createRecordPage(makeHost({ perms: () => ({}) }));
+
+    expect(page.perms.write).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  // Two Proxies on one object (ticket 49 §2): read-only is the outer one, so a
+  // write is refused before the advisory underneath it gets a say, and a read
+  // still reaches the advisory.
+  it("still warns on an unknown right through the read-only wrapper", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { page } = createRecordPage(makeHost({ perms: () => ({ read: 1 }) }));
+
+    void page.perms.wrtie;
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    expect(() => {
+      (page.perms as any).write = 1;
+    }).toThrow("page.perms.write is read-only");
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("page.roles", () => {
+  beforeEach(reset);
+
+  it("is the session user's roles, plain and synchronous", () => {
+    state.roles = ["Sales Manager", "Sales User"];
+    const { page } = createRecordPage(makeHost());
+
+    expect(page.roles.includes("Sales Manager")).toBe(true);
+  });
+
+  it("is an empty array, never null, when roles are unavailable", () => {
+    const { page } = createRecordPage(makeHost());
+
+    expect(page.roles).toEqual([]);
+  });
+});
+
+describe("page.fieldAccess", () => {
+  beforeEach(reset);
+
+  it("reads a permlevel'd field against the roles' DocPerm rows", () => {
+    state.roles = ["Sales User"];
+    state.meta = {
+      name: "CRM Deal",
+      fields: FIELDS,
+      permissions: [
+        { role: "Sales User", permlevel: 0, read: 1, write: 1 },
+        { role: "Sales User", permlevel: 1, read: 1, write: 0 },
+      ],
+    };
+    const { page } = createRecordPage(makeHost());
+
+    expect(page.fieldAccess("status")).toBe("write");
+    expect(page.fieldAccess("margin")).toBe("read");
+    expect(page.fieldAccess("secret")).toBe("none");
+  });
+
+  it("answers none for a fieldname the meta does not have, and warns", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { page } = createRecordPage(makeHost());
+
+    expect(page.fieldAccess("staus")).toBe("none");
+    expect(warn.mock.calls[0][0]).toContain('page.fieldAccess("staus")');
+  });
+
+  it("fails open while the meta is still loading", () => {
+    const { page } = createRecordPage(makeHost({ meta: ref(null) }));
+
+    expect(page.fieldAccess("anything")).toBe("write");
+  });
+});
+
+// The replay waits on this, so a handler never reads roles that have not landed.
+describe("the gate the replay waits on", () => {
+  it("holds until the permission sources have loaded", async () => {
+    const loading = ref(true);
+    let resolved = false;
+    void whenLoaded(computed(() => loading.value)).then(
+      () => (resolved = true),
+    );
+
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    loading.value = false;
+    await new Promise((done) => setTimeout(done));
+    expect(resolved).toBe(true);
+  });
+
+  it("resolves at once when they already have", async () => {
+    await expect(whenLoaded(computed(() => false))).resolves.toBeUndefined();
+  });
+});
+
+function reset() {
+  state.roles = null;
+  state.meta = null;
+  resetRegistry();
+  resetDoctypeMeta();
+  resetUserRoles();
+  vi.restoreAllMocks();
+}

--- a/frontend/src/recordPage/tests/readOnly.test.ts
+++ b/frontend/src/recordPage/tests/readOnly.test.ts
@@ -193,6 +193,26 @@ describe("page.roles", () => {
     expect(state.roles).toEqual(["Sales User", "Accounts User"]);
   });
 
+  it("refuses setPrototypeOf, the mutation that never reaches the set trap", () => {
+    state.roles = ["Sales User"];
+    const { page } = createRecordPage(makeHost());
+
+    expect(() =>
+      Object.setPrototypeOf(page.roles, { includes: () => true }),
+    ).toThrow("page.roles's prototype is read-only");
+    expect(state.roles!.includes("System Manager")).toBe(false);
+  });
+
+  it("refuses freeze, which would lock the shared array non-extensible", () => {
+    state.roles = ["Sales User"];
+    const { page } = createRecordPage(makeHost());
+
+    expect(() => Object.freeze(page.roles)).toThrow(
+      "page.roles's extensibility is read-only",
+    );
+    expect(Object.isFrozen(state.roles)).toBe(false);
+  });
+
   it("still reads, so a copy sorts fine", () => {
     state.roles = ["Sales User", "Accounts User"];
     const { page } = createRecordPage(makeHost());

--- a/frontend/src/recordPage/tests/readOnly.test.ts
+++ b/frontend/src/recordPage/tests/readOnly.test.ts
@@ -1,0 +1,320 @@
+// The outbound half of the compatibility policy (wayfinder ticket 47) as
+// executable claims: nothing `page` hands back may be mutated into shared
+// state, the refusal names the path and the supported verb, and `page.doc` is
+// the one exception.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+
+const state = vi.hoisted(() => ({ roles: null as string[] | null }));
+
+vi.mock("frappe-ui", () => ({
+  call: vi.fn(),
+  toast: { success: vi.fn(), error: vi.fn() },
+  frappeRequest: vi.fn(),
+  createResource: (options: any) => ({
+    get data() {
+      return options.url.endsWith("get_current_user_roles")
+        ? state.roles
+        : null;
+    },
+    loading: false,
+    fetch() {},
+    reload() {},
+  }),
+}));
+
+import { createRecordPage, type RecordPageHost } from "../createRecordPage";
+import { withRunningSource } from "../context";
+import { loadPageScripts, resetPageScripts } from "../pageScripts";
+import { readOnly } from "../readOnly";
+import { resetRegistry } from "../registry";
+import { resetCustomizationErrorReports } from "../reportError";
+import { resetUserRoles } from "@framework/ui/composables/useUserRoles";
+import { call as mockedCall, toast as mockedToast } from "frappe-ui";
+
+const REPORT_METHOD =
+  "frappe.desk.customization_error.report_customization_error";
+
+const META = {
+  name: "CRM Deal",
+  fields: [
+    { fieldname: "status", fieldtype: "Select", hidden: 0 },
+    { fieldname: "qty", fieldtype: "Int", hidden: 0 },
+  ],
+};
+
+const ADVICE = { path: "page.meta", instead: "page.fields.update(...)" };
+
+function makeHost(overrides: Partial<RecordPageHost> = {}): RecordPageHost {
+  return {
+    doctype: "CRM Deal",
+    docname: "CRM-DEAL-1",
+    doc: ref({ status: "Open" }),
+    saved: ref({ status: "Open" }),
+    meta: ref(structuredClone(META)),
+    perms: () => ({ read: 1, write: 1 }),
+    isDirty: () => false,
+    activeTab: () => "activity",
+    activateTab: () => {},
+    save: async () => {},
+    reload: async () => {},
+    router: {} as any,
+    ...overrides,
+  };
+}
+
+/** The tier's fetch is what carries whether this session may write scripts. */
+async function withEditorPermission(canWrite: boolean) {
+  (mockedCall as any).mockResolvedValue({ scripts: [], can_write: canWrite });
+  await loadPageScripts("CRM Deal");
+  (mockedCall as any).mockClear();
+}
+
+function reset() {
+  state.roles = null;
+  resetRegistry();
+  resetUserRoles();
+  resetPageScripts();
+  resetCustomizationErrorReports();
+  (mockedCall as any).mockReset();
+  (mockedCall as any).mockResolvedValue({});
+  (mockedToast as any).error.mockReset();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+}
+
+describe("readOnly", () => {
+  beforeEach(reset);
+
+  it("refuses a nested write, naming the path it was reached through", () => {
+    const meta = readOnly(structuredClone(META), ADVICE);
+
+    expect(() => {
+      meta.fields[1].hidden = 1;
+    }).toThrow("page.meta.fields[1].hidden is read-only");
+  });
+
+  it("names the supported verb, so the refusal is a redirect and not a removal", () => {
+    const meta = readOnly(structuredClone(META), ADVICE);
+
+    expect(() => {
+      meta.fields[1].hidden = 1;
+    }).toThrow("use page.fields.update(...)");
+  });
+
+  it("refuses a delete and a defineProperty, not only an assignment", () => {
+    const meta = readOnly(structuredClone(META), ADVICE);
+
+    expect(() => {
+      delete (meta.fields[0] as any).hidden;
+    }).toThrow("page.meta.fields[0].hidden is read-only");
+    expect(() =>
+      Object.defineProperty(meta.fields[0], "hidden", { value: 1 }),
+    ).toThrow("page.meta.fields[0].hidden is read-only");
+  });
+
+  it("hands back the same wrapper for the same object, so identity holds", () => {
+    const meta = readOnly(structuredClone(META), ADVICE);
+
+    expect(meta.fields[0]).toBe(meta.fields[0]);
+    expect(meta.fields.indexOf(meta.fields[0])).toBe(0);
+  });
+
+  it("leaves every read alone — find, filter, map and spread all still work", () => {
+    const meta = readOnly(structuredClone(META), ADVICE);
+
+    expect(meta.name).toBe("CRM Deal");
+    expect(
+      meta.fields.find((one: any) => one.fieldname === "qty"),
+    ).toBeTruthy();
+    expect(meta.fields.map((one: any) => one.fieldname)).toEqual([
+      "status",
+      "qty",
+    ]);
+    expect([...meta.fields]).toHaveLength(2);
+    expect(Object.keys(meta)).toEqual(["name", "fields"]);
+  });
+
+  it("lets a script that wants to mutate copy first", () => {
+    const meta = readOnly(structuredClone(META), ADVICE);
+    const copy = meta.fields.map((one: any) => ({ ...one }));
+
+    copy[0].hidden = 1;
+
+    expect(copy[0].hidden).toBe(1);
+    expect(meta.fields[0].hidden).toBe(0);
+  });
+
+  // A Proxy `get` must hand back a non-configurable, non-writable property
+  // exactly as the target holds it. Deep-freezing meta at source is still on the
+  // table (ticket 47 §1); without this, the day it lands every read throws.
+  it("reads a frozen property without the engine refusing the read", () => {
+    const frozen = { fields: Object.freeze([{ fieldname: "qty" }]) };
+    const held = readOnly(frozen as any, ADVICE);
+
+    expect(() => held.fields[0]).not.toThrow();
+    expect(held.fields[0].fieldname).toBe("qty");
+  });
+
+  it("is idempotent — wrapping a wrapper hands the same wrapper back", () => {
+    const once = readOnly(structuredClone(META), ADVICE);
+    const twice = readOnly(once, ADVICE);
+
+    expect(twice).toBe(once);
+  });
+
+  it("wraps nothing that is not a plain object or an array", () => {
+    const when = new Date();
+    const held = readOnly({ when, count: 3 } as any, ADVICE);
+
+    expect(held.when).toBe(when);
+    expect(held.when.getFullYear()).toBe(when.getFullYear());
+    expect(held.count).toBe(3);
+  });
+});
+
+describe("page.roles", () => {
+  beforeEach(reset);
+
+  it("refuses push — the write that corrupts the session-global array", () => {
+    state.roles = ["Sales User"];
+    const { page } = createRecordPage(makeHost());
+
+    expect(() => page.roles.push("System Manager")).toThrow(
+      "page.roles[1] is read-only",
+    );
+    expect(state.roles).toEqual(["Sales User"]);
+  });
+
+  it("refuses sort, which writes through indices like every array mutator", () => {
+    state.roles = ["Sales User", "Accounts User"];
+    const { page } = createRecordPage(makeHost());
+
+    expect(() => page.roles.sort()).toThrow("is read-only");
+    expect(state.roles).toEqual(["Sales User", "Accounts User"]);
+  });
+
+  it("still reads, so a copy sorts fine", () => {
+    state.roles = ["Sales User", "Accounts User"];
+    const { page } = createRecordPage(makeHost());
+
+    expect([...page.roles].sort()).toEqual(["Accounts User", "Sales User"]);
+  });
+});
+
+describe("page.meta and page.perms at the door", () => {
+  beforeEach(reset);
+
+  it("refuses a write to the cached meta that outlives this record", () => {
+    const host = makeHost();
+    const { page } = createRecordPage(host);
+
+    expect(() => {
+      page.meta.fields[1].hidden = 1;
+    }).toThrow("page.meta.fields[1].hidden is read-only");
+    expect(host.meta.value.fields[1].hidden).toBe(0);
+  });
+
+  it("refuses a write to the memoised rights view shared by every source", () => {
+    const { page } = createRecordPage(makeHost());
+
+    expect(() => {
+      (page.perms as any).write = 1;
+    }).toThrow("page.perms.write is read-only");
+  });
+
+  it("keeps page.doc writable, because mutating the document is the API", () => {
+    const { page } = createRecordPage(makeHost());
+
+    page.doc.status = "Won";
+
+    expect(page.doc.status).toBe("Won");
+  });
+});
+
+// The saved mirror (wayfinder ticket 46): the v2 answer to "what was the
+// previous value", and one letter away from the draft you may edit.
+describe("page.saved", () => {
+  beforeEach(reset);
+
+  it("is the document as the server last showed it, defined before any edit", () => {
+    const { page } = createRecordPage(makeHost());
+
+    page.doc.status = "Won";
+
+    expect(page.saved.status).toBe("Open");
+    expect(page.saved.status !== page.doc.status).toBe(true);
+  });
+
+  it("refuses a write, and points at page.doc — the plausible typo", () => {
+    const host = makeHost();
+    const { page } = createRecordPage(host);
+
+    expect(() => {
+      page.saved.status = "Won";
+    }).toThrow("page.saved.status is read-only — use page.doc");
+    expect(host.saved.value.status).toBe("Open");
+  });
+
+  it("tracks the baseline the host repaints after a save", () => {
+    const host = makeHost();
+    const { page } = createRecordPage(host);
+
+    host.saved.value = { status: "Won" };
+
+    expect(page.saved.status).toBe("Won");
+  });
+});
+
+describe("the refusal reports on the tombstone channel", () => {
+  beforeEach(reset);
+
+  it("files an Error Log row and toasts an author who can edit scripts", async () => {
+    await withEditorPermission(true);
+    const { page } = createRecordPage(makeHost());
+
+    await withRunningSource("page-script:products", async () => {
+      expect(() => {
+        page.meta.fields[0].hidden = 1;
+      }).toThrow();
+    });
+
+    expect(mockedCall).toHaveBeenCalledWith(REPORT_METHOD, expect.anything());
+    const payload = (mockedCall as any).mock.calls[0][1];
+    expect(payload.source).toBe("page-script:products");
+    expect(payload.event).toBe("readonly:page.meta");
+    expect(payload.message).toContain("page.meta.fields[0].hidden");
+    expect((mockedToast as any).error).toHaveBeenCalledWith(
+      expect.stringContaining("read-only"),
+    );
+  });
+
+  it("files once per member per script, however many rows it walks", async () => {
+    await withEditorPermission(true);
+    const { page } = createRecordPage(makeHost());
+
+    await withRunningSource("page-script:products", async () => {
+      for (const field of page.meta.fields)
+        expect(() => {
+          field.hidden = 1;
+        }).toThrow();
+    });
+
+    const reports = (mockedCall as any).mock.calls.filter(
+      ([method]: [string]) => method === REPORT_METHOD,
+    );
+    expect(reports).toHaveLength(1);
+    expect((mockedToast as any).error).toHaveBeenCalledTimes(1);
+  });
+
+  it("still files the row for a reader who cannot edit scripts, without toasting", async () => {
+    await withEditorPermission(false);
+    const { page } = createRecordPage(makeHost());
+
+    expect(() => {
+      page.meta.fields[0].hidden = 1;
+    }).toThrow();
+
+    expect(mockedCall).toHaveBeenCalledWith(REPORT_METHOD, expect.anything());
+    expect((mockedToast as any).error).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/recordPage/tests/reportError.test.ts
+++ b/frontend/src/recordPage/tests/reportError.test.ts
@@ -1,0 +1,150 @@
+// The reporter (wayfinder ticket 19 §3) as executable claims: it caps itself, and
+// it never becomes the failure it is reporting.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { call } = vi.hoisted(() => ({ call: vi.fn() }));
+
+vi.mock("frappe-ui", () => ({
+  call,
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  reportCustomizationError,
+  resetCustomizationErrorReports,
+  tierOf,
+} from "../reportError";
+
+function payload(index = 0) {
+  return call.mock.calls[index][1];
+}
+
+describe("the customization error reporter", () => {
+  beforeEach(() => {
+    resetCustomizationErrorReports();
+    call.mockReset();
+    call.mockResolvedValue({});
+  });
+
+  it("reads the tier off the source, because attribution already carries it", () => {
+    expect(tierOf("page-script:Refund Button")).toBe("page_script");
+    expect(tierOf("host")).toBe("file_script");
+    expect(tierOf("audit")).toBe("extension");
+  });
+
+  it("sends the error's message and stack apart", () => {
+    const error = new Error("boom");
+    error.stack = "at somewhere";
+    reportCustomizationError(error, { source: "audit", event: "load" });
+
+    expect(payload().message).toBe("boom");
+    expect(payload().stack).toBe("at somewhere");
+    expect(payload().tier).toBe("extension");
+  });
+
+  it("truncates before the request, not just at the server", () => {
+    const error = new Error("m".repeat(5000));
+    error.stack = "s".repeat(9000);
+    reportCustomizationError(error, { source: "host", event: "onRefresh" });
+
+    expect(payload().message).toHaveLength(1000);
+    expect(payload().stack).toHaveLength(4000);
+  });
+
+  it("reports a source's event once per page session, killing the replay storm", () => {
+    for (let attempt = 0; attempt < 5; attempt++)
+      reportCustomizationError(new Error("boom"), {
+        source: "page-script:A",
+        event: "onRefresh",
+      });
+
+    expect(call).toHaveBeenCalledTimes(1);
+  });
+
+  it("still reports the same source's other events", () => {
+    for (const event of ["onRefresh", "afterSave"])
+      reportCustomizationError(new Error("boom"), {
+        source: "page-script:A",
+        event,
+      });
+
+    expect(call).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports afresh once the session is reset", () => {
+    const report = () =>
+      reportCustomizationError(new Error("boom"), {
+        source: "page-script:A",
+        event: "onRefresh",
+      });
+    report();
+    resetCustomizationErrorReports();
+    report();
+
+    expect(call).toHaveBeenCalledTimes(2);
+  });
+
+  it("swallows a rejected report rather than reporting the reporter", async () => {
+    call.mockRejectedValue(new Error("network down"));
+
+    expect(() =>
+      reportCustomizationError(new Error("boom"), {
+        source: "host",
+        event: "load",
+      }),
+    ).not.toThrow();
+    await Promise.resolve();
+  });
+
+  it("swallows a synchronous throw from call", () => {
+    call.mockImplementation(() => {
+      throw new Error("frappe-ui is not ready");
+    });
+
+    expect(() =>
+      reportCustomizationError(new Error("boom"), {
+        source: "host",
+        event: "load",
+      }),
+    ).not.toThrow();
+  });
+
+  it("survives a call that hands back nothing at all", () => {
+    call.mockReturnValue(undefined);
+
+    expect(() =>
+      reportCustomizationError(new Error("boom"), {
+        source: "host",
+        event: "load",
+      }),
+    ).not.toThrow();
+  });
+
+  it("takes an explicit tier, because the tier's own fetch has no script", () => {
+    reportCustomizationError(new Error("boom"), {
+      source: "page-scripts",
+      tier: "page_script",
+      event: "load",
+      doctype: "CRM Deal",
+    });
+
+    expect(payload().tier).toBe("page_script");
+    expect(payload().doctype).toBe("CRM Deal");
+  });
+
+  it("files one error once, at whichever site knew most about it", () => {
+    // A tombstone hit reports itself, then throws into the handler catch, which
+    // would otherwise file the same failure again under a duller name.
+    const error = new Error("page.dialog.prompt was removed in 0.3.0");
+    reportCustomizationError(error, {
+      source: "page-script:A",
+      event: "removed:dialog.prompt",
+    });
+    reportCustomizationError(error, {
+      source: "page-script:A",
+      event: "onRefresh",
+    });
+
+    expect(call).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/recordPage/tests/rows.test.ts
+++ b/frontend/src/recordPage/tests/rows.test.ts
@@ -1,0 +1,331 @@
+// `page.rows`, the row handle and the dotted vocabulary (wayfinder tickets 43, 45).
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { isRef, reactive, ref, toRaw } from "vue";
+
+vi.mock("frappe-ui", () => ({
+  call: vi.fn(),
+  toast: { success: vi.fn(), error: vi.fn() },
+  createResource: () => ({ data: null, loading: false, fetch() {}, reload() {} }),
+  frappeRequest: vi.fn(),
+}));
+
+import { createRecordPage, type RecordPageHost } from "../createRecordPage";
+import { registerRecordPage, resetRegistry } from "../registry";
+import { withRegisteringSource } from "../context";
+import { resetCustomizationErrorReports } from "../reportError";
+import { resetRowWarnings } from "../rows";
+import { ROW_ID } from "@framework/ui/components/Fields/rowIdentity";
+import type { RecordPageApi, PageRow } from "../types";
+
+const CHILD_FIELDS = [
+  { fieldname: "qty", fieldtype: "Int" },
+  { fieldname: "rate", fieldtype: "Currency" },
+  { fieldname: "amount", fieldtype: "Currency" },
+];
+
+const META = {
+  fields: [
+    { fieldname: "status", fieldtype: "Select" },
+    { fieldname: "products", fieldtype: "Table", options: "Deal Product" },
+  ],
+};
+
+function makeHost(overrides: Partial<RecordPageHost> = {}): RecordPageHost {
+  return {
+    doctype: "CRM Deal",
+    docname: "CRM-DEAL-1",
+    doc: ref({
+      status: "Open",
+      products: [
+        { name: "row-a", qty: 2, rate: 50 },
+        { name: "row-b", qty: 1, rate: 10 },
+      ],
+    }),
+    saved: ref({}),
+    meta: ref(META),
+    perms: () => ({}),
+    isDirty: () => false,
+    activeTab: () => "activity",
+    activateTab: () => {},
+    save: async () => {},
+    reload: async () => {},
+    router: {} as any,
+    ...overrides,
+  };
+}
+
+function makePage(overrides: Partial<RecordPageHost> = {}) {
+  const host = makeHost(overrides);
+  return { host, controller: createRecordPage(host) };
+}
+
+beforeEach(() => {
+  // A second `spyOn` of a console method hands back the *same* mock, calls and
+  // all, so a test that silences one must not leak into the next one's reading.
+  vi.restoreAllMocks();
+  resetRegistry();
+  resetCustomizationErrorReports();
+  resetRowWarnings();
+});
+
+describe("page.rows", () => {
+  it("hands back a handle per row, in array order", () => {
+    const { controller } = makePage();
+    const rows = controller.page.rows("products");
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => row.qty)).toEqual([2, 1]);
+  });
+
+  it("mints an id for a row a script pushed onto the doc itself", () => {
+    const { host, controller } = makePage();
+    host.doc.value.products.push({ qty: 7 });
+    expect(controller.page.rows("products").at(-1)!.qty).toBe(7);
+    expect(host.doc.value.products[2][ROW_ID]).toMatch(/^row-\d+$/);
+  });
+
+  it("dev-warns and answers empty for a fieldname that is not a child table", () => {
+    const warnings = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { controller } = makePage();
+    expect(controller.page.rows("status")).toEqual([]);
+    expect(String(warnings.mock.calls[0][0])).toContain("not a child table");
+    warnings.mockRestore();
+  });
+
+  // Without this `indexOf`, `includes` and every `===` a script writes are
+  // quietly wrong, and a handler cannot find the row it was handed in the table.
+  it("hands back the same handle for the same row, every time", () => {
+    const { controller } = makePage();
+    const rows = controller.page.rows("products");
+    expect(controller.page.rows("products")[0]).toBe(rows[0]);
+    expect(rows.indexOf(rows[1])).toBe(1);
+  });
+
+  // A script copying a row copies its `__row_id`; two rows on one key would read
+  // as one, and a handle would write into whichever came first.
+  it("re-mints a duplicated key rather than letting two rows alias", () => {
+    const { host, controller } = makePage();
+    const [original] = host.doc.value.products;
+    delete original.name;
+    host.doc.value.products.push({ ...original });
+    const rows = controller.page.rows("products");
+    expect(rows[0]).not.toBe(rows[2]);
+    rows[2].qty = 99;
+    expect(host.doc.value.products[0].qty).not.toBe(99);
+    expect(host.doc.value.products[2].qty).toBe(99);
+  });
+
+  // 47's rule, and its exemption: pushing to the array is meaningless, while
+  // writing through a handle is the whole point of having one.
+  it("refuses a write to the array but not to a handle", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { controller } = makePage();
+    const rows = controller.page.rows("products");
+    expect(() => rows.push({} as PageRow)).toThrow("read-only");
+    rows[0].qty = 9;
+    expect(controller.page.doc.products[0].qty).toBe(9);
+  });
+});
+
+describe("the handle re-finds its row on every access (ticket 43 §2)", () => {
+  it("follows a reorder, because it never captured a position", () => {
+    const { host, controller } = makePage();
+    const first = controller.page.rows("products")[0];
+    host.doc.value.products.reverse();
+    expect(first.rate).toBe(50);
+  });
+
+  it("survives a save, which replaces every row object", () => {
+    const { host, controller } = makePage();
+    const row = controller.page.rows("products")[0];
+    host.doc.value = JSON.parse(JSON.stringify(host.doc.value));
+    row.qty = 4;
+    expect(host.doc.value.products[0].qty).toBe(4);
+  });
+
+  it("writes what a v1 script writes, bare", () => {
+    const { host, controller } = makePage();
+    const row = controller.page.rows("products")[0];
+    row.amount = row.qty * row.rate;
+    expect(host.doc.value.products[0].amount).toBe(100);
+  });
+
+  it("throws on a removed row, naming the path — where v1 loses the write", () => {
+    const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { host, controller } = makePage();
+    const row = controller.page.rows("products")[0];
+    host.doc.value.products.shift();
+    expect(() => {
+      row.product_name = "Widget";
+    }).toThrow("products.product_name");
+    expect(() => row.qty).toThrow("no longer in the document");
+    expect(String(errors.mock.calls[0][0])).toContain("has been removed");
+    errors.mockRestore();
+  });
+
+  it("attributes the refusal to the source whose handler held the row", async () => {
+    const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+    await withRegisteringSource("page-script:C22", async () => {
+      registerRecordPage("CRM Deal", {
+        products: {
+          onAdd: (page: RecordPageApi, row: PageRow) => {
+            page.doc.products.length = 0;
+            row.qty = 1;
+          },
+        },
+      });
+    });
+    const { controller } = makePage();
+    await controller.fireEvent("products.onAdd", {
+      parentfield: "products",
+      key: "name:row-a",
+    });
+    expect(String(errors.mock.calls[0][0])).toContain("page-script:C22 reached");
+    errors.mockRestore();
+  });
+
+  // Vue's own flags are plain strings, so the symbol test alone would let a
+  // removed handle throw from inside a render effect.
+  it("answers a probe rather than throwing on being looked at", () => {
+    const { host, controller } = makePage();
+    const row = controller.page.rows("products")[0];
+    host.doc.value.products.shift();
+    expect((row as any)[Symbol.toStringTag]).toBeUndefined();
+    expect((row as any).__v_isRef).toBeUndefined();
+    expect(isRef(row)).toBe(false);
+    expect(toRaw(row)).toBe(row);
+  });
+
+  // The same stamp that keeps the outbound read-only guard off a handle: Vue
+  // must not deep-proxy one either, or a write would land on a copy.
+  it("is raw to Vue, so reactive() hands it back as itself", () => {
+    const { controller } = makePage();
+    const row = controller.page.rows("products")[0];
+    expect(reactive({ row }).row).toBe(row);
+  });
+
+  it("spreads and enumerates as the row's own data", () => {
+    const { controller } = makePage();
+    const row = controller.page.rows("products")[0];
+    expect({ ...row }).toEqual({ name: "row-a", qty: 2, rate: 50 });
+    expect(Object.keys(row)).not.toContain("trigger");
+  });
+});
+
+describe("row.trigger", () => {
+  it("takes a bare fieldname and forms the dotted key itself", async () => {
+    const seen: any[] = [];
+    registerRecordPage("CRM Deal", {
+      "products.rate": (page: RecordPageApi, row: PageRow) =>
+        seen.push([page.doctype, row.rate]),
+    });
+    const { controller } = makePage();
+    await controller.page.rows("products")[1].trigger("rate");
+    expect(seen).toEqual([["CRM Deal", 10]]);
+  });
+
+  it("resolves only once the handlers have run, where v1 lets the promise escape", async () => {
+    const order: string[] = [];
+    registerRecordPage("CRM Deal", {
+      "products.rate": async () => {
+        await Promise.resolve();
+        order.push("handler");
+      },
+    });
+    const { controller } = makePage();
+    await controller.page.rows("products")[0].trigger("rate");
+    order.push("after");
+    expect(order).toEqual(["handler", "after"]);
+  });
+
+  it("throws when the row it would trigger for is gone", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { host, controller } = makePage();
+    const row = controller.page.rows("products")[0];
+    host.doc.value.products.shift();
+    expect(() => row.trigger("rate")).toThrow("no longer in the document");
+  });
+
+  // 45 §3 gives `.onRemove` no row, so a verb that could fire it from a live row
+  // would hand a handler the grenade that decision exists to withhold.
+  it("refuses the structural keys, a dotted argument and an unknown field", async () => {
+    const fired: string[] = [];
+    registerRecordPage("CRM Deal", {
+      products: {
+        onAdd: () => fired.push("add"),
+        onRemove: () => fired.push("remove"),
+        rate: () => fired.push("rate"),
+      },
+    });
+    const warnings = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { controller } = makePage({ childFields: () => CHILD_FIELDS });
+    const row = controller.page.rows("products")[0];
+    await row.trigger("onAdd");
+    await row.trigger("onRemove");
+    await row.trigger("products.rate");
+    await row.trigger("ratte");
+    expect(fired).toEqual([]);
+    expect(warnings.mock.calls).toHaveLength(4);
+    await row.trigger("rate");
+    expect(fired).toEqual(["rate"]);
+    warnings.mockRestore();
+  });
+
+  // The whole reason the lifecycle keys are `on`-prefixed (ticket 54): `add` is
+  // a legal, unreserved fieldname, so under the old spelling this row's own
+  // field was unaddressable and `products.add` meant two different events.
+  it("triggers a child field genuinely called add", async () => {
+    const fired: string[] = [];
+    registerRecordPage("CRM Deal", { products: { add: () => fired.push("add") } });
+    const warnings = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { controller } = makePage({
+      childFields: () => [...CHILD_FIELDS, { fieldname: "add", fieldtype: "Check" }],
+    });
+    await controller.page.rows("products")[0].trigger("add");
+    expect(fired).toEqual(["add"]);
+    expect(warnings).not.toHaveBeenCalled();
+    warnings.mockRestore();
+  });
+
+  // The verb wins the namespace; the field stays reachable through `page.doc`.
+  it("shadows a child field of the same name", () => {
+    const { host, controller } = makePage();
+    host.doc.value.products[0].trigger = "manual";
+    expect(typeof controller.page.rows("products")[0].trigger).toBe("function");
+    expect(host.doc.value.products[0].trigger).toBe("manual");
+  });
+});
+
+describe("fireEvent carries the row (ticket 45 §3)", () => {
+  it("hands a dotted key its row and a bare key nothing", async () => {
+    const seen: Record<string, any> = {};
+    registerRecordPage("CRM Deal", {
+      "products.qty": (_page: RecordPageApi, row: PageRow) => (seen.qty = row.rate),
+      status: (_page: RecordPageApi, row: PageRow) => (seen.status = row),
+    });
+    const { controller } = makePage();
+    await controller.fireEvent("products.qty", {
+      parentfield: "products",
+      key: "name:row-b",
+    });
+    await controller.fireEvent("status");
+    expect(seen.qty).toBe(10);
+    expect(seen.status).toBeUndefined();
+  });
+
+  it("hands every source the same live row", async () => {
+    const seen: any[] = [];
+    registerRecordPage("CRM Deal", {
+      "products.qty": (_page: RecordPageApi, row: PageRow) => {
+        row.amount = 1;
+        seen.push(row.qty);
+      },
+    });
+    const { host, controller } = makePage();
+    await controller.fireEvent("products.qty", {
+      parentfield: "products",
+      key: "name:row-a",
+    });
+    expect(seen).toEqual([2]);
+    expect(host.doc.value.products[0].amount).toBe(1);
+  });
+});

--- a/frontend/src/recordPage/tests/surface.test.ts
+++ b/frontend/src/recordPage/tests/surface.test.ts
@@ -1,0 +1,193 @@
+// The merge & ordering rules (wayfinder ticket 06) as executable claims.
+import { describe, expect, it } from "vitest";
+import { nextTick, watchEffect } from "vue";
+import { Surface } from "../surface";
+import { registerRecordPage, registrationsFor, resetRegistry } from "../registry";
+import { withRegisteringSource } from "../context";
+
+function names(surface: Surface) {
+	return surface.visible().map((item) => item.name);
+}
+
+function builtins(surface: Surface, ...list: string[]) {
+	surface.provideBuiltins(() => list.map((name) => ({ name, label: name })));
+}
+
+describe("surface verbs", () => {
+	it("appends an add without a position and splices one with an anchor", () => {
+		const surface = new Surface();
+		builtins(surface, "email", "print");
+		surface.add({ name: "convert" });
+		surface.add({ name: "dial" }, { before: "print" });
+		expect(names(surface)).toEqual(["email", "dial", "print", "convert"]);
+	});
+
+	it("degrades an unknown anchor to append", () => {
+		const surface = new Surface();
+		builtins(surface, "email");
+		surface.add({ name: "dial" }, { before: "missing" });
+		expect(names(surface)).toEqual(["email", "dial"]);
+	});
+
+	it("hides reversibly and never deletes", () => {
+		const surface = new Surface();
+		builtins(surface, "email", "print");
+		surface.hide("email");
+		expect(names(surface)).toEqual(["print"]);
+		surface.show("email");
+		expect(names(surface)).toEqual(["email", "print"]);
+	});
+
+	it("replaces a colliding name in place, keeping the slot", () => {
+		const surface = new Surface();
+		builtins(surface, "email", "print");
+		surface.add({ name: "convert" }, { before: "print" });
+		surface.add({ name: "convert", label: "Rewritten" });
+		expect(names(surface)).toEqual(["email", "convert", "print"]);
+		expect(surface.visible()[1].label).toBe("Rewritten");
+	});
+
+	it("orders listed names to the front, unlisted keep their relative order", () => {
+		const surface = new Surface();
+		builtins(surface, "email", "comment", "print", "attach");
+		surface.add({ name: "convert" });
+		surface.order(["convert", "email", "missing"]);
+		expect(names(surface)).toEqual(["convert", "email", "comment", "print", "attach"]);
+	});
+
+	it("does not re-enforce an earlier order over a later add", () => {
+		const surface = new Surface();
+		builtins(surface, "email", "print");
+		surface.order(["print", "email"]);
+		surface.add({ name: "late" }, { before: "email" });
+		expect(names(surface)).toEqual(["print", "late", "email"]);
+	});
+
+	it("updates shallow-merge into the item", () => {
+		const surface = new Surface();
+		builtins(surface, "email");
+		surface.update("email", { label: "Email the customer" });
+		expect(surface.visible()[0].label).toBe("Email the customer");
+	});
+
+	it("resets to built-ins alone on replay", () => {
+		const surface = new Surface();
+		builtins(surface, "email");
+		surface.add({ name: "convert" });
+		surface.hide("email");
+		surface.beginReplay();
+		surface.commitReplay();
+		expect(names(surface)).toEqual(["email"]);
+	});
+
+	it("resolves over the built-ins as they are now, not as they were", () => {
+		const surface = new Surface();
+		let tags = true;
+		surface.provideBuiltins(() =>
+			["email", ...(tags ? ["tags"] : [])].map((name) => ({ name })),
+		);
+		surface.order(["tags", "email"]);
+		expect(names(surface)).toEqual(["tags", "email"]);
+		tags = false;
+		expect(names(surface)).toEqual(["email"]);
+	});
+});
+
+// Ticket 71: a replay used to clear the ops synchronously and re-add them a
+// microtask later, so the host rendered the strip without its scripted items in
+// between -- and a keyless `v-for` rebuilt everything under it, losing the
+// reader's place. The staged replay is the fix, and these are its rules.
+describe("staged replay", () => {
+	it("never renders the middle of a replay", async () => {
+		const surface = new Surface();
+		builtins(surface, "email");
+		surface.add({ name: "convert" });
+
+		const seen: string[][] = [];
+		const stop = watchEffect(() => seen.push(names(surface)));
+		await nextTick();
+
+		surface.beginReplay();
+		await nextTick(); // where the old `reset()` flushed a strip of built-ins alone
+		surface.add({ name: "convert" });
+		surface.commitReplay();
+		await nextTick();
+		stop();
+
+		expect(seen.length).toBeGreaterThan(0);
+		for (const render of seen) expect(render).toEqual(["email", "convert"]);
+	});
+
+	it("starts the replay from built-ins, so a dropped op does not survive it", () => {
+		const surface = new Surface();
+		builtins(surface, "email");
+		surface.add({ name: "convert" });
+		surface.beginReplay();
+		surface.add({ name: "dial" });
+		surface.commitReplay();
+		expect(names(surface)).toEqual(["email", "dial"]);
+	});
+
+	it("renders an op recorded outside a replay immediately", () => {
+		const surface = new Surface();
+		builtins(surface, "email");
+		surface.beginReplay();
+		surface.commitReplay();
+		// A `run` handler, an `onTabChange`, a quick-action callback.
+		surface.add({ name: "dial" });
+		expect(names(surface)).toEqual(["email", "dial"]);
+	});
+
+	it("tells a source about its own work mid-replay, and only its own", () => {
+		const surface = new Surface();
+		builtins(surface, "email");
+		surface.add({ name: "convert" });
+		surface.beginReplay();
+		// Last replay's `convert` is gone from the source's view the moment the
+		// new one opens, even though it is still what the host renders.
+		expect(surface.has("convert")).toBe(false);
+		expect(names(surface)).toEqual(["email", "convert"]);
+		surface.add({ name: "dial" });
+		expect(surface.has("dial")).toBe(true);
+		expect(names(surface)).toEqual(["email", "convert"]);
+	});
+
+	it("publishes only on the outermost commit of a nested replay", () => {
+		const surface = new Surface();
+		builtins(surface, "email");
+		surface.beginReplay();
+		surface.add({ name: "convert" });
+		// A script calling `page.refresh()` from its own `refresh` handler.
+		surface.beginReplay();
+		surface.add({ name: "dial" });
+		surface.commitReplay();
+		expect(names(surface)).toEqual(["email"]);
+		surface.add({ name: "print" });
+		surface.commitReplay();
+		expect(names(surface)).toEqual(["email", "dial", "print"]);
+	});
+
+	it("ignores a commit with no replay open", () => {
+		const surface = new Surface();
+		builtins(surface, "email");
+		surface.add({ name: "convert" });
+		surface.commitReplay();
+		expect(names(surface)).toEqual(["email", "convert"]);
+	});
+});
+
+describe("registry run order", () => {
+	it("keeps sources in registration order, generic before specific within one", async () => {
+		resetRegistry();
+		registerRecordPage("CRM Deal", { onRefresh: () => {} });
+		registerRecordPage("*", { onRefresh: () => {} });
+		await withRegisteringSource("audit", async () => {
+			registerRecordPage("CRM Deal", { onRefresh: () => {} });
+		});
+		const order = registrationsFor("CRM Deal").map(
+			(registration) => `${registration.source}:${registration.doctype}`,
+		);
+		expect(order).toEqual(["host:*", "host:CRM Deal", "audit:CRM Deal"]);
+		resetRegistry();
+	});
+});

--- a/frontend/src/recordPage/tests/tabActivation.test.ts
+++ b/frontend/src/recordPage/tests/tabActivation.test.ts
@@ -1,0 +1,336 @@
+// `activate` on both tab strips (wayfinder ticket 75) as executable claims: a
+// verb rather than a writable `active`, three ways to miss, a name resolved at
+// the moment of the call, and a replay's move delivered when the strip settles.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+
+vi.mock("frappe-ui", () => ({
+  call: vi.fn(),
+  toast: { success: vi.fn(), error: vi.fn() },
+  createResource: () => ({
+    data: null,
+    loading: false,
+    fetch() {},
+    reload() {},
+  }),
+  frappeRequest: vi.fn(),
+}));
+
+import { createRecordPage, type RecordPageHost } from "../createRecordPage";
+import { registerRecordPage, resetRegistry } from "../registry";
+import type { FormLayoutSchema } from "@framework/ui/components/FormLayout/types";
+
+const RECORD_TABS = [
+  { name: "activity", label: "Activity" },
+  { name: "emails", label: "Emails" },
+  { name: "details", label: "Details" },
+];
+
+/** One named tab and one the doc's `with_products` decides. */
+const LAYOUT: FormLayoutSchema = [
+  { name: "lead_details", label: "Lead Details", sections: [] },
+  {
+    name: "products",
+    label: "Products",
+    dependsOn: "eval:doc.with_products",
+    sections: [],
+  },
+];
+
+/**
+ * The host's two halves of activation, recorded rather than performed: where
+ * the reader is *kept* is the host's business, and the engine's claim is only
+ * about what it hands over and when.
+ */
+function makeHost(overrides: Partial<RecordPageHost> = {}) {
+  const moved: string[] = [];
+  const movedInForm: string[] = [];
+  const host: RecordPageHost = {
+    doctype: "CRM Deal",
+    docname: "CRM-DEAL-1",
+    doc: ref({ with_products: 0 }),
+    saved: ref({}),
+    meta: ref(null),
+    perms: () => ({}),
+    isDirty: () => false,
+    activeTab: () => "activity",
+    activateTab: (name) => void moved.push(name),
+    formLayout: () => LAYOUT,
+    activeFormTab: () => "lead_details",
+    activateFormTab: (identity) => void movedInForm.push(identity),
+    save: async () => {},
+    reload: async () => {},
+    router: {} as any,
+    ...overrides,
+  };
+  return { host, moved, movedInForm };
+}
+
+function makePage(overrides: Partial<RecordPageHost> = {}) {
+  const { host, moved, movedInForm } = makeHost(overrides);
+  const controller = createRecordPage(host);
+  controller.tabs.provideBuiltins(() => RECORD_TABS as any[]);
+  return { controller, page: controller.page, moved, movedInForm };
+}
+
+let warnings: string[];
+
+beforeEach(() => {
+  resetRegistry();
+  warnings = [];
+  vi.spyOn(console, "warn").mockImplementation((message: string) =>
+    warnings.push(message),
+  );
+});
+
+describe("moving the reader", () => {
+  it("hands the record strip's tab to the host, and nothing else", () => {
+    const { page, moved, movedInForm } = makePage();
+
+    page.tabs.activate("emails");
+
+    expect(moved).toEqual(["emails"]);
+    expect(movedInForm).toEqual([]);
+    expect(warnings).toEqual([]);
+  });
+
+  it("hands the form strip's identity to its own host hook", () => {
+    const { page, moved, movedInForm } = makePage();
+
+    page.formTabs.activate("lead_details");
+
+    expect(movedInForm).toEqual(["lead_details"]);
+    expect(moved).toEqual([]);
+  });
+
+  it("moves the reader to a tab the script itself added", () => {
+    const { page, moved } = makePage();
+
+    page.tabs.add({ name: "audit", label: "Audit" });
+    page.tabs.activate("audit");
+
+    expect(moved).toEqual(["audit"]);
+  });
+
+  it("resolves during load against the strip the host has, not the one it draws", () => {
+    // The gap the pre-ready window opens: the host renders nothing until the
+    // first replay commits, while the surface already holds the built-ins. The
+    // strip a name resolves against is the surface's, so an activation before
+    // `ready` lands — and the reader arrives on it when the strip paints.
+    const { controller, page, moved } = makePage();
+
+    expect(controller.ready.value).toBe(false);
+    page.tabs.activate("details");
+
+    expect(moved).toEqual(["details"]);
+  });
+
+  it("writes the form strip's intent even where the reader is not in the form", () => {
+    // Not a queued activation: the identity resolved against the layout now,
+    // and this is the answer to the question the strip asks when it mounts.
+    const { page, movedInForm } = makePage({ activeFormTab: () => "" });
+
+    page.formTabs.activate("lead_details");
+
+    expect(movedInForm).toEqual(["lead_details"]);
+  });
+});
+
+describe("the three ways to miss", () => {
+  it("warns and stays put on a tab the strip does not carry", () => {
+    const { page, moved } = makePage();
+
+    page.tabs.activate("nope");
+
+    expect(moved).toEqual([]);
+    expect(warnings).toEqual([
+      '[record-page] page.tabs.activate("nope") — no such tab; the reader was not moved.',
+    ]);
+  });
+
+  it("warns and stays put on a hidden tab — `show()` is that verb", () => {
+    const { page, moved } = makePage();
+    page.tabs.hide("emails");
+
+    page.tabs.activate("emails");
+
+    expect(moved).toEqual([]);
+    expect(warnings[0]).toContain("it is hidden — show() reveals a tab");
+  });
+
+  it("counts a tab `depends_on` has closed as hidden on the form strip too", () => {
+    const { page, movedInForm } = makePage();
+
+    page.formTabs.activate("products");
+
+    expect(movedInForm).toEqual([]);
+    expect(warnings[0]).toContain("it is hidden");
+  });
+
+  it("names the other strip when the name belongs to it", () => {
+    const { page, moved, movedInForm } = makePage();
+
+    page.tabs.activate("lead_details");
+    page.formTabs.activate("emails");
+
+    expect(moved).toEqual([]);
+    expect(movedInForm).toEqual([]);
+    expect(warnings[0]).toContain(
+      `it is on the form's strip — page.formTabs.activate("lead_details")`,
+    );
+    expect(warnings[1]).toContain(
+      `it is on the record's strip — page.tabs.activate("emails")`,
+    );
+  });
+
+  it("says nothing about the form's strip while its layout is still loading", () => {
+    // "The administrator never authored this" and "it has not arrived yet" are
+    // the same answer in that window, and `hide`/`show`/`update` already keep
+    // quiet in it. The move is dropped, not queued.
+    const { page, movedInForm } = makePage({ formLayout: () => [] });
+
+    page.formTabs.activate("lead_details");
+
+    expect(movedInForm).toEqual([]);
+    expect(warnings).toEqual([]);
+  });
+
+  it("says so when the host draws the form's strip but cannot move it", () => {
+    const { page } = makePage({ activateFormTab: undefined });
+
+    page.formTabs.activate("lead_details");
+
+    expect(warnings[0]).toContain("cannot move the reader on that strip");
+  });
+
+  it("says so every time, because each miss is a move that did not happen", () => {
+    const { page } = makePage();
+
+    page.tabs.activate("nope");
+    page.tabs.activate("nope");
+
+    expect(warnings).toHaveLength(2);
+  });
+});
+
+describe("why this is a verb and not a writable `active`", () => {
+  it("leaves `active` reading the tab the reader is really on", () => {
+    // The round trip an assignment could not survive: `active` is derived from
+    // what the strip can show, so `page.tabs.active = 'nope'` would read back
+    // as something the script never wrote. A verb can say so instead.
+    const { page } = makePage();
+
+    page.tabs.activate("nope");
+
+    expect(page.tabs.active).toBe("activity");
+    expect(warnings).toHaveLength(1);
+  });
+});
+
+describe("a replay's activation", () => {
+  it("is delivered once the strip has settled, not from the middle", async () => {
+    // The name resolves against the staged strip — the script can see its own
+    // work — but the reader is moved only after the commit, since until then
+    // the host is still rendering the strip the tab is not on yet.
+    const seen: boolean[] = [];
+    registerRecordPage("CRM Deal", {
+      onRefresh: (page) => {
+        page.tabs.add({ name: "audit", label: "Audit" });
+        page.tabs.activate("audit");
+        seen.push(page.tabs.has("audit"));
+      },
+    });
+    const { controller, moved } = makePage();
+
+    const replay = controller.refresh();
+    expect(moved).toEqual([]);
+    await replay;
+
+    expect(seen).toEqual([true]);
+    expect(moved).toEqual(["audit"]);
+    expect(controller.tabs.visible().map((tab) => tab.name)).toContain("audit");
+  });
+
+  it("keeps the last move on each strip, as the reader's own last click would", async () => {
+    registerRecordPage("CRM Deal", {
+      onRefresh: (page) => {
+        page.tabs.activate("emails");
+        page.tabs.activate("details");
+        page.formTabs.activate("lead_details");
+      },
+    });
+    const { controller, moved, movedInForm } = makePage();
+
+    await controller.refresh();
+
+    expect(moved).toEqual(["details"]);
+    expect(movedInForm).toEqual(["lead_details"]);
+  });
+
+  it("still moves the reader when a later handler throws", async () => {
+    registerRecordPage("CRM Deal", {
+      onRefresh: (page) => {
+        page.tabs.activate("emails");
+        throw new Error("boom");
+      },
+    });
+    const { controller, moved } = makePage();
+
+    await controller.refresh();
+
+    expect(moved).toEqual(["emails"]);
+  });
+
+  it("is dropped when a later source takes the tab off the strip", async () => {
+    // The held move is re-read against the strip that settled, not delivered on
+    // the strength of the strip it was decided against — otherwise the reader
+    // lands on `?tab=emails` with no `emails` to resolve it, which is the
+    // fallback-tab dumping a miss exists to prevent.
+    registerRecordPage("CRM Deal", {
+      onRefresh: (page) => {
+        page.tabs.activate("emails");
+        page.tabs.hide("emails");
+      },
+    });
+    const { controller, moved } = makePage();
+
+    await controller.refresh();
+
+    expect(moved).toEqual([]);
+    expect(warnings[0]).toContain("it left the strip before the replay settled");
+  });
+
+  it("keeps the page up when the host's own navigation throws", async () => {
+    // The release runs inside `refresh`'s `finally`: a throw escaping it would
+    // strand `ready` false and leave the strip a skeleton for good.
+    registerRecordPage("CRM Deal", {
+      onRefresh: (page) => page.tabs.activate("emails"),
+    });
+    const { controller } = makePage({
+      activateTab: () => {
+        throw new Error("a router guard said no");
+      },
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(controller.refresh()).resolves.toBeUndefined();
+    expect(controller.ready.value).toBe(true);
+  });
+
+  it("misses a tab that only appears in the *next* replay, and is not queued", async () => {
+    let addAudit = false;
+    registerRecordPage("CRM Deal", {
+      onRefresh: (page) => {
+        if (addAudit) page.tabs.add({ name: "audit", label: "Audit" });
+      },
+    });
+    const { controller, page, moved } = makePage();
+
+    page.tabs.activate("audit");
+    addAudit = true;
+    await controller.refresh();
+
+    expect(moved).toEqual([]);
+    expect(warnings[0]).toContain("no such tab");
+  });
+});

--- a/frontend/src/recordPage/types.ts
+++ b/frontend/src/recordPage/types.ts
@@ -1,0 +1,505 @@
+// The Record page customization API: what a script's handlers receive and the
+// item schemas the four surfaces accept.
+import type { Component } from "vue";
+import type { Router } from "vue-router";
+import type { FieldAccess } from "@framework/ui/composables/useDocPermissions";
+
+/** Where an added or moved item lands; absent or unknown anchors append. */
+export type Position = { before?: string; after?: string };
+
+export interface SurfaceItem {
+  name: string;
+  label?: string;
+  icon?: string;
+  [key: string]: any;
+}
+
+export interface QuickAction extends SurfaceItem {
+  label: string;
+  description?: string;
+  run?: (page: RecordPageApi) => any;
+}
+
+/**
+ * An action in the record's header. `display` picks how it renders: a top-level
+ * button of its own, a top-level dropdown button of its own, a titled section,
+ * or — omitted, the default — an ordinary entry.
+ *
+ * A `dropdown` and a `section` are **containers**: ordinary addressable items
+ * that carry the label and the icon, differing only in when their members are
+ * visible — a dropdown hides them behind a trigger, a section shows them under
+ * a grey title. Either way the members point at the container with `group`, and
+ * a container that points at another container renders inside it.
+ *
+ * The list a script writes stays flat, so every item is reachable by its one
+ * name; only the rendering nests, and only two containers deep.
+ *
+ * How many top-level controls fit is the host's business and a script cannot
+ * observe it: one that does not fit is demoted into `⋯`, which is `add`'s
+ * promise — that the item is *reachable* — being kept.
+ */
+export interface HeaderAction extends SurfaceItem {
+  label: string;
+  display?: "button" | "dropdown" | "section";
+  /**
+   * Put me inside the item named this. If an item of that name is declared, you
+   * get what it declares; if nothing of that name exists, the engine
+   * synthesises an anonymous, untitled container — the adjacency band inside
+   * `⋯` that an omitted `group` (meaning `actions`) has always given.
+   */
+  group?: string;
+  run?: (page: RecordPageApi) => any;
+}
+
+export interface TabCreateAction {
+  label: string;
+  icon: string;
+  run: (page: RecordPageApi) => any;
+}
+
+export interface TabItem extends SurfaceItem {
+  label: string;
+  component?: Component;
+  props?: Record<string, any>;
+  /** Joins the composer's `+` menu while this tab is on the strip. */
+  create?: TabCreateAction;
+}
+
+export interface PanelSectionItem extends SurfaceItem {
+  component?: Component;
+  props?: Record<string, any>;
+  opened?: boolean;
+}
+
+export interface SurfaceVerbs<Item extends SurfaceItem = SurfaceItem> {
+  /** One item, or a block that splices as a unit at the anchor, in list order. */
+  add(item: Item | Item[], position?: Position): void;
+  hide(name: string): void;
+  show(name: string): void;
+  update(name: string, patch: Partial<Item>): void;
+  move(name: string, position: Position): void;
+  has(name: string): boolean;
+  order(names: string[]): void;
+}
+
+/** The tabs surface also tells a handler which tab the reader is on. */
+export interface TabsApi extends SurfaceVerbs<TabItem> {
+  readonly active: string;
+  /**
+   * Move the reader to a tab on *this* strip. A verb rather than a writable
+   * `active` because `active` is derived from what the strip can currently show:
+   * an assignment naming a hidden or unknown tab would read back as something
+   * the script never wrote, where a verb can say so. Hidden, unknown, or on the
+   * other strip all warn in a development build and do nothing — activation
+   * does not reveal a hidden tab, since `show()` is that verb already.
+   *
+   * The name resolves against the strip as it stands at the moment of the call;
+   * an activation fired before its tab is added misses, and is not queued.
+   *
+   * A *hit* is not synchronous either: the reader arrives by way of the host's
+   * own navigation, so `active` still reads the old tab on the line after the
+   * call. Read it in the next handler, not this one.
+   */
+  activate(name: string): void;
+}
+
+export interface PageToast {
+  success(message: string): void;
+  error(message: string): void;
+}
+
+/** A field as a script writes it: DocField vocabulary, not `FieldMeta`'s camelCase. */
+export interface PageDialogField {
+  fieldname: string;
+  fieldtype: string;
+  label?: string;
+  /** Link target, or a `Select`'s newline-separated choices. */
+  options?: string;
+  reqd?: boolean | 0 | 1;
+  read_only?: boolean | 0 | 1;
+  hidden?: boolean | 0 | 1;
+  depends_on?: string;
+  mandatory_depends_on?: string;
+  read_only_depends_on?: string;
+  description?: string;
+  /** Closed on purpose: `page.fields`' patch vocabulary is enumerated too, so
+   *  the two script-facing field types agree on what a script may write. */
+}
+
+/**
+ * What a script may override on one of the record's fields — v1's
+ * `setFieldProperty` vocabulary, enumerated and spelled as a DocField spells it
+ * (`PageDialogField`'s precedent: an author reads DocType Customize and writes
+ * what they read there). Closed, like every other curated forward: a key not
+ * named here is dropped with a dev-mode warning.
+ *
+ * v1's `button_color` is absent — no renderer here honours it.
+ */
+export interface PageFieldPatch {
+  // `0 | 1` alongside the boolean, as `PageDialogField` has it: a DocField
+  // spells these as ints, and `page.meta`'s own refusal advises `{ hidden: 1 }`.
+  hidden?: boolean | 0 | 1;
+  read_only?: boolean | 0 | 1;
+  reqd?: boolean | 0 | 1;
+  label?: string;
+  placeholder?: string;
+  description?: string;
+  /** Link target, or a `Select`'s newline-separated choices. */
+  options?: string;
+  /** Search filters for a `Link` field. v1 spells it this way; so do we. */
+  link_filters?: Record<string, unknown>;
+  /** Decimal places for a numeric field. */
+  precision?: number | string;
+  /** Renders this component in the field's slot instead of the default one. */
+  component?: Component;
+  /** Props bound onto whichever component renders the field. */
+  props?: Record<string, any>;
+}
+
+/**
+ * What `get` hands back: the same keys `update` writes, resolved as the renderer
+ * resolves them, plus the two that identify the field. Deliberately the *same*
+ * vocabulary rather than the internal `FieldMeta` — v1's `getField` cannot read
+ * back what its own setter wrote, and that asymmetry is the bug this avoids.
+ */
+export interface PageField extends PageFieldPatch {
+  fieldname: string;
+  fieldtype: string;
+  // Resolved, so these are answered as booleans however they were written.
+  hidden?: boolean;
+  read_only?: boolean;
+  reqd?: boolean;
+}
+
+/**
+ * The fields surface: a script overriding the properties of fields authored
+ * elsewhere. It speaks a strict subset of the surface verbs — there is no `add`,
+ * `move` or `order`, because a script that adds a field is inventing a docfield
+ * and ordering is the Form Layout's job.
+ *
+ * Overrides are a render-time overlay: never written into the layout, the Form
+ * Layout row, or the doctype meta, and cleared by the ordinary replay before
+ * every re-fire — so a conditional override is a plain `if` with no `else`.
+ *
+ * Two floors an override cannot cross: a permlevel denial (a `show()` on a
+ * denied field is a no-op with a dev warning), and a hidden `panelSection`,
+ * which is a container above its fields. Between an override and `depends_on`,
+ * the override wins.
+ */
+export interface PageFields {
+  hide(fieldname: string): void;
+  show(fieldname: string): void;
+  update(fieldname: string, patch: PageFieldPatch): void;
+  /** Whether the doctype has this field at all. */
+  has(fieldname: string): boolean;
+  /** The field as it currently resolves — post-override, post-`depends_on`. */
+  get(fieldname: string): PageField | null;
+}
+
+/** What a script may override on one of the Form Layout's tabs. */
+export interface PageFormTabPatch {
+  label?: string;
+}
+
+/** What `page.formTabs.get()` hands back: the tab as the strip resolves it. */
+export interface PageFormTab {
+  /** What the author wrote, if anything; the address is `identity`. */
+  name?: string;
+  identity: string;
+  label: string;
+  /** Resolved: `depends_on` and this surface's own ops both folded in. */
+  hidden: boolean;
+}
+
+/**
+ * The Form Layout tabs surface: the strip *inside* the record's Details form,
+ * which `page.tabs` has never reached — that one is the record's own strip, and
+ * it stays what `page.tabs` means. Reaches the Details form and no other place
+ * `FormLayout` renders (a `page.dialog` form's tabs are the script's own).
+ *
+ * A strict subset of the surface verbs, on the clause that already governs
+ * `page.fields`: these tabs are authored in a doctype an administrator edits, so
+ * a script overrides their properties and there is no `add`, `move` or `order`
+ * to mean anything.
+ *
+ * A tab is addressed by its **identity** (`name` if the author wrote one, else
+ * the label slugified, else its position), never by its position, and never by
+ * its label — a relabelled tab keeps its address. Between an override and
+ * `depends_on` the override wins, in both directions: `show()` lifts a tab the
+ * expression hides.
+ */
+export interface PageFormTabs {
+  hide(identity: string): void;
+  show(identity: string): void;
+  update(identity: string, patch: PageFormTabPatch): void;
+  /** Whether the layout carries this tab at all, on screen or not. */
+  has(identity: string): boolean;
+  /** The tab as it currently resolves — post-override, post-`depends_on`. */
+  get(identity: string): PageFormTab | null;
+  /**
+   * The identity of the tab the reader is on, or `''` when they are not in the
+   * form at all. Deliberately asymmetric with `page.tabs.active`, which returns
+   * a **name**: the record strip's tabs are named by their author, while a Form
+   * Layout tab's address is a resolved identity.
+   */
+  readonly active: string;
+  /**
+   * Move the reader to a tab of the form, on `TabsApi.activate`'s terms and
+   * missing in the same three ways. What it writes is the reader's *intent*,
+   * which is what this strip has always run on — so activating while the reader
+   * is elsewhere on the record is not a queued activation but an answer to a
+   * question the form will ask when it mounts: the identity resolves now, and
+   * that is where they arrive.
+   */
+  activate(identity: string): void;
+}
+
+/**
+ * A child row, as a script addresses it (ticket 43): an object holding
+ * `(parentfield, key)` that **re-finds its row on every access**, so nothing
+ * about a row's position is ever captured. Fields are read and written bare —
+ * `row.amount = row.qty * row.rate`, character for character what a v1 script
+ * writes — and a write through it is identical in effect to writing
+ * `page.doc.products[2].amount`: the handle is an address, not a write channel,
+ * and per ticket 44 neither fires anything.
+ *
+ * Reading or writing a row that has been removed **throws**, naming the path and
+ * aborting the handler. v1 loses those writes silently.
+ */
+export interface PageRow {
+  /**
+   * Fires this row's handler for one child field — `row.trigger('rate')`
+   * dispatches `'products.rate'` — across every registered source, and resolves
+   * when they have all run. The fieldname is bare: the handle knows its table.
+   *
+   * The one engine member on a row. It shares a namespace with the child
+   * doctype's fieldnames, and a child field literally named `trigger` is legal
+   * (Frappe reserves five names, and this is not one), so the collision is
+   * warned about once at load rather than defended against on every access.
+   */
+  trigger(fieldname: string): Promise<void>;
+  [fieldname: string]: any;
+}
+
+/** One column of a `tabs` layout; its fields are written, not named. */
+export interface PageDialogColumn {
+  name?: string;
+  label?: string;
+  fields: PageDialogField[];
+}
+
+export interface PageDialogSection {
+  name?: string;
+  label?: string;
+  hideLabel?: boolean;
+  hideBorder?: boolean;
+  collapsible?: boolean;
+  opened?: boolean;
+  depends_on?: string;
+  columns: PageDialogColumn[];
+}
+
+export interface PageDialogTab {
+  name?: string;
+  label?: string;
+  depends_on?: string;
+  sections: PageDialogSection[];
+}
+
+/** What a custom `form` action's `onClick` receives. */
+export interface PageDialogActionContext {
+  /** The dialog's current values, keyed by fieldname. */
+  data: Record<string, any>;
+  /** Closes the dialog, resolving the opener's promise with `result`. */
+  close: (result?: any) => void;
+  /** Runs the mandatory-field check; false leaves the errors on screen. */
+  validate: () => boolean;
+}
+
+export interface PageDialogAction {
+  label: string;
+  variant?: string;
+  theme?: string;
+  icon?: string;
+  /** Omitted means the default: validate, then close with the form's data. */
+  onClick?: (context: PageDialogActionContext) => any;
+}
+
+/**
+ * `page.dialog.form()`'s options. Exactly one layout mode may be given —
+ * `fields`, `tabs`, or `doctype` (optionally narrowed by `fieldnames`).
+ */
+export interface PageDialogFormOptions {
+  title?: string;
+  /** Flat field list, wrapped in one unlabelled section. */
+  fields?: PageDialogField[];
+  /** Full `tabs > sections > columns > fields` layout. */
+  tabs?: PageDialogTab[];
+  /** Renders the doctype's `Quick Entry` Form Layout, meta-derived if none. */
+  doctype?: string;
+  /** With `doctype`: only these fields, in this order. */
+  fieldnames?: string[];
+  defaults?: Record<string, any>;
+  /** Fieldnames forced mandatory, whatever the layout says. */
+  required?: string[];
+  size?: string;
+  /** Custom buttons; when given, Submit and `onSubmit` are not rendered. */
+  actions?: PageDialogAction[];
+  /** Runs on Submit after validation; throwing keeps the dialog open. */
+  onSubmit?: (data: Record<string, any>) => any;
+  onCancel?: () => any;
+  submitLabel?: string;
+  cancelLabel?: string;
+  dismissible?: boolean;
+}
+
+/** Chrome for `open()`'s host dialog; the component renders the body. */
+export interface PageDialogOpenOptions {
+  title?: string;
+  size?: string;
+  dismissible?: boolean;
+}
+
+/**
+ * What a `confirm`/`danger` callback receives: the engine's own object, not
+ * frappe-ui's `DialogControl`. A rename underneath must not change what a stored
+ * script does on an upgrade nobody reviewed.
+ */
+export interface PageDialogControl {
+  /** Closes the dialog; the verb's promise settles from the verb, as ever. */
+  close(): void;
+  /** Shows an inline error and re-enables the buttons; `null` clears it. */
+  setError(message: string | null): void;
+}
+
+/** One button on a `confirm`/`danger` — the five props `page` forwards. */
+export interface PageDialogConfirmAction {
+  label: string;
+  variant?: string;
+  theme?: string;
+  icon?: string;
+  /** Omitted means the button only dismisses, and the verb resolves `null`. */
+  onClick?: (control: PageDialogControl) => any;
+}
+
+/** `confirm`'s options; a key not named here is dropped, not forwarded. */
+export interface PageDialogConfirmOptions {
+  title?: string;
+  message?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  theme?: string;
+  icon?: string;
+  size?: string;
+  dismissible?: boolean;
+  onConfirm?: (control: PageDialogControl) => any;
+  onCancel?: () => any;
+  /** Custom buttons; when given, the confirm/cancel pair is not rendered. */
+  actions?: PageDialogConfirmAction[];
+}
+
+/** `danger` forces red and its own icon, so it names neither. */
+export type PageDialogDangerOptions = Omit<
+  PageDialogConfirmOptions,
+  "theme" | "icon"
+>;
+
+/**
+ * The dialog capability. Every verb resolves `null` when the reader dismissed
+ * the dialog — by Esc, the backdrop, the close button, or by navigating off the
+ * record — so `if (!result) return` is the idiom. Un-awaited promises are
+ * ignored: fire-and-forget stays legal.
+ */
+export interface PageDialog {
+  /** Renders `component` in a dialog, passing it a `close(result)` prop. */
+  open(
+    component: Component,
+    props?: Record<string, any>,
+    options?: PageDialogOpenOptions,
+  ): Promise<any>;
+  /** The declarative tier: resolves `{fieldname: value}` on submit. */
+  form(options: PageDialogFormOptions): Promise<Record<string, any> | null>;
+  /** Resolves `true` when confirmed. */
+  confirm(options: PageDialogConfirmOptions): Promise<true | null>;
+  /** `confirm` in red, labelled Delete by default. */
+  danger(options: PageDialogDangerOptions): Promise<true | null>;
+}
+
+/** The curated object every handler mutates — a script's whole capability surface. */
+export interface RecordPageApi {
+  doctype: string;
+  docname: string;
+  doc: Record<string, any>;
+  /**
+   * The document as the server last showed it — the v2 answer to "what was the
+   * previous value": `page.saved.status !== page.doc.status`. Defined on the
+   * first paint, readable in any handler, and read-only (`page.doc` is the
+   * draft you edit).
+   */
+  saved: Record<string, any>;
+  meta: Record<string, any> | null;
+  /**
+   * Every right frappe would check for this doctype — the 15 standard ones plus
+   * any `Permission Type` registered against it — valued `0` or `1`.
+   */
+  perms: Record<string, any>;
+  /** The session user's roles, resolved before any handler runs. */
+  roles: string[];
+  /** What this user may do with a field, by permlevel; an unknown one is `none`. */
+  fieldAccess(fieldname: string): FieldAccess;
+  isDirty: boolean;
+  quickActions: SurfaceVerbs<QuickAction>;
+  headerActions: SurfaceVerbs<HeaderAction>;
+  tabs: TabsApi;
+  panelSections: SurfaceVerbs<PanelSectionItem>;
+  fields: PageFields;
+  /** The Form Layout's own tab strip, inside the Details form. */
+  formTabs: PageFormTabs;
+  /**
+   * The child table's rows as handles, in array order. Not a surface — there is
+   * nothing here to arrange or override; it is how a row is *addressed*. A
+   * fieldname that is not a child table dev-warns and answers empty.
+   */
+  rows(parentfield: string): PageRow[];
+  save(): Promise<void>;
+  reload(): Promise<void>;
+  refresh(): Promise<void>;
+  toast: PageToast;
+  dialog: PageDialog;
+  call(method: string, params?: Record<string, any>): Promise<any>;
+  router: Router;
+}
+
+export type { FieldAccess };
+
+/**
+ * A handler's arguments are determined by its key (tickets 45 §3, 54). A
+ * top-level key — an event or a parent fieldname — receives `(page)`. One
+ * nested under a child table receives the row it happened to:
+ *
+ * ```js
+ * products: { onAdd(page, row) {}, qty(page, row) {} }
+ * ```
+ *
+ * `onRemove` is the exception, and gets `(page)` alone: its row is gone.
+ *
+ * The row is an address, not a payload: it carries no event data, and the same
+ * handle is obtainable from `page.rows()` in any handler at all. That is why
+ * ticket 14's rule against invisible arguments survives — the key announces it.
+ */
+export type Handler = (page: RecordPageApi, row?: PageRow) => any;
+
+/**
+ * What an author writes: named event handlers, plus — for a child table — a
+ * block of them nested under the table's fieldname (ticket 54).
+ */
+export type AuthoredHandlers = Record<
+  string,
+  Handler | Record<string, Handler>
+>;
+
+/**
+ * What the engine dispatches against: one flat keyspace, a nested block having
+ * been flattened onto dotted keys at registration.
+ */
+export type RecordPageHandlers = Record<string, Handler>;

--- a/ui/src/components/FormLayout/buildLayoutFromMeta.ts
+++ b/ui/src/components/FormLayout/buildLayoutFromMeta.ts
@@ -148,7 +148,7 @@ function resolveChildLayout(
   return buildLayoutFromMeta(childMeta, { childMetas, decorate });
 }
 
-function mapField(
+export function mapField(
   field: RawMetaField,
   childMetas: Record<string, RawMetaField[]>,
   decorate?: Decorator

--- a/ui/src/composables/useDocPermissions.ts
+++ b/ui/src/composables/useDocPermissions.ts
@@ -1,0 +1,63 @@
+import { computed, toValue } from "vue";
+import type { ComputedRef, MaybeRefOrGetter } from "vue";
+import { useDoctypeMeta } from "./useDoctypeMeta";
+import { useUserRoles } from "./useUserRoles";
+
+export type FieldAccess = "write" | "read" | "none";
+
+export interface UseDocPermissions {
+  /** Doc-level rights from `docinfo.permissions` (`getdoc`); false until provided. */
+  can: (right: string) => boolean;
+  /** Permlevels the user's roles hold `right` on, from the meta's DocPerm rows. */
+  allowedPermlevels: (right: "read" | "write") => number[];
+  /** What a permlevel'd field may render as. */
+  fieldAccess: (field: { permlevel?: number }) => FieldAccess;
+  /** True while roles or meta are still loading (field access is Write until then). */
+  loading: ComputedRef<boolean>;
+}
+
+/**
+ * The Vue port of desk's `frappe.perm`: doc-level rights come from the
+ * server-computed `docinfo.permissions`, field-level permlevel access from the
+ * meta's DocPerm rows crossed with the session user's roles. Display-only —
+ * enforcement stays server-side (`getdoc` applies field-level read permissions).
+ */
+export function useDocPermissions(
+  doctype: MaybeRefOrGetter<string>,
+  docPermissions?: MaybeRefOrGetter<Record<string, unknown> | null | undefined>
+): UseDocPermissions {
+  const { meta, loading: metaLoading } = useDoctypeMeta(doctype);
+  const { roles, loading: rolesLoading } = useUserRoles();
+
+  const permlevels = computed(() => {
+    if (!roles.value || !meta.value?.permissions) return null;
+    const held = { read: new Set<number>(), write: new Set<number>() };
+    for (const row of meta.value.permissions) {
+      if (!roles.value.includes(row.role)) continue;
+      if (row.read) held.read.add(row.permlevel ?? 0);
+      if (row.write) held.write.add(row.permlevel ?? 0);
+    }
+    return held;
+  });
+
+  function allowedPermlevels(right: "read" | "write"): number[] {
+    return [...(permlevels.value?.[right] ?? [])].sort((a, b) => a - b);
+  }
+
+  // Fail-open while roles/meta load: better a field the server refuses to save
+  // than a form that flashes empty. Permlevel 0 is doc-level territory (`can`).
+  function fieldAccess(field: { permlevel?: number }): FieldAccess {
+    const permlevel = field.permlevel ?? 0;
+    if (permlevel === 0 || !permlevels.value) return "write";
+    if (permlevels.value.write.has(permlevel)) return "write";
+    if (permlevels.value.read.has(permlevel)) return "read";
+    return "none";
+  }
+
+  return {
+    can: (right) => Boolean(toValue(docPermissions)?.[right]),
+    allowedPermlevels,
+    fieldAccess,
+    loading: computed(() => metaLoading.value || rolesLoading.value),
+  };
+}

--- a/ui/src/composables/useDoctypeMeta.ts
+++ b/ui/src/composables/useDoctypeMeta.ts
@@ -4,10 +4,20 @@ import { createResource, frappeRequest } from "frappe-ui";
 import type { RawMetaField } from "../components/FormLayout/types";
 import { memoizedState } from "../utils/sharedState";
 
+/** A DocPerm row as `getdoctype` returns it; booleans arrive as `0 | 1`. */
+export interface DocPermRow {
+  role: string;
+  permlevel?: number;
+  read?: 0 | 1;
+  write?: 0 | 1;
+  [right: string]: unknown;
+}
+
 export interface DoctypeMeta {
   name: string;
   title_field?: string;
   fields?: RawMetaField[];
+  permissions?: DocPermRow[];
 }
 
 interface GetDoctypeResponse {

--- a/ui/src/composables/useUserRoles.ts
+++ b/ui/src/composables/useUserRoles.ts
@@ -1,0 +1,42 @@
+import { computed } from "vue";
+import type { ComputedRef } from "vue";
+import { createResource, frappeRequest } from "frappe-ui";
+
+export interface UseUserRoles {
+  /** The session user's roles; `null` until they load. */
+  roles: ComputedRef<string[] | null>;
+  loading: ComputedRef<boolean>;
+  reload: () => void;
+}
+
+/** One session, one user: fetched once and shared by every caller. */
+let resource: any = null;
+
+/**
+ * Fetch the session user's roles (desk gets them from boot; hosts built on
+ * `@framework/ui` fetch them here instead).
+ */
+export function useUserRoles(): UseUserRoles {
+  resource ??= buildResource();
+
+  return {
+    roles: computed(() => (resource.data as string[] | undefined) ?? null),
+    loading: computed(() => resource.loading),
+    reload: () => resource.reload(),
+  };
+}
+
+/** Drops the shared fetch, so one test's roles cannot reach the next. */
+export function resetUserRoles(): void {
+  resource = null;
+}
+
+function buildResource() {
+  const created = createResource({
+    url: "frappe.core.doctype.user.user.get_current_user_roles",
+    cache: "User Roles",
+    resourceFetcher: frappeRequest,
+  });
+  if (!created.fetched && !created.loading) created.fetch();
+  return created;
+}


### PR DESCRIPTION
Part 3 of 4, splitting #42130 (ticket #42073, the walking skeleton). **#42171 and #42172 have merged, so this now targets `desk-v2` directly and the diff below is its own.**

| | PR | lines | |
| --- | --- | --- | --- |
| 1 | #42171 — serve apps by declared prefix | ~1,580 | ✅ merged |
| 2 | #42172 — the SPA shell and the contribution seam | ~4,120 | ✅ merged |
| 3 | **this one** — the record-page engine | ~7,960 | ← you are here |
| 4 | #42174 — the vitest runner for it | ~330 | stacked |

## Why this is its own PR

These 7,721 lines were carried into #42130 to make the asset build pass, inside a PR whose stated subject was routing and hosting. They have **never been reviewed upstream** — `feat/saved-view-sidebar` has no PR, open or closed — so this is the first and only review they will get. That is the whole reason for the split.

The engine is one connected component: `createRecordPage` transitively imports all 20 source modules, so it is all of it or a stub. A trimming pass already happened — the Vue dialog components, `loader.ts`, `commitChannel.ts` and `formDialogLayout.ts` (12 files, ~1,960 lines) were left behind, because `Record.vue` is a deliberately minimal host with no form layout, tabs or panel and the engine supports that shape rather than being forked for it.

## Where it lands, and why not `@framework/ui`

`frontend/src/recordPage/`, in the shell — not in `@framework/ui` where it sits on `feat/saved-view-sidebar`.

`@framework/ui` is the **generic layer**: self-contained components and composables any app may use however it likes. This is one opinionated record-page runtime that speaks doctype, `page.save()`, `page.quickActions`, permlevel and Page Script, with a single correct way to use it. That makes it **desk layer**.

It *consumes* the generic layer — `FormLayout`, `Fields`, `useDocPermissions` — and being a consumer is exactly what places it on this side of the boundary. The shell already keeps the list registrar locally for the same reason.

A contributed `record.js` is unaffected either way: it imports nothing at all, because its default export *is* the registration.

**The move is pure.** All 35 files are byte-identical to their `feat/saved-view-sidebar` originals apart from rewritten import specifiers — verified line by line, zero non-import changes. The 16 rewrites go to `@framework/ui/components/*` and `@framework/ui/composables/*`, which resolve through the existing `"./*": "./src/*"` exports entry, so `ui/`'s export surface is unchanged.

## The `ui/` commit is kept separate

`feat(ui): read doc and field-level permissions from the client` is its own commit and touches only `ui/src/composables/` and one `export` in `buildLayoutFromMeta.ts`. Those files exist on develop independently, so that commit is cherry-pickable and should be raised against develop on its own.

## Known gap: these tests have no runner

The 13 unit-test files come across, but **there is no `vitest` anywhere in frappe** — no dependency, no `test` script in `ui/` or `frontend/`, no CI job. Their only harness today is `crm/frontend2`'s, which is being deleted.

Wiring one into `frontend/` is **#42174**, stacked on this PR — kept separate because it forces a `frontend/yarn.lock` regeneration, and a lockfile change does not belong buried in an engine review. With it, the suite is 14 files / 247 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

>no-docs
