### PR TITLE
feat: process large linked document sets in the background

### DIFF
--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
+import hashlib
 import itertools
 from collections import defaultdict, deque
 
@@ -403,8 +404,15 @@ def cancel_all_linked_docs(
 
 	to_cancel = [doc for doc in deduplicated(docs) if validate_linked_doc(doc, ignore_doctypes_on_cancel_all)]
 	if len(to_cancel) > MAX_SYNCHRONOUS_LINKED_DOCS:
-		return enqueue_linked_docs_processing(to_cancel, "cancel", root_doctype, root_name)
+		return enqueue_linked_docs_processing(
+			to_cancel, "cancel", root_doctype, root_name, ignore_doctypes_on_cancel_all
+		)
 
+	if root_doctype and root_name:
+		# the list was built by an earlier request; drop what is no longer linked
+		to_cancel = keep_currently_linked(
+			to_cancel, "cancel", root_doctype, root_name, ignore_doctypes_on_cancel_all
+		)
 	process_linked_docs_in_dependency_order(to_cancel, cancel_linked_doc, _("Cancelling documents"))
 
 
@@ -437,14 +445,18 @@ def collect_deletion_blockers(doctype: str, name: str, limit: int | None = None)
 	root_key = (doctype, name)
 	depth_by_document = {root_key: 0}
 	queue = deque([root_key])
+	fetch_limit = limit + 1 if limit else None
 	while queue:
 		parent_key = queue.popleft()
 		# lightweight stand-in; a full get_doc per node is too expensive
 		parent = frappe._dict(doctype=parent_key[0], name=parent_key[1])
-		links = get_statically_linked_docs(parent, method="Delete") + get_dynamic_linked_docs(
-			parent, method="Delete"
-		)
-		for link in links:
+		links = get_statically_linked_docs(parent, method="Delete", limit=fetch_limit)
+		dynamic_links = get_dynamic_linked_docs(parent, method="Delete", limit=fetch_limit)
+		if fetch_limit and (len(links) >= fetch_limit or len(dynamic_links) >= fetch_limit):
+			# a single document with more direct references than the whole cap;
+			# the bounded queries cannot even tell how many, so give up early
+			return [], True
+		for link in [*links, *dynamic_links]:
 			key = (link["reference_doctype"], link["reference_docname"])
 			if key in depth_by_document:
 				continue
@@ -479,8 +491,33 @@ def delete_all_linked_docs(
 	if len(to_delete) > MAX_SYNCHRONOUS_LINKED_DOCS:
 		return enqueue_linked_docs_processing(to_delete, "delete", root_doctype, root_name)
 
+	if root_doctype and root_name:
+		# the list was built by an earlier request; drop what is no longer linked
+		to_delete = keep_currently_linked(
+			to_delete, "delete", root_doctype, root_name, limit=MAX_LINKED_DELETE_DOCUMENTS
+		)
+
 	# no realtime progress: late events strand the dialog; the freeze overlay suffices
 	process_linked_docs_in_dependency_order(to_delete, delete_linked_doc)
+
+
+def keep_currently_linked(
+	docs, action, root_doctype, root_name, ignore_doctypes_on_cancel_all=None, limit=None
+):
+	"""Drop entries that are no longer linked to the root: the list was built in
+	an earlier request and may be stale by the time it is processed."""
+	if action == "cancel":
+		tree = SubmittableDocumentTree(root_doctype, root_name)
+		visited = tree.get_all_children(frappe.parse_json(ignore_doctypes_on_cancel_all) or [])
+		current = {(dt, docname) for dt, names in visited.items() for docname in names}
+	else:
+		current_docs, truncated = collect_deletion_blockers(root_doctype, root_name, limit=limit)
+		if truncated:
+			# the graph outgrew the cap since it was listed; process nothing
+			return []
+		current = {(doc["doctype"], doc["name"]) for doc in current_docs}
+
+	return [doc for doc in docs if (doc.get("doctype"), doc.get("name")) in current]
 
 
 def delete_linked_doc(docinfo):
@@ -488,21 +525,26 @@ def delete_linked_doc(docinfo):
 	frappe.delete_doc(docinfo.get("doctype"), docinfo.get("name"))
 
 
-def enqueue_linked_docs_processing(docs, action, root_doctype, root_name, discover=False):
+def enqueue_linked_docs_processing(
+	docs, action, root_doctype, root_name, ignore_doctypes_on_cancel_all=None, discover=False
+):
 	"""Queue processing of a large set together with the root document, which
 	the caller must not touch before the job has processed its links. With
 	discover, the job walks the graph itself instead of receiving it."""
+	root = (root_doctype, root_name) if root_doctype and root_name else None
 	job_kwargs = {}
-	if root_doctype and root_name:
-		if not discover:
-			docs = [*docs, frappe._dict(doctype=root_doctype, name=root_name)]
-		job_kwargs = {"job_id": f"linked_docs_{action}::{root_doctype}::{root_name}", "deduplicate": True}
+	if root:
+		# hash the identity: doctype and name may contain any separator
+		digest = hashlib.sha256(str((action, root_doctype, root_name)).encode()).hexdigest()[:16]
+		job_kwargs = {"job_id": f"linked_docs_{digest}", "deduplicate": True}
 
 	frappe.enqueue(
 		process_linked_docs_in_background,
 		docs=docs,
 		action=action,
-		discover_root=(root_doctype, root_name) if discover else None,
+		root=root,
+		discover=discover,
+		ignore_doctypes_on_cancel_all=ignore_doctypes_on_cancel_all,
 		queue="long",
 		now=frappe.in_test,
 		**job_kwargs,
@@ -510,18 +552,31 @@ def enqueue_linked_docs_processing(docs, action, root_doctype, root_name, discov
 	return {"queued": True}
 
 
-def process_linked_docs_in_background(docs, action, discover_root=None):
+def process_linked_docs_in_background(
+	docs, action, root=None, discover=False, ignore_doctypes_on_cancel_all=None
+):
 	"""Process the docs and notify the user of the outcome, since a background
-	job has no response to report through. With discover_root, walk the graph
-	here, where the listing cap does not apply.
+	job has no response to report through. With discover, walk the graph here,
+	where the listing cap does not apply.
+
+	The queued list can be stale by the time the job runs, so it is filtered
+	against the current graph, and the root document is processed last, since
+	the caller could not touch it before its links were gone.
 
 	Cancellation is all or nothing, matching the synchronous behaviour, since a
 	half-cancelled tree cannot be uncancelled. Deletion is best effort: some
 	blockers are permanently undeletable yet harmless, so the rest proceeds and
 	the leftovers are counted."""
-	if discover_root:
-		docs, _truncated = collect_deletion_blockers(*discover_root)
-		docs = [*docs, frappe._dict(doctype=discover_root[0], name=discover_root[1])]
+	if not frappe.db.get_value("User", frappe.session.user, "enabled"):
+		# the initiating account was disabled after this job was queued
+		return
+
+	if root:
+		if discover:
+			docs, _truncated = collect_deletion_blockers(*root)
+		else:
+			docs = keep_currently_linked(docs, action, *root, ignore_doctypes_on_cancel_all)
+		docs = [*docs, frappe._dict(doctype=root[0], name=root[1])]
 
 	if action == "cancel":
 		side_effect_counts = capture_pending_side_effects()
@@ -554,10 +609,15 @@ def process_linked_docs_in_background(docs, action, discover_root=None):
 
 
 def notify_linked_docs_processed(message):
-	"""Tell the user live when they are still around, and durably via a notification."""
+	"""Tell the user live when they are still around, and durably via a notification.
+
+	Both wait for commit: reporting an outcome the transaction then fails to
+	commit would be a lie."""
 	from frappe.desk.doctype.notification_log.notification_log import enqueue_create_notification
 
-	frappe.publish_realtime("msgprint", {"message": message, "alert": True}, user=frappe.session.user)
+	frappe.publish_realtime(
+		"msgprint", {"message": message, "alert": True}, user=frappe.session.user, after_commit=True
+	)
 	enqueue_create_notification([frappe.session.user], {"type": "Alert", "subject": message})
 
 

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -432,31 +432,29 @@ def cancel_all_linked_docs(
 	"""Cancel the linked documents in dependency order, then the root, all or
 	nothing; sets larger than MAX_SYNCHRONOUS_LINKED_DOCS, or docs=None past
 	the listing cap, move to a job instead."""
-	if ignore_doctypes_on_cancel_all is None:
-		ignore_doctypes_on_cancel_all = []
-
+	ignore_doctypes_on_cancel_all = frappe.parse_json(ignore_doctypes_on_cancel_all) or []
 	if docs is None:
-		if not (root_doctype and root_name):
-			frappe.throw(_("Either the documents to cancel or a root document is required"))
-		frappe.has_permission(root_doctype, doc=root_name, throw=True)
-		return enqueue_linked_docs_processing(
-			[], "cancel", root_doctype, root_name, ignore_doctypes_on_cancel_all, discover=True
-		)
+		return enqueue_discovery("cancel", root_doctype, root_name, ignore_doctypes_on_cancel_all)
 
-	docs = frappe.parse_json(docs)
-	ignore_doctypes_on_cancel_all = frappe.parse_json(ignore_doctypes_on_cancel_all)
-
-	to_cancel = [doc for doc in deduplicated(docs) if validate_linked_doc(doc, ignore_doctypes_on_cancel_all)]
+	docs = deduplicated(frappe.parse_json(docs))
+	to_cancel = [doc for doc in docs if validate_linked_doc(doc, ignore_doctypes_on_cancel_all)]
 	if len(to_cancel) > MAX_SYNCHRONOUS_LINKED_DOCS:
 		return enqueue_linked_docs_processing(
 			to_cancel, "cancel", root_doctype, root_name, ignore_doctypes_on_cancel_all
 		)
 
 	if root_doctype and root_name:
-		# the list was built by an earlier request; drop what is no longer linked
-		to_cancel = keep_currently_linked(
-			to_cancel, "cancel", root_doctype, root_name, ignore_doctypes_on_cancel_all
-		)
+		try:
+			to_cancel = keep_currently_linked(
+				to_cancel,
+				"cancel",
+				root_doctype,
+				root_name,
+				ignore_doctypes_on_cancel_all,
+				limit=MAX_LINKED_DOCUMENTS_LISTED,
+			)
+		except LinkedDocumentsOverflow:
+			return enqueue_discovery("cancel", root_doctype, root_name, ignore_doctypes_on_cancel_all)
 		# the root goes last, in the same transaction as its links
 		to_cancel = [*to_cancel, frappe._dict(doctype=root_doctype, name=root_name)]
 	process_linked_docs_in_dependency_order(to_cancel, cancel_linked_doc, _("Cancelling documents"))
@@ -524,20 +522,19 @@ def delete_all_linked_docs(
 	nothing; sets larger than MAX_SYNCHRONOUS_LINKED_DOCS, or docs=None past
 	the listing cap, move to a job instead."""
 	if docs is None:
-		if not (root_doctype and root_name):
-			frappe.throw(_("Either the documents to delete or a root document is required"))
-		frappe.has_permission(root_doctype, doc=root_name, throw=True)
-		return enqueue_linked_docs_processing([], "delete", root_doctype, root_name, discover=True)
+		return enqueue_discovery("delete", root_doctype, root_name)
 
 	to_delete = deduplicated(frappe.parse_json(docs))
 	if len(to_delete) > MAX_SYNCHRONOUS_LINKED_DOCS:
 		return enqueue_linked_docs_processing(to_delete, "delete", root_doctype, root_name)
 
 	if root_doctype and root_name:
-		# the list was built by an earlier request; drop what is no longer linked
-		to_delete = keep_currently_linked(
-			to_delete, "delete", root_doctype, root_name, limit=MAX_LINKED_DOCUMENTS_LISTED
-		)
+		try:
+			to_delete = keep_currently_linked(
+				to_delete, "delete", root_doctype, root_name, limit=MAX_LINKED_DOCUMENTS_LISTED
+			)
+		except LinkedDocumentsOverflow:
+			return enqueue_discovery("delete", root_doctype, root_name)
 		# the root goes last: its on_trash may remove blockers nothing else can
 		to_delete = [*to_delete, frappe._dict(doctype=root_doctype, name=root_name)]
 
@@ -548,8 +545,8 @@ def delete_all_linked_docs(
 def keep_currently_linked(
 	docs, action, root_doctype, root_name, ignore_doctypes_on_cancel_all=None, limit=None
 ):
-	"""Drop entries that are no longer linked to the root: the list was built in
-	an earlier request and may be stale by the time it is processed."""
+	"""Drop entries no longer linked to the root: the list was built in an earlier
+	request and may be stale; raise LinkedDocumentsOverflow past `limit`."""
 	if action == "cancel":
 		current_docs, truncated = collect_cancellation_blockers(
 			root_doctype, root_name, ignore_doctypes_on_cancel_all, limit=limit
@@ -557,8 +554,7 @@ def keep_currently_linked(
 	else:
 		current_docs, truncated = collect_deletion_blockers(root_doctype, root_name, limit=limit)
 	if truncated:
-		# the graph outgrew the cap since it was listed; process nothing
-		return []
+		raise LinkedDocumentsOverflow
 
 	current = {(doc["doctype"], doc["name"]) for doc in current_docs}
 	return [doc for doc in docs if (doc.get("doctype"), doc.get("name")) in current]
@@ -567,6 +563,16 @@ def keep_currently_linked(
 def delete_linked_doc(docinfo):
 	"""Delete a document; one already removed by another document's on_trash hook is ignored."""
 	frappe.delete_doc(docinfo.get("doctype"), docinfo.get("name"))
+
+
+def enqueue_discovery(action, root_doctype, root_name, ignore_doctypes_on_cancel_all=None):
+	"""Queue a job that discovers the root's graph itself, uncapped, and processes it."""
+	if not (root_doctype and root_name):
+		frappe.throw(_("Either the documents to process or a root document is required"))
+	frappe.has_permission(root_doctype, doc=root_name, throw=True)
+	return enqueue_linked_docs_processing(
+		[], action, root_doctype, root_name, ignore_doctypes_on_cancel_all, discover=True
+	)
 
 
 def enqueue_linked_docs_processing(

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -602,8 +602,8 @@ def enqueue_linked_docs_processing(
 def process_linked_docs_in_background(
 	docs, action, root=None, discover=False, ignore_doctypes_on_cancel_all=None
 ):
-	"""Process the docs, root last, and notify the user; the queued list is
-	refreshed or discovered uncapped, cancel all-or-nothing, delete best effort."""
+	"""Process the docs, root last, all or nothing, and notify the user; the
+	queued list is refreshed, or discovered uncapped, before processing."""
 	if not frappe.db.get_value("User", frappe.session.user, "enabled"):
 		# the initiating account was disabled after this job was queued
 		return
@@ -617,34 +617,27 @@ def process_linked_docs_in_background(
 			docs = keep_currently_linked(docs, action, *root, ignore_doctypes_on_cancel_all)
 		docs = [*docs, frappe._dict(doctype=root[0], name=root[1])]
 
-	if action == "cancel":
-		side_effect_counts = capture_pending_side_effects()
-		frappe.db.savepoint("cancel_linked_docs_job")
-		try:
-			process_linked_docs_in_dependency_order(docs, cancel_linked_doc)
-		except (
-			frappe.ValidationError,
-			frappe.PermissionError,
-			frappe.QueryTimeoutError,
-			frappe.QueryDeadlockError,
-		) as error:
-			frappe.db.rollback(save_point="cancel_linked_docs_job")
-			discard_side_effects_since(side_effect_counts)
-			notify_linked_docs_processed(
-				_("Could not cancel {0} linked documents: {1}").format(len(docs), str(error))
-			)
-			return
-		notify_linked_docs_processed(_("Cancelled {0} linked documents.").format(len(docs)))
+	process = cancel_linked_doc if action == "cancel" else delete_linked_doc
+	side_effect_counts = capture_pending_side_effects()
+	frappe.db.savepoint("linked_docs_job")
+	try:
+		process_linked_docs_in_dependency_order(docs, process)
+	except DEFERRABLE_ERRORS as error:
+		frappe.db.rollback(save_point="linked_docs_job")
+		discard_side_effects_since(side_effect_counts)
+		notify_linked_docs_processed(linked_docs_job_message(action, len(docs), error))
 		return
+	notify_linked_docs_processed(linked_docs_job_message(action, len(docs)))
 
-	skipped = process_linked_docs_in_dependency_order(docs, delete_linked_doc, raise_when_stuck=False)
-	done = len(docs) - len(skipped)
-	message = (
-		_("Deleted {0} linked documents; {1} could not be deleted.").format(done, len(skipped))
-		if skipped
-		else _("Deleted {0} linked documents.").format(done)
-	)
-	notify_linked_docs_processed(message)
+
+def linked_docs_job_message(action, count, error=None):
+	"""The notification text for a finished or failed job."""
+	messages = {
+		"cancel": (_("Cancelled {0} linked documents."), _("Could not cancel {0} linked documents: {1}")),
+		"delete": (_("Deleted {0} linked documents."), _("Could not delete {0} linked documents: {1}")),
+	}
+	done, failed = messages[action]
+	return failed.format(count, error) if error else done.format(count)
 
 
 def notify_linked_docs_processed(message):
@@ -669,6 +662,15 @@ def deduplicated(docs):
 	return unique
 
 
+# a document blocked by another one, or by a lock, may go through on a later pass
+DEFERRABLE_ERRORS = (
+	frappe.ValidationError,
+	frappe.PermissionError,
+	frappe.QueryTimeoutError,
+	frappe.QueryDeadlockError,
+)
+
+
 def process_linked_docs_in_dependency_order(docs, process, progress_title=None):
 	"""Run process over docs, deferring blocked ones to later passes until a
 	pass makes no progress, then raise the first blocker's error."""
@@ -689,7 +691,7 @@ def process_linked_docs_in_dependency_order(docs, process, progress_title=None):
 			frappe.db.savepoint(save_point)
 			try:
 				process(doc)
-			except (frappe.ValidationError, frappe.PermissionError, frappe.QueryTimeoutError):
+			except DEFERRABLE_ERRORS:
 				# hooks ran before the failing check; undo their writes and side effects
 				# (not on a deadlock: the database has already rolled the whole transaction back)
 				frappe.db.rollback(save_point=save_point)

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -40,10 +40,8 @@ def get_submitted_linked_docs(
 	3. Searching for links is going to be a tree like structure where at every level,
 	        you will be finding documents using parent document and parent document links.
 
-	Traversal stops once MAX_LINKED_DOCUMENTS_LISTED is exceeded and returns no
-	documents marked truncated; cancellation can still proceed through
-	cancel_all_linked_docs without docs, which discovers the graph in a
-	background job where the cap does not apply.
+	Past MAX_LINKED_DOCUMENTS_LISTED the result is empty and marked truncated;
+	cancel_all_linked_docs without docs then discovers the graph in a job.
 	"""
 
 	frappe.has_permission(doctype, doc=name, throw=True)
@@ -100,9 +98,7 @@ class SubmittableDocumentTree:
 		"""Get all nodes of a tree except the root node (all the nested submitted
 		documents those are present in referencing tables dependent tables).
 
-		Past `limit` discovered documents, stop walking, mark the tree truncated
-		and return nothing: the walk is checked per level, so a single very wide
-		level can still overshoot before the check.
+		Past `limit` documents (checked per level), mark truncated and return nothing.
 		"""
 		depth = 0
 		while self.to_be_visited_documents:
@@ -487,8 +483,7 @@ def collect_deletion_blockers(doctype: str, name: str, limit: int | None = None)
 		links = get_statically_linked_docs(parent, method="Delete", limit=fetch_limit)
 		dynamic_links = get_dynamic_linked_docs(parent, method="Delete", limit=fetch_limit)
 		if fetch_limit and (len(links) >= fetch_limit or len(dynamic_links) >= fetch_limit):
-			# a single document with more direct references than the whole cap;
-			# the bounded queries cannot even tell how many, so give up early
+			# one document saturated the bounded lookup; give up early
 			return [], True
 		for link in [*links, *dynamic_links]:
 			key = (link["reference_doctype"], link["reference_docname"])
@@ -562,9 +557,7 @@ def delete_linked_doc(docinfo):
 def enqueue_linked_docs_processing(
 	docs, action, root_doctype, root_name, ignore_doctypes_on_cancel_all=None, discover=False
 ):
-	"""Queue processing of a large set together with the root document, which
-	the caller must not touch before the job has processed its links. With
-	discover, the job walks the graph itself instead of receiving it."""
+	"""Queue processing of a large set; the job handles the root too."""
 	root = (root_doctype, root_name) if root_doctype and root_name else None
 	job_kwargs = {}
 	if root:
@@ -589,18 +582,11 @@ def enqueue_linked_docs_processing(
 def process_linked_docs_in_background(
 	docs, action, root=None, discover=False, ignore_doctypes_on_cancel_all=None
 ):
-	"""Process the docs and notify the user of the outcome, since a background
-	job has no response to report through. With discover, walk the graph here,
-	where the listing cap does not apply.
+	"""Process the docs and notify the user of the outcome.
 
-	The queued list can be stale by the time the job runs, so it is filtered
-	against the current graph, and the root document is processed last, since
-	the caller could not touch it before its links were gone.
-
-	Cancellation is all or nothing, matching the synchronous behaviour, since a
-	half-cancelled tree cannot be uncancelled. Deletion is best effort: some
-	blockers are permanently undeletable yet harmless, so the rest proceeds and
-	the leftovers are counted."""
+	The queued list is refreshed against the current graph (or discovered here,
+	uncapped), the root goes last, cancel is all-or-nothing, delete best-effort.
+	"""
 	if not frappe.db.get_value("User", frappe.session.user, "enabled"):
 		# the initiating account was disabled after this job was queued
 		return
@@ -645,10 +631,7 @@ def process_linked_docs_in_background(
 
 
 def notify_linked_docs_processed(message):
-	"""Tell the user live when they are still around, and durably via a notification.
-
-	Both wait for commit: reporting an outcome the transaction then fails to
-	commit would be a lie."""
+	"""Notify live and via Notification Log, both after commit."""
 	from frappe.desk.doctype.notification_log.notification_log import enqueue_create_notification
 
 	frappe.publish_realtime(

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -383,10 +383,18 @@ def get_referencing_documents(
 	return documents
 
 
+MAX_SYNCHRONOUS_LINKED_DOCS = 50
+
+
 @frappe.whitelist()
-def cancel_all_linked_docs(docs: str | list, ignore_doctypes_on_cancel_all: str | list[str] | None = None):
-	"""Cancel the linked documents, deferring blocked ones so callers need not
-	order them; doctypes in ignore_doctypes_on_cancel_all are skipped."""
+def cancel_all_linked_docs(
+	docs: str | list,
+	ignore_doctypes_on_cancel_all: str | list[str] | None = None,
+	root_doctype: str | None = None,
+	root_name: str | None = None,
+):
+	"""Cancel the linked documents in dependency order; sets larger than
+	MAX_SYNCHRONOUS_LINKED_DOCS move to a job that also cancels the root."""
 	if ignore_doctypes_on_cancel_all is None:
 		ignore_doctypes_on_cancel_all = []
 
@@ -394,6 +402,9 @@ def cancel_all_linked_docs(docs: str | list, ignore_doctypes_on_cancel_all: str 
 	ignore_doctypes_on_cancel_all = frappe.parse_json(ignore_doctypes_on_cancel_all)
 
 	to_cancel = [doc for doc in deduplicated(docs) if validate_linked_doc(doc, ignore_doctypes_on_cancel_all)]
+	if len(to_cancel) > MAX_SYNCHRONOUS_LINKED_DOCS:
+		return enqueue_linked_docs_processing(to_cancel, "cancel", root_doctype, root_name)
+
 	process_linked_docs_in_dependency_order(to_cancel, cancel_linked_doc, _("Cancelling documents"))
 
 
@@ -412,10 +423,16 @@ def get_linked_docs_to_delete(doctype: str, name: str) -> dict:
 	"""Get the documents blocking deletion of the given document, recursively,
 	deepest first; unreadable ones are neither returned nor traversed. Past
 	MAX_LINKED_DELETE_DOCUMENTS the result is empty and marked truncated."""
+	frappe.has_permission(doctype, doc=name, throw=True)
+	docs, truncated = collect_deletion_blockers(doctype, name, limit=MAX_LINKED_DELETE_DOCUMENTS)
+	return {"docs": docs, "count": len(docs), "truncated": truncated}
+
+
+def collect_deletion_blockers(doctype: str, name: str, limit: int | None = None) -> tuple[list, bool]:
+	"""Walk the delete-blocking graph breadth first, deepest documents first in
+	the result; past `limit` discovered documents, give up and report truncated."""
 	from frappe.model.delete_doc import get_dynamic_linked_docs
 	from frappe.model.delete_doc import get_linked_docs as get_statically_linked_docs
-
-	frappe.has_permission(doctype, doc=name, throw=True)
 
 	root_key = (doctype, name)
 	depth_by_document = {root_key: 0}
@@ -431,8 +448,8 @@ def get_linked_docs_to_delete(doctype: str, name: str) -> dict:
 			key = (link["reference_doctype"], link["reference_docname"])
 			if key in depth_by_document:
 				continue
-			if len(depth_by_document) > MAX_LINKED_DELETE_DOCUMENTS:
-				return {"docs": [], "count": 0, "truncated": True}
+			if limit and len(depth_by_document) > limit:
+				return [], True
 			if not frappe.has_permission(key[0], doc=key[1]):
 				continue
 			depth_by_document[key] = depth_by_document[parent_key] + 1
@@ -442,13 +459,25 @@ def get_linked_docs_to_delete(doctype: str, name: str) -> dict:
 		{"doctype": dt, "name": docname} for dt, docname in depth_by_document if (dt, docname) != root_key
 	]
 	docs.sort(key=lambda doc: depth_by_document[doc["doctype"], doc["name"]], reverse=True)
-	return {"docs": docs, "count": len(docs), "truncated": False}
+	return docs, False
 
 
 @frappe.whitelist()
-def delete_all_linked_docs(docs: str | list):
-	"""Delete the given documents in dependency order; a blocked one fails the whole request."""
+def delete_all_linked_docs(
+	docs: str | list | None = None, root_doctype: str | None = None, root_name: str | None = None
+) -> dict | None:
+	"""Delete the given documents in dependency order, failing the request if one
+	stays blocked; sets larger than MAX_SYNCHRONOUS_LINKED_DOCS, or docs=None
+	past the listing cap, move to a job that also deletes the root."""
+	if docs is None:
+		if not (root_doctype and root_name):
+			frappe.throw(_("Either the documents to delete or a root document is required"))
+		frappe.has_permission(root_doctype, doc=root_name, throw=True)
+		return enqueue_linked_docs_processing([], "delete", root_doctype, root_name, discover=True)
+
 	to_delete = deduplicated(frappe.parse_json(docs))
+	if len(to_delete) > MAX_SYNCHRONOUS_LINKED_DOCS:
+		return enqueue_linked_docs_processing(to_delete, "delete", root_doctype, root_name)
 
 	# no realtime progress: late events strand the dialog; the freeze overlay suffices
 	process_linked_docs_in_dependency_order(to_delete, delete_linked_doc)
@@ -457,6 +486,79 @@ def delete_all_linked_docs(docs: str | list):
 def delete_linked_doc(docinfo):
 	"""Delete a document; one already removed by another document's on_trash hook is ignored."""
 	frappe.delete_doc(docinfo.get("doctype"), docinfo.get("name"))
+
+
+def enqueue_linked_docs_processing(docs, action, root_doctype, root_name, discover=False):
+	"""Queue processing of a large set together with the root document, which
+	the caller must not touch before the job has processed its links. With
+	discover, the job walks the graph itself instead of receiving it."""
+	job_kwargs = {}
+	if root_doctype and root_name:
+		if not discover:
+			docs = [*docs, frappe._dict(doctype=root_doctype, name=root_name)]
+		job_kwargs = {"job_id": f"linked_docs_{action}::{root_doctype}::{root_name}", "deduplicate": True}
+
+	frappe.enqueue(
+		process_linked_docs_in_background,
+		docs=docs,
+		action=action,
+		discover_root=(root_doctype, root_name) if discover else None,
+		queue="long",
+		now=frappe.in_test,
+		**job_kwargs,
+	)
+	return {"queued": True}
+
+
+def process_linked_docs_in_background(docs, action, discover_root=None):
+	"""Process the docs and notify the user of the outcome, since a background
+	job has no response to report through. With discover_root, walk the graph
+	here, where the listing cap does not apply.
+
+	Cancellation is all or nothing, matching the synchronous behaviour, since a
+	half-cancelled tree cannot be uncancelled. Deletion is best effort: some
+	blockers are permanently undeletable yet harmless, so the rest proceeds and
+	the leftovers are counted."""
+	if discover_root:
+		docs, _truncated = collect_deletion_blockers(*discover_root)
+		docs = [*docs, frappe._dict(doctype=discover_root[0], name=discover_root[1])]
+
+	if action == "cancel":
+		side_effect_counts = capture_pending_side_effects()
+		frappe.db.savepoint("cancel_linked_docs_job")
+		try:
+			process_linked_docs_in_dependency_order(docs, cancel_linked_doc)
+		except (
+			frappe.ValidationError,
+			frappe.PermissionError,
+			frappe.QueryTimeoutError,
+			frappe.QueryDeadlockError,
+		) as error:
+			frappe.db.rollback(save_point="cancel_linked_docs_job")
+			discard_side_effects_since(side_effect_counts)
+			notify_linked_docs_processed(
+				_("Could not cancel {0} linked documents: {1}").format(len(docs), str(error))
+			)
+			return
+		notify_linked_docs_processed(_("Cancelled {0} linked documents.").format(len(docs)))
+		return
+
+	skipped = process_linked_docs_in_dependency_order(docs, delete_linked_doc, raise_when_stuck=False)
+	done = len(docs) - len(skipped)
+	message = (
+		_("Deleted {0} linked documents; {1} could not be deleted.").format(done, len(skipped))
+		if skipped
+		else _("Deleted {0} linked documents.").format(done)
+	)
+	notify_linked_docs_processed(message)
+
+
+def notify_linked_docs_processed(message):
+	"""Tell the user live when they are still around, and durably via a notification."""
+	from frappe.desk.doctype.notification_log.notification_log import enqueue_create_notification
+
+	frappe.publish_realtime("msgprint", {"message": message, "alert": True}, user=frappe.session.user)
+	enqueue_create_notification([frappe.session.user], {"type": "Alert", "subject": message})
 
 
 def deduplicated(docs):

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -72,6 +72,10 @@ def collect_cancellation_blockers(
 	return docs, False
 
 
+class LinkedDocumentsOverflow(Exception):
+	"""A bounded reference lookup returned as many rows as its limit allowed."""
+
+
 class SubmittableDocumentTree:
 	def __init__(self, doctype: str, name: str):
 		"""Construct a tree for the submitable linked documents.
@@ -90,6 +94,7 @@ class SubmittableDocumentTree:
 		self.visited_documents = defaultdict(list)
 		self.depth_by_document = {(doctype, name): 0}
 		self.truncated = False
+		self.fetch_limit = None
 
 		self._submittable_doctypes = None  # All submittable doctypes in the system
 		self._references_across_doctypes = None  # doctype wise links/references
@@ -100,13 +105,18 @@ class SubmittableDocumentTree:
 
 		Past `limit` documents (checked per level), mark truncated and return nothing.
 		"""
+		self.fetch_limit = limit + 1 if limit else None
 		depth = 0
 		while self.to_be_visited_documents:
 			depth += 1
 			current_level = self.visit_current_level(ignore_doctypes_on_cancel_all)
 			next_level_children = defaultdict(list)
 			for parent_dt, parent_docs in current_level.items():
-				child_docs = self.get_next_level_children(parent_dt, parent_docs)
+				try:
+					child_docs = self.get_next_level_children(parent_dt, parent_docs)
+				except LinkedDocumentsOverflow:
+					self.truncated = True
+					return defaultdict(list)
 				for linked_dt, linked_names in child_docs.items():
 					new_child_docs = (
 						set(linked_names)
@@ -162,6 +172,7 @@ class SubmittableDocumentTree:
 					get_parent_if_child_table_doc=True,
 					parent_filters=[("docstatus", "=", 1)],
 					allowed_parents=self.get_link_sources(),
+					limit=self.fetch_limit,
 				)
 				or {}
 			)
@@ -370,6 +381,7 @@ def get_referencing_documents(
 	parent_filters: list[list] | None = None,
 	child_filters=None,
 	allowed_parents=None,
+	limit: int | None = None,
 ):
 	"""Get linked documents based on link_info.
 
@@ -391,10 +403,17 @@ def get_referencing_documents(
 
 	if not link_info.get("is_child"):
 		filters.extend(parent_filters or [])
-		return {from_table: frappe.get_all(from_table, filters, pluck="name", order_by=None)}
+		names = frappe.get_all(from_table, filters, pluck="name", order_by=None, limit=limit)
+		if limit and len(names) >= limit:
+			raise LinkedDocumentsOverflow
+		return {from_table: names}
 
 	filters.extend(child_filters or [])
-	res = frappe.get_all(from_table, filters=filters, fields=["name", "parenttype", "parent"], order_by=None)
+	res = frappe.get_all(
+		from_table, filters=filters, fields=["name", "parenttype", "parent"], order_by=None, limit=limit
+	)
+	if limit and len(res) >= limit:
+		raise LinkedDocumentsOverflow
 	documents = defaultdict(list)
 
 	for parent, rows in itertools.groupby(res, key=lambda row: row["parenttype"]):
@@ -525,6 +544,8 @@ def delete_all_linked_docs(
 		to_delete = keep_currently_linked(
 			to_delete, "delete", root_doctype, root_name, limit=MAX_LINKED_DOCUMENTS_LISTED
 		)
+		# the root goes last: its on_trash may remove blockers nothing else can
+		to_delete = [*to_delete, frappe._dict(doctype=root_doctype, name=root_name)]
 
 	# no realtime progress: late events strand the dialog; the freeze overlay suffices
 	process_linked_docs_in_dependency_order(to_delete, delete_linked_doc)

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -39,22 +39,39 @@ def get_submitted_linked_docs(
 	        finding the relationships(Foreign key references) across submittable doctypes.
 	3. Searching for links is going to be a tree like structure where at every level,
 	        you will be finding documents using parent document and parent document links.
+
+	Traversal stops once MAX_LINKED_DOCUMENTS_LISTED is exceeded and returns no
+	documents marked truncated; cancellation can still proceed through
+	cancel_all_linked_docs without docs, which discovers the graph in a
+	background job where the cap does not apply.
 	"""
 
+	frappe.has_permission(doctype, doc=name, throw=True)
+	docs, truncated = collect_cancellation_blockers(
+		doctype, name, ignore_doctypes_on_cancel_all, limit=MAX_LINKED_DOCUMENTS_LISTED
+	)
+	return {"docs": docs, "count": len(docs), "truncated": truncated}
+
+
+def collect_cancellation_blockers(
+	doctype: str, name: str, ignore_doctypes_on_cancel_all=None, limit: int | None = None
+) -> tuple[list, bool]:
+	"""Walk the submitted linked documents, deepest documents first in the
+	result; past `limit` discovered documents, give up and report truncated."""
 	ignore_doctypes_on_cancel_all = frappe.parse_json(ignore_doctypes_on_cancel_all) or []
 
-	frappe.has_permission(doctype, doc=name, throw=True)
 	tree = SubmittableDocumentTree(doctype, name)
-	visited_documents = tree.get_all_children(ignore_doctypes_on_cancel_all)
-	docs = []
+	visited_documents = tree.get_all_children(ignore_doctypes_on_cancel_all, limit=limit)
+	if tree.truncated:
+		return [], True
 
+	docs = []
 	for dt, names in visited_documents.items():
-		docs.extend([{"doctype": dt, "name": name, "docstatus": 1} for name in names])
+		docs.extend([{"doctype": dt, "name": docname, "docstatus": 1} for docname in names])
 
 	# deepest first, so referencing documents get cancelled before the referenced
 	docs.sort(key=lambda doc: tree.depth_by_document[doc["doctype"], doc["name"]], reverse=True)
-
-	return {"docs": docs, "count": len(docs)}
+	return docs, False
 
 
 class SubmittableDocumentTree:
@@ -74,13 +91,18 @@ class SubmittableDocumentTree:
 		self.to_be_visited_documents = {doctype: [name]}
 		self.visited_documents = defaultdict(list)
 		self.depth_by_document = {(doctype, name): 0}
+		self.truncated = False
 
 		self._submittable_doctypes = None  # All submittable doctypes in the system
 		self._references_across_doctypes = None  # doctype wise links/references
 
-	def get_all_children(self, ignore_doctypes_on_cancel_all):
+	def get_all_children(self, ignore_doctypes_on_cancel_all, limit=None):
 		"""Get all nodes of a tree except the root node (all the nested submitted
 		documents those are present in referencing tables dependent tables).
+
+		Past `limit` discovered documents, stop walking, mark the tree truncated
+		and return nothing: the walk is checked per level, so a single very wide
+		level can still overshoot before the check.
 		"""
 		depth = 0
 		while self.to_be_visited_documents:
@@ -100,6 +122,9 @@ class SubmittableDocumentTree:
 						self.depth_by_document[(linked_dt, linked_name)] = depth
 
 			self.to_be_visited_documents = next_level_children
+			if limit and len(self.depth_by_document) - 1 > limit:
+				self.truncated = True
+				return defaultdict(list)
 
 		# Remove root node from visited documents
 		if self.root_docname in self.visited_documents.get(self.root_doctype, []):
@@ -389,15 +414,24 @@ MAX_SYNCHRONOUS_LINKED_DOCS = 50
 
 @frappe.whitelist()
 def cancel_all_linked_docs(
-	docs: str | list,
+	docs: str | list | None = None,
 	ignore_doctypes_on_cancel_all: str | list[str] | None = None,
 	root_doctype: str | None = None,
 	root_name: str | None = None,
 ):
 	"""Cancel the linked documents in dependency order; sets larger than
-	MAX_SYNCHRONOUS_LINKED_DOCS move to a job that also cancels the root."""
+	MAX_SYNCHRONOUS_LINKED_DOCS, or docs=None past the listing cap, move to
+	a job that also cancels the root."""
 	if ignore_doctypes_on_cancel_all is None:
 		ignore_doctypes_on_cancel_all = []
+
+	if docs is None:
+		if not (root_doctype and root_name):
+			frappe.throw(_("Either the documents to cancel or a root document is required"))
+		frappe.has_permission(root_doctype, doc=root_name, throw=True)
+		return enqueue_linked_docs_processing(
+			[], "cancel", root_doctype, root_name, ignore_doctypes_on_cancel_all, discover=True
+		)
 
 	docs = frappe.parse_json(docs)
 	ignore_doctypes_on_cancel_all = frappe.parse_json(ignore_doctypes_on_cancel_all)
@@ -423,16 +457,16 @@ def cancel_linked_doc(docinfo):
 		doc.cancel()
 
 
-MAX_LINKED_DELETE_DOCUMENTS = 500
+MAX_LINKED_DOCUMENTS_LISTED = 500
 
 
 @frappe.whitelist()
 def get_linked_docs_to_delete(doctype: str, name: str) -> dict:
 	"""Get the documents blocking deletion of the given document, recursively,
 	deepest first; unreadable ones are neither returned nor traversed. Past
-	MAX_LINKED_DELETE_DOCUMENTS the result is empty and marked truncated."""
+	MAX_LINKED_DOCUMENTS_LISTED the result is empty and marked truncated."""
 	frappe.has_permission(doctype, doc=name, throw=True)
-	docs, truncated = collect_deletion_blockers(doctype, name, limit=MAX_LINKED_DELETE_DOCUMENTS)
+	docs, truncated = collect_deletion_blockers(doctype, name, limit=MAX_LINKED_DOCUMENTS_LISTED)
 	return {"docs": docs, "count": len(docs), "truncated": truncated}
 
 
@@ -494,7 +528,7 @@ def delete_all_linked_docs(
 	if root_doctype and root_name:
 		# the list was built by an earlier request; drop what is no longer linked
 		to_delete = keep_currently_linked(
-			to_delete, "delete", root_doctype, root_name, limit=MAX_LINKED_DELETE_DOCUMENTS
+			to_delete, "delete", root_doctype, root_name, limit=MAX_LINKED_DOCUMENTS_LISTED
 		)
 
 	# no realtime progress: late events strand the dialog; the freeze overlay suffices
@@ -507,16 +541,16 @@ def keep_currently_linked(
 	"""Drop entries that are no longer linked to the root: the list was built in
 	an earlier request and may be stale by the time it is processed."""
 	if action == "cancel":
-		tree = SubmittableDocumentTree(root_doctype, root_name)
-		visited = tree.get_all_children(frappe.parse_json(ignore_doctypes_on_cancel_all) or [])
-		current = {(dt, docname) for dt, names in visited.items() for docname in names}
+		current_docs, truncated = collect_cancellation_blockers(
+			root_doctype, root_name, ignore_doctypes_on_cancel_all, limit=limit
+		)
 	else:
 		current_docs, truncated = collect_deletion_blockers(root_doctype, root_name, limit=limit)
-		if truncated:
-			# the graph outgrew the cap since it was listed; process nothing
-			return []
-		current = {(doc["doctype"], doc["name"]) for doc in current_docs}
+	if truncated:
+		# the graph outgrew the cap since it was listed; process nothing
+		return []
 
+	current = {(doc["doctype"], doc["name"]) for doc in current_docs}
 	return [doc for doc in docs if (doc.get("doctype"), doc.get("name")) in current]
 
 
@@ -572,7 +606,9 @@ def process_linked_docs_in_background(
 		return
 
 	if root:
-		if discover:
+		if discover and action == "cancel":
+			docs, _truncated = collect_cancellation_blockers(*root, ignore_doctypes_on_cancel_all)
+		elif discover:
 			docs, _truncated = collect_deletion_blockers(*root)
 		else:
 			docs = keep_currently_linked(docs, action, *root, ignore_doctypes_on_cancel_all)

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -9,6 +9,8 @@ import frappe
 import frappe.desk.form.load
 import frappe.desk.form.meta
 from frappe import _
+from frappe.model.delete_doc import LinkedDocumentsOverflow, get_dynamic_linked_docs
+from frappe.model.delete_doc import get_linked_docs as get_statically_linked_docs
 from frappe.model.meta import is_single
 from frappe.modules import load_doctype_module
 
@@ -69,10 +71,6 @@ def collect_cancellation_blockers(
 	# deepest first, so referencing documents get cancelled before the referenced
 	docs.sort(key=lambda doc: tree.depth_by_document[doc["doctype"], doc["name"]], reverse=True)
 	return docs, False
-
-
-class LinkedDocumentsOverflow(Exception):
-	"""A bounded reference lookup returned as many rows as its limit allowed."""
 
 
 class SubmittableDocumentTree:
@@ -487,9 +485,6 @@ def get_linked_docs_to_delete(doctype: str, name: str) -> dict:
 def collect_deletion_blockers(doctype: str, name: str, limit: int | None = None) -> tuple[list, bool]:
 	"""Walk the delete-blocking graph breadth first, deepest documents first in
 	the result; past `limit` discovered documents, give up and report truncated."""
-	from frappe.model.delete_doc import get_dynamic_linked_docs
-	from frappe.model.delete_doc import get_linked_docs as get_statically_linked_docs
-
 	root_key = (doctype, name)
 	depth_by_document = {root_key: 0}
 	queue = deque([root_key])
@@ -498,10 +493,10 @@ def collect_deletion_blockers(doctype: str, name: str, limit: int | None = None)
 		parent_key = queue.popleft()
 		# lightweight stand-in; a full get_doc per node is too expensive
 		parent = frappe._dict(doctype=parent_key[0], name=parent_key[1])
-		links = get_statically_linked_docs(parent, method="Delete", limit=fetch_limit)
-		dynamic_links = get_dynamic_linked_docs(parent, method="Delete", limit=fetch_limit)
-		if fetch_limit and (len(links) >= fetch_limit or len(dynamic_links) >= fetch_limit):
-			# one document saturated the bounded lookup; give up early
+		try:
+			links = get_statically_linked_docs(parent, method="Delete", limit=fetch_limit)
+			dynamic_links = get_dynamic_linked_docs(parent, method="Delete", limit=fetch_limit)
+		except LinkedDocumentsOverflow:
 			return [], True
 		for link in [*links, *dynamic_links]:
 			key = (link["reference_doctype"], link["reference_docname"])

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -431,9 +431,9 @@ def cancel_all_linked_docs(
 	root_doctype: str | None = None,
 	root_name: str | None = None,
 ):
-	"""Cancel the linked documents in dependency order; sets larger than
-	MAX_SYNCHRONOUS_LINKED_DOCS, or docs=None past the listing cap, move to
-	a job that also cancels the root."""
+	"""Cancel the linked documents in dependency order, then the root, all or
+	nothing; sets larger than MAX_SYNCHRONOUS_LINKED_DOCS, or docs=None past
+	the listing cap, move to a job instead."""
 	if ignore_doctypes_on_cancel_all is None:
 		ignore_doctypes_on_cancel_all = []
 
@@ -459,6 +459,8 @@ def cancel_all_linked_docs(
 		to_cancel = keep_currently_linked(
 			to_cancel, "cancel", root_doctype, root_name, ignore_doctypes_on_cancel_all
 		)
+		# the root goes last, in the same transaction as its links
+		to_cancel = [*to_cancel, frappe._dict(doctype=root_doctype, name=root_name)]
 	process_linked_docs_in_dependency_order(to_cancel, cancel_linked_doc, _("Cancelling documents"))
 
 
@@ -523,9 +525,9 @@ def collect_deletion_blockers(doctype: str, name: str, limit: int | None = None)
 def delete_all_linked_docs(
 	docs: str | list | None = None, root_doctype: str | None = None, root_name: str | None = None
 ) -> dict | None:
-	"""Delete the given documents in dependency order, failing the request if one
-	stays blocked; sets larger than MAX_SYNCHRONOUS_LINKED_DOCS, or docs=None
-	past the listing cap, move to a job that also deletes the root."""
+	"""Delete the linked documents in dependency order, then the root, all or
+	nothing; sets larger than MAX_SYNCHRONOUS_LINKED_DOCS, or docs=None past
+	the listing cap, move to a job instead."""
 	if docs is None:
 		if not (root_doctype and root_name):
 			frappe.throw(_("Either the documents to delete or a root document is required"))

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -13,6 +13,7 @@ from frappe.model.delete_doc import LinkedDocumentsOverflow, get_dynamic_linked_
 from frappe.model.delete_doc import get_linked_docs as get_statically_linked_docs
 from frappe.model.meta import is_single
 from frappe.modules import load_doctype_module
+from frappe.utils.scheduler import is_scheduler_inactive
 
 
 @frappe.whitelist()
@@ -430,15 +431,15 @@ def cancel_all_linked_docs(
 	root_name: str | None = None,
 ):
 	"""Cancel the linked documents in dependency order, then the root, all or
-	nothing; sets larger than MAX_SYNCHRONOUS_LINKED_DOCS, or docs=None past
-	the listing cap, move to a job instead."""
+	nothing; large sets, roots that queue their cancellations, and docs=None
+	past the listing cap move to a job instead."""
 	ignore_doctypes_on_cancel_all = frappe.parse_json(ignore_doctypes_on_cancel_all) or []
 	if docs is None:
 		return enqueue_discovery("cancel", root_doctype, root_name, ignore_doctypes_on_cancel_all)
 
 	docs = deduplicated(frappe.parse_json(docs))
 	to_cancel = [doc for doc in docs if validate_linked_doc(doc, ignore_doctypes_on_cancel_all)]
-	if len(to_cancel) > MAX_SYNCHRONOUS_LINKED_DOCS:
+	if len(to_cancel) > MAX_SYNCHRONOUS_LINKED_DOCS or is_cancelled_in_background(root_doctype):
 		return enqueue_linked_docs_processing(
 			to_cancel, "cancel", root_doctype, root_name, ignore_doctypes_on_cancel_all
 		)
@@ -465,6 +466,11 @@ def cancel_linked_doc(docinfo):
 	doc = frappe.get_doc(docinfo.get("doctype"), docinfo.get("name"))
 	if doc.docstatus.is_submitted():
 		doc.cancel()
+
+
+def is_cancelled_in_background(doctype):
+	"""Whether the doctype queues its cancellations, as the form's own Cancel honours."""
+	return bool(doctype and frappe.get_meta(doctype).queue_in_background and not is_scheduler_inactive())
 
 
 MAX_LINKED_DOCUMENTS_LISTED = 500

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -40,8 +40,7 @@ def get_submitted_linked_docs(
 	3. Searching for links is going to be a tree like structure where at every level,
 	        you will be finding documents using parent document and parent document links.
 
-	Past MAX_LINKED_DOCUMENTS_LISTED the result is empty and marked truncated;
-	cancel_all_linked_docs without docs then discovers the graph in a job.
+	Past MAX_LINKED_DOCUMENTS_LISTED the result is empty and marked truncated.
 	"""
 
 	frappe.has_permission(doctype, doc=name, throw=True)
@@ -101,10 +100,8 @@ class SubmittableDocumentTree:
 
 	def get_all_children(self, ignore_doctypes_on_cancel_all, limit=None):
 		"""Get all nodes of a tree except the root node (all the nested submitted
-		documents those are present in referencing tables dependent tables).
-
-		Past `limit` documents (checked per level), mark truncated and return nothing.
-		"""
+		documents those are present in referencing tables dependent tables); past
+		`limit` documents, mark the tree truncated and return nothing."""
 		self.fetch_limit = limit + 1 if limit else None
 		depth = 0
 		while self.to_be_visited_documents:
@@ -603,11 +600,8 @@ def enqueue_linked_docs_processing(
 def process_linked_docs_in_background(
 	docs, action, root=None, discover=False, ignore_doctypes_on_cancel_all=None
 ):
-	"""Process the docs and notify the user of the outcome.
-
-	The queued list is refreshed against the current graph (or discovered here,
-	uncapped), the root goes last, cancel is all-or-nothing, delete best-effort.
-	"""
+	"""Process the docs, root last, and notify the user; the queued list is
+	refreshed or discovered uncapped, cancel all-or-nothing, delete best effort."""
 	if not frappe.db.get_value("User", frappe.session.user, "enabled"):
 		# the initiating account was disabled after this job was queued
 		return

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -620,14 +620,18 @@ def process_linked_docs_in_background(
 	process = cancel_linked_doc if action == "cancel" else delete_linked_doc
 	side_effect_counts = capture_pending_side_effects()
 	frappe.db.savepoint("linked_docs_job")
+	error = None
 	try:
 		process_linked_docs_in_dependency_order(docs, process)
-	except DEFERRABLE_ERRORS as error:
+	except DEFERRABLE_ERRORS as blocker:
 		frappe.db.rollback(save_point="linked_docs_job")
 		discard_side_effects_since(side_effect_counts)
-		notify_linked_docs_processed(linked_docs_job_message(action, len(docs), error))
-		return
-	notify_linked_docs_processed(linked_docs_job_message(action, len(docs)))
+		error = blocker
+	except frappe.QueryDeadlockError as deadlock:
+		# the database has already discarded the whole transaction, savepoint included
+		frappe.db.rollback()
+		error = deadlock
+	notify_linked_docs_processed(linked_docs_job_message(action, len(docs), error))
 
 
 def linked_docs_job_message(action, count, error=None):
@@ -662,13 +666,9 @@ def deduplicated(docs):
 	return unique
 
 
-# a document blocked by another one, or by a lock, may go through on a later pass
-DEFERRABLE_ERRORS = (
-	frappe.ValidationError,
-	frappe.PermissionError,
-	frappe.QueryTimeoutError,
-	frappe.QueryDeadlockError,
-)
+# a document blocked by another one, or by a lock, may go through on a later pass;
+# not a deadlocked one: the database has already rolled the whole transaction back
+DEFERRABLE_ERRORS = (frappe.ValidationError, frappe.PermissionError, frappe.QueryTimeoutError)
 
 
 def process_linked_docs_in_dependency_order(docs, process, progress_title=None):
@@ -693,7 +693,6 @@ def process_linked_docs_in_dependency_order(docs, process, progress_title=None):
 				process(doc)
 			except DEFERRABLE_ERRORS:
 				# hooks ran before the failing check; undo their writes and side effects
-				# (not on a deadlock: the database has already rolled the whole transaction back)
 				frappe.db.rollback(save_point=save_point)
 				discard_side_effects_since(side_effect_counts)
 				deferred.append(doc)

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -300,9 +300,12 @@ def check_permission_and_not_submitted(doc):
 		)
 
 
-def get_linked_docs(doc, method="Delete") -> list[dict]:
+def get_linked_docs(doc, method="Delete", limit: int | None = None) -> list[dict]:
 	"""
 	Return a list of documents that are statically linked to the given document.
+
+	With limit, stop collecting once that many links are found, so callers that
+	only need to detect "too many" do not materialize every referencing row.
 	"""
 	from frappe.model.rename_doc import get_link_fields
 
@@ -341,12 +344,16 @@ def get_linked_docs(doc, method="Delete") -> list[dict]:
 		if meta.istable:
 			fields.extend(["parent", "parenttype"])
 
+		if limit and len(linked_docs) >= limit:
+			return linked_docs
+
 		for item in frappe.db.get_values(
 			link_dt,
 			{link_field: doc.name},
 			fields,
 			as_dict=True,
 			order_by=None,
+			limit=limit,
 		):
 			# available only in child table cases
 			item_parent = getattr(item, "parent", None)
@@ -385,13 +392,18 @@ def check_if_doc_is_linked(doc, method="Delete"):
 		raise_link_exists_exception(doc, link["reference_doctype"], link["reference_docname"])
 
 
-def get_dynamic_linked_docs(doc, method="Delete") -> list[dict]:
+def get_dynamic_linked_docs(doc, method="Delete", limit: int | None = None) -> list[dict]:
 	"""
 	Return a list of documents that are dynamically linked to the given document.
+
+	With limit, stop collecting once that many links are found, so callers that
+	only need to detect "too many" do not materialize every referencing row.
 	"""
 	linked_docs = []
 
 	for df in get_dynamic_link_map().get(doc.doctype, []):
+		if limit and len(linked_docs) >= limit:
+			return linked_docs
 		ignore_linked_doctypes = doc.get("ignore_linked_doctypes") or []
 
 		if df.parent in frappe.get_hooks("ignore_links_on_delete") or (
@@ -434,6 +446,8 @@ def get_dynamic_linked_docs(doc, method="Delete") -> list[dict]:
 				.where(RefDoc[df.options] == doc.doctype)
 				.where(RefDoc[df.fieldname] == doc.name)
 			)
+			if limit:
+				query = query.limit(limit)
 			for refdoc in query.run(as_dict=True):
 				# linked to an non-cancelled doc when deleting
 				# or linked to a submitted doc when cancelling

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -301,11 +301,7 @@ def check_permission_and_not_submitted(doc):
 
 
 def get_linked_docs(doc, method="Delete", limit: int | None = None) -> list[dict]:
-	"""
-	Return a list of documents that are statically linked to the given document.
-
-	With limit, stop collecting once that many links are found.
-	"""
+	"""Return the documents statically linked to the given document, at most `limit` of them."""
 	from frappe.model.rename_doc import get_link_fields
 
 	link_fields = get_link_fields(doc.doctype)
@@ -392,11 +388,7 @@ def check_if_doc_is_linked(doc, method="Delete"):
 
 
 def get_dynamic_linked_docs(doc, method="Delete", limit: int | None = None) -> list[dict]:
-	"""
-	Return a list of documents that are dynamically linked to the given document.
-
-	With limit, stop collecting once that many links are found.
-	"""
+	"""Return the documents dynamically linked to the given document, at most `limit` of them."""
 	linked_docs = []
 
 	for df in get_dynamic_link_map().get(doc.doctype, []):

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -300,8 +300,13 @@ def check_permission_and_not_submitted(doc):
 		)
 
 
+class LinkedDocumentsOverflow(Exception):
+	"""A bounded link lookup reached its limit, so the linked set may be larger than it shows."""
+
+
 def get_linked_docs(doc, method="Delete", limit: int | None = None) -> list[dict]:
-	"""Return the documents statically linked to the given document, at most `limit` of them."""
+	"""Return the documents statically linked to the given document; with `limit`,
+	raise LinkedDocumentsOverflow once a lookup reaches it."""
 	from frappe.model.rename_doc import get_link_fields
 
 	link_fields = get_link_fields(doc.doctype)
@@ -340,16 +345,21 @@ def get_linked_docs(doc, method="Delete", limit: int | None = None) -> list[dict
 			fields.extend(["parent", "parenttype"])
 
 		if limit and len(linked_docs) >= limit:
-			return linked_docs
+			raise LinkedDocumentsOverflow
 
-		for item in frappe.db.get_values(
+		rows = frappe.db.get_values(
 			link_dt,
 			{link_field: doc.name},
 			fields,
 			as_dict=True,
 			order_by=None,
 			limit=limit,
-		):
+		)
+		if limit and len(rows) >= limit:
+			# rows dropped below could hide blockers beyond the limit
+			raise LinkedDocumentsOverflow
+
+		for item in rows:
 			# available only in child table cases
 			item_parent = getattr(item, "parent", None)
 			linked_parent_doctype = item.parenttype if item_parent else link_dt
@@ -388,12 +398,13 @@ def check_if_doc_is_linked(doc, method="Delete"):
 
 
 def get_dynamic_linked_docs(doc, method="Delete", limit: int | None = None) -> list[dict]:
-	"""Return the documents dynamically linked to the given document, at most `limit` of them."""
+	"""Return the documents dynamically linked to the given document; with `limit`,
+	raise LinkedDocumentsOverflow once a lookup reaches it."""
 	linked_docs = []
 
 	for df in get_dynamic_link_map().get(doc.doctype, []):
 		if limit and len(linked_docs) >= limit:
-			return linked_docs
+			raise LinkedDocumentsOverflow
 		ignore_linked_doctypes = doc.get("ignore_linked_doctypes") or []
 
 		if df.parent in frappe.get_hooks("ignore_links_on_delete") or (
@@ -443,7 +454,11 @@ def get_dynamic_linked_docs(doc, method="Delete", limit: int | None = None) -> l
 				query = query.where(RefDoc.docstatus == DocStatus.submitted())
 			if limit:
 				query = query.limit(limit)
-			for refdoc in query.run(as_dict=True):
+			rows = query.run(as_dict=True)
+			if limit and len(rows) >= limit:
+				# rows dropped below could hide blockers beyond the limit
+				raise LinkedDocumentsOverflow
+			for refdoc in rows:
 				# linked to an non-cancelled doc when deleting
 				# or linked to a submitted doc when cancelling
 				if (method == "Delete" and not DocStatus(refdoc.docstatus).is_cancelled()) or (

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -304,8 +304,7 @@ def get_linked_docs(doc, method="Delete", limit: int | None = None) -> list[dict
 	"""
 	Return a list of documents that are statically linked to the given document.
 
-	With limit, stop collecting once that many links are found, so callers that
-	only need to detect "too many" do not materialize every referencing row.
+	With limit, stop collecting once that many links are found.
 	"""
 	from frappe.model.rename_doc import get_link_fields
 
@@ -396,8 +395,7 @@ def get_dynamic_linked_docs(doc, method="Delete", limit: int | None = None) -> l
 	"""
 	Return a list of documents that are dynamically linked to the given document.
 
-	With limit, stop collecting once that many links are found, so callers that
-	only need to detect "too many" do not materialize every referencing row.
+	With limit, stop collecting once that many links are found.
 	"""
 	linked_docs = []
 

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -444,6 +444,11 @@ def get_dynamic_linked_docs(doc, method="Delete", limit: int | None = None) -> l
 				.where(RefDoc[df.options] == doc.doctype)
 				.where(RefDoc[df.fieldname] == doc.name)
 			)
+			# filter before limiting, or irrelevant rows could fill the limit
+			if method == "Delete":
+				query = query.where(RefDoc.docstatus != DocStatus.cancelled())
+			elif method == "Cancel":
+				query = query.where(RefDoc.docstatus == DocStatus.submitted())
 			if limit:
 				query = query.limit(limit)
 			for refdoc in query.run(as_dict=True):

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1078,6 +1078,10 @@ frappe.ui.form.Form = class FrappeForm {
 			})
 			.then((r) => {
 				if (!r.exc) {
+					if (r.message.truncated) {
+						return me._cancel_all_in_background(btn, on_error);
+					}
+
 					let doctypes_to_cancel = (r.message.docs || []).map((value) => {
 						return value.doctype;
 					});
@@ -1108,6 +1112,44 @@ frappe.ui.form.Form = class FrappeForm {
 			links_text += `<li><strong>${__(doctype)}</strong>: ${docnames}</li>`;
 		}
 		return `<ul>${links_text}</ul>`;
+	}
+
+	_cancel_all_in_background(btn, on_error) {
+		const me = this;
+		const d = frappe.warn(
+			__("Confirm"),
+			__(
+				"{0} {1} is linked with too many submitted documents to list. Cancel all of them in the background along with {1}? You will be notified when it completes.",
+				[__(me.doc.doctype).bold(), cstr(me.doc.name).bold()]
+			),
+			() => {
+				frappe.call({
+					method: "frappe.desk.form.linked_with.cancel_all_linked_docs",
+					args: {
+						ignore_doctypes_on_cancel_all: me.ignore_doctypes_on_cancel_all || [],
+						root_doctype: me.doc.doctype,
+						root_name: me.doc.name,
+					},
+					freeze: true,
+					callback: (resp) => {
+						if (!resp.exc) {
+							frappe.show_alert({
+								message: __(
+									"Cancellation queued. You will be notified when it completes."
+								),
+								indicator: "blue",
+							});
+						}
+					},
+				});
+			},
+			__("Cancel All")
+		);
+		d.onhide = () => {
+			if (!d.primary_action_fulfilled) {
+				me.handle_save_fail(btn, on_error);
+			}
+		};
 	}
 
 	_cancel_all(r, btn, callback, on_error) {

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1122,27 +1122,7 @@ frappe.ui.form.Form = class FrappeForm {
 				"{0} {1} is linked with too many submitted documents to list. Cancel all of them in the background along with {1}? You will be notified when it completes.",
 				[__(me.doc.doctype).bold(), cstr(me.doc.name).bold()]
 			),
-			() => {
-				frappe.call({
-					method: "frappe.desk.form.linked_with.cancel_all_linked_docs",
-					args: {
-						ignore_doctypes_on_cancel_all: me.ignore_doctypes_on_cancel_all || [],
-						root_doctype: me.doc.doctype,
-						root_name: me.doc.name,
-					},
-					freeze: true,
-					callback: (resp) => {
-						if (!resp.exc) {
-							frappe.show_alert({
-								message: __(
-									"Cancellation queued. You will be notified when it completes."
-								),
-								indicator: "blue",
-							});
-						}
-					},
-				});
-			},
+			() => me._cancel_with_linked_docs(null, btn, null, on_error),
 			__("Cancel All")
 		);
 		d.onhide = () => {
@@ -1203,6 +1183,15 @@ frappe.ui.form.Form = class FrappeForm {
 
 	_cancel_with_linked_docs(links, btn, callback, on_error) {
 		const me = this;
+		const args = {
+			ignore_doctypes_on_cancel_all: me.ignore_doctypes_on_cancel_all || [],
+			root_doctype: me.doc.doctype,
+			root_name: cstr(me.doc.name),
+		};
+		if (links) {
+			// without a list the server discovers the graph in a background job
+			args.docs = links;
+		}
 		frappe.validated = true;
 		me.script_manager.trigger("before_cancel").then(() => {
 			if (!frappe.validated) {
@@ -1210,12 +1199,7 @@ frappe.ui.form.Form = class FrappeForm {
 			}
 			frappe.call({
 				method: "frappe.desk.form.linked_with.cancel_all_linked_docs",
-				args: {
-					docs: links,
-					ignore_doctypes_on_cancel_all: me.ignore_doctypes_on_cancel_all || [],
-					root_doctype: me.doc.doctype,
-					root_name: me.doc.name,
-				},
+				args: args,
 				freeze: true,
 				callback: (resp) => {
 					if (resp.exc) {
@@ -1224,7 +1208,7 @@ frappe.ui.form.Form = class FrappeForm {
 					if (resp.message && resp.message.queued) {
 						frappe.msgprint(
 							__(
-								"There are too many linked documents to cancel right away, so they will be cancelled in the background along with {0}. You will be notified when it completes.",
+								"The linked documents will be cancelled in the background along with {0}. You will be notified when it completes.",
 								[cstr(me.doc.name).bold()]
 							)
 						);
@@ -1370,28 +1354,42 @@ frappe.ui.form.Form = class FrappeForm {
 				"{0} {1} is linked with too many documents to list. Delete all of them in the background along with {1}? You will be notified when it completes.",
 				[__(me.doctype).bold(), cstr(me.docname).bold()]
 			),
-			() => {
-				frappe.call({
-					method: "frappe.desk.form.linked_with.delete_all_linked_docs",
-					args: {
-						root_doctype: me.doctype,
-						root_name: cstr(me.docname),
-					},
-					freeze: true,
-					callback: (resp) => {
-						if (!resp.exc) {
-							frappe.show_alert({
-								message: __(
-									"Deletion queued. You will be notified when it completes."
-								),
-								indicator: "blue",
-							});
-						}
-					},
-				});
-			},
+			() => me._delete_with_linked_docs(null),
 			__("Delete All")
 		);
+	}
+
+	_delete_with_linked_docs(links) {
+		const me = this;
+		const args = { root_doctype: me.doctype, root_name: cstr(me.docname) };
+		if (links) {
+			// without a list the server discovers the graph in a background job
+			args.docs = links;
+		}
+		frappe.call({
+			method: "frappe.desk.form.linked_with.delete_all_linked_docs",
+			args: args,
+			freeze: true,
+			freeze_message: __("Deleting documents..."),
+			callback: (resp) => {
+				if (resp.exc) {
+					return;
+				}
+				if (resp.message && resp.message.queued) {
+					frappe.msgprint(
+						__(
+							"The linked documents will be deleted in the background along with {0}. You will be notified when it completes.",
+							[cstr(me.docname).bold()]
+						)
+					);
+					return;
+				}
+				// the server deleted the root along with its links
+				frappe.utils.play_sound("delete");
+				frappe.model.delete_from_locals(me.doctype, me.docname);
+				window.history.back();
+			},
+		});
 	}
 
 	_delete_all(r) {
@@ -1418,34 +1416,7 @@ frappe.ui.form.Form = class FrappeForm {
 
 		d.set_primary_action(__("Delete All"), () => {
 			d.hide();
-			frappe.call({
-				method: "frappe.desk.form.linked_with.delete_all_linked_docs",
-				args: {
-					docs: links,
-					root_doctype: me.doctype,
-					root_name: cstr(me.docname),
-				},
-				freeze: true,
-				freeze_message: __("Deleting documents..."),
-				callback: (resp) => {
-					if (resp.exc) {
-						return;
-					}
-					if (resp.message && resp.message.queued) {
-						frappe.msgprint(
-							__(
-								"There are too many linked documents to delete right away, so they will be deleted in the background along with {0}. You will be notified when it completes.",
-								[cstr(me.docname).bold()]
-							)
-						);
-						return;
-					}
-					// the server deleted the root along with its links
-					frappe.utils.play_sound("delete");
-					frappe.model.delete_from_locals(me.doctype, me.docname);
-					window.history.back();
-				},
-			});
+			me._delete_with_linked_docs(links);
 		});
 
 		d.show();

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1194,36 +1194,51 @@ frappe.ui.form.Form = class FrappeForm {
 		if (can_cancel) {
 			d.set_primary_action(__("Cancel All"), () => {
 				d.hide();
-				frappe.call({
-					method: "frappe.desk.form.linked_with.cancel_all_linked_docs",
-					args: {
-						docs: links,
-						ignore_doctypes_on_cancel_all: me.ignore_doctypes_on_cancel_all || [],
-						root_doctype: me.doc.doctype,
-						root_name: me.doc.name,
-					},
-					freeze: true,
-					callback: (resp) => {
-						if (resp.exc) {
-							return;
-						}
-						if (resp.message && resp.message.queued) {
-							frappe.msgprint(
-								__(
-									"There are too many linked documents to cancel right away, so they will be cancelled in the background along with {0}. You will be notified when it completes.",
-									[cstr(me.doc.name).bold()]
-								)
-							);
-							return;
-						}
-						me.reload_doc();
-						me._cancel(btn, callback, on_error, true);
-					},
-				});
+				me._cancel_with_linked_docs(links, btn, callback, on_error);
 			});
 		}
 
 		d.show();
+	}
+
+	_cancel_with_linked_docs(links, btn, callback, on_error) {
+		const me = this;
+		frappe.validated = true;
+		me.script_manager.trigger("before_cancel").then(() => {
+			if (!frappe.validated) {
+				return me.handle_save_fail(btn, on_error);
+			}
+			frappe.call({
+				method: "frappe.desk.form.linked_with.cancel_all_linked_docs",
+				args: {
+					docs: links,
+					ignore_doctypes_on_cancel_all: me.ignore_doctypes_on_cancel_all || [],
+					root_doctype: me.doc.doctype,
+					root_name: me.doc.name,
+				},
+				freeze: true,
+				callback: (resp) => {
+					if (resp.exc) {
+						return me.handle_save_fail(btn, on_error);
+					}
+					if (resp.message && resp.message.queued) {
+						frappe.msgprint(
+							__(
+								"There are too many linked documents to cancel right away, so they will be cancelled in the background along with {0}. You will be notified when it completes.",
+								[cstr(me.doc.name).bold()]
+							)
+						);
+						return;
+					}
+					// the server cancelled the root along with its links
+					me.reload_doc().then(() => {
+						frappe.utils.play_sound("cancel");
+						callback && callback();
+						me.script_manager.trigger("after_cancel");
+					});
+				},
+			});
+		});
 	}
 
 	_cancel(btn, callback, on_error, skip_confirm) {
@@ -1341,15 +1356,10 @@ frappe.ui.form.Form = class FrappeForm {
 			});
 	}
 
-	_delete(skip_confirm) {
-		frappe.model.delete_doc(
-			this.doctype,
-			this.docname,
-			function () {
-				window.history.back();
-			},
-			skip_confirm
-		);
+	_delete() {
+		frappe.model.delete_doc(this.doctype, this.docname, function () {
+			window.history.back();
+		});
 	}
 
 	_delete_all_in_background() {

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1430,7 +1430,10 @@ frappe.ui.form.Form = class FrappeForm {
 						);
 						return;
 					}
-					me._delete(true);
+					// the server deleted the root along with its links
+					frappe.utils.play_sound("delete");
+					frappe.model.delete_from_locals(me.doctype, me.docname);
+					window.history.back();
 				},
 			});
 		});

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1157,13 +1157,25 @@ frappe.ui.form.Form = class FrappeForm {
 					args: {
 						docs: links,
 						ignore_doctypes_on_cancel_all: me.ignore_doctypes_on_cancel_all || [],
+						root_doctype: me.doc.doctype,
+						root_name: me.doc.name,
 					},
 					freeze: true,
 					callback: (resp) => {
-						if (!resp.exc) {
-							me.reload_doc();
-							me._cancel(btn, callback, on_error, true);
+						if (resp.exc) {
+							return;
 						}
+						if (resp.message && resp.message.queued) {
+							frappe.msgprint(
+								__(
+									"There are too many linked documents to cancel right away, so they will be cancelled in the background along with {0}. You will be notified when it completes.",
+									[cstr(me.doc.name).bold()]
+								)
+							);
+							return;
+						}
+						me.reload_doc();
+						me._cancel(btn, callback, on_error, true);
 					},
 				});
 			});
@@ -1277,6 +1289,9 @@ frappe.ui.form.Form = class FrappeForm {
 				freeze: true,
 			})
 			.then((r) => {
+				if (!r.exc && r.message.truncated) {
+					return me._delete_all_in_background();
+				}
 				if (!r.exc && (r.message.docs || []).length) {
 					return me._delete_all(r);
 				}
@@ -1292,6 +1307,38 @@ frappe.ui.form.Form = class FrappeForm {
 				window.history.back();
 			},
 			skip_confirm
+		);
+	}
+
+	_delete_all_in_background() {
+		const me = this;
+		frappe.warn(
+			__("Confirm"),
+			__(
+				"{0} {1} is linked with too many documents to list. Delete all of them in the background along with {1}? You will be notified when it completes.",
+				[__(me.doctype).bold(), cstr(me.docname).bold()]
+			),
+			() => {
+				frappe.call({
+					method: "frappe.desk.form.linked_with.delete_all_linked_docs",
+					args: {
+						root_doctype: me.doctype,
+						root_name: cstr(me.docname),
+					},
+					freeze: true,
+					callback: (resp) => {
+						if (!resp.exc) {
+							frappe.show_alert({
+								message: __(
+									"Deletion queued. You will be notified when it completes."
+								),
+								indicator: "blue",
+							});
+						}
+					},
+				});
+			},
+			__("Delete All")
 		);
 	}
 
@@ -1323,13 +1370,25 @@ frappe.ui.form.Form = class FrappeForm {
 				method: "frappe.desk.form.linked_with.delete_all_linked_docs",
 				args: {
 					docs: links,
+					root_doctype: me.doctype,
+					root_name: cstr(me.docname),
 				},
 				freeze: true,
 				freeze_message: __("Deleting documents..."),
 				callback: (resp) => {
-					if (!resp.exc) {
-						me._delete(true);
+					if (resp.exc) {
+						return;
 					}
+					if (resp.message && resp.message.queued) {
+						frappe.msgprint(
+							__(
+								"There are too many linked documents to delete right away, so they will be deleted in the background along with {0}. You will be notified when it completes.",
+								[cstr(me.docname).bold()]
+							)
+						);
+						return;
+					}
+					me._delete(true);
 				},
 			});
 		});

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -732,7 +732,7 @@ $.extend(frappe.model, {
 		return no_copy_list;
 	},
 
-	delete_doc: function (doctype, docname, callback, skip_confirm) {
+	delete_doc: function (doctype, docname, callback) {
 		let title = docname.toString();
 		const title_field = frappe.get_meta(doctype).title_field;
 		if (title_field) {
@@ -741,33 +741,28 @@ $.extend(frappe.model, {
 				title = `${value} (${docname})`;
 			}
 		}
-		const perform_delete = function () {
-			return frappe.call({
-				method: "frappe.client.delete",
-				args: {
-					doctype: doctype,
-					name: docname,
-				},
-				freeze: true,
-				freeze_message: __("Deleting {0}...", [title]),
-				callback: function (r, rt) {
-					if (!r.exc) {
-						frappe.utils.play_sound("delete");
-						frappe.model.delete_from_locals(doctype, docname);
-						if (callback) callback(r, rt);
-					}
-				},
-			});
-		};
-		if (skip_confirm) {
-			perform_delete();
-			return;
-		}
 		// destructive: red primary via frappe.warn, not a neutral confirm
 		frappe.warn(
 			__("Confirm"),
 			__("Permanently delete {0}?", [title.bold()]),
-			perform_delete,
+			function () {
+				return frappe.call({
+					method: "frappe.client.delete",
+					args: {
+						doctype: doctype,
+						name: docname,
+					},
+					freeze: true,
+					freeze_message: __("Deleting {0}...", [title]),
+					callback: function (r, rt) {
+						if (!r.exc) {
+							frappe.utils.play_sound("delete");
+							frappe.model.delete_from_locals(doctype, docname);
+							if (callback) callback(r, rt);
+						}
+					},
+				});
+			},
 			__("Delete")
 		);
 	},

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -586,9 +586,54 @@ class TestLinkedWith(IntegrationTestCase):
 			root_name=parent.name,
 		)
 
-		self.assertEqual(result["deleted"], [{"doctype": "Child DocType1", "name": child1.name}])
+		self.assertEqual(
+			result["deleted"],
+			[
+				{"doctype": "Child DocType1", "name": child1.name},
+				{"doctype": "Parent DocType", "name": parent.name},
+			],
+		)
 		self.assertFalse(frappe.db.exists("Child DocType1", child1.name))
 		self.assertTrue(frappe.db.exists("Child DocType1", unrelated.name))
+
+	def test_delete_all_linked_docs_lets_the_root_clean_up_blockers(self):
+		"""A blocker only the root's on_trash can remove must not stop the run
+		from attempting the root."""
+		child1 = frappe.get_doc({"doctype": "Child DocType1"}).insert()
+		child2 = (
+			frappe.get_doc({"doctype": "Child DocType2", "child_doctype1": child1.name}).insert().submit()
+		)
+
+		hook = f"{__name__}.hard_delete_referencing_child2_records"
+		self.addCleanup(setattr, frappe.local, "doc_events_hooks", None)
+		with self.patch_hooks({"doc_events": {"Child DocType1": {"on_trash": [hook]}}}):
+			frappe.local.doc_events_hooks = None
+			result = linked_with.delete_all_linked_docs(
+				docs=[{"doctype": "Child DocType2", "name": child2.name}],
+				root_doctype="Child DocType1",
+				root_name=child1.name,
+			)
+
+		self.assertIn({"doctype": "Child DocType1", "name": child1.name}, result["deleted"])
+		self.assertFalse(frappe.db.exists("Child DocType1", child1.name))
+		self.assertFalse(frappe.db.exists("Child DocType2", child2.name))
+
+	def test_bounded_dynamic_link_lookup_ignores_cancelled_rows(self):
+		"""Cancelled references must not fill the bounded lookup and hide a live one."""
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert()
+		reference = {
+			"doctype": "Child DocType1",
+			"reference_doctype": "Parent DocType",
+			"reference_name": parent.name,
+		}
+		for _ in range(3):
+			frappe.get_doc(reference).insert().submit().cancel()
+		live = frappe.get_doc(reference).insert()
+
+		docs, truncated = linked_with.collect_deletion_blockers(parent.doctype, parent.name, limit=1)
+
+		self.assertFalse(truncated)
+		self.assertEqual(docs, [{"doctype": "Child DocType1", "name": live.name}])
 
 	def test_get_linked_docs_to_delete_deepest_first(self):
 		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert()

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -518,6 +518,48 @@ class TestLinkedWith(IntegrationTestCase):
 		self.assertFalse(frappe.db.exists("Child DocType1", child1.name))
 		self.assertFalse(frappe.db.exists("Parent DocType", parent.name))
 
+	def test_cancel_all_linked_docs_drops_stale_entries(self):
+		"""The confirmed list comes from an earlier request; a document unlinked
+		since then must not be cancelled."""
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert().submit()
+		child1 = (
+			frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert().submit()
+		)
+		unrelated = frappe.get_doc({"doctype": "Child DocType1"}).insert().submit()
+
+		linked_with.cancel_all_linked_docs(
+			docs=[
+				{"doctype": "Child DocType1", "name": child1.name, "docstatus": 1},
+				{"doctype": "Child DocType1", "name": unrelated.name, "docstatus": 1},
+			],
+			root_doctype=parent.doctype,
+			root_name=parent.name,
+		)
+
+		self.assertTrue(child1.reload().docstatus.is_cancelled())
+		self.assertTrue(unrelated.reload().docstatus.is_submitted())
+		unrelated.cancel()
+
+	def test_delete_all_linked_docs_drops_stale_entries(self):
+		"""The confirmed list comes from an earlier request; a document unlinked
+		since then must not be deleted."""
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert()
+		child1 = frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert()
+		unrelated = frappe.get_doc({"doctype": "Child DocType1"}).insert()
+
+		result = linked_with.delete_all_linked_docs(
+			docs=[
+				{"doctype": "Child DocType1", "name": child1.name},
+				{"doctype": "Child DocType1", "name": unrelated.name},
+			],
+			root_doctype=parent.doctype,
+			root_name=parent.name,
+		)
+
+		self.assertEqual(result["deleted"], [{"doctype": "Child DocType1", "name": child1.name}])
+		self.assertFalse(frappe.db.exists("Child DocType1", child1.name))
+		self.assertTrue(frappe.db.exists("Child DocType1", unrelated.name))
+
 	def test_get_linked_docs_to_delete_deepest_first(self):
 		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert()
 		child1 = frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert()

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -6,6 +6,7 @@ import frappe
 from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.database import savepoint
 from frappe.desk.form import linked_with
+from frappe.model.delete_doc import LinkedDocumentsOverflow, get_linked_docs
 from frappe.tests import IntegrationTestCase
 
 
@@ -681,6 +682,77 @@ class TestLinkedWith(IntegrationTestCase):
 
 		self.assertFalse(truncated)
 		self.assertEqual(docs, [{"doctype": "Child DocType1", "name": live.name}])
+		# the table outlives the fixture doctype; leftover references break the dlink test
+		frappe.db.delete("Child DocType1", {"reference_name": parent.name})
+
+	def test_bounded_static_lookup_counts_the_rows_it_drops(self):
+		"""Rows the lookup drops after the query still count towards its limit,
+		or they could hide blockers beyond it."""
+		new_doctype(
+			"Self Linked DocType",
+			fields=[{"fieldname": "previous", "fieldtype": "Link", "options": "Self Linked DocType"}],
+		).insert()
+		self.addCleanup(frappe.delete_doc, "DocType", "Self Linked DocType")
+		doc = frappe.get_doc({"doctype": "Self Linked DocType"}).insert()
+		# a self link, which the lookup drops
+		doc.previous = doc.name
+		doc.save()
+
+		with self.assertRaises(LinkedDocumentsOverflow):
+			get_linked_docs(doc, method="Delete", limit=1)
+		doc.delete()
+
+	def test_background_run_rolls_back_outright_on_a_deadlock(self):
+		"""A deadlock discards the whole transaction, savepoint included, so the
+		job must roll back outright and still notify."""
+		notifications = []
+		with (
+			patch.object(linked_with, "cancel_linked_doc", side_effect=frappe.QueryDeadlockError("deadlock")),
+			patch.object(frappe.db, "rollback") as rollback,
+			patch.object(linked_with, "notify_linked_docs_processed", notifications.append),
+		):
+			linked_with.process_linked_docs_in_background(
+				[{"doctype": "Parent DocType", "name": "deadlocked"}], "cancel"
+			)
+
+		rollback.assert_called_once_with()
+		self.assertEqual(notifications, ["Could not cancel 1 linked documents: deadlock"])
+
+	def test_cancel_all_linked_docs_discovers_in_background_past_the_cap(self):
+		"""Revalidating the list must not walk a graph that outgrew the listing
+		cap since the list was built; the job discovers it instead."""
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert().submit()
+		child1 = (
+			frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert().submit()
+		)
+		frappe.get_doc({"doctype": "Child DocType2", "parent_doctype": parent.name}).insert().submit()
+
+		with patch.object(linked_with, "MAX_LINKED_DOCUMENTS_LISTED", 1):
+			result = linked_with.cancel_all_linked_docs(
+				docs=[{"doctype": "Child DocType1", "name": child1.name, "docstatus": 1}],
+				root_doctype=parent.doctype,
+				root_name=parent.name,
+			)
+
+		self.assertEqual(result, {"queued": True})
+		self.assertTrue(parent.reload().docstatus.is_cancelled())
+
+	def test_delete_all_linked_docs_discovers_in_background_past_the_cap(self):
+		"""Revalidating the list must not walk a graph that outgrew the listing
+		cap since the list was built; the job discovers it instead."""
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert()
+		child1 = frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert()
+		frappe.get_doc({"doctype": "Child DocType2", "parent_doctype": parent.name}).insert()
+
+		with patch.object(linked_with, "MAX_LINKED_DOCUMENTS_LISTED", 1):
+			result = linked_with.delete_all_linked_docs(
+				docs=[{"doctype": "Child DocType1", "name": child1.name}],
+				root_doctype=parent.doctype,
+				root_name=parent.name,
+			)
+
+		self.assertEqual(result, {"queued": True})
+		self.assertFalse(frappe.db.exists("Parent DocType", parent.name))
 
 	def test_get_linked_docs_to_delete_deepest_first(self):
 		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert()

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -447,6 +447,77 @@ class TestLinkedWith(IntegrationTestCase):
 		self.assertTrue(child1.reload().docstatus.is_cancelled())
 		self.assertTrue(child2.reload().docstatus.is_cancelled())
 
+	def test_cancel_all_linked_docs_queues_large_sets(self):
+		"""A set above the synchronous limit moves to a background job that also
+		cancels the root document, which the caller skips when queued."""
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert().submit()
+		child1 = (
+			frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert().submit()
+		)
+
+		with patch.object(linked_with, "MAX_SYNCHRONOUS_LINKED_DOCS", 0):
+			result = linked_with.cancel_all_linked_docs(
+				docs=[{"doctype": "Child DocType1", "name": child1.name, "docstatus": 1}],
+				root_doctype=parent.doctype,
+				root_name=parent.name,
+			)
+
+		self.assertEqual(result, {"queued": True})
+		self.assertTrue(child1.reload().docstatus.is_cancelled())
+		self.assertTrue(parent.reload().docstatus.is_cancelled())
+
+	def test_background_cancel_is_all_or_nothing(self):
+		"""When a document outside the set blocks the run, the job must undo its
+		cancellations, matching the synchronous all-or-nothing behaviour."""
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert().submit()
+		child1 = (
+			frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert().submit()
+		)
+		# blocks child1 but is not part of the set, so the run can never finish
+		frappe.get_doc({"doctype": "Child DocType2", "child_doctype1": child1.name}).insert().submit()
+
+		with patch.object(linked_with, "MAX_SYNCHRONOUS_LINKED_DOCS", 0):
+			result = linked_with.cancel_all_linked_docs(
+				docs=[{"doctype": "Child DocType1", "name": child1.name, "docstatus": 1}],
+				root_doctype=parent.doctype,
+				root_name=parent.name,
+			)
+
+		self.assertEqual(result, {"queued": True})
+		self.assertTrue(child1.reload().docstatus.is_submitted())
+		self.assertTrue(parent.reload().docstatus.is_submitted())
+
+	def test_delete_all_linked_docs_queues_large_sets(self):
+		"""A set above the synchronous limit moves to a background job that also
+		deletes the root document, which the caller skips when queued."""
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert()
+		child1 = frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert()
+
+		with patch.object(linked_with, "MAX_SYNCHRONOUS_LINKED_DOCS", 0):
+			result = linked_with.delete_all_linked_docs(
+				docs=[{"doctype": "Child DocType1", "name": child1.name}],
+				root_doctype=parent.doctype,
+				root_name=parent.name,
+			)
+
+		self.assertEqual(result, {"queued": True})
+		self.assertFalse(frappe.db.exists("Child DocType1", child1.name))
+		self.assertFalse(frappe.db.exists("Parent DocType", parent.name))
+
+	def test_delete_all_linked_docs_discovers_in_background_without_docs(self):
+		"""Without docs the graph was too large to list; the background job must
+		discover and delete it itself, root included."""
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert()
+		child1 = frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert()
+		child2 = frappe.get_doc({"doctype": "Child DocType2", "child_doctype1": child1.name}).insert()
+
+		result = linked_with.delete_all_linked_docs(root_doctype=parent.doctype, root_name=parent.name)
+
+		self.assertEqual(result, {"queued": True})
+		self.assertFalse(frappe.db.exists("Child DocType2", child2.name))
+		self.assertFalse(frappe.db.exists("Child DocType1", child1.name))
+		self.assertFalse(frappe.db.exists("Parent DocType", parent.name))
+
 	def test_get_linked_docs_to_delete_deepest_first(self):
 		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert()
 		child1 = frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert()
@@ -474,12 +545,13 @@ class TestLinkedWith(IntegrationTestCase):
 		self.assertEqual(docs, [{"doctype": "Child DocType1", "name": child1.name}])
 
 	def test_get_linked_docs_to_delete_truncates_large_graphs(self):
-		"""A graph larger than the cap returns no documents, so the caller falls
-		back to a plain delete instead of walking everything."""
+		"""A graph larger than the cap returns no documents marked truncated, so
+		the caller offers background deletion instead of walking everything."""
 		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert()
 		frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert()
+		frappe.get_doc({"doctype": "Child DocType2", "parent_doctype": parent.name}).insert()
 
-		with patch.object(linked_with, "MAX_LINKED_DELETE_DOCUMENTS", 0):
+		with patch.object(linked_with, "MAX_LINKED_DELETE_DOCUMENTS", 1):
 			result = linked_with.get_linked_docs_to_delete(parent.doctype, parent.name)
 
 		self.assertEqual(result, {"docs": [], "count": 0, "truncated": True})

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -517,6 +517,25 @@ class TestLinkedWith(IntegrationTestCase):
 		self.assertTrue(child1.reload().docstatus.is_submitted())
 		self.assertTrue(parent.reload().docstatus.is_submitted())
 
+	def test_background_delete_is_all_or_nothing(self):
+		"""When a document outside the set blocks the run, the job must undo its
+		deletions instead of leaving the root with some dependents gone."""
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert()
+		child1 = frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert()
+		# blocks child1 but is not part of the set, so the run can never finish
+		frappe.get_doc({"doctype": "Child DocType2", "child_doctype1": child1.name}).insert().submit()
+
+		with patch.object(linked_with, "MAX_SYNCHRONOUS_LINKED_DOCS", 0):
+			result = linked_with.delete_all_linked_docs(
+				docs=[{"doctype": "Child DocType1", "name": child1.name}],
+				root_doctype=parent.doctype,
+				root_name=parent.name,
+			)
+
+		self.assertEqual(result, {"queued": True})
+		self.assertTrue(frappe.db.exists("Child DocType1", child1.name))
+		self.assertTrue(frappe.db.exists("Parent DocType", parent.name))
+
 	def test_delete_all_linked_docs_queues_large_sets(self):
 		"""A set above the synchronous limit moves to a background job that also
 		deletes the root document, which the caller skips when queued."""
@@ -548,6 +567,41 @@ class TestLinkedWith(IntegrationTestCase):
 		self.assertFalse(frappe.db.exists("Child DocType1", child1.name))
 		self.assertFalse(frappe.db.exists("Parent DocType", parent.name))
 
+	def test_cancel_all_linked_docs_cancels_the_root_last(self):
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert().submit()
+		child1 = (
+			frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert().submit()
+		)
+
+		linked_with.cancel_all_linked_docs(
+			docs=[{"doctype": "Child DocType1", "name": child1.name, "docstatus": 1}],
+			root_doctype=parent.doctype,
+			root_name=parent.name,
+		)
+
+		self.assertTrue(child1.reload().docstatus.is_cancelled())
+		self.assertTrue(parent.reload().docstatus.is_cancelled())
+
+	def test_cancel_all_linked_docs_fails_when_a_doc_stays_blocked(self):
+		"""A blocker outside the set must fail the run with its error and leave
+		the root and its links submitted."""
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert().submit()
+		child1 = (
+			frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert().submit()
+		)
+		frappe.get_doc({"doctype": "Child DocType2", "child_doctype1": child1.name}).insert().submit()
+
+		with savepoint(frappe.LinkExistsError):
+			linked_with.cancel_all_linked_docs(
+				docs=[{"doctype": "Child DocType1", "name": child1.name, "docstatus": 1}],
+				root_doctype=parent.doctype,
+				root_name=parent.name,
+			)
+			self.fail("a blocked document should have failed the run")
+
+		self.assertTrue(child1.reload().docstatus.is_submitted())
+		self.assertTrue(parent.reload().docstatus.is_submitted())
+
 	def test_cancel_all_linked_docs_drops_stale_entries(self):
 		"""The confirmed list comes from an earlier request; a document unlinked
 		since then must not be cancelled."""
@@ -577,7 +631,7 @@ class TestLinkedWith(IntegrationTestCase):
 		child1 = frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert()
 		unrelated = frappe.get_doc({"doctype": "Child DocType1"}).insert()
 
-		result = linked_with.delete_all_linked_docs(
+		linked_with.delete_all_linked_docs(
 			docs=[
 				{"doctype": "Child DocType1", "name": child1.name},
 				{"doctype": "Child DocType1", "name": unrelated.name},
@@ -586,14 +640,8 @@ class TestLinkedWith(IntegrationTestCase):
 			root_name=parent.name,
 		)
 
-		self.assertEqual(
-			result["deleted"],
-			[
-				{"doctype": "Child DocType1", "name": child1.name},
-				{"doctype": "Parent DocType", "name": parent.name},
-			],
-		)
 		self.assertFalse(frappe.db.exists("Child DocType1", child1.name))
+		self.assertFalse(frappe.db.exists("Parent DocType", parent.name))
 		self.assertTrue(frappe.db.exists("Child DocType1", unrelated.name))
 
 	def test_delete_all_linked_docs_lets_the_root_clean_up_blockers(self):
@@ -608,13 +656,12 @@ class TestLinkedWith(IntegrationTestCase):
 		self.addCleanup(setattr, frappe.local, "doc_events_hooks", None)
 		with self.patch_hooks({"doc_events": {"Child DocType1": {"on_trash": [hook]}}}):
 			frappe.local.doc_events_hooks = None
-			result = linked_with.delete_all_linked_docs(
+			linked_with.delete_all_linked_docs(
 				docs=[{"doctype": "Child DocType2", "name": child2.name}],
 				root_doctype="Child DocType1",
 				root_name=child1.name,
 			)
 
-		self.assertIn({"doctype": "Child DocType1", "name": child1.name}, result["deleted"])
 		self.assertFalse(frappe.db.exists("Child DocType1", child1.name))
 		self.assertFalse(frappe.db.exists("Child DocType2", child2.name))
 

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -583,6 +583,27 @@ class TestLinkedWith(IntegrationTestCase):
 		self.assertTrue(child1.reload().docstatus.is_cancelled())
 		self.assertTrue(parent.reload().docstatus.is_cancelled())
 
+	def test_cancel_all_linked_docs_queues_when_the_root_cancels_in_background(self):
+		"""A root whose doctype queues cancellation must not be cancelled inside
+		the request, however small its set."""
+		frappe.db.set_value("DocType", "Parent DocType", "queue_in_background", 1)
+		frappe.clear_cache(doctype="Parent DocType")
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert().submit()
+		child1 = (
+			frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert().submit()
+		)
+
+		with patch.object(linked_with, "is_scheduler_inactive", return_value=False):
+			result = linked_with.cancel_all_linked_docs(
+				docs=[{"doctype": "Child DocType1", "name": child1.name, "docstatus": 1}],
+				root_doctype=parent.doctype,
+				root_name=parent.name,
+			)
+
+		self.assertEqual(result, {"queued": True})
+		self.assertTrue(child1.reload().docstatus.is_cancelled())
+		self.assertTrue(parent.reload().docstatus.is_cancelled())
+
 	def test_cancel_all_linked_docs_fails_when_a_doc_stays_blocked(self):
 		"""A blocker outside the set must fail the run with its error and leave
 		the root and its links submitted."""

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -424,6 +424,36 @@ class TestLinkedWith(IntegrationTestCase):
 
 		self.assertEqual(attempts, ["first", "second", "first", "second"])
 
+	def test_get_submitted_linked_docs_truncates_large_graphs(self):
+		"""A graph larger than the cap returns no documents marked truncated, so
+		the caller offers background cancellation instead of walking everything."""
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert().submit()
+		frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert().submit()
+		frappe.get_doc({"doctype": "Child DocType2", "parent_doctype": parent.name}).insert().submit()
+
+		with patch.object(linked_with, "MAX_LINKED_DOCUMENTS_LISTED", 1):
+			result = linked_with.get_submitted_linked_docs(parent.doctype, parent.name)
+
+		self.assertEqual(result, {"docs": [], "count": 0, "truncated": True})
+
+	def test_cancel_all_linked_docs_discovers_in_background_without_docs(self):
+		"""Without docs the graph was too large to list; the background job must
+		discover and cancel it itself, root included."""
+		parent = frappe.get_doc({"doctype": "Parent DocType"}).insert().submit()
+		child1 = (
+			frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert().submit()
+		)
+		child2 = (
+			frappe.get_doc({"doctype": "Child DocType2", "child_doctype1": child1.name}).insert().submit()
+		)
+
+		result = linked_with.cancel_all_linked_docs(root_doctype=parent.doctype, root_name=parent.name)
+
+		self.assertEqual(result, {"queued": True})
+		self.assertTrue(child2.reload().docstatus.is_cancelled())
+		self.assertTrue(child1.reload().docstatus.is_cancelled())
+		self.assertTrue(parent.reload().docstatus.is_cancelled())
+
 	def test_cancel_all_linked_docs_defers_controller_blocked_docs(self):
 		"""A controller check that wants a referencing document cancelled first
 		raises a plain ValidationError; the document must get deferred, not fail
@@ -581,7 +611,19 @@ class TestLinkedWith(IntegrationTestCase):
 		add_permission("Parent DocType", "All")
 		add_permission("Child DocType1", "All")
 
-		with self.set_user("test1@example.com"):
+		# a fresh user with no roles beyond the defaults, since fixture users
+		# accumulate roles on long-lived sites
+		restricted_user = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": f"restricted-{frappe.generate_hash(length=8)}@example.com",
+				"first_name": "Restricted",
+				"user_type": "System User",
+				"send_welcome_email": 0,
+			}
+		).insert(ignore_permissions=True)
+
+		with self.set_user(restricted_user.name):
 			docs = linked_with.get_linked_docs_to_delete(parent.doctype, parent.name)["docs"]
 
 		self.assertEqual(docs, [{"doctype": "Child DocType1", "name": child1.name}])
@@ -593,7 +635,7 @@ class TestLinkedWith(IntegrationTestCase):
 		frappe.get_doc({"doctype": "Child DocType1", "parent_doctype": parent.name}).insert()
 		frappe.get_doc({"doctype": "Child DocType2", "parent_doctype": parent.name}).insert()
 
-		with patch.object(linked_with, "MAX_LINKED_DELETE_DOCUMENTS", 1):
+		with patch.object(linked_with, "MAX_LINKED_DOCUMENTS_LISTED", 1):
 			result = linked_with.get_linked_docs_to_delete(parent.doctype, parent.name)
 
 		self.assertEqual(result, {"docs": [], "count": 0, "truncated": True})


### PR DESCRIPTION
Stacked on #42055 (which stacks on #42054).

Cancel All and Delete All run through one synchronous request, which grows with the dependency graph and risks the request timeout rolling everything back at the finish line.

- past `MAX_SYNCHRONOUS_LINKED_DOCS` (50) documents, both endpoints enqueue the work on the long queue and return `{queued: true}`; the form explains the handoff instead of processing the root itself. A root whose DocType queues cancellation in the background moves its whole set to the job however small, as the plain Cancel would
- the job re-checks the queued list against the current graph (it may be stale), also cancels/deletes the root document, and reports the outcome through a realtime message and a Notification Log entry, both after commit; repeat clicks deduplicate on a hashed job id, and a job whose initiating account was disabled does nothing
- both actions are all or nothing everywhere: the synchronous request now cancels or deletes the root last, in the same transaction as its links (the form used to cancel the root in a second request, which could leave dependents cancelled when the root failed), and the job runs under a savepoint and reports the blocker's error on failure; a deadlock, which discards the transaction outright, is rolled back outright and reported the same way
- both listings share one cap, `MAX_LINKED_DOCUMENTS_LISTED` (500): up to it the dialog lists blockers (at most ten names per doctype), past it the form asks for a list-free confirmation and the background job discovers the graph itself, uncapped — identical tiering for cancel and delete; the synchronous revalidation of a confirmed list runs under the same cap and hands over to that job when the graph has outgrown it
- the reference lookups behind the cap are themselves bounded, and a lookup that reaches its bound reports the listing truncated whatever it filtered out, so a document with very many direct references can neither exhaust the request nor hide blockers behind the limit
- every Cancel All path, listed or not, runs the form's `before_cancel`/`after_cancel` script events around its single request

no-docs