### PR TITLE
fix: apply consistent HTTP method validation to whitelisted callback dispatch

### DIFF
--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -222,6 +222,7 @@ def upload_file():
 	if method:
 		method = frappe.get_attr(method)
 		is_whitelisted(method)
+		is_valid_http_method(method)
 		return method()
 	else:
 		doc = frappe.get_doc(

--- a/frappe/tests/test_client.py
+++ b/frappe/tests/test_client.py
@@ -4,7 +4,13 @@ from unittest.mock import patch
 
 import frappe
 from frappe.tests import IntegrationTestCase
+from frappe.tests.utils import whitelist_for_tests
 from frappe.utils import get_site_url
+
+
+@whitelist_for_tests(methods=["GET"])
+def _get_only_marker():
+	return "executed"
 
 
 class TestClient(IntegrationTestCase):
@@ -70,6 +76,17 @@ class TestClient(IntegrationTestCase):
 		)
 
 		self.assertRaises(frappe.PermissionError, execute_cmd, "frappe.client.save")
+
+	def test_upload_file_respects_method_http_restriction(self):
+		"""`upload_file`'s `method` param must respect the target's HTTP method policy."""
+		from frappe.handler import upload_file
+
+		frappe.set_user("Administrator")
+
+		frappe.local.request = frappe._dict(method="POST", files={})
+		frappe.local.form_dict = frappe._dict(method="frappe.tests.test_client._get_only_marker")
+
+		self.assertRaises(frappe.PermissionError, upload_file)
 
 	def test_run_doc_method(self):
 		from frappe.handler import execute_cmd


### PR DESCRIPTION
This PR applies consistent HTTP method validation to whitelisted callback dispatch.

closes Ticket 77061

Thanks to @Darshan060224 for reporting.