### PR TITLE
fix: `Allowed In Mentions` cache invalidation on User update.

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -358,7 +358,7 @@ class User(Document):
 		if self.has_value_changed("enabled"):
 			frappe.cache.delete_key("users_for_mentions")
 			frappe.cache.delete_key("enabled_users")
-		elif self.has_value_changed("allow_in_mentions") or self.has_value_changed("user_type"):
+		elif self.has_value_changed("allowed_in_mentions") or self.has_value_changed("user_type"):
 			frappe.cache.delete_key("users_for_mentions")
 
 		if self.has_value_changed("user_type"):


### PR DESCRIPTION
**Issue**

`Allowed In Mentions` changes are not reflected in mention suggestions

Updating the `Allowed In Mentions` field on a User does not invalidate the cached list of users available for mentions. As a result, enabling or disabling the option does not immediately reflect in @mentions until the cache is cleared manually.

The User `on_update` handler checks the incorrect field name `allow_in_mentions` instead of `allowed_in_mentions`, so the `users_for_mentions` cache is not invalidated when the setting changes. 

Issue Link: #42388 

**Fix**

Use the correct field name `allowed_in_mentions` when checking whether the value has changed, so the `users_for_mentions` cache is invalidated after updating the User.

```
elif self.has_value_changed("allowed_in_mentions") or self.has_value_changed("user_type"):
    frappe.cache.delete_key("users_for_mentions")
```

This ensures that changes to Allowed In Mentions are reflected immediately in subsequent mention searches. The mention search itself filters users using allowed_in_mentions.

