### PR TITLE
fix: 2FA login says the code was emailed when nothing was sent

### DIFF
--- a/frappe/tests/test_twofactor.py
+++ b/frappe/tests/test_twofactor.py
@@ -18,6 +18,7 @@ from frappe.twofactor import (
 	get_email_body_for_qr_code,
 	get_otpsecret_for_,
 	get_verification_obj,
+	process_2fa_for_email,
 	should_run_2fa,
 	two_factor_is_enabled_for_,
 )
@@ -55,6 +56,24 @@ class TestTwoFactor(IntegrationTestCase):
 
 		qr_body = get_email_body_for_qr_code({"qrcode_link": "https://example.com/qrcode/abc"})
 		self.assertIn("https://example.com/qrcode/abc", qr_body)
+
+	def test_2fa_email_delivery_status(self):
+		"""Verification object should report failure when the mail is never queued."""
+		otp_secret = get_otpsecret_for_(self.user)
+		token = int(pyotp.TOTP(otp_secret).now())
+
+		verification_obj = process_2fa_for_email(self.user, token, otp_secret, "Frappe")
+		self.assertTrue(verification_obj["setup"])
+		self.assertTrue(verification_obj["prompt"])
+
+		unsubscribe = frappe.get_doc(
+			doctype="Email Unsubscribe", email=self.user, global_unsubscribe=1
+		).insert(ignore_permissions=True)
+		self.addCleanup(unsubscribe.delete, ignore_permissions=True)
+
+		verification_obj = process_2fa_for_email(self.user, token, otp_secret, "Frappe")
+		self.assertFalse(verification_obj["setup"])
+		self.assertFalse(verification_obj["prompt"])
 
 	def test_authenticate_for_2factor(self):
 		"""Verification obj and tmp_id should be set in frappe.local."""

--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -354,16 +354,17 @@ def send_token_via_email(user, token, otp_secret, otp_issuer, subject=None, mess
 	otp = hotp.at(int(token))
 	template_args = {"otp": otp, "otp_issuer": otp_issuer}
 
-	frappe.sendmail(
-		recipients=user_email,
-		subject=subject or get_email_subject_for_2fa(template_args),
-		message=message or get_email_body_for_2fa(template_args),
-		with_container=True,
-		wrapper="templates/emails/auth_email.html",
-		delayed=False,
-		retry=3,
+	return bool(
+		frappe.sendmail(
+			recipients=user_email,
+			subject=subject or get_email_subject_for_2fa(template_args),
+			message=message or get_email_body_for_2fa(template_args),
+			with_container=True,
+			wrapper="templates/emails/auth_email.html",
+			delayed=False,
+			retry=3,
+		)
 	)
-	return True
 
 
 def get_qr_svg_code(totp_uri):


### PR DESCRIPTION
## Description

`send_token_via_email` always returned `True`, even when `frappe.sendmail` did not queue an email. This made the login page show that the verification code was sent when it was not.

This can happen when emails are unsubscribed, muted, or the email queue is paused.

The function now returns the actual `sendmail` status, allowing the existing login failure message to be shown when the email was not sent.

The email 2FA flow now matches the existing SMS flow. SMTP failures are not covered because emails are sent after the login response is returned.
