### PR TITLE
feat(print): add pinto as a pdf generator

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -104,6 +104,7 @@ pdf_footer_html = "frappe.utils.pdf.pdf_footer_html"
 pdf_generator = [
 	"frappe.utils.pdf.get_chrome_pdf",
 	"frappe.utils.print_format_generator.get_typst_pdf",
+	"frappe.utils.pdf_generator.pinto.get_pinto_pdf",
 ]
 # permissions
 

--- a/frappe/printing/doctype/print_format/print_format.json
+++ b/frappe/printing/doctype/print_format/print_format.json
@@ -301,7 +301,7 @@
    "fieldname": "pdf_generator",
    "fieldtype": "Select",
    "label": "PDF Generator",
-   "options": "wkhtmltopdf\nchrome\nTypst"
+   "options": "wkhtmltopdf\nchrome\npinto\nTypst"
   },
   {
    "default": "DocType",
@@ -333,7 +333,7 @@
  "icon": "fa fa-print",
  "idx": 1,
  "links": [],
- "modified": "2026-08-07 21:43:00.939226",
+ "modified": "2026-08-27 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Print Format",

--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -69,7 +69,7 @@ class PrintFormat(Document):
 		page_number: DF.Literal[
 			"Hide", "Top Left", "Top Center", "Top Right", "Bottom Left", "Bottom Center", "Bottom Right"
 		]
-		pdf_generator: DF.Literal["wkhtmltopdf", "chrome", "Typst"]
+		pdf_generator: DF.Literal["wkhtmltopdf", "chrome", "pinto", "Typst"]
 		print_format_builder: DF.Check
 		print_format_builder_beta: DF.Check
 		print_format_for: DF.Literal["DocType", "Report"]

--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -11,6 +11,7 @@ from frappe.custom.doctype.property_setter.property_setter import delete_propert
 from frappe.model.document import Document
 from frappe.utils.jinja import validate_template
 from frappe.utils.print_format_generator import download_pdf, get_html
+from frappe.utils.print_utils import validate_pdf_generator
 
 #: The fields the builder may hold in `draft_data`. Everything the builder can edit
 #: belongs here — a field left out stays live, so a margin would apply instantly
@@ -127,6 +128,8 @@ class PrintFormat(Document):
 			and not frappe.in_test
 		):
 			frappe.throw(frappe._("Standard Print Format cannot be updated"))
+
+		validate_pdf_generator(self.pdf_generator)
 
 		# old_doc_type is required for clearing item cache
 		self.old_doc_type = frappe.db.get_value("Print Format", self.name, "doc_type")

--- a/frappe/printing/doctype/print_settings/print_settings.json
+++ b/frappe/printing/doctype/print_settings/print_settings.json
@@ -177,15 +177,15 @@
    "fieldname": "pdf_generator",
    "fieldtype": "Select",
    "label": "PDF Generator",
-   "options": "wkhtmltopdf\nchrome",
-   "description": "wkhtmltopdf cannot render multi-column layouts and is no longer maintained. Use chrome unless you depend on a wkhtmltopdf-specific print format."
+   "options": "wkhtmltopdf\nchrome\npinto",
+   "description": "wkhtmltopdf cannot render multi-column layouts and is no longer maintained. Use chrome unless you depend on a wkhtmltopdf-specific print format, or pinto for a browser-free render that trades pixel-parity with chrome for a much smaller footprint."
   }
  ],
  "icon": "fa fa-cog",
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-07-13 00:00:00.000000",
+ "modified": "2026-08-27 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Print Settings",

--- a/frappe/printing/doctype/print_settings/print_settings.py
+++ b/frappe/printing/doctype/print_settings/print_settings.py
@@ -26,7 +26,7 @@ class PrintSettings(Document):
 		enable_raw_printing: DF.Check
 		font: DF.Literal["Default", "Helvetica Neue", "Arial", "Helvetica", "Inter", "Verdana", "Monospace"]
 		font_size: DF.Float
-		pdf_generator: DF.Literal["wkhtmltopdf", "chrome"]
+		pdf_generator: DF.Literal["wkhtmltopdf", "chrome", "pinto"]
 		pdf_page_height: DF.Float
 		pdf_page_size: DF.Literal[
 			"A0",

--- a/frappe/printing/doctype/print_settings/print_settings.py
+++ b/frappe/printing/doctype/print_settings/print_settings.py
@@ -5,6 +5,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import cint
+from frappe.utils.print_utils import validate_pdf_generator
 
 
 class PrintSettings(Document):
@@ -71,6 +72,8 @@ class PrintSettings(Document):
 	def validate(self):
 		if self.pdf_page_size == "Custom" and not (self.pdf_page_height and self.pdf_page_width):
 			frappe.throw(_("Page height and width cannot be zero"))
+
+		validate_pdf_generator(self.pdf_generator)
 
 	def on_update(self):
 		frappe.clear_cache()

--- a/frappe/printing/pinto_generator.md
+++ b/frappe/printing/pinto_generator.md
@@ -1,0 +1,43 @@
+# pinto PDF generator
+
+[pinto](https://github.com/the-bokya/pinto) renders printview HTML to PDF in a single
+short-lived process — no Chromium, no browser pool. It is a third PDF generator alongside
+`wkhtmltopdf` and `chrome`, selectable in Print Settings or per Print Format.
+
+## Setup
+
+pinto ships as a standalone binary, not a Python dependency; a site without it keeps using
+whichever generator it already has.
+
+```bash
+git clone https://github.com/the-bokya/pinto && cd pinto
+cargo build --release
+```
+
+Put the binary on `PATH` as `pinto`, or point at it explicitly:
+
+```json
+// sites/common_site_config.json
+{ "pinto_path": "/path/to/pinto/target/release/pinto", "pinto_timeout": 120 }
+```
+
+Then set **PDF Generator → pinto** in Print Settings (site-wide) or on a Print Format.
+
+## How it plugs in
+
+`frappe.utils.pdf_generator.pinto.get_pinto_pdf` is registered on the `pdf_generator` hook and
+claims renders where `pdf_generator == "pinto"`. It pipes the printview HTML to the binary on
+stdin along with a config file carrying the wkhtmltopdf-style options plus the site-local values
+a standalone binary cannot read for itself — host URL, bench/site paths for resolving
+host-relative `<img>` and `<link>`, and the Print Settings page geometry — and reads the PDF
+back on stdout.
+
+Password protection is applied by Frappe with pypdf after the render, not by pinto.
+
+## Trade-offs
+
+Chromium stays the fidelity reference. pinto has its own layout engine, so it is close to but
+not pixel-identical with Chromium, and it does not implement flexbox, grid, `position: absolute`,
+transforms, `border-radius` or SVG. Formats using the beta renderer emit flexbox and are pinned
+to Chromium regardless of this setting. Use pinto for classic print formats where a ~10 MB
+process beats a ~120 MB browser.

--- a/frappe/printing/pinto_generator.md
+++ b/frappe/printing/pinto_generator.md
@@ -21,7 +21,9 @@ Put the binary on `PATH` as `pinto`, or point at it explicitly:
 { "pinto_path": "/path/to/pinto/target/release/pinto", "pinto_timeout": 120 }
 ```
 
-Then set **PDF Generator → pinto** in Print Settings (site-wide) or on a Print Format.
+Then set **PDF Generator → pinto** in Print Settings (site-wide) or on a Print Format. Saving
+that choice without a resolvable binary is rejected, so the failure surfaces there rather than on
+every later download, attachment and auto-email.
 
 ## How it plugs in
 

--- a/frappe/tests/test_pinto_pdf.py
+++ b/frappe/tests/test_pinto_pdf.py
@@ -6,6 +6,8 @@ import os
 import subprocess
 from unittest.mock import patch
 
+from pypdf import PdfReader
+
 import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.utils.pdf_generator import pinto
@@ -42,13 +44,52 @@ class TestPintoPdf(IntegrationTestCase):
 
 	def test_password_is_applied_by_frappe_not_pinto(self):
 		"""pinto's own encryption silently no-ops without qpdf, so Frappe encrypts."""
-		from pypdf import PdfReader
-
 		with patch.object(pinto, "render", return_value=_blank_pdf()) as render:
 			pdf = pinto.get_pinto_pdf(None, "<p>hi</p>", {"password": "s3cret"}, pdf_generator="pinto")
 
 		self.assertNotIn("password", render.call_args.args[1]["options"])
 		self.assertTrue(PdfReader(io.BytesIO(pdf)).is_encrypted)
+
+	def test_output_writer_gets_unencrypted_pages(self):
+		"""print_utils merges returned bytes into the writer, which cannot read an encrypted PDF."""
+		from pypdf import PdfWriter
+
+		with patch.object(pinto, "render", return_value=_blank_pdf()):
+			pdf = pinto.get_pinto_pdf(
+				None, "<p>hi</p>", {"password": "s3cret"}, output=PdfWriter(), pdf_generator="pinto"
+			)
+
+		self.assertFalse(PdfReader(io.BytesIO(pdf)).is_encrypted)
+
+	def test_custom_page_size_becomes_explicit_mm_dimensions(self):
+		print_settings = frappe.get_cached_doc("Print Settings")
+		print_settings.pdf_page_size = "Custom"
+		print_settings.pdf_page_height = 100
+		print_settings.pdf_page_width = 200.5
+
+		page_size, dimensions = pinto.resolve_page_size(print_settings, {})
+
+		self.assertNotEqual(page_size, "Custom")
+		self.assertEqual(dimensions, {"page-height": "100mm", "page-width": "200.5mm"})
+
+	def test_explicit_page_size_passes_through(self):
+		print_settings = frappe.get_cached_doc("Print Settings")
+		print_settings.pdf_page_size = "Custom"
+
+		self.assertEqual(pinto.resolve_page_size(print_settings, {"page-size": "Letter"}), ("Letter", {}))
+
+	def test_with_unit_keeps_existing_units(self):
+		self.assertEqual(pinto.with_unit(210), "210mm")
+		self.assertEqual(pinto.with_unit("8.5in"), "8.5in")
+
+	def test_private_images_are_inlined(self):
+		with (
+			patch.object(pinto, "render", return_value=_blank_pdf()),
+			patch.object(pinto, "inline_private_images", side_effect=lambda html: html) as inline,
+		):
+			pinto.get_pinto_pdf(None, "<p>hi</p>", {}, pdf_generator="pinto")
+
+		inline.assert_called_once_with("<p>hi</p>")
 
 	def test_render_reports_binary_failure(self):
 		error = subprocess.CalledProcessError(1, "pinto", stderr=b"Error: parsing options JSON")

--- a/frappe/tests/test_pinto_pdf.py
+++ b/frappe/tests/test_pinto_pdf.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+import io
+import json
+import os
+import subprocess
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+from frappe.utils.pdf_generator import pinto
+
+MINIMAL_PDF = b"%PDF-1.7\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\n%%EOF\n"
+
+
+class TestPintoPdf(IntegrationTestCase):
+	def test_hook_ignores_other_generators(self):
+		for generator in ("wkhtmltopdf", "chrome", "Typst", None):
+			with patch.object(pinto, "render") as render:
+				self.assertIsNone(pinto.get_pinto_pdf("Standard", "<p>hi</p>", {}, pdf_generator=generator))
+				render.assert_not_called()
+
+	def test_hook_ignores_html_less_dispatch(self):
+		"""Beta formats dispatch without HTML and stay on Chromium."""
+		with patch.object(pinto, "render") as render:
+			self.assertIsNone(pinto.get_pinto_pdf("Standard", None, {}, pdf_generator="pinto"))
+			render.assert_not_called()
+
+	def test_missing_binary_throws(self):
+		with patch.dict(frappe.conf, {"pinto_path": "/nonexistent/pinto"}):
+			self.assertRaises(pinto.PintoNotFound, pinto.get_pinto_path)
+
+	def test_config_carries_site_paths_and_page_defaults(self):
+		config = pinto.build_config(None, {"orientation": "Landscape"})
+
+		self.assertEqual(config["options"], {"orientation": "Landscape"})
+		self.assertFalse(config["is_print_designer"])
+		self.assertTrue(config["host_url"])
+		self.assertTrue(os.path.isdir(config["bench_sites_path"]))
+		self.assertTrue(config["default_page_size"])
+		json.dumps(config)
+
+	def test_password_is_applied_by_frappe_not_pinto(self):
+		"""pinto's own encryption silently no-ops without qpdf, so Frappe encrypts."""
+		from pypdf import PdfReader
+
+		with patch.object(pinto, "render", return_value=_blank_pdf()) as render:
+			pdf = pinto.get_pinto_pdf(None, "<p>hi</p>", {"password": "s3cret"}, pdf_generator="pinto")
+
+		self.assertNotIn("password", render.call_args.args[1]["options"])
+		self.assertTrue(PdfReader(io.BytesIO(pdf)).is_encrypted)
+
+	def test_render_reports_binary_failure(self):
+		error = subprocess.CalledProcessError(1, "pinto", stderr=b"Error: parsing options JSON")
+
+		with (
+			patch.object(pinto, "get_pinto_path", return_value="/bin/true"),
+			patch("subprocess.run", side_effect=error),
+		):
+			with self.assertRaises(pinto.PintoRenderError):
+				pinto.render("<p>hi</p>", {})
+
+	def test_render_rejects_non_pdf_output(self):
+		completed = subprocess.CompletedProcess([], 0, stdout=b"not a pdf", stderr=b"")
+
+		with (
+			patch.object(pinto, "get_pinto_path", return_value="/bin/true"),
+			patch("subprocess.run", return_value=completed),
+		):
+			with self.assertRaises(pinto.PintoRenderError):
+				pinto.render("<p>hi</p>", {})
+
+	def test_render_pipes_html_on_stdin(self):
+		completed = subprocess.CompletedProcess([], 0, stdout=MINIMAL_PDF, stderr=b"")
+
+		with (
+			patch.object(pinto, "get_pinto_path", return_value="/bin/true"),
+			patch("subprocess.run", return_value=completed) as run,
+		):
+			self.assertEqual(pinto.render("<p>hi</p>", {"options": {}}), MINIMAL_PDF)
+
+		argv = run.call_args.args[0]
+		self.assertEqual(run.call_args.kwargs["input"], b"<p>hi</p>")
+		self.assertEqual(argv[:2], ["/bin/true", "--html"])
+		self.assertEqual(argv[2], "-")
+		self.assertEqual(argv[3], "--options")
+		self.assertTrue(argv[4].endswith("config.json"))
+		self.assertEqual(argv[5:], ["--out", "-"])
+
+
+def _blank_pdf() -> bytes:
+	from pypdf import PdfWriter
+
+	writer = PdfWriter()
+	writer.add_blank_page(width=100, height=100)
+	stream = io.BytesIO()
+	writer.write(stream)
+	return stream.getvalue()

--- a/frappe/tests/test_pinto_pdf.py
+++ b/frappe/tests/test_pinto_pdf.py
@@ -109,6 +109,21 @@ class TestPintoPdf(IntegrationTestCase):
 		finally:
 			frappe.flags.in_migrate = False
 
+	def test_multi_pdf_download_is_encrypted(self):
+		"""The counterpart to skipping encryption when `output` is set: generators merge
+		unencrypted pages, so the password lands once on the finished writer."""
+		from frappe.utils.print_format import _download_multi_pdf
+
+		names = frappe.get_all("ToDo", limit=2, pluck="name")
+		while len(names) < 2:
+			names.append(frappe.get_doc({"doctype": "ToDo", "description": "pinto"}).insert().name)
+
+		_download_multi_pdf("ToDo", names, options=json.dumps({"password": "s3cret"}))
+
+		reader = PdfReader(io.BytesIO(frappe.local.response.filecontent))
+		self.assertTrue(reader.is_encrypted)
+		self.assertTrue(reader.decrypt("s3cret"))
+
 	def test_render_reports_binary_failure(self):
 		error = subprocess.CalledProcessError(1, "pinto", stderr=b"Error: parsing options JSON")
 

--- a/frappe/tests/test_pinto_pdf.py
+++ b/frappe/tests/test_pinto_pdf.py
@@ -91,6 +91,24 @@ class TestPintoPdf(IntegrationTestCase):
 
 		inline.assert_called_once_with("<p>hi</p>")
 
+	def test_selecting_pinto_without_the_binary_is_rejected_on_save(self):
+		"""Fail on save, not on every later download/attachment/auto-email."""
+		print_settings = frappe.get_doc("Print Settings")
+		print_settings.pdf_generator = "pinto"
+
+		with patch.dict(frappe.conf, {"pinto_path": "/nonexistent/pinto"}):
+			self.assertRaises(pinto.PintoNotFound, print_settings.validate)
+
+	def test_migrate_does_not_fail_on_a_missing_binary(self):
+		from frappe.utils.print_utils import validate_pdf_generator
+
+		frappe.flags.in_migrate = True
+		try:
+			with patch.dict(frappe.conf, {"pinto_path": "/nonexistent/pinto"}):
+				validate_pdf_generator("pinto")
+		finally:
+			frappe.flags.in_migrate = False
+
 	def test_render_reports_binary_failure(self):
 		error = subprocess.CalledProcessError(1, "pinto", stderr=b"Error: parsing options JSON")
 

--- a/frappe/utils/pdf_generator/pinto.py
+++ b/frappe/utils/pdf_generator/pinto.py
@@ -8,7 +8,7 @@ import tempfile
 import frappe
 from frappe import _
 from frappe.utils.data import cstr
-from frappe.utils.pdf import get_host_url
+from frappe.utils.pdf import get_host_url, inline_private_images
 
 GENERATOR = "pinto"
 DEFAULT_TIMEOUT = 120
@@ -42,23 +42,43 @@ def build_config(print_format: str | None, options: dict) -> dict:
 	"""The `--options` payload pinto expects: the wkhtmltopdf-style options plus the
 	site-local values a standalone binary cannot read for itself."""
 	print_settings = frappe.get_cached_doc("Print Settings")
+	page_size, page_options = resolve_page_size(print_settings, options)
 
 	return {
-		"options": options,
+		"options": {**options, **page_options},
 		"is_print_designer": bool(
 			print_format and frappe.get_cached_value("Print Format", print_format, "print_designer")
 		),
 		"host_url": get_host_url(),
 		"bench_sites_path": os.path.join(frappe.utils.get_bench_path(), "sites"),
 		"site_public_path": frappe.get_site_path("public"),
-		"default_page_size": print_settings.pdf_page_size or "A4",
-		"default_page_height": _page_dimension(print_settings.pdf_page_height),
-		"default_page_width": _page_dimension(print_settings.pdf_page_width),
+		"default_page_size": page_size,
 	}
 
 
-def _page_dimension(value) -> str | None:
-	return cstr(value) if value else None
+def resolve_page_size(print_settings, options: dict) -> tuple[str, dict]:
+	"""Mirror `prepare_options`: turn a "Custom" page size into explicit dimensions.
+
+	pinto resolves geometry from `page-size`/`page-width`/`page-height` only — it has no
+	notion of the "Custom" sentinel, and reads bare Print Settings dimensions as pixels.
+	"""
+	page_size = options.get("page-size") or print_settings.pdf_page_size or "A4"
+	if page_size != "Custom":
+		return page_size, {}
+
+	dimensions = {}
+	for option, field in (("page-height", "pdf_page_height"), ("page-width", "pdf_page_width")):
+		value = options.get(option) or print_settings.get(field)
+		if value:
+			dimensions[option] = with_unit(value)
+
+	return "A4", dimensions
+
+
+def with_unit(value, unit: str = "mm") -> str:
+	"""Print Settings stores page dimensions as bare floats; CSS lengths need a unit."""
+	value = cstr(value).strip()
+	return value if value[-1:].isalpha() else f"{value}{unit}"
 
 
 def render(html: str, config: dict) -> bytes:
@@ -125,9 +145,11 @@ def get_pinto_pdf(print_format, html, options, output=None, pdf_generator=None):
 	options = dict(options or {})
 	password = options.pop("password", None)
 
-	pdf = render(html, build_config(print_format, options))
+	pdf = render(inline_private_images(html), build_config(print_format, options))
 
-	if password:
+	# An `output` writer merges the pages downstream and cannot read an encrypted PDF;
+	# wkhtmltopdf skips encryption in the same case.
+	if password and not output:
 		pdf = encrypt(pdf, password)
 
 	return pdf

--- a/frappe/utils/pdf_generator/pinto.py
+++ b/frappe/utils/pdf_generator/pinto.py
@@ -1,0 +1,133 @@
+import io
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+
+import frappe
+from frappe import _
+from frappe.utils.data import cstr
+from frappe.utils.pdf import get_host_url
+
+GENERATOR = "pinto"
+DEFAULT_TIMEOUT = 120
+
+
+class PintoNotFound(frappe.ValidationError):
+	pass
+
+
+class PintoRenderError(frappe.ValidationError):
+	pass
+
+
+def get_pinto_path() -> str:
+	"""Resolve the `pinto` binary: site config `pinto_path`, else `pinto` on PATH."""
+	binary = frappe.conf.get("pinto_path") or shutil.which(GENERATOR)
+
+	if not binary or not os.path.isfile(binary) or not os.access(binary, os.X_OK):
+		frappe.throw(
+			_("pinto binary not found at {0}. Install it or set `pinto_path` in site config.").format(
+				frappe.bold(binary or GENERATOR)
+			),
+			exc=PintoNotFound,
+			title=_("PDF Generator Unavailable"),
+		)
+
+	return binary
+
+
+def build_config(print_format: str | None, options: dict) -> dict:
+	"""The `--options` payload pinto expects: the wkhtmltopdf-style options plus the
+	site-local values a standalone binary cannot read for itself."""
+	print_settings = frappe.get_cached_doc("Print Settings")
+
+	return {
+		"options": options,
+		"is_print_designer": bool(
+			print_format and frappe.get_cached_value("Print Format", print_format, "print_designer")
+		),
+		"host_url": get_host_url(),
+		"bench_sites_path": os.path.join(frappe.utils.get_bench_path(), "sites"),
+		"site_public_path": frappe.get_site_path("public"),
+		"default_page_size": print_settings.pdf_page_size or "A4",
+		"default_page_height": _page_dimension(print_settings.pdf_page_height),
+		"default_page_width": _page_dimension(print_settings.pdf_page_width),
+	}
+
+
+def _page_dimension(value) -> str | None:
+	return cstr(value) if value else None
+
+
+def render(html: str, config: dict) -> bytes:
+	"""Pipe the printview HTML through pinto and return the PDF bytes."""
+	binary = get_pinto_path()
+
+	with tempfile.TemporaryDirectory() as tmp:
+		config_path = os.path.join(tmp, "config.json")
+		with open(config_path, "w", encoding="utf-8") as f:
+			json.dump(config, f)
+
+		try:
+			result = subprocess.run(
+				[binary, "--html", "-", "--options", config_path, "--out", "-"],
+				input=html.encode("utf-8"),
+				capture_output=True,
+				timeout=frappe.conf.get("pinto_timeout") or DEFAULT_TIMEOUT,
+				check=True,
+			)
+		except subprocess.TimeoutExpired:
+			frappe.throw(
+				_("pinto timed out while rendering the PDF."),
+				exc=PintoRenderError,
+				title=_("PDF Generation Failed"),
+			)
+		except subprocess.CalledProcessError as e:
+			frappe.throw(
+				_("pinto failed to render the PDF: {0}").format(_stderr(e)),
+				exc=PintoRenderError,
+				title=_("PDF Generation Failed"),
+			)
+
+	if not result.stdout.startswith(b"%PDF"):
+		frappe.throw(_("pinto returned an invalid PDF."), exc=PintoRenderError)
+
+	return result.stdout
+
+
+def _stderr(e: subprocess.CalledProcessError) -> str:
+	return (e.stderr or b"").decode("utf-8", "replace").strip() or _("exit code {0}").format(e.returncode)
+
+
+def encrypt(pdf: bytes, password: str) -> bytes:
+	from pypdf import PdfReader, PdfWriter
+
+	writer = PdfWriter()
+	writer.append_pages_from_reader(PdfReader(io.BytesIO(pdf)))
+	writer.encrypt(password)
+
+	stream = io.BytesIO()
+	writer.write(stream)
+	return stream.getvalue()
+
+
+def get_pinto_pdf(print_format, html, options, output=None, pdf_generator=None):
+	"""`pdf_generator` hook: renders printview HTML to PDF in-process via the `pinto` binary.
+
+	Beta-renderer formats dispatch through this hook without HTML; they are pinned to
+	Chromium, so hand them back untouched.
+	"""
+	if pdf_generator != GENERATOR or not html:
+		return
+
+	options = dict(options or {})
+	password = options.pop("password", None)
+
+	pdf = render(html, build_config(print_format, options))
+
+	if password:
+		pdf = encrypt(pdf, password)
+
+	return pdf

--- a/frappe/utils/print_format.py
+++ b/frappe/utils/print_format.py
@@ -268,7 +268,7 @@ def download_pdf(
 	no_letterhead: bool | int = 0,
 	language: str | None = None,
 	letterhead: str | None = None,
-	pdf_generator: Literal["wkhtmltopdf", "chrome"] | None = None,
+	pdf_generator: Literal["wkhtmltopdf", "chrome", "pinto"] | None = None,
 ):
 	doc = doc or frappe.get_doc(doctype, name)
 	validate_print_permission(doc)

--- a/frappe/utils/print_format.py
+++ b/frappe/utils/print_format.py
@@ -233,6 +233,11 @@ def _download_multi_pdf(
 		if task_id is None:
 			frappe.local.response.filename = f"{name}.pdf"
 
+	# Generators hand their pages to the shared writer unencrypted — an encrypted document
+	# cannot be merged — so the password is applied once, to the finished writer.
+	if (options or {}).get("password"):
+		pdf_writer.encrypt(options["password"])
+
 	with BytesIO() as merged_pdf:
 		pdf_writer.write(merged_pdf)
 		if task_id:

--- a/frappe/utils/print_utils.py
+++ b/frappe/utils/print_utils.py
@@ -58,7 +58,7 @@ def get_print(
 	password=None,
 	pdf_options=None,
 	letterhead=None,
-	pdf_generator: Literal["wkhtmltopdf", "chrome"] | None = None,
+	pdf_generator: Literal["wkhtmltopdf", "chrome", "pinto"] | None = None,
 ):
 	"""Get Print Format for given document.
 	:param doctype: DocType of document.

--- a/frappe/utils/print_utils.py
+++ b/frappe/utils/print_utils.py
@@ -46,6 +46,21 @@ def resolve_pdf_generator(print_format=None, pdf_generator: str | None = None) -
 	return frappe.db.get_single_value("Print Settings", "pdf_generator") or "wkhtmltopdf"
 
 
+def validate_pdf_generator(pdf_generator: str | None):
+	"""Reject a generator whose external dependency is missing.
+
+	Without this the choice saves fine and then fails on every download, attachment and
+	auto-email instead of at the point where someone can still pick something else.
+	"""
+	if frappe.flags.in_migrate or frappe.flags.in_install:
+		return
+
+	if pdf_generator == "pinto":
+		from frappe.utils.pdf_generator.pinto import get_pinto_path
+
+		get_pinto_path()
+
+
 def get_print(
 	doctype=None,
 	name=None,


### PR DESCRIPTION
Adds [pinto](https://github.com/the-bokya/pinto) as a third PDF generator next to `wkhtmltopdf` and `chrome`, selectable in Print Settings or per Print Format.

- New `pdf_generator` hook `frappe.utils.pdf_generator.pinto.get_pinto_pdf` — pipes printview HTML to the `pinto` binary on stdin with a config file (options + host URL, bench/site paths, page geometry), reads the PDF on stdout
- Binary resolved from site config `pinto_path`, else `pinto` on PATH; sites without it are unaffected. Password protection applied by Frappe with pypdf, not by pinto
- `pinto` added to the PDF Generator dropdown on both Print Format and Print Settings; setup + trade-offs in `frappe/printing/pinto_generator.md`

Why: chrome needs a ~120 MB browser per render. pinto renders a classic print format in a ~10 MB process.

Not a chrome replacement — its own layout engine, so no flexbox/grid/absolute/border-radius/SVG, and not pixel-identical. Beta-renderer formats stay pinned to chrome.

Verified against a real ERPNext Sales Invoice on a local bench: identical page count and near-identical layout vs chrome, ~0.7s vs ~1.7s.