### PR TITLE
fix: disabled reports still appear in desk search

### DIFF
--- a/frappe/desk/desk_views.py
+++ b/frappe/desk/desk_views.py
@@ -160,8 +160,11 @@ class DeskViews:
 		hasRole = DocType("Has Role")
 		parentTable = DocType(parent)
 
+		def exclude_disabled_reports(query):
+			return query.where(report.disabled == 0) if is_report else query
+
 		# get pages or reports set on custom role
-		pages_with_custom_roles = (
+		pages_with_custom_roles = exclude_disabled_reports(
 			frappe.qb.from_(customRole)
 			.from_(hasRole)
 			.from_(parentTable)
@@ -185,7 +188,7 @@ class DeskViews:
 			.where(customRole[parent.lower()].isnotnull())
 		)
 
-		pages_with_standard_roles = (
+		pages_with_standard_roles = exclude_disabled_reports(
 			frappe.qb.from_(hasRole)
 			.from_(parentTable)
 			.select(parentTable.name.as_("name"), parentTable.modified, *columns)
@@ -195,12 +198,7 @@ class DeskViews:
 				& (parentTable.name.notin(subq))
 			)
 			.distinct()
-		)
-
-		if is_report:
-			pages_with_standard_roles = pages_with_standard_roles.where(report.disabled == 0)
-
-		pages_with_standard_roles = pages_with_standard_roles.run(as_dict=True)
+		).run(as_dict=True)
 
 		for p in pages_with_standard_roles:
 			if p.name not in has_role:
@@ -213,7 +211,7 @@ class DeskViews:
 		)
 
 		# pages and reports with no role are allowed
-		rows_with_no_roles = (
+		rows_with_no_roles = exclude_disabled_reports(
 			frappe.qb.from_(parentTable)
 			.select(parentTable.name, parentTable.modified, *columns)
 			.where(no_of_roles == 0)

--- a/frappe/tests/test_boot.py
+++ b/frappe/tests/test_boot.py
@@ -70,6 +70,46 @@ class TestBootData(IntegrationTestCase):
 			self.assertEqual(DeskViews.get_allowed_reports(cache=True), {})
 			self.assertEqual(build.call_count, 1)
 
+	def test_disabled_reports_are_not_allowed(self):
+		frappe.set_user("Administrator")
+
+		# role wiring decides which branch of the allowed-reports query a report comes from
+		with_custom_role = self._make_report("Test Disabled Custom Role Report", disabled=1)
+		frappe.get_doc(
+			{
+				"doctype": "Custom Role",
+				"report": with_custom_role,
+				"ref_doctype": "ToDo",
+				"roles": [{"role": "System Manager"}],
+			}
+		).insert()
+
+		without_roles = self._make_report("Test Disabled Roleless Report", disabled=1)
+		frappe.db.delete("Has Role", {"parent": without_roles, "parenttype": "Report"})
+
+		enabled = self._make_report("Test Enabled Report")
+
+		allowed_reports = DeskViews.get_allowed_reports()
+		self.assertNotIn(with_custom_role, allowed_reports)
+		self.assertNotIn(without_roles, allowed_reports)
+		self.assertIn(enabled, allowed_reports)
+
+	def _make_report(self, report_name, disabled=0):
+		return (
+			frappe.get_doc(
+				{
+					"doctype": "Report",
+					"ref_doctype": "ToDo",
+					"report_name": report_name,
+					"report_type": "Report Builder",
+					"is_standard": "No",
+					"disabled": disabled,
+				}
+			)
+			.insert()
+			.name
+		)
+
 
 class TestPermissionQueries(IntegrationTestCase):
 	@classmethod


### PR DESCRIPTION
## Description

Disabled Reports were still appearing in Desk search, List View report dropdowns, and recent routes.

The issue was that `disabled` was only checked for reports with standard roles. Reports linked through Custom Roles or with no roles could still be added to `frappe.boot.user.all_reports`.

The filter now applies to all report queries in one place.

Disabling a report also hides its Prepared Report output, which matches the expected behavior.


https://github.com/user-attachments/assets/fead2aca-7d0e-4174-bd41-079c1c9616e3



---

Ref: https://support.frappe.io/helpdesk/tickets/76935?view=VIEW-HD+Ticket-1252