### PR TITLE
feat(treeview): cleaner tree view UI

### DIFF
--- a/cypress/integration/tree_view.js
+++ b/cypress/integration/tree_view.js
@@ -33,20 +33,19 @@ context("Tree View", () => {
 		// both actions live in one dropdown; the menu resolves fresh on every
 		// open, disabling whichever action doesn't apply right now. Rows are
 		// real <button disabled> elements per the es-menu contract.
-		const open_menu = () => cy.get(".tree-toolbar-actions .es-button").click();
-		const close_menu = () => cy.get(".tree-toolbar-actions .es-button").click();
+		const toggle_menu = () => cy.get(".tree-toolbar-actions .es-button").first().click();
 		const assert_buttons = (expand_enabled, collapse_enabled) => {
-			open_menu();
+			toggle_menu();
 			cy.contains('[role="menu"] .es-menu__item', "Expand All").should(
 				expand_enabled ? "not.be.disabled" : "be.disabled"
 			);
 			cy.contains('[role="menu"] .es-menu__item', "Collapse All").should(
 				collapse_enabled ? "not.be.disabled" : "be.disabled"
 			);
-			close_menu();
+			toggle_menu();
 		};
 		const click_toolbar_button = (label) => {
-			open_menu();
+			toggle_menu();
 			cy.contains('[role="menu"] .es-menu__item', label).click();
 		};
 

--- a/cypress/integration/tree_view.js
+++ b/cypress/integration/tree_view.js
@@ -30,19 +30,24 @@ context("Tree View", () => {
 	it("shows Expand All / Collapse All only when the tree's state warrants it", () => {
 		cy.visit("/app/custom-tree/view/tree");
 
-		const tree_view = (win) => win.frappe.views.trees["Custom Tree"];
-		// both buttons stay in the layout permanently; the inapplicable one
-		// is disabled instead of hidden
+		// both actions live in one dropdown; the menu resolves fresh on every
+		// open, disabling whichever action doesn't apply right now. Rows are
+		// real <button disabled> elements per the es-menu contract.
+		const open_menu = () => cy.get(".tree-toolbar-actions .es-button").click();
+		const close_menu = () => cy.get(".tree-toolbar-actions .es-button").click();
 		const assert_buttons = (expand_enabled, collapse_enabled) => {
-			cy.window().should((win) => {
-				let tv = tree_view(win);
-				expect(tv.$expand_all_btn.prop("disabled")).to.eq(!expand_enabled);
-				expect(tv.$collapse_all_btn.prop("disabled")).to.eq(!collapse_enabled);
-			});
+			open_menu();
+			cy.contains('[role="menu"] .es-menu__item', "Expand All").should(
+				expand_enabled ? "not.be.disabled" : "be.disabled"
+			);
+			cy.contains('[role="menu"] .es-menu__item', "Collapse All").should(
+				collapse_enabled ? "not.be.disabled" : "be.disabled"
+			);
+			close_menu();
 		};
 		const click_toolbar_button = (label) => {
-			// icon-only buttons: the espresso tooltip doubles as aria-label
-			cy.get(`.tree-toolbar-actions .es-button[aria-label="${label}"]`).click();
+			open_menu();
+			cy.contains('[role="menu"] .es-menu__item', label).click();
 		};
 
 		// root auto-expands; both groups underneath are still collapsed -> only "Expand All"

--- a/cypress/integration/tree_view.js
+++ b/cypress/integration/tree_view.js
@@ -31,38 +31,28 @@ context("Tree View", () => {
 		cy.visit("/app/custom-tree/view/tree");
 
 		const tree_view = (win) => win.frappe.views.trees["Custom Tree"];
-		// the toolbar only ever hides/shows these buttons via jQuery
-		// .hide()/.show()/.toggle() — assert against "none" vs. not-"none"
-		// instead of a specific display value
-		const assert_buttons = (expand_visible, collapse_visible) => {
+		// both buttons stay in the layout permanently; the inapplicable one
+		// is disabled instead of hidden
+		const assert_buttons = (expand_enabled, collapse_enabled) => {
 			cy.window().should((win) => {
 				let tv = tree_view(win);
-				let expand_display = tv.$expand_all_btn.css("display");
-				let collapse_display = tv.$collapse_all_btn.css("display");
-				if (expand_visible) {
-					expect(expand_display).to.not.eq("none");
-				} else {
-					expect(expand_display).to.eq("none");
-				}
-				if (collapse_visible) {
-					expect(collapse_display).to.not.eq("none");
-				} else {
-					expect(collapse_display).to.eq("none");
-				}
+				expect(tv.$expand_all_btn.prop("disabled")).to.eq(!expand_enabled);
+				expect(tv.$collapse_all_btn.prop("disabled")).to.eq(!collapse_enabled);
 			});
 		};
 		const click_toolbar_button = (label) => {
-			cy.contains(".tree-toolbar-actions .es-button", label).click();
+			// icon-only buttons: the espresso tooltip doubles as aria-label
+			cy.get(`.tree-toolbar-actions .es-button[aria-label="${label}"]`).click();
 		};
 
 		// root auto-expands; both groups underneath are still collapsed -> only "Expand All"
 		assert_buttons(true, false);
 
-		// expand one group, leave its sibling group collapsed -> not yet fully
-		// expanded, so still only "Expand All" (one button at a time)
+		// expand one group, leave its sibling group collapsed -> partially
+		// expanded, so both buttons offer their one-click action
 		cy.get('.tree-link[data-label="Parent Node"]').click();
 		cy.get('.tree-link[data-label="Child Node"]').should("be.visible");
-		assert_buttons(true, false);
+		assert_buttons(true, true);
 
 		// Expand All -> every node, including the untouched sibling group, opens -> only "Collapse All"
 		click_toolbar_button("Expand All");

--- a/cypress/integration/tree_view.js
+++ b/cypress/integration/tree_view.js
@@ -31,10 +31,9 @@ context("Tree View", () => {
 		cy.visit("/app/custom-tree/view/tree");
 
 		const tree_view = (win) => win.frappe.views.trees["Custom Tree"];
-		// the menu only ever hides/shows these <li>s via jQuery .hide()/.show()/.toggle(),
-		// which resolves the "visible" state to the tag's native default display
-		// (list-item, not block) — assert against "none" vs. not-"none" instead of
-		// a specific display value
+		// the toolbar only ever hides/shows these buttons via jQuery
+		// .hide()/.show()/.toggle() — assert against "none" vs. not-"none"
+		// instead of a specific display value
 		const assert_buttons = (expand_visible, collapse_visible) => {
 			cy.window().should((win) => {
 				let tv = tree_view(win);
@@ -52,24 +51,21 @@ context("Tree View", () => {
 				}
 			});
 		};
-		const click_menu_item = (label) => {
-			// the menu button's own .dropdown-menu is a hidden item store (see
-			// page.js build_dropdown_options) — the actual open menu is an
-			// espresso panel with role="menu", portaled elsewhere in the DOM
-			cy.get(".menu-btn-group > button").click();
-			cy.contains('[role="menu"] .es-menu__item', label).click();
+		const click_toolbar_button = (label) => {
+			cy.contains(".tree-toolbar-actions .es-button", label).click();
 		};
 
 		// root auto-expands; both groups underneath are still collapsed -> only "Expand All"
 		assert_buttons(true, false);
 
-		// expand one group, leave its sibling group collapsed -> mixed, both show
+		// expand one group, leave its sibling group collapsed -> not yet fully
+		// expanded, so still only "Expand All" (one button at a time)
 		cy.get('.tree-link[data-label="Parent Node"]').click();
 		cy.get('.tree-link[data-label="Child Node"]').should("be.visible");
-		assert_buttons(true, true);
+		assert_buttons(true, false);
 
 		// Expand All -> every node, including the untouched sibling group, opens -> only "Collapse All"
-		click_menu_item("Expand All");
+		click_toolbar_button("Expand All");
 		cy.get('.tree-link[data-label="Child Node"]').should("be.visible");
 		assert_buttons(false, true);
 
@@ -86,7 +82,7 @@ context("Tree View", () => {
 		assert_buttons(false, true);
 
 		// Collapse All -> back to the initial state
-		click_menu_item("Collapse All");
+		click_toolbar_button("Collapse All");
 		cy.get('.tree-link[data-label="Child Node"]').should("not.exist");
 		assert_buttons(true, false);
 	});

--- a/cypress/integration/tree_view.js
+++ b/cypress/integration/tree_view.js
@@ -30,9 +30,6 @@ context("Tree View", () => {
 	it("shows Expand All / Collapse All only when the tree's state warrants it", () => {
 		cy.visit("/app/custom-tree/view/tree");
 
-		// both actions live in one dropdown; the menu resolves fresh on every
-		// open, disabling whichever action doesn't apply right now. Rows are
-		// real <button disabled> elements per the es-menu contract.
 		const toggle_menu = () => cy.get(".tree-toolbar-actions .es-button").first().click();
 		const assert_buttons = (expand_enabled, collapse_enabled) => {
 			toggle_menu();

--- a/cypress/integration/tree_view.js
+++ b/cypress/integration/tree_view.js
@@ -49,6 +49,10 @@ context("Tree View", () => {
 			cy.contains('[role="menu"] .es-menu__item', label).click();
 		};
 
+		// wait for the root's children to render before opening the menu — the
+		// expansion state is only meaningful once the tree has actually loaded
+		cy.get('.tree-link[data-label="Parent Node"]').should("be.visible");
+
 		// root auto-expands; both groups underneath are still collapsed -> only "Expand All"
 		assert_buttons(true, false);
 

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -210,7 +210,7 @@ frappe.views.BaseList = class BaseList {
 				doctype: this.doctype,
 				page: this.page,
 				list_view: this,
-				icon_map: frappe.views.get_view_icon_map(),
+				icon_map: frappe.views.view_icon_map,
 				label_map: frappe.views.get_view_label_map(),
 			});
 		}
@@ -1425,7 +1425,7 @@ class FilterArea {
 
 // view identity shared by every switcher on a doctype page header — the
 // list-family views and the tree view all build their switcher from these
-frappe.views.get_view_icon_map = () => ({
+frappe.views.view_icon_map = {
 	Image: "image",
 	List: "list",
 	Report: "sheet",
@@ -1435,7 +1435,7 @@ frappe.views.get_view_icon_map = () => ({
 	Dashboard: "layout-dashboard",
 	Map: "map",
 	Tree: "list-tree",
-});
+};
 
 frappe.views.get_view_label_map = () => ({
 	List: __("List View"),

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -204,38 +204,14 @@ frappe.views.BaseList = class BaseList {
 
 	setup_view_menu() {
 		if (frappe.boot.desk_settings.view_switcher && !this.meta.force_re_route_to_default_view) {
-			const icon_map = {
-				Image: "image",
-				List: "list",
-				Report: "sheet",
-				Calendar: "calendar",
-				Gantt: "square-chart-gantt",
-				Kanban: "square-kanban",
-				Dashboard: "layout-dashboard",
-				Map: "map",
-			};
-
-			const label_map = {
-				List: __("List View"),
-				Report: __("Report View"),
-				Dashboard: __("Dashboard View"),
-				Gantt: __("Gantt View"),
-				Kanban: __("Kanban View"),
-				Calendar: __("Calendar View"),
-				Image: __("Image View"),
-				Inbox: __("Inbox View"),
-				Tree: __("Tree View"),
-				Map: __("Map View"),
-			};
-
 			// one nested dropdown: view rows + the current view's variants
 			// (saved layouts, kanban boards, ...) as its submenu
 			this.views_list = new frappe.views.ListViewSelect({
 				doctype: this.doctype,
 				page: this.page,
 				list_view: this,
-				icon_map: icon_map,
-				label_map: label_map,
+				icon_map: frappe.views.get_view_icon_map(),
+				label_map: frappe.views.get_view_label_map(),
 			});
 		}
 	}
@@ -1446,6 +1422,33 @@ class FilterArea {
 		);
 	}
 }
+
+// view identity shared by every switcher on a doctype page header — the
+// list-family views and the tree view all build their switcher from these
+frappe.views.get_view_icon_map = () => ({
+	Image: "image",
+	List: "list",
+	Report: "sheet",
+	Calendar: "calendar",
+	Gantt: "square-chart-gantt",
+	Kanban: "square-kanban",
+	Dashboard: "layout-dashboard",
+	Map: "map",
+	Tree: "list-tree",
+});
+
+frappe.views.get_view_label_map = () => ({
+	List: __("List View"),
+	Report: __("Report View"),
+	Dashboard: __("Dashboard View"),
+	Gantt: __("Gantt View"),
+	Kanban: __("Kanban View"),
+	Calendar: __("Calendar View"),
+	Image: __("Image View"),
+	Inbox: __("Inbox View"),
+	Tree: __("Tree View"),
+	Map: __("Map View"),
+});
 
 // utility function to validate view modes
 frappe.views.view_modes = [

--- a/frappe/public/js/frappe/ui/link_preview.js
+++ b/frappe/public/js/frappe/ui/link_preview.js
@@ -1,7 +1,9 @@
 frappe.ui.LinkPreview = class {
 	constructor() {
 		this.popovers_list = [];
-		this.LINK_CLASSES = 'a[data-doctype], input[data-fieldtype="Link"], .popover';
+		// tree labels carry their own hover card (frappe.ui.Tree)
+		this.LINK_CLASSES =
+			'a[data-doctype]:not(.tree-label), input[data-fieldtype="Link"], .popover';
 		this.popover_timeout = null;
 		this.setup_events();
 	}

--- a/frappe/public/js/frappe/ui/tree.js
+++ b/frappe/public/js/frappe/ui/tree.js
@@ -229,7 +229,6 @@ frappe.ui.Tree = class {
 	}
 
 	build_node_hover_card(node) {
-		// a previous fetch found nothing worth showing — stay silent
 		if (node.preview_empty) return null;
 
 		const $card = $(`
@@ -267,8 +266,7 @@ frappe.ui.Tree = class {
 					const has_value_column =
 						node.parent && node.parent.children(".balance-area").length;
 
-					// silence beats an empty box: no avatar, no fields, no
-					// value column means no card
+					// nothing worth showing — no card
 					if (
 						!data ||
 						(!meta?.image_field && !extra_fields.length && !has_value_column)

--- a/frappe/public/js/frappe/ui/tree.js
+++ b/frappe/public/js/frappe/ui/tree.js
@@ -12,6 +12,10 @@ frappe.ui.Tree = class {
 		toolbar,
 		expandable,
 		with_skeleton = 1,
+		// row mode: full-width rows, toolbar rendered as hover actions +
+		// context menu instead of the click-injected button group. Embedded
+		// consumers (BOM Configurator, dialogs) keep the legacy behavior.
+		use_row_actions = false,
 
 		args,
 		method,
@@ -26,8 +30,12 @@ frappe.ui.Tree = class {
 		}
 		this.setup_treenode_class();
 		this.nodes = {};
-		this.wrapper = $('<div class="tree">').appendTo(this.parent);
+		this.wrapper = $('<div class="tree" role="tree">').appendTo(this.parent);
 		if (with_skeleton) this.wrapper.addClass("with-skeleton");
+		if (this.use_row_actions) {
+			this.wrapper.addClass("tree-rows");
+			this.setup_context_menu();
+		}
 
 		if (!icon_set) {
 			this.icon_set = {
@@ -118,15 +126,274 @@ frappe.ui.Tree = class {
 	make_node_element(node) {
 		node.$tree_link = $('<span class="tree-link">')
 			.attr("data-label", node.label)
+			.attr("role", "treeitem")
+			.attr("aria-expanded", node.expandable ? "false" : null)
 			.data("node", node)
 			.appendTo(node.parent);
 
-		node.$ul = $('<ul class="tree-children">').hide().appendTo(node.parent);
+		node.$ul = $('<ul class="tree-children" role="group">').hide().appendTo(node.parent);
 
 		this.make_icon_and_label(node);
 		if (this.toolbar) {
-			node.$toolbar = this.get_toolbar(node).insertAfter(node.$tree_link);
+			if (this.use_row_actions) {
+				this.make_row_actions(node);
+			} else {
+				node.$toolbar = this.get_toolbar(node).insertAfter(node.$tree_link);
+			}
 		}
+		if (this.use_row_actions && !node.is_root) {
+			this.setup_node_hover_card(node);
+		}
+	}
+
+	// ─── row mode: node hover card ─────────────────────────────────────────
+
+	setup_node_hover_card(node) {
+		// same gate as the generic link preview this card replaces
+		if (!(frappe.boot.link_preview_doctypes || []).includes(this.args.doctype)) return;
+
+		node.hover_card = frappe.ui.hover_card(node.$tree_link.find("a.tree-label"), {
+			side: "bottom",
+			align: "start",
+			css_class: "tree-node-hover-panel",
+			content: () => this.build_node_hover_card(node),
+		});
+
+		// start the fetch on first hover, before the card's open delay
+		// elapses — an empty preview then destroys the card before it ever
+		// opens, instead of flashing a skeleton and vanishing
+		node.$tree_link.one("mouseenter", () => this.get_node_preview(node));
+	}
+
+	build_node_hover_card(node) {
+		// a previous fetch found nothing worth showing — stay silent
+		if (node.preview_empty) return null;
+
+		const $card = $(`
+			<div class="tree-hover-card">
+				${frappe.ui.skeleton.html({ width: "60%", height: "14px" })}
+				${frappe.ui.skeleton.html({ width: "40%", height: "12px", css_class: "mt-2" })}
+			</div>
+		`);
+		this.get_node_preview(node).then((data) => {
+			if (!document.body.contains($card[0])) return;
+			if (!data) {
+				node.hover_card && node.hover_card.close();
+				return;
+			}
+			$card.empty().append(this.render_node_hover_card(node, data));
+		});
+		return $card;
+	}
+
+	get_node_preview(node) {
+		if (!node.preview_promise) {
+			node.preview_promise = frappe
+				.call({
+					method: "frappe.desk.link_preview.get_preview_data",
+					args: { doctype: this.args.doctype, docname: node.label },
+				})
+				.then((r) => {
+					const data = r.message;
+					const meta = frappe.get_meta(this.args.doctype);
+					const extra_fields =
+						data &&
+						Object.keys(data).filter(
+							(key) => !["preview_image", "preview_title", "name"].includes(key)
+						);
+					const has_value_column =
+						node.parent && node.parent.children(".balance-area").length;
+
+					// silence beats an empty box: no avatar, no fields, no
+					// value column means no card
+					if (
+						!data ||
+						(!meta?.image_field && !extra_fields.length && !has_value_column)
+					) {
+						node.preview_empty = true;
+						node.hover_card && node.hover_card.destroy();
+						return null;
+					}
+					return data;
+				})
+				.catch(() => {
+					node.preview_empty = true;
+					node.hover_card && node.hover_card.destroy();
+					return null;
+				});
+		}
+		return node.preview_promise;
+	}
+
+	render_node_hover_card(node, data) {
+		const doctype = this.args.doctype;
+		const meta = frappe.get_meta(doctype);
+		const title = data.preview_title || data.name;
+		const subtitle =
+			data.preview_title && data.preview_title !== data.name
+				? `${__(doctype)} · ${data.name}`
+				: __(doctype);
+
+		const $content = $("<div></div>");
+		const $head = $(
+			'<div class="tree-hover-card-head flex items-start gap-2.5"></div>'
+		).appendTo($content);
+
+		// avatar only when the doctype defines an image field
+		if (meta && meta.image_field) {
+			$head.append(
+				frappe.ui.avatar.html({
+					label: title,
+					image: data.preview_image || undefined,
+					size: "lg",
+				})
+			);
+		}
+
+		const $titles = $('<div class="flex-1 min-w-0"></div>').appendTo($head);
+		$('<div class="text-base-semibold text-ink-gray-8 truncate"></div>')
+			.text(title)
+			.appendTo($titles);
+		$('<div class="text-sm text-ink-gray-6 truncate mt-0.5"></div>')
+			.text(subtitle)
+			.appendTo($titles);
+
+		$(
+			frappe.ui.button({
+				icon: "external-link",
+				variant: "ghost",
+				size: "xs",
+				title: __("Open"),
+				onclick: () => frappe.set_route("Form", doctype, data.name),
+			})
+		).appendTo($head);
+
+		if (node.expandable) {
+			$('<div class="flex gap-1.5 mt-2"></div>')
+				.append(frappe.ui.badge({ label: __("Group"), size: "sm" }))
+				.appendTo($content);
+		}
+
+		const rows = Object.entries(data).filter(
+			([key, value]) =>
+				!["preview_image", "preview_title", "name"].includes(key) && value != null
+		);
+		const $balance = node.parent && node.parent.children(".balance-area").first();
+		if (rows.length || ($balance && $balance.length)) {
+			$('<div class="border-t my-2.5"></div>').appendTo($content);
+			const add_row = (label, $value) => {
+				const $row = $(
+					'<div class="tree-hover-card-row flex items-center justify-between gap-3"></div>'
+				).appendTo($content);
+				$('<div class="text-sm text-ink-gray-6 shrink-0"></div>')
+					.text(label)
+					.appendTo($row);
+				$value.addClass("value text-sm text-ink-gray-7 truncate").appendTo($row);
+			};
+			rows.forEach(([label, value]) => {
+				// server-side frappe.format output (escaped/translated there)
+				add_row(__(label), $("<div></div>").html(value));
+			});
+			if ($balance && $balance.length) {
+				add_row(__("Balance"), $("<div></div>").text($balance.text().trim()));
+			}
+		}
+
+		return $content;
+	}
+
+	// ─── row mode: hover actions + context menu ────────────────────────────
+
+	setup_context_menu() {
+		this.context_node = null;
+		this.context_menu = new frappe.ui.ContextMenu({
+			target: this.wrapper,
+			options: () => this.get_node_menu_options(this.context_node),
+			on_open: (e) => {
+				const $link = $(e.target).closest(".tree-link");
+				this.context_node = $link.length ? $link.data("node") : null;
+			},
+		});
+	}
+
+	get_toolbar_items(node) {
+		// entries whose condition holds for this node, in declared order
+		return Object.values(this.toolbar || {}).filter(
+			(obj) => obj.label && (!obj.condition || obj.condition(node))
+		);
+	}
+
+	get_node_menu_options(node) {
+		if (!node) return [];
+		// inline entries (e.g. Edit) already have their own button beside the
+		// label — repeating them in the menu would be noise. Destructive
+		// entries (danger) sink to the end of the menu.
+		const items = this.get_toolbar_items(node).filter((obj) => !obj.inline);
+		items.sort((a, b) => (a.danger ? 1 : 0) - (b.danger ? 1 : 0));
+		return items.map((obj) => {
+			// an entry can explain why it's unavailable instead of hiding:
+			// get_disabled_reason(node) returning a string renders the row
+			// disabled with the reason as its description
+			const reason = obj.get_disabled_reason && obj.get_disabled_reason(node);
+			return {
+				label: obj.get_label ? obj.get_label() : obj.label,
+				icon: obj.icon,
+				theme: obj.danger ? "red" : undefined,
+				disabled: !!reason,
+				description: reason || undefined,
+				onclick: () => obj.click(node),
+			};
+		});
+	}
+
+	make_row_actions(node) {
+		const items = this.get_toolbar_items(node);
+		if (!items.length) return;
+
+		const $actions = $('<span class="tree-actions">').appendTo(node.$tree_link);
+
+		// entries flagged `inline` (with an icon) become hover icon-buttons
+		// beside the label; everything else collects under the ellipsis,
+		// which opens the same menu as right-click
+		const inline = items.filter((obj) => obj.inline && obj.icon);
+		const overflow = items.filter((obj) => !obj.inline);
+
+		inline.forEach((obj) => {
+			const label = obj.get_label ? obj.get_label() : obj.label;
+			$(
+				frappe.ui.button({
+					icon: obj.icon,
+					variant: "ghost",
+					size: "xs",
+					title: label,
+					onclick: (e) => {
+						e.stopPropagation();
+						obj.click(node);
+					},
+				})
+			).appendTo($actions);
+		});
+
+		if (overflow.length) {
+			const $more = $(
+				frappe.ui.button({
+					icon: "ellipsis",
+					variant: "ghost",
+					size: "xs",
+					title: __("More actions"),
+					onclick: (e) => {
+						e.stopPropagation();
+						this.context_node = node;
+						const rect = e.currentTarget.getBoundingClientRect();
+						this.context_menu.open_at(rect.left, rect.bottom + 2);
+					},
+				})
+			).appendTo($actions);
+			$more.addClass("tree-more-btn");
+		}
+
+		// keep clicks on the action strip from toggling the node
+		$actions.on("click", (e) => e.stopPropagation());
 	}
 
 	add_node(node, data) {
@@ -217,6 +484,9 @@ frappe.ui.Tree = class {
 
 		node.expanded = !node.expanded;
 		node.parent.toggleClass("opened", node.expanded);
+		if (node.expandable) {
+			node.$tree_link.attr("aria-expanded", String(!!node.expanded));
+		}
 	}
 
 	toggle_node(node) {
@@ -230,16 +500,15 @@ frappe.ui.Tree = class {
 				node.$ul.toggle(!node.expanded);
 			}
 
-			// open close icon
+			// open close icon — scoped to the toggle span (the row's first
+			// child); a bare .find(".icon") would also catch the icons inside
+			// the row's action buttons
 			if (this.icon_set) {
+				let $toggle = node.$tree_link.children().first();
 				if (!node.expanded) {
-					node.$tree_link.find(".icon").parent().html(this.icon_set.open);
+					$toggle.html(this.icon_set.open);
 				} else {
-					node.$tree_link
-						.find(".icon")
-						.parent()
-						.addClass("node-parent")
-						.html(this.icon_set.closed);
+					$toggle.addClass("node-parent").html(this.icon_set.closed);
 				}
 			}
 		}
@@ -295,14 +564,18 @@ frappe.ui.Tree = class {
 			}, 100);
 		});
 
-		node.$tree_link.hover(
-			function () {
-				$(this).parent().addClass("hover-active");
-			},
-			function () {
-				$(this).parent().removeClass("hover-active");
-			}
-		);
+		// row mode highlights via CSS :hover; the class is only for the
+		// legacy embedded layout (and import_tree_preview's copy of it)
+		if (!this.use_row_actions) {
+			node.$tree_link.hover(
+				function () {
+					$(this).parent().addClass("hover-active");
+				},
+				function () {
+					$(this).parent().removeClass("hover-active");
+				}
+			);
+		}
 	}
 
 	get_toolbar(node) {

--- a/frappe/public/js/frappe/ui/tree.js
+++ b/frappe/public/js/frappe/ui/tree.js
@@ -572,6 +572,9 @@ frappe.ui.Tree = class {
 	}
 
 	show_toolbar(node) {
+		// row-actions mode has no per-node $toolbar (actions are hover
+		// buttons + context menu), so this is a no-op there
+		if (!node.$toolbar) return;
 		if (this.cur_toolbar) $(this.cur_toolbar).hide();
 		this.cur_toolbar = node.$toolbar;
 		node.$toolbar.show();

--- a/frappe/public/js/frappe/ui/tree.js
+++ b/frappe/public/js/frappe/ui/tree.js
@@ -41,7 +41,6 @@ frappe.ui.Tree = class {
 		}
 		if (this.use_row_actions) {
 			this.wrapper.addClass("tree-has-row-actions");
-			this.setup_context_menu();
 		}
 
 		if (!icon_set) {
@@ -368,18 +367,6 @@ frappe.ui.Tree = class {
 
 	// ─── row mode: hover actions + context menu ────────────────────────────
 
-	setup_context_menu() {
-		this.context_node = null;
-		this.context_menu = new frappe.ui.ContextMenu({
-			target: this.wrapper,
-			options: () => this.get_node_menu_options(this.context_node),
-			on_open: (e) => {
-				const $link = $(e.target).closest(".tree-link");
-				this.context_node = $link.length ? $link.data("node") : null;
-			},
-		});
-	}
-
 	get_toolbar_items(node) {
 		// entries whose condition holds for this node, in declared order
 		return Object.values(this.toolbar || {}).filter(
@@ -439,6 +426,10 @@ frappe.ui.Tree = class {
 		});
 
 		if (overflow.length) {
+			node.context_menu = new frappe.ui.ContextMenu({
+				target: node.$tree_link,
+				options: () => this.get_node_menu_options(node),
+			});
 			const $more = $(
 				frappe.ui.button({
 					icon: "ellipsis",
@@ -447,9 +438,8 @@ frappe.ui.Tree = class {
 					title: __("More actions"),
 					onclick: (e) => {
 						e.stopPropagation();
-						this.context_node = node;
 						const rect = e.currentTarget.getBoundingClientRect();
-						this.context_menu.open_at(rect.left, rect.bottom + 2);
+						node.context_menu.open_at(rect.left, rect.bottom + 2);
 					},
 				})
 			).appendTo($actions);

--- a/frappe/public/js/frappe/ui/tree.js
+++ b/frappe/public/js/frappe/ui/tree.js
@@ -176,6 +176,10 @@ frappe.ui.Tree = class {
 	 */
 	get_expansion_state() {
 		if (!this.root_node.expanded) return "collapsed";
+		// root is open but its children are still loading (expand_node flips
+		// `expanded` before the async fetch renders them): there is something
+		// to expand, so report "collapsed" rather than a premature "none"
+		if (!this.root_node.loaded) return "collapsed";
 		const expandable = Object.values(this.nodes).filter(
 			(node) =>
 				node.expandable && !node.is_root && document.body.contains(node.$tree_link[0])

--- a/frappe/public/js/frappe/ui/tree.js
+++ b/frappe/public/js/frappe/ui/tree.js
@@ -461,14 +461,6 @@ frappe.ui.Tree = class {
 		});
 	}
 
-	reload_node(node) {
-		return this.load_children(node);
-	}
-
-	toggle() {
-		this.get_selected_node().toggle();
-	}
-
 	get_selected_node() {
 		return this.selected_node;
 	}

--- a/frappe/public/js/frappe/ui/tree.js
+++ b/frappe/public/js/frappe/ui/tree.js
@@ -16,6 +16,10 @@ frappe.ui.Tree = class {
 		// context menu instead of the click-injected button group. Embedded
 		// consumers (BOM Configurator, dialogs) keep the legacy behavior.
 		use_row_actions = false,
+		// the visual half of row mode only — rows, connectors, no leaf
+		// markers — without actions, menus, or hover cards. For read-only
+		// embedded previews (CoA importer, setup wizard).
+		row_style = false,
 
 		args,
 		method,
@@ -32,8 +36,11 @@ frappe.ui.Tree = class {
 		this.nodes = {};
 		this.wrapper = $('<div class="tree" role="tree">').appendTo(this.parent);
 		if (with_skeleton) this.wrapper.addClass("with-skeleton");
-		if (this.use_row_actions) {
+		if (this.use_row_actions || this.row_style) {
 			this.wrapper.addClass("tree-rows");
+		}
+		if (this.use_row_actions) {
+			this.wrapper.addClass("tree-has-row-actions");
 			this.setup_context_menu();
 		}
 
@@ -121,6 +128,63 @@ frappe.ui.Tree = class {
 
 	refresh() {
 		this.selected_node.parent_node && this.load_children(this.selected_node.parent_node, true);
+	}
+
+	/**
+	 * Show only nodes whose label or name contains `txt` (with their
+	 * ancestor paths); empty `txt` restores everything. Filters what is
+	 * currently rendered — deep-load first (load_children(root, true)) for
+	 * whole-tree coverage. Returns the match count, or null when cleared.
+	 */
+	filter_nodes(txt) {
+		txt = (txt || "").trim().toLowerCase();
+		const $wrapper = this.wrapper;
+
+		if (!txt) {
+			$wrapper.removeClass("tree-searching");
+			$wrapper.find("li.tree-node").show();
+			return null;
+		}
+
+		$wrapper.addClass("tree-searching");
+		const $nodes = $wrapper.find("li.tree-node");
+		$nodes.hide();
+
+		let matches = 0;
+		$nodes.each((i, li) => {
+			const $li = $(li);
+			const $link = $li.children(".tree-link");
+			// match the visible label AND the real name (data-label) — apps
+			// may display a cleaned label (e.g. account number as a badge)
+			const label =
+				($link.find(".tree-label").text() || "") + " " + ($link.attr("data-label") || "");
+			if (label.toLowerCase().includes(txt)) {
+				matches++;
+				// reveal the path to the match
+				$li.show();
+				$li.parentsUntil($wrapper, "li.tree-node").show();
+				$li.parents("ul.tree-children").show();
+			}
+		});
+		return matches;
+	}
+
+	/**
+	 * Overall expansion state, for expand/collapse-all controls:
+	 * "none" (nothing expandable), "collapsed", "expanded" or "partial".
+	 * A collapsed root hides every descendant, so their stale expanded flags
+	 * don't count.
+	 */
+	get_expansion_state() {
+		if (!this.root_node.expanded) return "collapsed";
+		const expandable = Object.values(this.nodes).filter(
+			(node) =>
+				node.expandable && !node.is_root && document.body.contains(node.$tree_link[0])
+		);
+		if (!expandable.length) return "none";
+		if (expandable.every((node) => node.expanded)) return "expanded";
+		if (expandable.every((node) => !node.expanded)) return "collapsed";
+		return "partial";
 	}
 
 	make_node_element(node) {
@@ -566,7 +630,7 @@ frappe.ui.Tree = class {
 
 		// row mode highlights via CSS :hover; the class is only for the
 		// legacy embedded layout (and import_tree_preview's copy of it)
-		if (!this.use_row_actions) {
+		if (!this.use_row_actions && !this.row_style) {
 			node.$tree_link.hover(
 				function () {
 					$(this).parent().addClass("hover-active");

--- a/frappe/public/js/frappe/views/reports/print_tree.html
+++ b/frappe/public/js/frappe/views/reports/print_tree.html
@@ -134,18 +134,7 @@
 				<path d="m15 18-6-6 6-6"></path>
 			</symbol>
 
-			<symbol viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg" id="icon-dot">
-				<path d="M9.5 6a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0z"></path>
-			</symbol>
 
-			<symbol viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" id="icon-folder-open">
-				<path d="M8.024 6.5H3a.5.5 0 0 0-.5.5v8a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2V9.5A.5.5 0 0 0 17 9h-6.783a.5.5 0 0 1-.417-.224L8.441 6.724a.5.5 0 0 0-.417-.224z" stroke="var(--icon-stroke)" stroke-miterlimit="10" stroke-linecap="square"></path>
-				<path d="M3.88 4.5v-1a.5.5 0 0 1 .5-.5h11.24a.5.5 0 0 1 .5.5V7" stroke="var(--icon-stroke)" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"></path>
-			</symbol>
-
-			<symbol viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" id="icon-folder">
-				<path d="M2.5 4v10a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2V6.5a1 1 0 0 0-1-1h-6.283a.5.5 0 0 1-.417-.224L8.441 3.224A.5.5 0 0 0 8.024 3H3.5a1 1 0 0 0-1 1z" stroke="var(--icon-stroke)" stroke-miterlimit="10" stroke-linecap="square"></path>
-			</symbol>
 		</svg>
 		<div class="print-format-gutter">
 			{% if print_settings.repeat_header_footer %}

--- a/frappe/public/js/frappe/views/reports/print_tree.html
+++ b/frappe/public/js/frappe/views/reports/print_tree.html
@@ -8,50 +8,132 @@
 		<meta name="author" content="">
 		<title>{{ title }}</title>
 		<link href="{{ base_url }}/assets/frappe/css/bootstrap.css" rel="stylesheet">
-		<link rel="stylesheet" type="text/css" href="{{ base_url }}/assets/frappe/css/tree.css">
 		<link rel="stylesheet" type="text/css" href="{{ base_url }}{{ print_format_css_path }}">
 		<style>
 			{{ print_css }}
 		</style>
 		<style>
-			.tree.opened::before,
-			.tree-node.opened::before,
-			.tree:last-child::after,
-			.tree-node:last-child::after {
-				z-index: 1;
-				border-left: 1px solid #d1d8dd;
-				background: none;
+			/* Self-contained print styles for the row-mode tree markup.
+			   This page loads no desk CSS, so colors are literal (no espresso
+			   vars here) and :has() is avoided (unsupported by the old WebKit
+			   in wkhtmltopdf). NOTE: this file compiles through the frappe
+			   microtemplate engine, which cannot handle single quotes in
+			   static text — never use apostrophes here. */
+			.tree {
+				font-size: 13px;
+				color: #1c2126;
+			}
+			.tree ul {
+				margin: 0;
+				padding: 0;
+				list-style: none;
 			}
 			.tree a,
 			.tree-link {
 				text-decoration: none;
+				color: inherit;
 				cursor: default;
 			}
-			.tree.opened > .tree-children > .tree-node > .tree-link::before,
-			.tree-node.opened > .tree-children > .tree-node > .tree-link::before {
-				border-top: 1px solid #d1d8dd;
-				z-index: 1;
-				background: none;
+			li.tree-node {
+				display: flex;
+				flex-wrap: wrap;
+				align-items: center;
+				margin: 0;
 			}
-			svg.icon {
-				z-index: 2;
+			.tree-link {
+				display: flex;
+				flex: 1 1 0%;
+				min-width: 0;
+				align-items: center;
+				min-height: 26px;
+				padding: 2px 8px;
+			}
+			/* icon slot: chevron for groups, empty for leaves (alignment) */
+			.tree-link > span:first-child {
+				flex: none;
+				width: 20px;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+			}
+			.tree-link > span:first-child:not(.node-parent) svg {
+				display: none;
+			}
+			.tree-link svg {
+				width: 14px;
+				height: 14px;
+				stroke: #74808b;
+				fill: none;
+				stroke-width: 1.5;
+				stroke-linecap: round;
+				stroke-linejoin: round;
+			}
+			.tree-label {
+				margin-left: 4px;
+				min-width: 0;
+			}
+			/* elbow guides — same geometry as the screen styles */
+			ul.tree-children {
+				flex: 1 1 100%;
+				padding-left: 24px;
+			}
+			ul.tree-children > li.tree-node {
 				position: relative;
 			}
-			.tree:last-child::after, .tree-node:last-child::after {
-				display: none;
+			ul.tree-children > li.tree-node::before {
+				content: "";
+				position: absolute;
+				left: -6px;
+				top: 0;
+				height: 13px;
+				width: 12px;
+				border-left: 1px solid #d1d8dd;
+				border-bottom: 1px solid #d1d8dd;
 			}
-			.tree-node-toolbar {
-				display: none;
+			ul.tree-children > li.tree-node:not(:last-child)::after {
+				content: "";
+				position: absolute;
+				left: -6px;
+				top: 13px;
+				bottom: 0;
+				border-left: 1px solid #d1d8dd;
 			}
-			@media (max-width: 767px) {
-				ul.tree-children {
-					padding-left: 20px;
-				}
+			ul.tree-children > li.tree-node > .tree-link {
+				margin-left: 6px;
+				padding-left: 2px;
+			}
+			/* value column (balances) at the right edge of the row */
+			li.tree-node > .balance-area {
+				float: none;
+				flex: none;
+				margin-left: auto;
+				padding: 2px 8px;
+				font-variant-numeric: tabular-nums;
+				white-space: nowrap;
+				color: #383e42;
+			}
+			/* interactive chrome has no place on paper */
+			.tree-node-toolbar,
+			.tree-actions,
+			.es-button {
+				display: none;
 			}
 		</style>
   	</head>
 	<body>
 		<svg id="frappe-symbols" aria-hidden="true" style="position: absolute; width: 0; height: 0; overflow: hidden;" class="d-block" xmlns="http://www.w3.org/2000/svg">
+			<symbol viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" id="icon-chevron-down">
+				<path d="m6 9 6 6 6-6"></path>
+			</symbol>
+
+			<symbol viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" id="icon-chevron-right">
+				<path d="m9 18 6-6-6-6"></path>
+			</symbol>
+
+			<symbol viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" id="icon-chevron-left">
+				<path d="m15 18-6-6 6-6"></path>
+			</symbol>
+
 			<symbol viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg" id="icon-dot">
 				<path d="M9.5 6a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0z"></path>
 			</symbol>
@@ -85,7 +167,7 @@
 					<div class="letter-head">{{ print_settings.letter_head.header }}</div>
 				</div>
 					{% endif %}
-					<div class="tree opened">
+					<div class="tree tree-rows opened">
 						{{ tree }}
 					</div>
 			</div>

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -188,29 +188,32 @@ frappe.views.TreeView = class TreeView {
 			).appendTo(this.page.page_form);
 			// don't return the load promise from onclick — the button would
 			// show its busy spinner on every toggle
-			this.$expand_all_btn = $(
-				frappe.ui.button({
-					label: __("Expand All"),
-					icon: "chevrons-up-down",
-					onclick: () => {
-						me.tree.load_children(me.tree.root_node, true);
-					},
-				})
-			).appendTo($actions);
-			this.$collapse_all_btn = $(
-				frappe.ui.button({
-					label: __("Collapse All"),
-					icon: "chevrons-down-up",
-					onclick: () => {
-						me.tree.load_children(me.tree.root_node, false);
-					},
-				})
-			).appendTo($actions);
-
-			// stay hidden until the tree renders — the applicable one is
-			// shown by update_expand_collapse_buttons
-			this.$expand_all_btn.hide();
-			this.$collapse_all_btn.hide();
+			// icon-only; both stay in the layout permanently — the
+			// non-applicable one is disabled instead of hidden, so nothing
+			// ever shifts. The espresso tooltip sits on a wrapper: a disabled
+			// es-button has pointer-events:none, so hover falls through to
+			// the wrapper and the tooltip still explains the button.
+			const make_action = (icon, label, onclick) => {
+				const $btn = $(
+					frappe.ui.button({
+						icon,
+						disabled: true,
+						onclick,
+						attrs: { "aria-label": label },
+					})
+				);
+				const $wrapper = $('<span class="inline-flex"></span>')
+					.append($btn)
+					.appendTo($actions);
+				frappe.ui.tooltip($wrapper, { text: label });
+				return $btn;
+			};
+			this.$expand_all_btn = make_action("chevrons-up-down", __("Expand All"), () => {
+				me.tree.load_children(me.tree.root_node, true);
+			});
+			this.$collapse_all_btn = make_action("chevrons-down-up", __("Collapse All"), () => {
+				me.tree.load_children(me.tree.root_node, false);
+			});
 		}
 	}
 	set_title() {
@@ -364,6 +367,7 @@ frappe.views.TreeView = class TreeView {
 			root_value: use_value,
 			expandable: true,
 			use_row_actions: !this.opts.do_not_make_page,
+			row_style: this.opts.row_style,
 
 			args: this.args,
 			method: this.get_tree_nodes,
@@ -409,32 +413,20 @@ frappe.views.TreeView = class TreeView {
 			return false;
 		});
 	}
-	get_expandable_nodes() {
-		return Object.values(this.tree.nodes).filter(
-			(node) =>
-				node.expandable && !node.is_root && document.body.contains(node.$tree_link[0])
-		);
-	}
 	update_expand_collapse_buttons() {
 		if (!this.opts.show_expand_all || !this.tree) return;
 
-		if (!this.tree.root_node.expanded) {
-			// root collapsed hides every descendant, so their stale expanded
-			// flags (from before the root was closed) don't reflect what's
-			// actually visible; only offer to expand back out
-			this.$collapse_all_btn && this.$collapse_all_btn.hide();
-			this.$expand_all_btn && this.$expand_all_btn.show();
-			return;
-		}
-
-		let expandable_nodes = this.get_expandable_nodes();
-		let has_expandable_nodes = expandable_nodes.length > 0;
-		let all_expanded = has_expandable_nodes && expandable_nodes.every((node) => node.expanded);
-
-		// exactly one button at a time: Expand All until everything is open,
-		// then Collapse All
-		this.$collapse_all_btn && this.$collapse_all_btn.toggle(all_expanded);
-		this.$expand_all_btn && this.$expand_all_btn.toggle(has_expandable_nodes && !all_expanded);
+		// fully collapsed → Expand All; fully expanded → Collapse All;
+		// partially expanded → both. The inapplicable button disables
+		// instead of hiding so the layout never shifts.
+		const state = this.tree.get_expansion_state();
+		this.$expand_all_btn &&
+			this.$expand_all_btn.prop("disabled", !(state === "collapsed" || state === "partial"));
+		this.$collapse_all_btn &&
+			this.$collapse_all_btn.prop(
+				"disabled",
+				!(state === "expanded" || state === "partial")
+			);
 	}
 	reset_search() {
 		this.search_deep_loaded = false;
@@ -447,12 +439,10 @@ frappe.views.TreeView = class TreeView {
 		this.search_text = txt;
 		if (!this.tree) return;
 
-		const $wrapper = this.tree.wrapper;
 		this.$search_empty_state && this.$search_empty_state.remove();
 
 		if (!txt) {
-			$wrapper.removeClass("tree-searching");
-			$wrapper.find("li.tree-node").show();
+			this.tree.filter_nodes("");
 			return;
 		}
 
@@ -460,28 +450,7 @@ frappe.views.TreeView = class TreeView {
 			// a newer keystroke superseded this one while the deep load ran
 			if (this.search_text !== txt) return;
 
-			$wrapper.addClass("tree-searching");
-			const $nodes = $wrapper.find("li.tree-node");
-			$nodes.hide();
-
-			let matches = 0;
-			$nodes.each((i, li) => {
-				const $li = $(li);
-				const $link = $li.children(".tree-link");
-				// match the visible label AND the real name (data-label) — apps
-				// may display a cleaned label (e.g. account number as a badge)
-				const label =
-					($link.find(".tree-label").text() || "") +
-					" " +
-					($link.attr("data-label") || "");
-				if (label.toLowerCase().includes(txt)) {
-					matches++;
-					$li.show();
-					// reveal the path to the match
-					$li.parentsUntil($wrapper, "li.tree-node").show();
-					$li.parents("ul.tree-children").show();
-				}
-			});
+			const matches = this.tree.filter_nodes(txt);
 
 			if (matches === 0) {
 				this.$search_empty_state = $(

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -652,21 +652,15 @@ frappe.views.TreeView = class TreeView {
 					// values are validated server-side
 					ignore_link_validation: 1,
 					get_query: () => {
-						// only groups (where the doctype has them), never the
-						// node or its subtree
-						const filters = { name: ["not in", excluded] };
+						// candidates = nodes the tree rendered (already
+						// server-filtered), minus the node's own subtree
+						const names = Object.values(me.tree.nodes)
+							.filter((n) => !n.is_root && !excluded.includes(n.label))
+							.map((n) => n.label);
+						const filters = { name: ["in", names] };
 						if (frappe.meta.has_field(me.doctype, "is_group")) {
 							filters.is_group = 1;
 						}
-						Object.keys(me.args).forEach((key) => {
-							if (
-								key !== "doctype" &&
-								me.args[key] &&
-								frappe.meta.has_field(me.doctype, key)
-							) {
-								filters[key] = me.args[key];
-							}
-						});
 						return { filters };
 					},
 				},

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -340,6 +340,34 @@ frappe.views.TreeView = class TreeView {
 		this.$tree_skeleton = null;
 		this.tree && this.tree.wrapper.show();
 	}
+	update_tree_empty_state() {
+		// once the root has loaded, a tree with no child nodes reads as a lone
+		// bare root; show a quiet in-body prompt beneath it instead. Guarded on
+		// root.loaded so it never flashes while children are still loading.
+		this.$tree_empty_state && this.$tree_empty_state.remove();
+		this.$tree_empty_state = null;
+
+		const root = this.tree && this.tree.root_node;
+		if (!this.body || !root || !root.loaded) return;
+		if (root.$ul && root.$ul.children().length) return;
+
+		const opts = {
+			icon: "list-tree",
+			title: __("No {0} records yet", [__(this.doctype)]),
+			description: __("Records you add will appear here."),
+		};
+		this.$tree_empty_state = (
+			frappe.ui.empty_state
+				? frappe.ui.empty_state(opts)
+				: $(
+						`<div class="text-muted text-center" style="padding: 40px 0;">${frappe.utils.escape_html(
+							opts.title
+						)}</div>`
+				  )
+		)
+			.addClass("tree-empty-state")
+			.appendTo(this.body);
+	}
 	make_tree() {
 		// remember open nodes across rebuilds (see restore_expanded_nodes)
 		this._expanded_labels = this.tree
@@ -349,6 +377,8 @@ frappe.views.TreeView = class TreeView {
 			: [];
 
 		$(this.parent).find(".tree").remove();
+		this.$tree_empty_state && this.$tree_empty_state.remove();
+		this.$tree_empty_state = null;
 		this.reset_search();
 		this.show_tree_skeleton();
 
@@ -363,7 +393,8 @@ frappe.views.TreeView = class TreeView {
 			label: use_label,
 			root_value: use_value,
 			expandable: true,
-			use_row_actions: !this.opts.do_not_make_page,
+			// page trees get full row actions; embedded trees opt in explicitly
+			use_row_actions: this.opts.use_row_actions ?? !this.opts.do_not_make_page,
 			row_style: this.opts.row_style,
 
 			args: this.args,
@@ -378,6 +409,7 @@ frappe.views.TreeView = class TreeView {
 			on_node_render: (node, deep) => {
 				this.hide_tree_skeleton();
 				this.restore_expanded_nodes();
+				this.update_tree_empty_state();
 				this.opts.on_node_render && this.opts.on_node_render(node, deep);
 			},
 			on_click: (node) => {

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -186,31 +186,33 @@ frappe.views.TreeView = class TreeView {
 			let $actions = $(
 				'<div class="tree-toolbar-actions ms-auto flex items-center gap-1 py-1"></div>'
 			).appendTo(this.page.page_form);
-			frappe.ui.dropdown({
-				button: { label: __("Expand/Collapse"), icon_right: "chevron-down" },
-				align: "end",
-				options: () => {
-					const state = this.tree ? this.tree.get_expansion_state() : "none";
-					return [
-						{
-							label: __("Expand All"),
-							icon: "copy-plus",
-							disabled: !(state === "collapsed" || state === "partial"),
-							onclick: () => {
-								this.tree.load_children(this.tree.root_node, true);
+			frappe.ui
+				.dropdown({
+					button: { label: __("Expand/Collapse"), icon_right: "chevron-down" },
+					align: "end",
+					options: () => {
+						const state = this.tree ? this.tree.get_expansion_state() : "none";
+						return [
+							{
+								label: __("Expand All"),
+								icon: "copy-plus",
+								disabled: !(state === "collapsed" || state === "partial"),
+								onclick: () => {
+									this.tree.load_children(this.tree.root_node, true);
+								},
 							},
-						},
-						{
-							label: __("Collapse All"),
-							icon: "copy-minus",
-							disabled: !(state === "expanded" || state === "partial"),
-							onclick: () => {
-								this.tree.load_children(this.tree.root_node, false);
+							{
+								label: __("Collapse All"),
+								icon: "copy-minus",
+								disabled: !(state === "expanded" || state === "partial"),
+								onclick: () => {
+									this.tree.load_children(this.tree.root_node, false);
+								},
 							},
-						},
-					];
-				},
-			}).appendTo($actions);
+						];
+					},
+				})
+				.appendTo($actions);
 		}
 	}
 	set_title() {

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -186,34 +186,31 @@ frappe.views.TreeView = class TreeView {
 			let $actions = $(
 				'<div class="tree-toolbar-actions ms-auto flex items-center gap-1 py-1"></div>'
 			).appendTo(this.page.page_form);
-			// don't return the load promise from onclick — the button would
-			// show its busy spinner on every toggle
-			// icon-only; both stay in the layout permanently — the
-			// non-applicable one is disabled instead of hidden, so nothing
-			// ever shifts. The espresso tooltip sits on a wrapper: a disabled
-			// es-button has pointer-events:none, so hover falls through to
-			// the wrapper and the tooltip still explains the button.
-			const make_action = (icon, label, onclick) => {
-				const $btn = $(
-					frappe.ui.button({
-						icon,
-						disabled: true,
-						onclick,
-						attrs: { "aria-label": label },
-					})
-				);
-				const $wrapper = $('<span class="inline-flex"></span>')
-					.append($btn)
-					.appendTo($actions);
-				frappe.ui.tooltip($wrapper, { text: label });
-				return $btn;
-			};
-			this.$expand_all_btn = make_action("chevrons-up-down", __("Expand All"), () => {
-				me.tree.load_children(me.tree.root_node, true);
-			});
-			this.$collapse_all_btn = make_action("chevrons-down-up", __("Collapse All"), () => {
-				me.tree.load_children(me.tree.root_node, false);
-			});
+			this.$expand_collapse_dropdown = frappe.ui.dropdown({
+				button: { label: __("Expand/Collapse"), icon_right: "chevron-down" },
+				align: "end",
+				options: () => {
+					const state = this.tree ? this.tree.get_expansion_state() : "none";
+					return [
+						{
+							label: __("Expand All"),
+							icon: "copy-plus",
+							disabled: !(state === "collapsed" || state === "partial"),
+							onclick: () => {
+								me.tree.load_children(me.tree.root_node, true);
+							},
+						},
+						{
+							label: __("Collapse All"),
+							icon: "copy-minus",
+							disabled: !(state === "expanded" || state === "partial"),
+							onclick: () => {
+								me.tree.load_children(me.tree.root_node, false);
+							},
+						},
+					];
+				},
+			}).appendTo($actions);
 		}
 	}
 	set_title() {
@@ -382,13 +379,9 @@ frappe.views.TreeView = class TreeView {
 				this.hide_tree_skeleton();
 				this.restore_expanded_nodes();
 				this.opts.on_node_render && this.opts.on_node_render(node, deep);
-				this.update_expand_collapse_buttons();
 			},
 			on_click: (node) => {
 				this.select_node(node);
-				// node.expanded is flipped synchronously right after this callback
-				// runs, so defer the state check to the next tick
-				setTimeout(() => this.update_expand_collapse_buttons(), 0);
 			},
 		});
 
@@ -412,21 +405,6 @@ frappe.views.TreeView = class TreeView {
 			this.tree.load_children(node);
 			return false;
 		});
-	}
-	update_expand_collapse_buttons() {
-		if (!this.opts.show_expand_all || !this.tree) return;
-
-		// fully collapsed → Expand All; fully expanded → Collapse All;
-		// partially expanded → both. The inapplicable button disables
-		// instead of hiding so the layout never shifts.
-		const state = this.tree.get_expansion_state();
-		this.$expand_all_btn &&
-			this.$expand_all_btn.prop("disabled", !(state === "collapsed" || state === "partial"));
-		this.$collapse_all_btn &&
-			this.$collapse_all_btn.prop(
-				"disabled",
-				!(state === "expanded" || state === "partial")
-			);
 	}
 	reset_search() {
 		this.search_deep_loaded = false;
@@ -801,7 +779,12 @@ frappe.views.TreeView = class TreeView {
 			frappe.msgprint(__("You are not allowed to print this report"));
 			return false;
 		}
-		var tree = $(".tree:visible").html();
+		// clone so the interactive chrome (hover action buttons) can be
+		// stripped without touching the live tree — a static print page has
+		// no use for buttons
+		var $print_tree = $(".tree:visible").clone();
+		$print_tree.find(".tree-actions").remove();
+		var tree = $print_tree.html();
 		var me = this;
 		frappe.ui.get_print_settings(false, function (print_settings) {
 			var title = __(me.docname || me.doctype);

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -47,6 +47,28 @@ frappe.views.TreeFactory = class TreeFactory extends frappe.views.Factory {
 	}
 };
 
+/**
+ * The standard view switcher, mounted on the tree page header so Tree keeps
+ * the same header anatomy as the list-family views (and switching back
+ * doesn't require digging through the ... menu).
+ */
+frappe.views.TreeViewSelect = class TreeViewSelect extends frappe.views.ListViewSelect {
+	set_current_view() {
+		// tree routes are ["Tree", doctype], not [doctype, "view", <name>],
+		// so the route-based detection in ListViewSelect would report "List"
+		this.current_view = "Tree";
+	}
+
+	set_route(view, calendar_name) {
+		// the tree page has no search box, so unlike the list switcher don't
+		// carry cur_list's search params — cur_list here is whatever list was
+		// visited last, possibly another doctype's
+		const route = [this.slug(), "view", view];
+		if (calendar_name) route.push(calendar_name);
+		frappe.set_route(route);
+	}
+};
+
 frappe.views.TreeView = class TreeView {
 	constructor(opts) {
 		var me = this;
@@ -104,54 +126,115 @@ frappe.views.TreeView = class TreeView {
 			);
 
 			this.set_title();
+			this.setup_view_switcher();
+
+			// same reload affordance as the list views' default secondary action
+			this.page.add_action_icon(
+				"refresh-cw",
+				() => {
+					this.make_tree();
+				},
+				"",
+				__("Reload Tree")
+			);
 
 			this.page.main.css({
 				"min-height": "300px",
 			});
 
-			this.page.main.addClass("frappe-card");
+			this.make_tree_toolbar();
+
+			if (this.opts.view_template) {
+				var row = $('<div class="row"><div>').appendTo(this.page.main);
+				this.body = $('<div class="col-sm-6 col-xs-12"></div>').appendTo(row);
+				this.node_view = $('<div class="col-sm-6 hidden-xs"></div>').appendTo(row);
+			} else {
+				this.body = $('<div class="tree-view-body"></div>').appendTo(this.page.main);
+			}
 		} else {
 			this.page = this.opts.page;
 			$(this.page[0]).addClass("frappe-card");
+			this.body = this.page.main;
 		}
+	}
+	make_tree_toolbar() {
+		var me = this;
 
-		if (frappe.meta.has_field(me.doctype, "disabled")) {
-			this.page.add_inner_button(
-				__("Include Disabled"),
-				function () {
-					me.toggle_disable(event.target);
-					me.make_tree();
-				},
-				__("Expand"),
-				"default",
-				true
-			);
-		}
+		// same filter-bar anatomy as the list views: page_form holding a
+		// .standard-filter-section, fields added through page.add_field
+		this.page.page_form.removeClass("row").addClass("flex");
+		this.$filter_area = $('<div class="standard-filter-section flex"></div>').appendTo(
+			this.page.page_form
+		);
+
+		// the same name filter every list view leads with
+		let search_field = this.page.add_field(
+			{
+				fieldtype: "Data",
+				fieldname: "tree_search",
+				label: __("ID"),
+			},
+			this.$filter_area
+		);
+		this.$search_input = search_field.$input;
+		this.$search_input.on(
+			"input",
+			frappe.utils.debounce(() => this.apply_search(search_field.get_value()), 300)
+		);
 
 		if (this.opts.show_expand_all) {
-			this.$collapse_all_btn = this.page
-				.add_menu_item(__("Collapse All"), function () {
-					me.tree.load_children(me.tree.root_node, false);
+			let $actions = $(
+				'<div class="tree-toolbar-actions ms-auto flex items-center gap-1 py-1"></div>'
+			).appendTo(this.page.page_form);
+			// don't return the load promise from onclick — the button would
+			// show its busy spinner on every toggle
+			this.$expand_all_btn = $(
+				frappe.ui.button({
+					label: __("Expand All"),
+					icon: "chevrons-up-down",
+					onclick: () => {
+						me.tree.load_children(me.tree.root_node, true);
+					},
 				})
-				.parent();
-
-			this.$expand_all_btn = this.page
-				.add_menu_item(__("Expand All"), function () {
-					me.tree.load_children(me.tree.root_node, true);
+			).appendTo($actions);
+			this.$collapse_all_btn = $(
+				frappe.ui.button({
+					label: __("Collapse All"),
+					icon: "chevrons-down-up",
+					onclick: () => {
+						me.tree.load_children(me.tree.root_node, false);
+					},
 				})
-				.parent();
-		}
+			).appendTo($actions);
 
-		if (this.opts.view_template) {
-			var row = $('<div class="row"><div>').appendTo(this.page.main);
-			this.body = $('<div class="col-sm-6 col-xs-12"></div>').appendTo(row);
-			this.node_view = $('<div class="col-sm-6 hidden-xs"></div>').appendTo(row);
-		} else {
-			this.body = this.page.main;
+			// stay hidden until the tree renders — the applicable one is
+			// shown by update_expand_collapse_buttons
+			this.$expand_all_btn.hide();
+			this.$collapse_all_btn.hide();
 		}
 	}
 	set_title() {
 		this.page.set_title(this.opts.title || __("{0} Tree", [__(this.doctype)]));
+	}
+	setup_view_switcher() {
+		if (
+			!frappe.boot.desk_settings.view_switcher ||
+			this.opts.meta?.force_re_route_to_default_view
+		) {
+			return;
+		}
+		// ListViewSelect only needs meta and settings from its list_view —
+		// hand it a minimal adapter since there is no list view on this page
+		this.views_list = new frappe.views.TreeViewSelect({
+			doctype: this.doctype,
+			page: this.page,
+			list_view: {
+				meta: this.opts.meta || frappe.get_meta(this.doctype),
+				settings: frappe.listview_settings[this.doctype] || {},
+			},
+			icon_map: frappe.views.get_view_icon_map(),
+			label_map: frappe.views.get_view_label_map(),
+		});
 	}
 	onload() {
 		var me = this;
@@ -159,7 +242,6 @@ frappe.views.TreeView = class TreeView {
 	}
 	make_filters() {
 		var me = this;
-		frappe.treeview_settings.filters = [];
 		$.each(this.opts.filters || [], function (i, filter) {
 			if (frappe.route_options && frappe.route_options[filter.fieldname]) {
 				filter.default = frappe.route_options[filter.fieldname];
@@ -180,16 +262,37 @@ frappe.views.TreeView = class TreeView {
 				};
 			}
 
-			if (filter.render_on_toolbar) {
-				me.page.add_field(filter, me.page.filters);
-			} else {
-				me.page.add_field(filter);
-			}
+			// every filter renders in the tree filter bar; render_on_toolbar is
+			// accepted for backward compatibility but no longer changes
+			// placement. Fields still register in page.fields_dict, which
+			// apps read (e.g. page.fields_dict.company.get_value()).
+			var field = me.page.add_field(filter, me.$filter_area || me.page.filters);
 
 			if (filter.default) {
-				$("[data-fieldname='" + filter.fieldname + "']").trigger("change");
+				if (field && field.$input) {
+					field.$input.trigger("change");
+				} else {
+					$("[data-fieldname='" + filter.fieldname + "']").trigger("change");
+				}
 			}
 		});
+
+		// disabled records toggle — a checkbox in the filter bar, the way
+		// list views render Check standard filters
+		if (!this.opts.do_not_make_page && frappe.meta.has_field(this.doctype, "disabled")) {
+			let field = me.page.add_field(
+				{
+					fieldname: "include_disabled",
+					fieldtype: "Check",
+					label: __("Show all (including disabled)"),
+					change: function () {
+						me.args["include_disabled"] = cint(field.get_value());
+						me.make_tree();
+					},
+				},
+				me.$filter_area
+			);
+		}
 	}
 	get_root() {
 		var me = this;
@@ -212,18 +315,42 @@ frappe.views.TreeView = class TreeView {
 			},
 		});
 	}
-	toggle_disable(el) {
-		if (this.args["include_disabled"]) {
-			this.args["include_disabled"] = false;
-			el.innerText = el.innerText.replace("Exclude", "Include");
-		} else {
-			this.args["include_disabled"] = true;
-			console.log(el);
-			el.innerText = el.innerText.replace("Include", "Exclude");
-		}
+	show_tree_skeleton() {
+		if (!this.body || this.opts.do_not_make_page) return;
+		this.hide_tree_skeleton();
+		const row = (indent, width) => `
+			<div class="flex items-center gap-2.5" style="height: 32px; padding-left: ${indent}px">
+				${frappe.ui.skeleton.html({ width: "14px", height: "14px" })}
+				${frappe.ui.skeleton.html({ width: width, height: "13px" })}
+			</div>`;
+		this.$tree_skeleton = $(`
+			<div class="tree-skeleton p-1" aria-busy="true" aria-label="${__("Loading")}">
+				${row(8, "90px")}
+				${row(32, "220px")}
+				${row(32, "180px")}
+				${row(32, "240px")}
+				${row(32, "160px")}
+			</div>
+		`).appendTo(this.body);
+	}
+	hide_tree_skeleton() {
+		this.$tree_skeleton && this.$tree_skeleton.remove();
+		this.$tree_skeleton = null;
+		this.tree && this.tree.wrapper.show();
 	}
 	make_tree() {
+		// a rebuild (filter change, Include Disabled, reload) must not cost
+		// the user their expansion — remember what was open and restore it
+		// as the nodes reappear (see restore_expanded_nodes)
+		this._expanded_labels = this.tree
+			? Object.values(this.tree.nodes)
+					.filter((node) => node.expanded && !node.is_root)
+					.map((node) => node.label)
+			: [];
+
 		$(this.parent).find(".tree").remove();
+		this.reset_search();
+		this.show_tree_skeleton();
 
 		var use_label = this.args[this.opts.root_label] || this.root_label || this.opts.root_label;
 		var use_value = this.root_value;
@@ -236,17 +363,20 @@ frappe.views.TreeView = class TreeView {
 			label: use_label,
 			root_value: use_value,
 			expandable: true,
+			use_row_actions: !this.opts.do_not_make_page,
 
 			args: this.args,
 			method: this.get_tree_nodes,
 
-			// array of button props: {label, condition, click, btnClass}
+			// array of button props: {label, condition, click, btnClass, icon}
 			toolbar: this.get_toolbar(),
 
 			get_label: this.opts.get_label,
 			on_render: this.opts.onrender,
 			on_get_node: this.opts.on_get_node,
 			on_node_render: (node, deep) => {
+				this.hide_tree_skeleton();
+				this.restore_expanded_nodes();
 				this.opts.on_node_render && this.opts.on_node_render(node, deep);
 				this.update_expand_collapse_buttons();
 			},
@@ -258,9 +388,26 @@ frappe.views.TreeView = class TreeView {
 			},
 		});
 
+		// the skeleton stands in until the first render
+		if (this.$tree_skeleton) {
+			this.tree.wrapper.hide();
+		}
+
 		cur_tree = this.tree;
 		cur_tree.view_name = "Tree";
 		this.post_render();
+	}
+	restore_expanded_nodes() {
+		if (!this._expanded_labels?.length || !this.tree) return;
+		this._expanded_labels = this._expanded_labels.filter((label) => {
+			const node = this.tree.nodes[label];
+			// not rendered yet — it may appear when an ancestor opens
+			if (!node) return true;
+			if (!node.expandable || node.expanded) return false;
+			if (!document.body.contains(node.$tree_link[0])) return true;
+			this.tree.load_children(node);
+			return false;
+		});
 	}
 	get_expandable_nodes() {
 		return Object.values(this.tree.nodes).filter(
@@ -283,15 +430,81 @@ frappe.views.TreeView = class TreeView {
 		let expandable_nodes = this.get_expandable_nodes();
 		let has_expandable_nodes = expandable_nodes.length > 0;
 		let all_expanded = has_expandable_nodes && expandable_nodes.every((node) => node.expanded);
-		let all_collapsed =
-			has_expandable_nodes && expandable_nodes.every((node) => !node.expanded);
 
-		this.$collapse_all_btn &&
-			this.$collapse_all_btn.toggle(has_expandable_nodes && !all_collapsed);
+		// exactly one button at a time: Expand All until everything is open,
+		// then Collapse All
+		this.$collapse_all_btn && this.$collapse_all_btn.toggle(all_expanded);
 		this.$expand_all_btn && this.$expand_all_btn.toggle(has_expandable_nodes && !all_expanded);
 	}
-	toggle_label() {
-		console.log("hello");
+	reset_search() {
+		this.search_deep_loaded = false;
+		this.$search_input && this.$search_input.val("");
+		this.$search_empty_state && this.$search_empty_state.remove();
+		this.tree && this.tree.wrapper.removeClass("tree-searching");
+	}
+	apply_search(txt) {
+		txt = (txt || "").trim().toLowerCase();
+		this.search_text = txt;
+		if (!this.tree) return;
+
+		const $wrapper = this.tree.wrapper;
+		this.$search_empty_state && this.$search_empty_state.remove();
+
+		if (!txt) {
+			$wrapper.removeClass("tree-searching");
+			$wrapper.find("li.tree-node").show();
+			return;
+		}
+
+		const run = () => {
+			// a newer keystroke superseded this one while the deep load ran
+			if (this.search_text !== txt) return;
+
+			$wrapper.addClass("tree-searching");
+			const $nodes = $wrapper.find("li.tree-node");
+			$nodes.hide();
+
+			let matches = 0;
+			$nodes.each((i, li) => {
+				const $li = $(li);
+				const $link = $li.children(".tree-link");
+				// match the visible label AND the real name (data-label) — apps
+				// may display a cleaned label (e.g. account number as a badge)
+				const label =
+					($link.find(".tree-label").text() || "") +
+					" " +
+					($link.attr("data-label") || "");
+				if (label.toLowerCase().includes(txt)) {
+					matches++;
+					$li.show();
+					// reveal the path to the match
+					$li.parentsUntil($wrapper, "li.tree-node").show();
+					$li.parents("ul.tree-children").show();
+				}
+			});
+
+			if (matches === 0) {
+				this.$search_empty_state = $(
+					frappe.ui.empty_state({
+						icon: "search",
+						title: __("No matching records"),
+						description: __("Try a different search."),
+					})
+				).appendTo(this.body);
+			}
+		};
+
+		if (this.search_deep_loaded) {
+			run();
+			return;
+		}
+		frappe.dom.freeze(__("Loading full tree..."));
+		Promise.resolve(this.tree.load_children(this.tree.root_node, true))
+			.then(() => {
+				this.search_deep_loaded = true;
+				run();
+			})
+			.finally(() => frappe.dom.unfreeze());
 	}
 	rebuild_tree() {
 		let me = this;
@@ -334,6 +547,10 @@ frappe.views.TreeView = class TreeView {
 		var toolbar = [
 			{
 				label: __(me.can_write ? "Edit" : "Details"),
+				icon: "pencil",
+				// renders as the hover icon-button beside the label, so it
+				// stays out of the row's ... menu
+				inline: true,
 				condition: function (node) {
 					return !node.is_root && me.can_read;
 				},
@@ -343,6 +560,7 @@ frappe.views.TreeView = class TreeView {
 			},
 			{
 				label: __("Add Child"),
+				icon: "plus",
 				condition: function (node) {
 					return me.can_create && node.expandable && !node.hide_add;
 				},
@@ -352,13 +570,25 @@ frappe.views.TreeView = class TreeView {
 				btnClass: "hidden-xs",
 			},
 			{
-				label: __("Rename"),
+				label: __("Move to..."),
+				icon: "corner-down-right",
 				condition: function (node) {
-					let allow_rename = true;
-					if (me.doctype && frappe.get_meta(me.doctype)) {
-						if (!frappe.get_meta(me.doctype).allow_rename) allow_rename = false;
-					}
-					return !node.is_root && me.can_write && allow_rename;
+					return !node.is_root && me.can_write;
+				},
+				click: function (node) {
+					me.move_node(node);
+				},
+			},
+			{
+				label: __("Rename"),
+				icon: "text-cursor-input",
+				// doctype-level allow_rename and user permission are constant
+				// for every node — hide instead of repeating a disabled row
+				condition: function (node) {
+					return me.can_write && frappe.get_meta(me.doctype)?.allow_rename != 0;
+				},
+				get_disabled_reason: function (node) {
+					if (node.is_root) return __("Root records can't be renamed");
 				},
 				click: function (node) {
 					frappe.model.rename_doc(me.doctype, node.label, function (new_name) {
@@ -371,8 +601,13 @@ frappe.views.TreeView = class TreeView {
 			},
 			{
 				label: __("Delete"),
+				icon: "trash-2",
+				danger: true,
 				condition: function (node) {
-					return !node.is_root && me.can_delete;
+					return me.can_delete;
+				},
+				get_disabled_reason: function (node) {
+					if (node.is_root) return __("Root records can't be deleted");
 				},
 				click: function (node) {
 					frappe.model.delete_doc(me.doctype, node.label, function () {
@@ -393,6 +628,99 @@ frappe.views.TreeView = class TreeView {
 		} else {
 			return toolbar;
 		}
+	}
+	move_node(node) {
+		var me = this;
+
+		// a group must never be offered its own subtree as a target (moving
+		// under a descendant is a cycle) — collect the subtree up front and
+		// exclude it from the picker; the server's validate_loop remains the
+		// backstop for anything this misses
+		let excluded = [node.label];
+		const fetch_descendants = !node.expandable
+			? Promise.resolve()
+			: frappe.db.get_value(me.doctype, node.label, ["lft", "rgt"]).then((r) => {
+					const { lft, rgt } = r.message || {};
+					if (lft == null) return;
+					return frappe.db
+						.get_list(me.doctype, {
+							filters: { lft: [">", lft], rgt: ["<", rgt] },
+							limit: 0,
+						})
+						.then((rows) => {
+							excluded = excluded.concat(rows.map((row) => row.name));
+						});
+			  });
+
+		fetch_descendants.then(() => me.show_move_dialog(node, excluded));
+	}
+	show_move_dialog(node, excluded) {
+		var me = this;
+		const parent_fieldname =
+			"parent_" + me.doctype.toLowerCase().replace(/ /g, "_").replace(/-/g, "_");
+
+		const dialog = new frappe.ui.Dialog({
+			title: __("Move {0}", [node.label]),
+			fields: [
+				{
+					fieldtype: "Link",
+					fieldname: "new_parent",
+					label: __("New Parent"),
+					options: me.doctype,
+					reqd: 1,
+					// closing the dialog with half-typed text must not toast
+					// "did not match any results" — a submitted value is still
+					// validated server-side
+					ignore_link_validation: 1,
+					get_query: () => {
+						// only groups qualify — never the node or its own
+						// subtree; stay within the tree currently shown
+						const filters = { is_group: 1, name: ["not in", excluded] };
+						Object.keys(me.args).forEach((key) => {
+							if (
+								key !== "doctype" &&
+								me.args[key] &&
+								frappe.meta.has_field(me.doctype, key)
+							) {
+								filters[key] = me.args[key];
+							}
+						});
+						return { filters };
+					},
+				},
+			],
+			primary_action_label: __("Move"),
+			primary_action(values) {
+				dialog.hide();
+				frappe.dom.freeze(__("Moving {0}", [node.label]));
+				frappe.call({
+					method: "frappe.client.set_value",
+					args: {
+						doctype: me.doctype,
+						name: node.label,
+						fieldname: parent_fieldname,
+						value: values.new_parent,
+					},
+					callback: function (r) {
+						if (r.exc) return;
+						// re-render the branch it left and the one it joined
+						node.parent_node && me.tree.load_children(node.parent_node);
+						const target = me.tree.nodes[values.new_parent];
+						if (target && target !== node.parent_node && target.loaded) {
+							me.tree.load_children(target);
+						}
+						frappe.show_alert({
+							message: __("{0} moved under {1}", [node.label, values.new_parent]),
+							indicator: "green",
+						});
+					},
+					always: function () {
+						frappe.dom.unfreeze();
+					},
+				});
+			},
+		});
+		dialog.show();
 	}
 	new_node() {
 		var me = this;
@@ -467,7 +795,9 @@ frappe.views.TreeView = class TreeView {
 		];
 
 		if (this.opts.fields) {
-			this.fields = this.opts.fields;
+			// work on a copy — the mandatory-field append below must not
+			// accumulate into the app's settings object across dialog opens
+			this.fields = this.opts.fields.slice();
 		}
 
 		this.ignore_fields = this.opts.ignore_fields || [];
@@ -513,13 +843,30 @@ frappe.views.TreeView = class TreeView {
 	set_primary_action() {
 		var me = this;
 		if (!this.opts.disable_add_node && this.can_create) {
+			// same primary action as the list views: "Add {doctype}", short
+			// "Add" below the md breakpoint, ctrl+b shortcut
+			const primary_action = () => me.new_node();
 			me.page.set_primary_action(
-				__("New"),
-				function () {
-					me.new_node();
+				{
+					label: __("Add {0}", [__(this.doctype)], "Primary action in tree view"),
+					short_label: __("Add"),
 				},
+				primary_action,
 				"plus"
 			);
+			frappe.ui.keys.add_shortcut({
+				shortcut: "ctrl+b",
+				action: () => {
+					primary_action();
+					return true;
+				},
+				description: __(
+					"Create a new document",
+					null,
+					"Description of a tree view shortcut"
+				),
+				page: this.page,
+			});
 		}
 	}
 	set_menu_item() {
@@ -527,24 +874,23 @@ frappe.views.TreeView = class TreeView {
 
 		this.menu_items = [
 			{
-				label: __("View List"),
-				action: function () {
-					frappe.set_route(["List", me.doctype, "List"]);
-				},
-			},
-			{
 				label: __("Print"),
 				action: function () {
 					me.print_tree();
 				},
 			},
-			{
-				label: __("Refresh"),
-				action: function () {
-					me.make_tree();
-				},
-			},
 		];
+
+		// the view switcher covers navigation and the header icon covers
+		// reload; only fall back to menu items when the switcher is disabled
+		if (!this.views_list) {
+			this.menu_items.unshift({
+				label: __("View List"),
+				action: function () {
+					frappe.set_route(["List", me.doctype, "List"]);
+				},
+			});
+		}
 
 		if (
 			frappe.user.has_role("System Manager") &&
@@ -566,7 +912,12 @@ frappe.views.TreeView = class TreeView {
 		$.each(me.menu_items, function (i, menu_item) {
 			var has_perm = true;
 			if (menu_item["condition"]) {
-				has_perm = eval(menu_item["condition"]);
+				// apps historically pass condition as an eval'd string; new
+				// code should pass a function
+				has_perm =
+					typeof menu_item["condition"] === "function"
+						? menu_item["condition"]()
+						: eval(menu_item["condition"]);
 			}
 
 			if (has_perm) {

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -609,27 +609,38 @@ frappe.views.TreeView = class TreeView {
 	move_node(node) {
 		var me = this;
 
-		// exclude the node's own subtree from the picker (a cycle otherwise);
-		// the server's validate_loop stays the backstop
-		let excluded = [node.label];
-		const fetch_descendants = !node.expandable
-			? Promise.resolve()
-			: frappe.db.get_value(me.doctype, node.label, ["lft", "rgt"]).then((r) => {
-					const { lft, rgt } = r.message || {};
-					if (lft == null) return;
-					return frappe.db
-						.get_list(me.doctype, {
-							filters: { lft: [">", lft], rgt: ["<", rgt] },
-							limit: 0,
-						})
-						.then((rows) => {
-							excluded = excluded.concat(rows.map((row) => row.name));
-						});
-			  });
+		// pull the whole server-filtered tree (same get_children + filters the
+		// tree uses) so valid parents in unexpanded branches are offered too
+		me.tree.get_all_nodes(me.tree.root_value, true, me.tree.label).then((groups) => {
+			const children_of = {};
+			const all = [];
+			(groups || []).forEach((group) => {
+				(group.data || []).forEach((d) => {
+					all.push(d.value);
+					children_of[group.parent] = children_of[group.parent] || [];
+					children_of[group.parent].push(d.value);
+				});
+			});
 
-		fetch_descendants.then(() => me.show_move_dialog(node, excluded));
+			// exclude the node's own subtree (cycle; validate_loop is the backstop)
+			const subtree = new Set([node.label]);
+			const stack = [node.label];
+			while (stack.length) {
+				(children_of[stack.pop()] || []).forEach((name) => {
+					if (!subtree.has(name)) {
+						subtree.add(name);
+						stack.push(name);
+					}
+				});
+			}
+
+			me.show_move_dialog(
+				node,
+				all.filter((name) => !subtree.has(name))
+			);
+		});
 	}
-	show_move_dialog(node, excluded) {
+	show_move_dialog(node, candidates) {
 		var me = this;
 		// mirror the server (frappe.desk.treeview): nested sets may use a
 		// custom parent field (e.g. Employee's reports_to)
@@ -650,12 +661,7 @@ frappe.views.TreeView = class TreeView {
 					// values are validated server-side
 					ignore_link_validation: 1,
 					get_query: () => {
-						// candidates = nodes the tree rendered (already
-						// server-filtered), minus the node's own subtree
-						const names = Object.values(me.tree.nodes)
-							.filter((n) => !n.is_root && !excluded.includes(n.label))
-							.map((n) => n.label);
-						const filters = { name: ["in", names] };
+						const filters = { name: ["in", candidates] };
 						if (frappe.meta.has_field(me.doctype, "is_group")) {
 							filters.is_group = 1;
 						}

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -160,8 +160,6 @@ frappe.views.TreeView = class TreeView {
 	make_tree_toolbar() {
 		var me = this;
 
-		// same filter-bar anatomy as the list views: page_form holding a
-		// .standard-filter-section, fields added through page.add_field
 		this.page.page_form.removeClass("row").addClass("flex");
 		this.$filter_area = $('<div class="standard-filter-section flex"></div>').appendTo(
 			this.page.page_form

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -656,7 +656,10 @@ frappe.views.TreeView = class TreeView {
 	}
 	show_move_dialog(node, excluded) {
 		var me = this;
+		// mirror the server (frappe.desk.treeview): nested sets may use a
+		// custom parent field (e.g. Employee's reports_to)
 		const parent_fieldname =
+			frappe.get_meta(me.doctype)?.nsm_parent_field ||
 			"parent_" + me.doctype.toLowerCase().replace(/ /g, "_").replace(/-/g, "_");
 
 		const dialog = new frappe.ui.Dialog({
@@ -673,9 +676,14 @@ frappe.views.TreeView = class TreeView {
 					// validated server-side
 					ignore_link_validation: 1,
 					get_query: () => {
-						// only groups qualify — never the node or its own
-						// subtree; stay within the tree currently shown
-						const filters = { is_group: 1, name: ["not in", excluded] };
+						// never the node or its own subtree; only groups
+						// qualify where the doctype has that concept (trees
+						// like Employee have none — any node can be a parent);
+						// stay within the tree currently shown
+						const filters = { name: ["not in", excluded] };
+						if (frappe.meta.has_field(me.doctype, "is_group")) {
+							filters.is_group = 1;
+						}
 						Object.keys(me.args).forEach((key) => {
 							if (
 								key !== "doctype" &&

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -186,7 +186,7 @@ frappe.views.TreeView = class TreeView {
 			let $actions = $(
 				'<div class="tree-toolbar-actions ms-auto flex items-center gap-1 py-1"></div>'
 			).appendTo(this.page.page_form);
-			this.$expand_collapse_dropdown = frappe.ui.dropdown({
+			frappe.ui.dropdown({
 				button: { label: __("Expand/Collapse"), icon_right: "chevron-down" },
 				align: "end",
 				options: () => {
@@ -197,7 +197,7 @@ frappe.views.TreeView = class TreeView {
 							icon: "copy-plus",
 							disabled: !(state === "collapsed" || state === "partial"),
 							onclick: () => {
-								me.tree.load_children(me.tree.root_node, true);
+								this.tree.load_children(this.tree.root_node, true);
 							},
 						},
 						{
@@ -205,7 +205,7 @@ frappe.views.TreeView = class TreeView {
 							icon: "copy-minus",
 							disabled: !(state === "expanded" || state === "partial"),
 							onclick: () => {
-								me.tree.load_children(me.tree.root_node, false);
+								this.tree.load_children(this.tree.root_node, false);
 							},
 						},
 					];
@@ -232,7 +232,7 @@ frappe.views.TreeView = class TreeView {
 				meta: this.opts.meta || frappe.get_meta(this.doctype),
 				settings: frappe.listview_settings[this.doctype] || {},
 			},
-			icon_map: frappe.views.get_view_icon_map(),
+			icon_map: frappe.views.view_icon_map,
 			label_map: frappe.views.get_view_label_map(),
 		});
 	}
@@ -339,9 +339,7 @@ frappe.views.TreeView = class TreeView {
 		this.tree && this.tree.wrapper.show();
 	}
 	make_tree() {
-		// a rebuild (filter change, Include Disabled, reload) must not cost
-		// the user their expansion — remember what was open and restore it
-		// as the nodes reappear (see restore_expanded_nodes)
+		// remember open nodes across rebuilds (see restore_expanded_nodes)
 		this._expanded_labels = this.tree
 			? Object.values(this.tree.nodes)
 					.filter((node) => node.expanded && !node.is_root)
@@ -579,10 +577,8 @@ frappe.views.TreeView = class TreeView {
 	move_node(node) {
 		var me = this;
 
-		// a group must never be offered its own subtree as a target (moving
-		// under a descendant is a cycle) — collect the subtree up front and
-		// exclude it from the picker; the server's validate_loop remains the
-		// backstop for anything this misses
+		// exclude the node's own subtree from the picker (a cycle otherwise);
+		// the server's validate_loop stays the backstop
 		let excluded = [node.label];
 		const fetch_descendants = !node.expandable
 			? Promise.resolve()
@@ -618,15 +614,12 @@ frappe.views.TreeView = class TreeView {
 					label: __("New Parent"),
 					options: me.doctype,
 					reqd: 1,
-					// closing the dialog with half-typed text must not toast
-					// "did not match any results" — a submitted value is still
-					// validated server-side
+					// half-typed text on close must not toast; submitted
+					// values are validated server-side
 					ignore_link_validation: 1,
 					get_query: () => {
-						// never the node or its own subtree; only groups
-						// qualify where the doctype has that concept (trees
-						// like Employee have none — any node can be a parent);
-						// stay within the tree currently shown
+						// only groups (where the doctype has them), never the
+						// node or its subtree
 						const filters = { name: ["not in", excluded] };
 						if (frappe.meta.has_field(me.doctype, "is_group")) {
 							filters.is_group = 1;
@@ -750,8 +743,7 @@ frappe.views.TreeView = class TreeView {
 		];
 
 		if (this.opts.fields) {
-			// work on a copy — the mandatory-field append below must not
-			// accumulate into the app's settings object across dialog opens
+			// copy: the append below must not accumulate into app settings
 			this.fields = this.opts.fields.slice();
 		}
 

--- a/frappe/public/scss/desk/tree.scss
+++ b/frappe/public/scss/desk/tree.scss
@@ -252,12 +252,8 @@
 			}
 		}
 
-		// an all-leaf sibling group has no chevrons to align with — drop the
-		// empty icon slots so labels start near the elbows, with a touch of
-		// breathing room. Groups that mix leaves and subgroups keep the
-		// slot, so their labels line up. (span.node-parent = a group's
-		// toggle, present from first render; class-based :has re-evaluates
-		// on DOM change only.)
+		// all-leaf levels drop the empty icon slots; mixed levels keep them
+		// so labels align (span.node-parent marks a group from first render)
 		&:not(:has(span.node-parent)) {
 			.tree-link > span:first-child {
 				display: none;
@@ -269,9 +265,8 @@
 		}
 	}
 
-	// hover actions sit right beside the label (Option E): Edit + ⋯,
-	// shortest travel from where the pointer already is; the amount at the
-	// row's end stays untouched
+	// hover actions sit beside the label — shortest pointer travel; the
+	// value column at the row's end stays untouched
 	.tree-actions {
 		display: none;
 		align-items: center;
@@ -285,8 +280,7 @@
 		display: inline-flex;
 	}
 
-	// no hover on touch devices — keep the actions visible (approved mobile
-	// design: the per-row controls are always shown there)
+	// no hover on touch devices — keep the actions always visible
 	@media (hover: none) {
 		.tree-actions {
 			display: inline-flex;

--- a/frappe/public/scss/desk/tree.scss
+++ b/frappe/public/scss/desk/tree.scss
@@ -127,10 +127,6 @@
 	text-align: center;
 }
 
-.tree-link .node-leaf {
-	color: var(--ink-gray-5);
-}
-
 .tree-link.active {
 	a {
 		color: var(--ink-gray-8);

--- a/frappe/public/scss/desk/tree.scss
+++ b/frappe/public/scss/desk/tree.scss
@@ -18,6 +18,15 @@
 	.standard-filter-section .frappe-control:not([data-fieldtype="Check"]) {
 		min-width: 220px;
 	}
+
+	// the checkbox sizes to its label instead of the col-md-2 column, so a
+	// longer label ("Show all (including disabled)") stays on one line
+	.standard-filter-section .frappe-control[data-fieldtype="Check"] {
+		flex: none;
+		width: auto;
+		max-width: none;
+		white-space: nowrap;
+	}
 }
 
 .tree-view-body {

--- a/frappe/public/scss/desk/tree.scss
+++ b/frappe/public/scss/desk/tree.scss
@@ -1,5 +1,3 @@
-// the tree page keeps a centered, width-capped column — value columns
-// (balances) stay near their labels
 .treeview {
 	.layout-main-section {
 		margin: auto;
@@ -10,17 +8,11 @@
 	}
 }
 
-// ─── filter bar + tree body (same page_form anatomy as list views) ─────────
-
 .treeview .page-form {
-	// a tree page has few filters, so give them more room than the list
-	// default (150px) — they read cramped otherwise
 	.standard-filter-section .frappe-control:not([data-fieldtype="Check"]) {
 		min-width: 220px;
 	}
 
-	// the checkbox sizes to its label instead of the col-md-2 column, so a
-	// longer label ("Show all (including disabled)") stays on one line
 	.standard-filter-section .frappe-control[data-fieldtype="Check"] {
 		flex: none;
 		width: auto;
@@ -28,8 +20,6 @@
 		white-space: nowrap;
 	}
 
-	// Pin it to the top and align it with the first
-	// filter row instead (the +4px matches the field's in-section offset).
 	.tree-toolbar-actions {
 		align-self: flex-start;
 		margin-top: 4px;
@@ -40,8 +30,6 @@
 	padding: var(--spacing) calc(var(--spacing) * 2) calc(var(--spacing) * 2);
 }
 
-// node hover card: the panel is widened past the component default (256px)
-// so account names and amounts fit without scrolling; the content fills it
 .es-hover-card.tree-node-hover-panel {
 	width: calc(var(--spacing) * 78);
 	max-width: 90vw;
@@ -50,11 +38,7 @@
 .tree-hover-card {
 	width: 100%;
 
-	// layout and type come from utility/typography classes on the markup;
-	// only what those can't express lives here
 	.tree-hover-card-head {
-		// the avatar spans both text lines, so it stays vertically centered
-		// while the open button top-aligns with the title
 		.es-avatar {
 			align-self: center;
 		}
@@ -66,7 +50,6 @@
 	}
 
 	.tree-hover-card-row {
-		// a little breathing room between fields
 		padding-block: 3px;
 
 		.value {
@@ -76,13 +59,10 @@
 	}
 }
 
-// ─── tree widget ────────────────────────────────────────────────────────────
-
 .tree {
 	padding: var(--spacing);
 	font-size: var(--text-base);
 
-	// legacy click-injected toolbar (embedded trees: BOM Configurator etc.)
 	.btn-group {
 		.btn {
 			box-shadow: none;
@@ -151,16 +131,9 @@
 	font-weight: 600;
 }
 
-// ─── row mode (.tree-rows): full-width rows, guides, hover actions ─────────
-// standard desk tree pages only; embedded trees keep the legacy layout above
-
 .tree.tree-rows {
 	padding: 0;
 
-	// a node's <li> holds [row link][optional value column][children <ul>] —
-	// flex-wrap puts link + value on one visual row, children wrap below.
-	// No vertical margins: sibling connector segments must touch to draw as
-	// one continuous line.
 	li.tree-node {
 		display: flex;
 		flex-wrap: wrap;
@@ -180,8 +153,6 @@
 		font-weight: var(--font-weight-regular);
 		color: var(--ink-gray-8);
 
-		// icon slot: chevron for groups; leaves keep the slot for alignment
-		// but draw no marker (frappe-ui tree convention)
 		> span:first-child {
 			flex: none;
 			width: 20px;
@@ -214,14 +185,6 @@
 		}
 	}
 
-	// every label carries the same weight (frappe-ui tree convention) —
-	// hierarchy is shown by indent and chevrons, selection by background
-
-	// indent guides: frappe-ui-style elbow connectors. The line hangs from
-	// the parent's chevron center (8px row padding + half of the 20px icon
-	// slot = 18px into the <ul>, i.e. -6px relative to each 24px-indented
-	// child <li>): an └ elbow into each row, the vertical continuing past
-	// every child except the last
 	ul.tree-children {
 		flex: 1 1 100%;
 		padding-left: 24px;
@@ -255,8 +218,6 @@
 			}
 		}
 
-		// all-leaf levels drop the empty icon slots; mixed levels keep them
-		// so labels align (span.node-parent marks a group from first render)
 		&:not(:has(span.node-parent)) {
 			.tree-link > span:first-child {
 				display: none;
@@ -268,8 +229,6 @@
 		}
 	}
 
-	// hover actions sit beside the label — shortest pointer travel; the
-	// value column at the row's end stays untouched
 	.tree-actions {
 		display: none;
 		align-items: center;
@@ -283,16 +242,12 @@
 		display: inline-flex;
 	}
 
-	// no hover on touch devices — keep the actions always visible
 	@media (hover: none) {
 		.tree-actions {
 			display: inline-flex;
 		}
 	}
 
-	// value column (e.g. account balances) — apps insert .balance-area after
-	// the tree-link; as a flex sibling it sits at the row's right edge and
-	// can never overlap the label
 	li.tree-node > .balance-area {
 		float: none;
 		flex: none;
@@ -307,7 +262,6 @@
 		white-space: nowrap;
 	}
 
-	// link + value paint as ONE continuous row: square the touching corners
 	li.tree-node:has(> .balance-area) > .tree-link {
 		border-radius: var(--radius) 0 0 var(--radius);
 	}
@@ -317,13 +271,11 @@
 		background-color: var(--surface-gray-2);
 	}
 
-	// legacy click-toolbar never shows in row mode
 	.tree-node-toolbar {
 		display: none !important;
 	}
 }
 
-// legacy hover treatment for embedded trees
 .tree:not(.tree-rows) .tree-node.hover-active {
 	background-color: var(--surface-gray-2);
 	border-radius: var(--radius);

--- a/frappe/public/scss/desk/tree.scss
+++ b/frappe/public/scss/desk/tree.scss
@@ -58,9 +58,14 @@
 		}
 	}
 
-	.tree-hover-card-row .value {
-		text-align: right;
-		font-variant-numeric: tabular-nums;
+	.tree-hover-card-row {
+		// a little breathing room between fields
+		padding-block: 3px;
+
+		.value {
+			text-align: right;
+			font-variant-numeric: tabular-nums;
+		}
 	}
 }
 

--- a/frappe/public/scss/desk/tree.scss
+++ b/frappe/public/scss/desk/tree.scss
@@ -30,7 +30,7 @@
 }
 
 .tree-view-body {
-	padding: 4px var(--padding-sm) var(--padding-sm);
+	padding: var(--spacing) calc(var(--spacing) * 2) calc(var(--spacing) * 2);
 }
 
 // node hover card: the panel is widened past the component default (256px)
@@ -72,21 +72,21 @@
 // ─── tree widget ────────────────────────────────────────────────────────────
 
 .tree {
-	padding: var(--padding-xs);
+	padding: var(--spacing);
 	font-size: var(--text-base);
 
 	// legacy click-injected toolbar (embedded trees: BOM Configurator etc.)
 	.btn-group {
 		.btn {
 			box-shadow: none;
-			outline: 1px solid var(--btn-group-border-color);
+			outline: 1px solid var(--outline-gray-2);
 
 			&:not(:first-child) {
 				margin-left: 1px;
 			}
 
 			&:focus {
-				outline: 2px solid var(--dark-border-color);
+				outline: 2px solid var(--outline-gray-3);
 			}
 		}
 	}
@@ -101,47 +101,47 @@
 	cursor: pointer;
 	display: inline-flex;
 	align-items: center;
-	padding: var(--padding-xs);
-	color: var(--text-color);
+	padding: var(--spacing);
+	color: var(--ink-gray-8);
 }
 
 .tree-label {
-	margin-left: var(--margin-xs);
+	margin-left: var(--spacing);
 	line-height: 1.4em;
 }
 
 .tree-children {
-	padding-left: var(--padding-xl);
+	padding-left: calc(var(--spacing) * 8);
 	margin-bottom: 0;
 }
 
 .tree-link .node-parent {
-	color: var(--text-muted);
+	color: var(--ink-gray-5);
 	text-align: center;
 }
 
 .tree-link .node-leaf {
-	color: var(--text-muted);
+	color: var(--ink-gray-5);
 }
 
 .tree-link.active {
 	a {
-		color: var(--text-color);
+		color: var(--ink-gray-8);
 	}
 }
 
 .tree-node-toolbar {
 	display: inline-flex;
-	padding: 0px var(--padding-xs);
-	margin-left: var(--margin-md);
+	padding: 0px var(--spacing);
+	margin-left: calc(var(--spacing) * 4);
 	margin-bottom: -4px;
 	margin-top: -8px;
 }
 
-.balance-area {
-	color: var(--text-color) !important;
-	font-size: var(--text-md);
-	padding: var(--padding-xs);
+.tree:not(.tree-rows) .balance-area {
+	color: var(--ink-gray-8) !important;
+	font-size: var(--text-base);
+	padding: var(--spacing);
 }
 
 .tree:not(.tree-rows) .tree-link.active ~ .balance-area {
@@ -171,10 +171,11 @@
 		min-width: 0;
 		align-items: center;
 		min-height: 32px;
-		padding: 2px var(--padding-sm);
+		padding: 2px calc(var(--spacing) * 2);
 		border-radius: var(--radius);
 		font-size: var(--text-base);
 		font-weight: var(--font-weight-regular);
+		color: var(--ink-gray-8);
 
 		// icon slot: chevron for groups; leaves keep the slot for alignment
 		// but draw no marker (frappe-ui tree convention)
@@ -192,7 +193,7 @@
 		}
 
 		.tree-label {
-			margin-left: var(--margin-xs);
+			margin-left: var(--spacing);
 			min-width: 0;
 			overflow: hidden;
 			text-overflow: ellipsis;
@@ -204,8 +205,9 @@
 			text-decoration: none;
 		}
 
-		&:hover {
-			background-color: var(--fg-hover-color);
+		&:hover,
+		&[data-state="open"] {
+			background-color: var(--surface-gray-2);
 		}
 	}
 
@@ -233,7 +235,6 @@
 				width: 12px;
 				border-left: 1px solid var(--outline-gray-2);
 				border-bottom: 1px solid var(--outline-gray-2);
-				border-bottom-left-radius: 3px;
 			}
 
 			&:not(:last-child)::after {
@@ -243,6 +244,27 @@
 				top: 16px;
 				bottom: 0;
 				border-left: 1px solid var(--outline-gray-2);
+			}
+
+			> .tree-link {
+				margin-left: 6px;
+				padding-left: calc(var(--spacing) * 2 - 6px);
+			}
+		}
+
+		// an all-leaf sibling group has no chevrons to align with — drop the
+		// empty icon slots so labels start near the elbows, with a touch of
+		// breathing room. Groups that mix leaves and subgroups keep the
+		// slot, so their labels line up. (span.node-parent = a group's
+		// toggle, present from first render; class-based :has re-evaluates
+		// on DOM change only.)
+		&:not(:has(span.node-parent)) {
+			.tree-link > span:first-child {
+				display: none;
+			}
+
+			> li.tree-node > .tree-link {
+				padding-left: calc(var(--spacing) * 2.5);
 			}
 		}
 	}
@@ -255,10 +277,11 @@
 		align-items: center;
 		gap: 2px;
 		flex: none;
-		margin-left: var(--margin-sm);
+		margin-left: calc(var(--spacing) * 2);
 	}
 
-	.tree-link:hover .tree-actions {
+	.tree-link:hover .tree-actions,
+	.tree-link[data-state="open"] .tree-actions {
 		display: inline-flex;
 	}
 
@@ -279,7 +302,7 @@
 		min-height: 32px;
 		display: flex;
 		align-items: center;
-		padding: 2px var(--padding-sm);
+		padding: 2px calc(var(--spacing) * 2);
 		border-radius: 0 var(--radius) var(--radius) 0;
 		font-size: var(--text-sm);
 		color: var(--ink-gray-7);
@@ -292,9 +315,9 @@
 		border-radius: var(--radius) 0 0 var(--radius);
 	}
 
-	// carry the row highlight across the value column
-	li.tree-node:has(> .tree-link:hover) > .balance-area {
-		background-color: var(--fg-hover-color);
+	.tree-link:hover + .balance-area,
+	.tree-link[data-state="open"] + .balance-area {
+		background-color: var(--surface-gray-2);
 	}
 
 	// legacy click-toolbar never shows in row mode
@@ -305,6 +328,6 @@
 
 // legacy hover treatment for embedded trees
 .tree:not(.tree-rows) .tree-node.hover-active {
-	background-color: var(--fg-hover-color);
+	background-color: var(--surface-gray-2);
 	border-radius: var(--radius);
 }

--- a/frappe/public/scss/desk/tree.scss
+++ b/frappe/public/scss/desk/tree.scss
@@ -27,6 +27,13 @@
 		max-width: none;
 		white-space: nowrap;
 	}
+
+	// Pin it to the top and align it with the first
+	// filter row instead (the +4px matches the field's in-section offset).
+	.tree-toolbar-actions {
+		align-self: flex-start;
+		margin-top: 4px;
+	}
 }
 
 .tree-view-body {

--- a/frappe/public/scss/desk/tree.scss
+++ b/frappe/public/scss/desk/tree.scss
@@ -1,3 +1,5 @@
+// the tree page keeps a centered, width-capped column — value columns
+// (balances) stay near their labels
 .treeview {
 	.layout-main-section {
 		margin: auto;
@@ -8,9 +10,58 @@
 	}
 }
 
-.tree {
-	padding: var(--padding-sm);
+// ─── filter bar + tree body (same page_form anatomy as list views) ─────────
 
+.treeview .page-form {
+	// a tree page has few filters, so give them more room than the list
+	// default (150px) — they read cramped otherwise
+	.standard-filter-section .frappe-control:not([data-fieldtype="Check"]) {
+		min-width: 220px;
+	}
+}
+
+.tree-view-body {
+	padding: 4px var(--padding-sm) var(--padding-sm);
+}
+
+// node hover card: the panel is widened past the component default (256px)
+// so account names and amounts fit without scrolling; the content fills it
+.es-hover-card.tree-node-hover-panel {
+	width: calc(var(--spacing) * 78);
+	max-width: 90vw;
+}
+
+.tree-hover-card {
+	width: 100%;
+
+	// layout and type come from utility/typography classes on the markup;
+	// only what those can't express lives here
+	.tree-hover-card-head {
+		// the avatar spans both text lines, so it stays vertically centered
+		// while the open button top-aligns with the title
+		.es-avatar {
+			align-self: center;
+		}
+
+		> .es-button {
+			margin-top: -1px;
+			margin-right: -4px;
+		}
+	}
+
+	.tree-hover-card-row .value {
+		text-align: right;
+		font-variant-numeric: tabular-nums;
+	}
+}
+
+// ─── tree widget ────────────────────────────────────────────────────────────
+
+.tree {
+	padding: var(--padding-xs);
+	font-size: var(--text-base);
+
+	// legacy click-injected toolbar (embedded trees: BOM Configurator etc.)
 	.btn-group {
 		.btn {
 			box-shadow: none;
@@ -29,38 +80,29 @@
 
 .tree li {
 	list-style: none;
-	margin: 2px 0px;
+	margin: 0;
 }
 
 .tree-link {
 	cursor: pointer;
 	display: inline-flex;
-	align-items: flex-end;
+	align-items: center;
 	padding: var(--padding-xs);
-	font-size: $font-size-lg;
-	font-weight: 600;
 	color: var(--text-color);
 }
 
 .tree-label {
-	margin-left: var(--margin-sm);
+	margin-left: var(--margin-xs);
 	line-height: 1.4em;
 }
 
 .tree-children {
 	padding-left: var(--padding-xl);
 	margin-bottom: 0;
-
-	.tree-link {
-		font-size: var(--text-md);
-		font-weight: normal;
-	}
 }
 
 .tree-link .node-parent {
 	color: var(--text-muted);
-	font-size: $font-size-base;
-	// width: 10px;
 	text-align: center;
 }
 
@@ -68,38 +110,10 @@
 	color: var(--text-muted);
 }
 
-// .tree-link .node-parent, .tree-link .node-leaf {
-// 	margin-right: 10px;
-// }
-
 .tree-link.active {
-	i {
-		color: var(--indicator-blue);
-	}
-
 	a {
 		color: var(--text-color);
-		font-weight: 600;
 	}
-}
-
-.tree-link .file-doc-link {
-	opacity: 0;
-}
-
-.tree-link:hover .file-doc-link {
-	opacity: 0.4;
-}
-
-.tree-link .file-doc-link:hover {
-	transform: scale(1.1);
-	opacity: 0.5;
-}
-
-.tree-hover {
-	background-color: var(--highlight-color);
-	min-height: 25px;
-	border: 1px solid var(--border-color);
 }
 
 .tree-node-toolbar {
@@ -110,64 +124,173 @@
 	margin-top: -8px;
 }
 
-// @media (max-width: @screen-xs) {
-// 	.tree-children {
-// 		padding-left: 10px;
-// 	}
-// }
-
-// decoration
-// .tree, .tree-node {
-.tree.with-skeleton,
-.tree.with-skeleton .tree-node {
-	position: relative;
-
-	// &.opened::before, &:last-child::after {
-	// 	content: '';
-	// 	position: absolute;
-	// 	top: 16px;
-	// 	left: 8px;
-	// 	height: calc(100% - 26px);
-	// 	width: 1px;
-	// 	background: var(--border-color);
-	// }
-
-	// &:last-child::after {
-	// 	top: 11px;
-	// 	left: -13px;
-	// 	height: calc(100% - 15px);
-	// 	width: 3px;
-	// 	background: #fff;
-	// }
-}
-
-// .tree.with-skeleton .tree-children > .tree-node > .tree-link::before {
-// 	content: '';
-// 	position: absolute;
-// 	width: 12px;
-// 	height: 1px;
-// 	top: 10px;
-// 	left: -11px;
-// 	background: var(--border-color);
-// }
-
-// .tree.with-skeleton.opened::before {
-// 	left: 23px;
-// 	top: 33px;
-// 	height: calc(100% - 67px);
-// }
-
 .balance-area {
 	color: var(--text-color) !important;
 	font-size: var(--text-md);
 	padding: var(--padding-xs);
 }
 
-.tree-link.active ~ .balance-area {
+.tree:not(.tree-rows) .tree-link.active ~ .balance-area {
 	font-weight: 600;
 }
 
-.tree-node.hover-active {
+// ─── row mode (.tree-rows): full-width rows, guides, hover actions ─────────
+// standard desk tree pages only; embedded trees keep the legacy layout above
+
+.tree.tree-rows {
+	padding: 0;
+
+	// a node's <li> holds [row link][optional value column][children <ul>] —
+	// flex-wrap puts link + value on one visual row, children wrap below.
+	// No vertical margins: sibling connector segments must touch to draw as
+	// one continuous line.
+	li.tree-node {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		margin: 0;
+	}
+
+	.tree-link {
+		display: flex;
+		flex: 1 1 0%;
+		min-width: 0;
+		align-items: center;
+		min-height: 32px;
+		padding: 2px var(--padding-sm);
+		border-radius: var(--radius);
+		font-size: var(--text-base);
+		font-weight: var(--font-weight-regular);
+
+		// icon slot: chevron for groups; leaves keep the slot for alignment
+		// but draw no marker (frappe-ui tree convention)
+		> span:first-child {
+			flex: none;
+			width: 20px;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			color: var(--ink-gray-5);
+
+			&:not(.node-parent) svg {
+				display: none;
+			}
+		}
+
+		.tree-label {
+			margin-left: var(--margin-xs);
+			min-width: 0;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+			text-decoration: none;
+		}
+
+		a:hover {
+			text-decoration: none;
+		}
+
+		&:hover {
+			background-color: var(--fg-hover-color);
+		}
+	}
+
+	// every label carries the same weight (frappe-ui tree convention) —
+	// hierarchy is shown by indent and chevrons, selection by background
+
+	// indent guides: frappe-ui-style elbow connectors. The line hangs from
+	// the parent's chevron center (8px row padding + half of the 20px icon
+	// slot = 18px into the <ul>, i.e. -6px relative to each 24px-indented
+	// child <li>): an └ elbow into each row, the vertical continuing past
+	// every child except the last
+	ul.tree-children {
+		flex: 1 1 100%;
+		padding-left: 24px;
+
+		> li.tree-node {
+			position: relative;
+
+			&::before {
+				content: "";
+				position: absolute;
+				left: -6px;
+				top: 0;
+				height: 16px;
+				width: 12px;
+				border-left: 1px solid var(--outline-gray-2);
+				border-bottom: 1px solid var(--outline-gray-2);
+				border-bottom-left-radius: 3px;
+			}
+
+			&:not(:last-child)::after {
+				content: "";
+				position: absolute;
+				left: -6px;
+				top: 16px;
+				bottom: 0;
+				border-left: 1px solid var(--outline-gray-2);
+			}
+		}
+	}
+
+	// hover actions sit right beside the label (Option E): Edit + ⋯,
+	// shortest travel from where the pointer already is; the amount at the
+	// row's end stays untouched
+	.tree-actions {
+		display: none;
+		align-items: center;
+		gap: 2px;
+		flex: none;
+		margin-left: var(--margin-sm);
+	}
+
+	.tree-link:hover .tree-actions {
+		display: inline-flex;
+	}
+
+	// no hover on touch devices — keep the actions visible (approved mobile
+	// design: the per-row controls are always shown there)
+	@media (hover: none) {
+		.tree-actions {
+			display: inline-flex;
+		}
+	}
+
+	// value column (e.g. account balances) — apps insert .balance-area after
+	// the tree-link; as a flex sibling it sits at the row's right edge and
+	// can never overlap the label
+	li.tree-node > .balance-area {
+		float: none;
+		flex: none;
+		min-height: 32px;
+		display: flex;
+		align-items: center;
+		padding: 2px var(--padding-sm);
+		border-radius: 0 var(--radius) var(--radius) 0;
+		font-size: var(--text-sm);
+		color: var(--ink-gray-7);
+		font-variant-numeric: tabular-nums;
+		white-space: nowrap;
+	}
+
+	// link + value paint as ONE continuous row: square the touching corners
+	li.tree-node:has(> .balance-area) > .tree-link {
+		border-radius: var(--radius) 0 0 var(--radius);
+	}
+
+	// carry the row highlight across the value column
+	li.tree-node:has(> .tree-link:hover) > .balance-area {
+		background-color: var(--fg-hover-color);
+	}
+
+	// legacy click-toolbar never shows in row mode
+	.tree-node-toolbar {
+		display: none !important;
+	}
+}
+
+// legacy hover treatment for embedded trees
+.tree:not(.tree-rows) .tree-node.hover-active {
 	background-color: var(--fg-hover-color);
 	border-radius: var(--radius);
 }


### PR DESCRIPTION
Updated the UI of tree view pages + added support for context and drop-down menus. Links also support hover cards now. Prints of these tree views were also updated.


<img width="3948" height="2096" alt="CleanShot 2026-08-31 at 16 57 50@2x" src="https://github.com/user-attachments/assets/5943fb54-d2fc-4b06-b3b3-e24cbdc22a63" />
<img width="3080" height="2082" alt="CleanShot 2026-08-31 at 16 58 27@2x" src="https://github.com/user-attachments/assets/c3f9bbcf-4c32-454c-b514-b4ec5681eae9" />


`no-docs`