### PR TITLE
fix(datatable): make "rows selected" toast readable in dark mode

### DIFF
--- a/frappe/public/scss/desk/frappe_datatable.scss
+++ b/frappe/public/scss/desk/frappe_datatable.scss
@@ -5,7 +5,7 @@
 	--dt-light-yellow: var(--yellow-50);
 	--dt-orange: var(--orange-500);
 	--dt-text-color: var(--text-muted);
-	--dt-text-light: var(--ink-base);
+	--dt-text-light: var(--gray-50);
 	--dt-spacer-1: 0.25rem;
 	--dt-spacer-2: var(--padding-xs);
 	--dt-spacer-3: 1rem;


### PR DESCRIPTION
**Before:** 

<img width="894" height="384" alt="image" src="https://github.com/user-attachments/assets/ca3fcca8-8491-4d40-a97c-fcc1892abcce" />

**After:**
<img width="907" height="374" alt="image" src="https://github.com/user-attachments/assets/4f9e0a49-16cf-4380-9bef-4ee8d96476e6" />
