### PR TITLE
fix: keep a filtered sidebar item, and land on a doctype

### DIFF
--- a/frappe/desk/doctype/sidebar/sidebar.py
+++ b/frappe/desk/doctype/sidebar/sidebar.py
@@ -65,12 +65,23 @@ SIDEBAR_ITEM_FIELDS = (
 # my module", and the fixture conversion drops it rather than guessing. An app that wants the
 # claim sets it in the `sidebar` file it ships.
 
-# These four columns identify a sidebar item that points somewhere. We match on the columns
+# These columns identify a sidebar item that points somewhere. We match on the columns
 # themselves instead of storing a hash of them, so customizations survive a rename: `link_to`
 # is a Dynamic Link, so `rename_dynamic_links` updates every `Sidebar Item` naming the renamed
 # document in one statement, base rows and customization rows alike. A stored hash could not be
 # updated that way, and the customization would keep pointing at the old name.
-LINKED_IDENTITY_FIELDS = ("type", "link_type", "link_to", "url")
+#
+# `filters` is one of them because a filtered list is a different destination, not a second name
+# for the same one. A sidebar may offer both "Sales Invoice" and "Credit Note", which is the same
+# doctype narrowed to returns; without the filters they share an identity and
+# `filter_sidebar_items` keeps the first and silently drops the rest.
+#
+# The label is deliberately *not* here, though it is the other thing that tells those two rows
+# apart on screen. Relabelling an item is something a `Custom Sidebar` does, so a label in the
+# identity would break the very delta that set it -- `narrow_reference` stores label and icon as
+# overrides for exactly that reason, and stores no filters, which is what makes filters stable
+# enough to identify by.
+LINKED_IDENTITY_FIELDS = ("type", "link_type", "link_to", "url", "filters")
 
 # Flags that mean the system is installing app content, not that a user is editing.
 #
@@ -1624,24 +1635,51 @@ def get_module_landing_route(items: list[dict]) -> str | None:
 	first item in the sidebar that links anywhere. So this takes the resolved items, already
 	filtered by permission and customized, not the module's workspaces, which are neither.
 
-	Only workspaces get an answer. A workspace route is a slug, while every other kind of item
-	is turned into a route by `frappe.utils.generate_route` on the client, which handles doc
-	views, report types and filters as query parameters. The desktop asks the client first and
-	falls back to this, so this is the answer a tile has before the sidebar object exists, not a
-	second copy of the routing rules.
+	Workspaces and doctypes get an answer. A module whose sidebar opens on a list rather than a
+	workspace is ordinary -- `Bulk Transaction` has no workspace at all -- and answering `None`
+	for it left its tile with nowhere to go. Reports, pages and filtered views are still left to
+	`frappe.utils.generate_route` on the client, which knows about report types, doc views and
+	filters as query parameters. The desktop asks the client first and falls back to this, so
+	this is the answer a tile has before the sidebar object exists, not a second copy of the
+	routing rules.
 
-	It stops at the first item that links anywhere instead of reading on for a workspace it
-	could answer for. A tile is a link with a click handler and the two must agree: a route
-	found further down the sidebar would send a middle-click somewhere a normal click never
-	goes.
+	It stops at the first item that links anywhere instead of reading on for one it could answer
+	for. A tile is a link with a click handler and the two must agree: a route found further
+	down the sidebar would send a middle-click somewhere a normal click never goes.
 	"""
 	item = next((item for item in items or [] if item.get("type") == "Link"), None)
-	if not item or item.get("link_type") != "Workspace" or not item.get("link_to"):
+	if not item or not item.get("link_to"):
 		return None
 
-	public = frappe.db.get_value("Workspace", item["link_to"], "public")
-	if public is None:
+	if item.get("link_type") == "Workspace":
+		public = frappe.db.get_value("Workspace", item["link_to"], "public")
+		if public is None:
+			return None
+
+		prefix = "/desk/" if public else "/desk/private/"
+		return prefix + frappe.utils.slug(item["link_to"])
+
+	if item.get("link_type") == "DocType":
+		return doctype_landing_route(item)
+
+	return None
+
+
+def doctype_landing_route(item: dict) -> str | None:
+	"""Where a sidebar item pointing at a doctype opens, matching the client's `generate_route`.
+
+	A single opens on the document itself, since there is no list to show, and a `tab` is a
+	fragment on the end. Anything the client would decorate further -- a filtered list, a
+	non-default view -- is left to it, because a tile that led somewhere the sidebar item does
+	not would be worse than a tile that falls back.
+	"""
+	meta = frappe.get_meta(item["link_to"]) if frappe.db.exists("DocType", item["link_to"]) else None
+	if not meta or meta.istable:
 		return None
 
-	prefix = "/desk/" if public else "/desk/private/"
-	return prefix + frappe.utils.slug(item["link_to"])
+	slug = frappe.utils.slug(item["link_to"])
+	route = f"/desk/{slug}/{item['link_to']}" if meta.issingle else f"/desk/{slug}"
+	if item.get("tab"):
+		route += f"#{item['tab']}"
+
+	return route

--- a/frappe/desk/doctype/sidebar/test_sidebar.py
+++ b/frappe/desk/doctype/sidebar/test_sidebar.py
@@ -10,6 +10,7 @@ from frappe.desk.doctype.sidebar.sidebar import (
 	MODULE_CONTENT_DOCTYPES,
 	SYSTEM_WRITE_FLAGS,
 	clear_computed_base_cache,
+	filter_sidebar_items,
 	get_computed_base,
 	get_sidebar,
 	item_key,
@@ -222,7 +223,7 @@ class TestItemIdentity(IntegrationTestCase):
 		"""
 		row = {"type": "Link", "link_type": "DocType", "link_to": "User", "label": "Users"}
 
-		self.assertEqual(item_key(row), "Link|DocType|User|")
+		self.assertEqual(item_key(row), "Link|DocType|User||")
 
 	def test_identity_ignores_the_label_of_a_linked_row(self):
 		"""Renaming an item in the sidebar must not orphan a user's delta."""
@@ -230,6 +231,33 @@ class TestItemIdentity(IntegrationTestCase):
 			item_key({"type": "Link", "link_type": "DocType", "link_to": "User", "label": "Users"}),
 			item_key({"type": "Link", "link_type": "DocType", "link_to": "User", "label": "People"}),
 		)
+
+	def test_a_filtered_row_is_a_different_item(self):
+		"""The same doctype narrowed to a subset is somewhere else to go, not a second name for the
+		same place. Without this the two share an identity and `filter_sidebar_items` keeps only the
+		first -- which is how erpnext's Accounts sidebar lost "Credit Note" to "Sales Invoice".
+		"""
+		plain = {"type": "Link", "link_type": "DocType", "link_to": "Sales Invoice"}
+		returns = {**plain, "filters": '{"is_return": 1}'}
+
+		self.assertNotEqual(item_key(plain), item_key(returns))
+
+	def test_both_survive_the_filter_that_drops_duplicates(self):
+		"""The identity is only worth having if it reaches the pass that reads it."""
+		rows = [
+			frappe._dict(type="Link", link_type="DocType", link_to="User", label="Users", filters=None),
+			frappe._dict(
+				type="Link",
+				link_type="DocType",
+				link_to="User",
+				label="Disabled Users",
+				filters='{"enabled": 0}',
+			),
+		]
+
+		kept = filter_sidebar_items(rows, None, check_permission=False)
+
+		self.assertEqual([row["label"] for row in kept], ["Users", "Disabled Users"])
 
 	def test_identity_follows_a_renamed_target(self):
 		"""The other half: the identity does move when the target does, which is why base row and delta
@@ -306,7 +334,7 @@ class TestItemIdentity(IntegrationTestCase):
 			base = get_sidebar_bases([module])[module]
 
 			self.assertIsNone(base.rows[0].get("key"))
-			self.assertEqual(item_key(base.rows[0]), "Link|DocType|User|")
+			self.assertEqual(item_key(base.rows[0]), "Link|DocType|User||")
 
 
 class TestSidebarDocument(IntegrationTestCase):

--- a/frappe/tests/test_module_sidebar_boot.py
+++ b/frappe/tests/test_module_sidebar_boot.py
@@ -116,6 +116,44 @@ class TestTheResolverSeam(IntegrationTestCase):
 			self.assertEqual(resolved.landing, "/desk/test-seam-landing-page")
 			self.assertEqual(resolved.landing, get_module_landing_route(resolved.items))
 
+	def test_a_module_opening_on_a_doctype_lands_on_its_list(self):
+		"""A sidebar need not start on a workspace. `Bulk Transaction` has no workspace at all, and
+		answering `None` for it left its tile with nowhere to go, so a module whose first entry is a
+		list opens on that list.
+		"""
+		self.assertEqual(
+			get_module_landing_route([{"type": "Link", "link_type": "DocType", "link_to": "ToDo"}]),
+			"/desk/todo",
+		)
+
+	def test_a_single_opens_on_the_document_itself(self):
+		"""There is no list to send anyone to."""
+		self.assertEqual(
+			get_module_landing_route(
+				[{"type": "Link", "link_type": "DocType", "link_to": "System Settings"}]
+			),
+			"/desk/system-settings/System Settings",
+		)
+
+	def test_a_child_table_is_not_somewhere_to_land(self):
+		"""It has no list view, so a tile pointing at one would open on nothing. Better to fall back
+		to the client, which knows the rest of the routing rules.
+		"""
+		child = frappe.get_all("DocType", filters={"istable": 1}, limit=1, pluck="name")[0]
+
+		self.assertIsNone(
+			get_module_landing_route([{"type": "Link", "link_type": "DocType", "link_to": child}])
+		)
+
+	def test_a_report_is_still_left_to_the_client(self):
+		"""Report types and filters live in `generate_route`, and a second copy of those rules here
+		would be one to keep in step."""
+		self.assertIsNone(
+			get_module_landing_route(
+				[{"type": "Link", "link_type": "Report", "link_to": "Permitted Documents For User"}]
+			)
+		)
+
 	def test_the_landing_is_derived_rather_than_carried(self):
 		"""Boot never asks for it, since seventy modules would be seventy lookups to answer a question
 		the desk asks about the one it is opening. So it is not in the payload, and the tile list


### PR DESCRIPTION
DocType can the first item of a sidebar 