### PR TITLE
fix: honour ignore_if_duplicate on a unique key violation

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -790,9 +790,15 @@ class BaseDocument:
 			and frappe.db.db_type == "postgres"
 			and (self.flags.retry_count or 0) < 5
 		):
-			conflict_handler = "on conflict (name) do nothing"
 			if self.meta.autoname == "hash":
+				# A hash name that collides has to be regenerated, so only `name` may be skipped.
+				conflict_handler = "on conflict (name) do nothing"
 				returning = "RETURNING name"
+			else:
+				# Any unique index, not only the primary key: a doctype named after a unique field
+				# breaks both with one row. Letting postgres skip the row keeps the transaction
+				# usable, which catching the error below would not.
+				conflict_handler = "on conflict do nothing"
 
 		if not self.creation:
 			self.creation = self.modified = now()

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -837,8 +837,13 @@ class BaseDocument:
 					raise frappe.DuplicateEntryError(self.doctype, self.name, e)
 
 			elif frappe.db.is_unique_key_violation(e):
-				# unique constraint
-				self.show_unique_validation_message(e)
+				# A doctype named after a unique field breaks two indexes with one row, and which
+				# one the backend blames is its own choice: MariaDB says PRIMARY and is handled
+				# above, SQLite says the secondary index and arrives here. `ignore_if_duplicate`
+				# has to mean the same thing in both places.
+				if not ignore_if_duplicate:
+					# unique constraint
+					self.show_unique_validation_message(e)
 
 			else:
 				raise

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -599,6 +599,24 @@ class TestDocument(IntegrationTestCase):
 		doc.save()
 		self.assertEqual(frappe.db.get_value("ToDo", doc.name, "docstatus"), 1)
 
+	def test_ignore_if_duplicate_on_a_unique_autoname_field(self):
+		"""A doctype named after a unique field breaks two indexes with one row.
+
+		`Role` is `autoname: field:role_name` and `role_name` is unique, so re-inserting the
+		same role violates the primary key AND the unique index. Which one the backend reports
+		is its own choice: MariaDB names PRIMARY, SQLite names the secondary index. Callers that
+		seed idempotently pass `ignore_if_duplicate` and must not have to know the difference.
+		"""
+		role = frappe.get_doc(doctype="Role", role_name="_Test Duplicate Role").insert()
+		self.addCleanup(role.delete)
+
+		frappe.get_doc(doctype="Role", role_name="_Test Duplicate Role").insert(ignore_if_duplicate=True)
+		self.assertEqual(frappe.db.count("Role", {"role_name": "_Test Duplicate Role"}), 1)
+
+		# Without the flag it is still an error, whichever index the backend blames.
+		with self.assertRaises((frappe.UniqueValidationError, frappe.DuplicateEntryError)):
+			frappe.get_doc(doctype="Role", role_name="_Test Duplicate Role").insert()
+
 
 class TestDocumentWebView(IntegrationTestCase):
 	def get(self, path, user="Guest"):

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -613,9 +613,40 @@ class TestDocument(IntegrationTestCase):
 		frappe.get_doc(doctype="Role", role_name="_Test Duplicate Role").insert(ignore_if_duplicate=True)
 		self.assertEqual(frappe.db.count("Role", {"role_name": "_Test Duplicate Role"}), 1)
 
-		# Without the flag it is still an error, whichever index the backend blames.
+		# A skipped row has to leave the transaction usable. Postgres aborts it on any failed
+		# statement, so a write here is what proves the row was skipped and not caught.
+		role.db_set("disabled", 1)
+		self.assertEqual(frappe.db.get_value("Role", role.name, "disabled"), 1)
+
+		# Without the flag it is still an error, whichever index the backend blames. The
+		# savepoint is for postgres: the failed insert aborts the transaction, so nothing
+		# after this test could read or write without it.
+		frappe.db.savepoint("test_ignore_if_duplicate")
 		with self.assertRaises((frappe.UniqueValidationError, frappe.DuplicateEntryError)):
 			frappe.get_doc(doctype="Role", role_name="_Test Duplicate Role").insert()
+		frappe.db.rollback(save_point="test_ignore_if_duplicate")
+
+	def test_ignore_if_duplicate_on_a_unique_field_that_is_not_the_name(self):
+		"""The clash can be on a unique index alone, with a name that is free.
+
+		The row still has to be skipped, and the transaction still has to work afterwards.
+		Postgres aborts a transaction on any failed statement, so there the row has to be
+		skipped by the database rather than caught in python.
+		"""
+		doctype = new_doctype(unique=True).insert()
+		self.addCleanup(doctype.delete, force=True)
+
+		first = frappe.get_doc(doctype=doctype.name, some_fieldname="_Test Unique Value").insert()
+		frappe.get_doc(doctype=doctype.name, some_fieldname="_Test Unique Value").insert(
+			ignore_if_duplicate=True
+		)
+		self.assertEqual(frappe.db.count(doctype.name, {"some_fieldname": "_Test Unique Value"}), 1)
+
+		# A write, not a read: this is what an aborted postgres transaction would fail on.
+		first.db_set("some_fieldname", "_Test Unique Value 2")
+		self.assertEqual(
+			frappe.db.get_value(doctype.name, first.name, "some_fieldname"), "_Test Unique Value 2"
+		)
 
 
 class TestDocumentWebView(IntegrationTestCase):


### PR DESCRIPTION
`bench new-site --db-type sqlite` has been failing on develop since #41636 merged. It dies while installing frappe itself:

```
File "frappe/installer.py", line 371, in install_app
  add_module_defs(name, ignore_if_duplicate=True)
frappe.exceptions.UniqueValidationError:
  ('Module Def', 'Core', IntegrityError('UNIQUE constraint failed: tabModule Def.module_name'))
```

Note the flag is `True` and the insert raised anyway.

## Cause

`db_insert` classifies a duplicate in two branches. Only the primary key branch honours `ignore_if_duplicate`:

```python
if frappe.db.is_primary_key_violation(e):
    if not ignore_if_duplicate:          # flag respected
        raise frappe.DuplicateEntryError(...)
elif frappe.db.is_unique_key_violation(e):
    self.show_unique_validation_message(e)   # raises regardless
```

`Module Def` is `autoname: field:module_name` and `module_name` is `unique: 1`, so one duplicate row breaks the primary key **and** the unique index. Which one the backend blames is its own choice:

```
('Core', 'Other') -> code 1555 | UNIQUE constraint failed: t.name
('Other', 'Core') -> code 2067 | UNIQUE constraint failed: t.module_name
('Core', 'Core')  -> code 2067 | UNIQUE constraint failed: t.module_name   <- the install case
```

SQLite reports the secondary index (2067), so `is_primary_key_violation` is False and the flag is discarded. MariaDB reports errno 1062 against `PRIMARY` for the same insert, which is why this never showed on MariaDB.

#41636 did not introduce the bug. It made install create `Module Def "Core"` twice, which exposed it. The same latent break hits every idempotent seed on SQLite: `Role`, `File`, and the ~20 other `ignore_if_duplicate=True` call sites.

Postgres already has a workaround one layer up in the same function (`on conflict (name) do nothing`), added because "pg can't implicitly ignore PK collision". SQLite has the same property and no equivalent.

## Change

The unique key branch now respects the flag, as the primary key branch already does. Without the flag the error is unchanged.

## Verification

Run on a local bench, `frappe.tests.test_document`. The new test fails on SQLite before the change and passes after it.

| | before | after |
|---|---|---|
| SQLite | 69 tests, 3 failures + 1 error | 70 tests, 3 failures + 1 error |
| MariaDB | 69 tests, 1 error | 70 tests, 1 error |

Those failures and errors are pre-existing on develop and unrelated. Neither count moves.
