### PR TITLE
fix: report PDF export clips columns beyond the page width

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -206,7 +206,7 @@ class AutoEmailReport(Document):
 			if len(columns) > 8:
 				options["orientation"] = "landscape"
 			html = get_formatted_html(subject=self.name, message=self.get_html_table(columns, data))
-			return get_pdf(html, options)
+			return get_pdf(html, options, smart_shrinking=True)
 
 		else:
 			frappe.throw(_("Invalid Output Format"))

--- a/frappe/tests/test_pdf.py
+++ b/frappe/tests/test_pdf.py
@@ -97,7 +97,10 @@ class TestPdf(IntegrationTestCase):
 			captured.update(options or {})
 			return blank_pdf()
 
-		with patch.object(pdfgen.pdfkit, "from_string", side_effect=capture_options):
+		with (
+			patch.object(pdfgen.pdfkit, "from_string", side_effect=capture_options),
+			patch.object(pdfgen, "get_wkhtmltopdf_version", return_value="0.12.6"),
+		):
 			pdfgen.get_pdf(self.html)
 			self.assertIn("disable-smart-shrinking", captured)
 

--- a/frappe/tests/test_pdf.py
+++ b/frappe/tests/test_pdf.py
@@ -10,6 +10,16 @@ from frappe.core.doctype.file.test_file import make_test_image_file
 from frappe.tests import IntegrationTestCase
 
 
+def blank_pdf() -> bytes:
+	from pypdf import PdfWriter
+
+	writer = PdfWriter()
+	writer.add_blank_page(width=72, height=72)
+	stream = io.BytesIO()
+	writer.write(stream)
+	return stream.getvalue()
+
+
 class TestPdf(IntegrationTestCase):
 	@property
 	def html(self):
@@ -76,6 +86,33 @@ class TestPdf(IntegrationTestCase):
 		reader = PdfReader(io.BytesIO(pdf))
 		self.assertTrue(reader.is_encrypted)
 		self.assertTrue(reader.decrypt(password))
+
+	def test_smart_shrinking_is_opt_in(self):
+		from unittest.mock import patch
+
+		captured = {}
+
+		def capture_options(html, options=None, verbose=True):
+			captured.clear()
+			captured.update(options or {})
+			return blank_pdf()
+
+		with patch.object(pdfgen.pdfkit, "from_string", side_effect=capture_options):
+			pdfgen.get_pdf(self.html)
+			self.assertIn("disable-smart-shrinking", captured)
+
+			pdfgen.get_pdf(self.html, smart_shrinking=True)
+			self.assertNotIn("disable-smart-shrinking", captured)
+
+	def test_report_pdf_is_scaled_to_fit_the_page(self):
+		from unittest.mock import patch
+
+		from frappe.utils import print_format
+
+		with patch.object(print_format, "get_pdf", return_value=blank_pdf()) as get_report_pdf:
+			print_format.report_to_pdf("<table><tr><td>a wide report</td></tr></table>")
+
+		self.assertTrue(get_report_pdf.call_args.kwargs["smart_shrinking"])
 
 	def test_pdf_generation_as_a_user(self):
 		frappe.set_user("Administrator")

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -104,14 +104,19 @@ def pdf_footer_html(soup, head, content, styles, html_id, css, path=None):
 	)
 
 
-def get_pdf(html, options=None, output: "PdfWriter" | None = None):
+def get_pdf(html, options=None, output: "PdfWriter" | None = None, smart_shrinking: bool = False):
+	"""Render `html` to PDF.
+
+	:param smart_shrinking: scale content that is wider than the page down to fit it, instead of
+	        clipping the overflow.
+	"""
 	html = scrub_urls(html)
 	html, options = prepare_options(html, options)
 
 	options.update({"disable-javascript": "", "disable-local-file-access": ""})
 
 	filedata = ""
-	if Version(get_wkhtmltopdf_version()) > Version("0.12.3"):
+	if not smart_shrinking and Version(get_wkhtmltopdf_version()) > Version("0.12.3"):
 		options.update({"disable-smart-shrinking": ""})
 
 	try:

--- a/frappe/utils/print_format.py
+++ b/frappe/utils/print_format.py
@@ -303,6 +303,7 @@ def report_to_pdf(html: str, orientation: str = "Landscape"):
 			"bypass-proxy-for": _pdf_bypass_proxy_hosts(),
 			"load-error-handling": "ignore",
 		},
+		smart_shrinking=True,
 	)
 	frappe.local.response.type = "pdf"
 


### PR DESCRIPTION
## Description

PDF exports were clipping report columns that did not fit on the page. This was caused by `--disable-smart-shrinking`, which is needed for Print Formats but not for wide report tables.

`get_pdf` now supports `smart_shrinking`, enabled for Report and Auto Email Report PDFs while keeping the existing behavior for Print Formats.

This scales wide reports to fit the page, preventing columns from being lost. Report PDFs may be slightly smaller and have different page breaks.


## Before/After
<img width="1600" height="780" alt="report-pdf-before" src="https://github.com/user-attachments/assets/c6d3f8ac-546d-49b0-bed6-f90031a53427" />

<img width="1600" height="780" alt="report-pdf-after" src="https://github.com/user-attachments/assets/04ad7574-04fe-4919-a9d1-a9f8ef91537d" />

---

Ref: https://support.frappe.io/helpdesk/tickets/77011?view=VIEW-HD+Ticket-1252