### PR TITLE
fix(utils): revalidate redirect targets in get_web_image()

### DIFF
--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -7,7 +7,7 @@ import tempfile
 import zipfile
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import frappe
 from frappe import _
@@ -19,7 +19,7 @@ from frappe.core.api.file import (
 	unzip_file,
 )
 from frappe.core.doctype.file.exceptions import FileTypeNotAllowed
-from frappe.core.doctype.file.utils import get_corrupted_image_msg, get_extension
+from frappe.core.doctype.file.utils import get_corrupted_image_msg, get_extension, get_web_image
 from frappe.desk.form.utils import add_comment, remove_attach
 from frappe.exceptions import ValidationError
 from frappe.tests import IntegrationTestCase
@@ -1300,6 +1300,38 @@ class TestFileUtils(IntegrationTestCase):
 	def test_create_new_folder(self):
 		folder = create_new_folder("test_folder", "Home")
 		self.assertTrue(folder.is_folder)
+
+	def test_get_web_image_follows_redirect_to_allowed_address(self):
+		from io import BytesIO
+
+		from PIL import Image as PILImage
+
+		buf = BytesIO()
+		PILImage.new("RGB", (2, 2)).save(buf, format="JPEG")
+		image_bytes = buf.getvalue()
+
+		redirect_response = MagicMock(is_redirect=True, headers={"Location": "http://8.8.4.4/final.jpg"})
+		final_response = MagicMock(is_redirect=False, content=image_bytes)
+		final_response.raise_for_status.return_value = None
+
+		with patch("requests.get", side_effect=[redirect_response, final_response]) as mock_get:
+			_, _, extn = get_web_image("http://8.8.8.8/initial.jpg")
+
+		self.assertEqual(mock_get.call_count, 2)
+		self.assertEqual(extn, "jpg")
+
+	def test_get_web_image_rejects_redirect_to_restricted_address(self):
+		redirect_response = MagicMock(is_redirect=True, headers={"Location": "http://127.0.0.1/secret"})
+
+		with patch("requests.get", side_effect=[redirect_response]) as mock_get:
+			self.assertRaisesRegex(
+				ValidationError,
+				"restricted address",
+				get_web_image,
+				"http://8.8.8.8/initial.jpg",
+			)
+
+		mock_get.assert_called_once()
 
 
 class TestFileOptimization(IntegrationTestCase):

--- a/frappe/core/doctype/file/utils.py
+++ b/frappe/core/doctype/file/utils.py
@@ -5,7 +5,7 @@ import re
 from binascii import Error as BinasciiError
 from io import BytesIO
 from typing import TYPE_CHECKING, Optional
-from urllib.parse import unquote
+from urllib.parse import unquote, urljoin
 
 import filetype
 
@@ -114,6 +114,9 @@ def get_local_image(file_url: str) -> tuple["ImageFile", str, str]:
 	return image, filename, extn
 
 
+MAX_WEB_IMAGE_REDIRECTS = 5
+
+
 def get_web_image(file_url: str) -> tuple["ImageFile", str, str]:
 	import requests
 	import requests.exceptions
@@ -123,15 +126,30 @@ def get_web_image(file_url: str) -> tuple["ImageFile", str, str]:
 
 	file_url = frappe.utils.get_url(file_url)
 	site_url = frappe.utils.get_url().rstrip("/")
-	if not (file_url == site_url or file_url.startswith(site_url + "/")):
+
+	def validate_external_url(url: str) -> None:
+		if url == site_url or url.startswith(site_url + "/"):
+			return
 		try:
-			validate_egress_url(file_url)
+			validate_egress_url(url)
 		except ValueError:
 			frappe.throw(
-				_("Cannot fetch image from {0}: the URL resolves to a restricted address").format(file_url)
+				_("Cannot fetch image from {0}: the URL resolves to a restricted address").format(url)
 			)
 
-	r = requests.get(file_url, stream=True)
+	validate_external_url(file_url)
+
+	# Redirects are followed manually so each hop's destination gets the same
+	# validation as the original URL.
+	for _attempt in range(MAX_WEB_IMAGE_REDIRECTS + 1):
+		r = requests.get(file_url, stream=True, allow_redirects=False)
+		if not r.is_redirect:
+			break
+		file_url = urljoin(file_url, r.headers["Location"])
+		validate_external_url(file_url)
+	else:
+		frappe.throw(_("Too many redirects while fetching {0}").format(file_url))
+
 	try:
 		r.raise_for_status()
 	except requests.exceptions.HTTPError as e:


### PR DESCRIPTION
This PR ensures that revalidation of redirect targets in `get_web_image()` takes place.
closes Ticket 77060

Thanks to @Darshan060224 for reporting.