### PR TITLE
fix: web form save fails when the form has a currency field

### DIFF
--- a/cypress/integration/currency_formatter.js
+++ b/cypress/integration/currency_formatter.js
@@ -49,3 +49,36 @@ context("Currency Formatter", () => {
 		format_amount(97.646, "BHD", { currency_precision: 2 }).should("eq", "BD 97.65");
 	});
 });
+
+context("Currency Formatter outside desk", () => {
+	before(() => {
+		cy.login();
+		cy.visit("/me");
+	});
+
+	it("resolves precision from system defaults on portal pages", () => {
+		cy.window().then((win) => {
+			Object.assign(win.frappe.sys_defaults, {
+				currency: "USD",
+				number_format: "#,###.##",
+				currency_precision: 3,
+				float_precision: 4,
+			});
+
+			expect(
+				win.frappe.format(
+					97.646,
+					{ fieldtype: "Currency", fieldname: "amount" },
+					{ only_value: true }
+				)
+			).to.eq("USD 97.646");
+			expect(
+				win.frappe.format(
+					97.64646,
+					{ fieldtype: "Float", fieldname: "qty" },
+					{ only_value: true }
+				)
+			).to.eq("97.6465");
+		});
+	});
+});

--- a/frappe/public/js/frappe/sys_defaults.js
+++ b/frappe/public/js/frappe/sys_defaults.js
@@ -17,4 +17,10 @@ Object.assign(frappe.defaults, {
 	is_enabled: function (key) {
 		return cint(this.get_global_default(key)) === 1;
 	},
+	get_default: function (key) {
+		return this.get_global_default(key);
+	},
+	get_user_default: function (key) {
+		return this.get_global_default(key);
+	},
 });

--- a/frappe/tests/test_website.py
+++ b/frappe/tests/test_website.py
@@ -6,7 +6,7 @@ from frappe.tests import IntegrationTestCase
 from frappe.utils import set_request
 from frappe.website.page_renderers.static_page import StaticPage
 from frappe.website.serve import get_response, get_response_content
-from frappe.website.utils import build_response, clear_website_cache, get_home_page
+from frappe.website.utils import build_response, clear_website_cache, get_boot_data, get_home_page
 
 
 class TestWebsite(IntegrationTestCase):
@@ -292,6 +292,19 @@ class TestWebsite(IntegrationTestCase):
 
 		# assert template block rendered
 		self.assertIn("<p>Test content</p>", content)
+
+	def test_boot_data_number_settings(self):
+		with self.change_settings(
+			"System Settings",
+			currency_precision=3,
+			float_precision=4,
+			rounding_method="Commercial Rounding",
+		):
+			sysdefaults = get_boot_data()["sysdefaults"]
+
+		self.assertEqual(sysdefaults["currency_precision"], 3)
+		self.assertEqual(sysdefaults["float_precision"], 4)
+		self.assertEqual(sysdefaults["rounding_method"], "Commercial Rounding")
 
 	def test_index_and_next_comment(self):
 		content = get_response_content("/_test/_test_folder")

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -195,10 +195,12 @@ def get_boot_data():
 		},
 		"sysdefaults": {
 			"float_precision": cint(frappe.get_system_settings("float_precision")) or 3,
+			"currency_precision": cint(frappe.get_system_settings("currency_precision")),
 			"date_format": get_date_format(),
 			"time_format": get_time_format(),
 			"first_day_of_the_week": get_first_day_of_the_week(),
 			"number_format": get_number_format().string,
+			"rounding_method": frappe.get_system_settings("rounding_method"),
 			"currency": frappe.get_system_settings("currency"),
 		},
 		"time_zone": {


### PR DESCRIPTION
## Description

Regression from #41708. 
Currency formatting on portal pages started failing because `frappe.meta.get_field_precision` depends on `frappe.defaults.get_default`, which is only available in Desk.

On Web Forms, this caused currency fields in child tables to break and prevented saving.

The portal-safe default handling is now moved to `sys_defaults.js`, which is loaded by both Desk and web bundles. Desk still overrides these with user-specific defaults as before.

Also added `currency_precision` and `rounding_method` to website boot so currency formatting is consistent between Desk and Web Forms.
