### PR TITLE
fix(contact): enforce one primary contact per party

### DIFF
--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -74,11 +74,33 @@ class Contact(Document):
 		self.set_user()
 
 		set_link_title(self)
+		deduplicate_dynamic_links(self)
+		self.validate_primary_contact()
 
 		if self.get("sync_with_google_contacts") and not self.get("google_contacts"):
 			frappe.throw(_("Select Google Contacts to which contact should be synced."))
 
-		deduplicate_dynamic_links(self)
+	def validate_primary_contact(self):
+		if not self.is_primary_contact:
+			return
+
+		primary_contacts = set()
+		for link in self.links:
+			primary_contacts.update(
+				frappe.get_all(
+					"Contact",
+					filters=[
+						["Dynamic Link", "link_doctype", "=", link.link_doctype],
+						["Dynamic Link", "link_name", "=", link.link_name],
+						["is_primary_contact", "=", 1],
+						["name", "!=", self.name],
+					],
+					pluck="name",
+				)
+			)
+
+		if primary_contacts:
+			frappe.db.set_value("Contact", {"name": ["in", list(primary_contacts)]}, "is_primary_contact", 0)
 
 	def set_user(self):
 		if not self.user and self.email_id:

--- a/frappe/contacts/doctype/contact/test_contact.py
+++ b/frappe/contacts/doctype/contact/test_contact.py
@@ -65,6 +65,35 @@ class TestContact(IntegrationTestCase):
 		self.assertEqual(results[0].value, "test_contact@example.com")
 		self.assertEqual(results[0].description, "_Test Contact For _Test Supplier")
 
+	def test_only_one_primary_contact_per_link(self):
+		first_contact = create_contact("First Primary Contact", "Mr", save=False)
+		first_contact.is_primary_contact = 1
+		first_contact.append("links", {"link_doctype": "User", "link_name": "Administrator"})
+		first_contact.insert()
+
+		second_contact = create_contact("Second Primary Contact", "Mr", save=False)
+		second_contact.is_primary_contact = 1
+		second_contact.append("links", {"link_doctype": "User", "link_name": "Administrator"})
+		second_contact.insert()
+
+		self.assertFalse(first_contact.reload().is_primary_contact)
+		self.assertTrue(second_contact.is_primary_contact)
+
+	def test_promoting_contact_clears_existing_primary_contact(self):
+		first_contact = create_contact("Existing Primary Contact", "Mr", save=False)
+		first_contact.is_primary_contact = 1
+		first_contact.append("links", {"link_doctype": "User", "link_name": "Administrator"})
+		first_contact.insert()
+
+		second_contact = create_contact("Promoted Primary Contact", "Mr", save=False)
+		second_contact.append("links", {"link_doctype": "User", "link_name": "Administrator"})
+		second_contact.insert()
+		second_contact.is_primary_contact = 1
+		second_contact.save()
+
+		self.assertFalse(first_contact.reload().is_primary_contact)
+		self.assertTrue(second_contact.is_primary_contact)
+
 
 def create_contact(name, salutation, emails=None, phones=None, save=True):
 	doc = frappe.get_doc(


### PR DESCRIPTION
  ### Issue

  Multiple contacts linked to the same party can be marked as primary. This makes the default contact selection ambiguous in transactions.

Fixes : [#18811](https://github.com/frappe/frappe/issues/42221)

  ### Steps to reproduce

  1. Create a party such as a Customer.
  2. Create a Contact linked to that party and enable **Is Primary Contact**.
  3. Create another Contact linked to the same party.
  4. Enable **Is Primary Contact** on the second Contact and save it.

  ### Actual behaviour

  Both contacts remain marked as primary so that ERPNext may select an unexpected contact in downstream transactions.

  ### Expected behaviour

  When a Contact is marked as primary, the primary flag should be cleared from other contacts linked to the same party.

  ### Backport needed For V15 and V16