### PR TITLE
feat(ui): read doc and field-level permissions from the client

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -950,6 +950,16 @@ def get_all_roles():
 
 
 @frappe.whitelist()
+def get_current_user_roles() -> list[str]:
+	"""Return the logged-in user's roles.
+
+	Desk reads these from `frappe.boot.user.roles`. Clients that do not load
+	bootinfo have no such payload, so they fetch them here.
+	"""
+	return frappe.get_roles()
+
+
+@frappe.whitelist()
 def get_perm_info(role: str):
 	"""get permission info"""
 	from frappe.permissions import get_all_perms

--- a/ui/src/components/FormLayout/buildLayoutFromMeta.ts
+++ b/ui/src/components/FormLayout/buildLayoutFromMeta.ts
@@ -148,7 +148,7 @@ function resolveChildLayout(
   return buildLayoutFromMeta(childMeta, { childMetas, decorate });
 }
 
-function mapField(
+export function mapField(
   field: RawMetaField,
   childMetas: Record<string, RawMetaField[]>,
   decorate?: Decorator

--- a/ui/src/composables/tests/useDocPermissions.test.ts
+++ b/ui/src/composables/tests/useDocPermissions.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoisted so the factory passed to `vi.mock` can reference them.
+const { createResourceMock, state } = vi.hoisted(() => ({
+  createResourceMock: vi.fn(),
+  state: {
+    roles: null as string[] | null,
+    permissions: undefined as Record<string, unknown>[] | undefined,
+    loading: false,
+  },
+}));
+
+vi.mock("frappe-ui", () => ({
+  createResource: createResourceMock,
+  frappeRequest: vi.fn(),
+}));
+
+const ROLES_URL = "frappe.core.doctype.user.user.get_current_user_roles";
+
+createResourceMock.mockImplementation((options: any) => {
+  const roles = options.url === ROLES_URL;
+  return {
+    get data() {
+      if (roles) return state.roles ?? undefined;
+      return {
+        docs: [
+          {
+            name: options.params.doctype,
+            fields: [],
+            permissions: state.permissions,
+          },
+        ],
+      };
+    },
+    get loading() {
+      return state.loading;
+    },
+    fetched: false,
+    error: null,
+    fetch: vi.fn(),
+    reload: vi.fn(),
+  };
+});
+
+import { useDocPermissions } from "../useDocPermissions";
+import { resetDoctypeMeta } from "../useDoctypeMeta";
+import { resetUserRoles } from "../useUserRoles";
+
+function reset() {
+  resetDoctypeMeta();
+  resetUserRoles();
+  vi.clearAllMocks();
+  state.roles = null;
+  state.permissions = undefined;
+  state.loading = false;
+}
+
+describe("useUserRoles' endpoint", () => {
+  beforeEach(reset);
+
+  // The composable is useless if this name drifts from the whitelisted method,
+  // and nothing else would notice: every other test here mocks the transport, so
+  // the URL is never resolved against a server. It was in fact wrong once — the
+  // method was left behind when this code was split out of its original branch.
+  it("asks the whitelisted method that returns the session user's roles", () => {
+    useDocPermissions("Note");
+
+    const urls = createResourceMock.mock.calls.map(([o]: any[]) => o.url);
+    expect(urls).toContain(ROLES_URL);
+  });
+
+  it("fetches the roles once, however many callers ask", () => {
+    useDocPermissions("Note");
+    useDocPermissions("ToDo");
+
+    const rolesCalls = createResourceMock.mock.calls.filter(
+      ([o]: any[]) => o.url === ROLES_URL
+    );
+    expect(rolesCalls).toHaveLength(1);
+  });
+});
+
+describe("field-level access", () => {
+  beforeEach(reset);
+
+  it("leaves permlevel 0 to the doc-level rights", () => {
+    state.roles = [];
+    state.permissions = [];
+    const { fieldAccess } = useDocPermissions("Note");
+
+    expect(fieldAccess({ permlevel: 0 })).toBe("write");
+    expect(fieldAccess({})).toBe("write");
+  });
+
+  it("grants write on a permlevel one of the user's roles writes", () => {
+    state.roles = ["Accounts Manager"];
+    state.permissions = [
+      { role: "Accounts Manager", permlevel: 1, read: 1, write: 1 },
+    ];
+
+    expect(useDocPermissions("Note").fieldAccess({ permlevel: 1 })).toBe(
+      "write"
+    );
+  });
+
+  it("grants read only, when the row reads but does not write", () => {
+    state.roles = ["Sales User"];
+    state.permissions = [{ role: "Sales User", permlevel: 2, read: 1 }];
+
+    expect(useDocPermissions("Note").fieldAccess({ permlevel: 2 })).toBe(
+      "read"
+    );
+  });
+
+  it("refuses a permlevel no role of the user's holds", () => {
+    state.roles = ["Sales User"];
+    state.permissions = [
+      { role: "Accounts Manager", permlevel: 1, read: 1, write: 1 },
+    ];
+
+    expect(useDocPermissions("Note").fieldAccess({ permlevel: 1 })).toBe(
+      "none"
+    );
+  });
+
+  it("ignores a DocPerm row for a role the user does not hold", () => {
+    state.roles = ["Sales User"];
+    state.permissions = [
+      { role: "Sales User", permlevel: 1, read: 1 },
+      { role: "Accounts Manager", permlevel: 1, read: 1, write: 1 },
+    ];
+
+    expect(useDocPermissions("Note").fieldAccess({ permlevel: 1 })).toBe(
+      "read"
+    );
+  });
+
+  // Better a field the server refuses to save than a form that flashes empty.
+  it("fails open while the roles are still loading", () => {
+    state.roles = null;
+    state.permissions = [
+      { role: "Accounts Manager", permlevel: 1, read: 1, write: 1 },
+    ];
+
+    expect(useDocPermissions("Note").fieldAccess({ permlevel: 1 })).toBe(
+      "write"
+    );
+  });
+});
+
+describe("allowedPermlevels", () => {
+  beforeEach(reset);
+
+  it("lists the permlevels the user's roles hold the right on, in order", () => {
+    state.roles = ["Sales User", "Accounts Manager"];
+    state.permissions = [
+      { role: "Accounts Manager", permlevel: 2, read: 1, write: 1 },
+      { role: "Sales User", permlevel: 1, read: 1 },
+      { role: "Sales User", permlevel: 0, read: 1, write: 1 },
+    ];
+    const { allowedPermlevels } = useDocPermissions("Note");
+
+    expect(allowedPermlevels("read")).toEqual([0, 1, 2]);
+    expect(allowedPermlevels("write")).toEqual([0, 2]);
+  });
+
+  it("is empty while the meta is still loading", () => {
+    expect(useDocPermissions("Note").allowedPermlevels("read")).toEqual([]);
+  });
+});
+
+describe("doc-level rights", () => {
+  beforeEach(reset);
+
+  it("reads the server-computed docinfo permissions", () => {
+    const { can } = useDocPermissions("Note", { write: 1, delete: 0 });
+
+    expect(can("write")).toBe(true);
+    expect(can("delete")).toBe(false);
+  });
+
+  it("refuses everything until docinfo provides them", () => {
+    expect(useDocPermissions("Note").can("write")).toBe(false);
+  });
+});

--- a/ui/src/composables/useDocPermissions.ts
+++ b/ui/src/composables/useDocPermissions.ts
@@ -1,0 +1,63 @@
+import { computed, toValue } from "vue";
+import type { ComputedRef, MaybeRefOrGetter } from "vue";
+import { useDoctypeMeta } from "./useDoctypeMeta";
+import { useUserRoles } from "./useUserRoles";
+
+export type FieldAccess = "write" | "read" | "none";
+
+export interface UseDocPermissions {
+  /** Doc-level rights from `docinfo.permissions` (`getdoc`); false until provided. */
+  can: (right: string) => boolean;
+  /** Permlevels the user's roles hold `right` on, from the meta's DocPerm rows. */
+  allowedPermlevels: (right: "read" | "write") => number[];
+  /** What a permlevel'd field may render as. */
+  fieldAccess: (field: { permlevel?: number }) => FieldAccess;
+  /** True while roles or meta are still loading (field access is Write until then). */
+  loading: ComputedRef<boolean>;
+}
+
+/**
+ * The Vue port of desk's `frappe.perm`: doc-level rights come from the
+ * server-computed `docinfo.permissions`, field-level permlevel access from the
+ * meta's DocPerm rows crossed with the session user's roles. Display-only —
+ * enforcement stays server-side (`getdoc` applies field-level read permissions).
+ */
+export function useDocPermissions(
+  doctype: MaybeRefOrGetter<string>,
+  docPermissions?: MaybeRefOrGetter<Record<string, unknown> | null | undefined>
+): UseDocPermissions {
+  const { meta, loading: metaLoading } = useDoctypeMeta(doctype);
+  const { roles, loading: rolesLoading } = useUserRoles();
+
+  const permlevels = computed(() => {
+    if (!roles.value || !meta.value?.permissions) return null;
+    const held = { read: new Set<number>(), write: new Set<number>() };
+    for (const row of meta.value.permissions) {
+      if (!roles.value.includes(row.role)) continue;
+      if (row.read) held.read.add(row.permlevel ?? 0);
+      if (row.write) held.write.add(row.permlevel ?? 0);
+    }
+    return held;
+  });
+
+  function allowedPermlevels(right: "read" | "write"): number[] {
+    return [...(permlevels.value?.[right] ?? [])].sort((a, b) => a - b);
+  }
+
+  // Fail-open while roles/meta load: better a field the server refuses to save
+  // than a form that flashes empty. Permlevel 0 is doc-level territory (`can`).
+  function fieldAccess(field: { permlevel?: number }): FieldAccess {
+    const permlevel = field.permlevel ?? 0;
+    if (permlevel === 0 || !permlevels.value) return "write";
+    if (permlevels.value.write.has(permlevel)) return "write";
+    if (permlevels.value.read.has(permlevel)) return "read";
+    return "none";
+  }
+
+  return {
+    can: (right) => Boolean(toValue(docPermissions)?.[right]),
+    allowedPermlevels,
+    fieldAccess,
+    loading: computed(() => metaLoading.value || rolesLoading.value),
+  };
+}

--- a/ui/src/composables/useDoctypeMeta.ts
+++ b/ui/src/composables/useDoctypeMeta.ts
@@ -4,10 +4,20 @@ import { createResource, frappeRequest } from "frappe-ui";
 import type { RawMetaField } from "../components/FormLayout/types";
 import { memoizedState } from "../utils/sharedState";
 
+/** A DocPerm row as `getdoctype` returns it; booleans arrive as `0 | 1`. */
+export interface DocPermRow {
+  role: string;
+  permlevel?: number;
+  read?: 0 | 1;
+  write?: 0 | 1;
+  [right: string]: unknown;
+}
+
 export interface DoctypeMeta {
   name: string;
   title_field?: string;
   fields?: RawMetaField[];
+  permissions?: DocPermRow[];
 }
 
 interface GetDoctypeResponse {

--- a/ui/src/composables/useUserRoles.ts
+++ b/ui/src/composables/useUserRoles.ts
@@ -1,0 +1,42 @@
+import { computed } from "vue";
+import type { ComputedRef } from "vue";
+import { createResource, frappeRequest } from "frappe-ui";
+
+export interface UseUserRoles {
+  /** The session user's roles; `null` until they load. */
+  roles: ComputedRef<string[] | null>;
+  loading: ComputedRef<boolean>;
+  reload: () => void;
+}
+
+/** One session, one user: fetched once and shared by every caller. */
+let resource: any = null;
+
+/**
+ * Fetch the session user's roles (desk gets them from boot; hosts built on
+ * `@framework/ui` fetch them here instead).
+ */
+export function useUserRoles(): UseUserRoles {
+  resource ??= buildResource();
+
+  return {
+    roles: computed(() => (resource.data as string[] | undefined) ?? null),
+    loading: computed(() => resource.loading),
+    reload: () => resource.reload(),
+  };
+}
+
+/** Drops the shared fetch, so one test's roles cannot reach the next. */
+export function resetUserRoles(): void {
+  resource = null;
+}
+
+function buildResource() {
+  const created = createResource({
+    url: "frappe.core.doctype.user.user.get_current_user_roles",
+    cache: "User Roles",
+    resourceFetcher: frappeRequest,
+  });
+  if (!created.fetched && !created.loading) created.fetch();
+  return created;
+}


### PR DESCRIPTION
The Vue port of desk's `frappe.perm`, for hosts built on `@framework/ui` that have no boot to read permissions from.

These files live outside `experimental/` and exist on `develop` independently, so they are raised here on their own rather than riding in on a desk-v2 PR. The `ui/` commit is the same one that merged to `desk-v2` in #42173, unchanged.

## What it adds

| | |
| --- | --- |
| `useUserRoles` | fetches the session user's roles once and shares the resource |
| `useDoctypeMeta` | now carries the meta's DocPerm rows, which is where permlevel access is decided |
| `useDocPermissions` | crosses the two — doc-level rights from the server-computed `docinfo.permissions`, field-level access from the DocPerm rows |

`mapField` is exported for the same reason: a caller outside `FormLayout` needs to build one node at a time.

**Display-only.** Enforcement stays server-side, and `getdoc` already applies field-level read permissions. This decides what renders, not what saves.

**It fails open while loading.** `fieldAccess` returns `write` until both roles and meta have arrived — better a field the server refuses to save than a form that flashes empty.

## The second commit is a bug fix, not new surface

`useUserRoles` calls `frappe.core.doctype.user.user.get_current_user_roles`. **That method does not currently exist anywhere in this repo** — not on `develop`, and not on `desk-v2` where the composable has already merged.

It was written alongside the composable in the original branch and dropped when the desk-v2 walking skeleton was carved into its PR stack: the JavaScript half was carried, the six lines of Python were not. Nothing caught it because the tests stub `createResource` wholesale, so the URL is never resolved against the server.

```python
@frappe.whitelist()
def get_current_user_roles() -> list[str]:
	"""Return the session user's roles, for clients that boot without desk."""
	return frappe.get_roles()
```

`get_all_roles` is not a substitute — it returns every role in the system, not the session user's.

Consequence today on `desk-v2`: the roles request fails, `roles` stays `null`, `permlevels` stays `null`, and `fieldAccess` takes its fail-open path — so every permlevel'd field renders writable for everyone. Not a security hole, since the server still refuses the write, but the feature is inert.

## Review notes

- Two commits, deliberately separate: the `ui/` composables, then the endpoint they depend on.
- No behaviour changes for existing callers. Both edits to existing files are additive: `mapField` gains an `export`, `DoctypeMeta` gains an optional `permissions?`.
- `useDoctypeMeta` needed no mapping change — it stores the whole doc (`map[d.name] = d`), so DocPerm rows already survive; only the type was missing.

>no-docs
