### PR TITLE
fix: attach files linked by url to attach fields

### DIFF
--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -948,6 +948,59 @@ class TestAttachment(IntegrationTestCase):
 
 		self.assertTrue(exists)
 
+	def test_file_attachment_on_update_for_url(self):
+		doc = frappe.get_doc(doctype=self.test_doctype, title="test for url attachment").insert()
+
+		doc.attachment = "https://example.com/logo.png"
+		doc.save()
+
+		self.assertTrue(
+			frappe.db.exists(
+				"File",
+				{
+					"file_url": "https://example.com/logo.png",
+					"attached_to_doctype": self.test_doctype,
+					"attached_to_name": doc.name,
+					"attached_to_field": "attachment",
+				},
+			)
+		)
+
+	def test_url_attachment_is_attached_to_duplicated_document(self):
+		doc = frappe.get_doc(doctype=self.test_doctype, title="test url attachment on duplicate")
+		doc.attachment = "https://example.com/spec.pdf"
+		doc.insert()
+
+		duplicate = frappe.copy_doc(doc).insert()
+
+		self.assertTrue(
+			frappe.db.exists(
+				"File",
+				{
+					"file_url": "https://example.com/spec.pdf",
+					"attached_to_doctype": self.test_doctype,
+					"attached_to_name": duplicate.name,
+					"attached_to_field": "attachment",
+				},
+			)
+		)
+
+	def test_no_file_created_for_non_file_attach_value(self):
+		doc = frappe.get_doc(doctype=self.test_doctype, title="test non file attach value")
+		doc.attachment = "not a file"
+		doc.insert()
+
+		self.assertFalse(
+			frappe.db.exists(
+				"File",
+				{
+					"attached_to_doctype": self.test_doctype,
+					"attached_to_name": doc.name,
+					"attached_to_field": "attachment",
+				},
+			)
+		)
+
 	def test_delete_file_referenced_in_attach_field(self):
 		doc = frappe.get_doc(doctype=self.test_doctype, title="test delete referenced file").insert()
 		file = frappe.get_doc(

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -948,24 +948,6 @@ class TestAttachment(IntegrationTestCase):
 
 		self.assertTrue(exists)
 
-	def test_file_attachment_on_update_for_url(self):
-		doc = frappe.get_doc(doctype=self.test_doctype, title="test for url attachment").insert()
-
-		doc.attachment = "https://example.com/logo.png"
-		doc.save()
-
-		self.assertTrue(
-			frappe.db.exists(
-				"File",
-				{
-					"file_url": "https://example.com/logo.png",
-					"attached_to_doctype": self.test_doctype,
-					"attached_to_name": doc.name,
-					"attached_to_field": "attachment",
-				},
-			)
-		)
-
 	def test_url_attachment_is_attached_to_duplicated_document(self):
 		doc = frappe.get_doc(doctype=self.test_doctype, title="test url attachment on duplicate")
 		doc.attachment = "https://example.com/spec.pdf"

--- a/frappe/core/doctype/file/utils.py
+++ b/frappe/core/doctype/file/utils.py
@@ -346,7 +346,7 @@ def attach_files_to_document(doc: "Document", event) -> None:
 		# this method runs in on_update hook of all documents
 		# we dont want the update to fail if file cannot be attached for some reason
 		value = doc.get(df.fieldname)
-		if not (value or "").startswith(("/files", "/private/files")):
+		if not (value or "").startswith(("/files", "/private/files", "http://", "https://")):
 			continue
 
 		if frappe.db.exists(


### PR DESCRIPTION
- `attach_files_to_document` only backfilled a `File` record when an Attach field pointed at `/files` or `/private/files`; now accepts `http://` / `https://` too
- Duplicating a document copied the Attach field value but created no `File`, so the Attachments sidebar was empty for anything attached by link

https://support.frappe.io/helpdesk/tickets/77098