### PR TITLE
fix(desk-v2): add the missing get_current_user_roles endpoint

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -940,6 +940,16 @@ def get_all_roles():
 
 
 @frappe.whitelist()
+def get_current_user_roles() -> list[str]:
+	"""Return the logged-in user's roles.
+
+	Desk reads these from `frappe.boot.user.roles`. Clients that do not load
+	bootinfo have no such payload, so they fetch them here.
+	"""
+	return frappe.get_roles()
+
+
+@frappe.whitelist()
 def get_perm_info(role: str):
 	"""get permission info"""
 	from frappe.permissions import get_all_perms

--- a/ui/src/composables/tests/useDocPermissions.test.ts
+++ b/ui/src/composables/tests/useDocPermissions.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoisted so the factory passed to `vi.mock` can reference them.
+const { createResourceMock, state } = vi.hoisted(() => ({
+  createResourceMock: vi.fn(),
+  state: {
+    roles: null as string[] | null,
+    permissions: undefined as Record<string, unknown>[] | undefined,
+    loading: false,
+  },
+}));
+
+vi.mock("frappe-ui", () => ({
+  createResource: createResourceMock,
+  frappeRequest: vi.fn(),
+}));
+
+const ROLES_URL = "frappe.core.doctype.user.user.get_current_user_roles";
+
+createResourceMock.mockImplementation((options: any) => {
+  const roles = options.url === ROLES_URL;
+  return {
+    get data() {
+      if (roles) return state.roles ?? undefined;
+      return {
+        docs: [
+          {
+            name: options.params.doctype,
+            fields: [],
+            permissions: state.permissions,
+          },
+        ],
+      };
+    },
+    get loading() {
+      return state.loading;
+    },
+    fetched: false,
+    error: null,
+    fetch: vi.fn(),
+    reload: vi.fn(),
+  };
+});
+
+import { useDocPermissions } from "../useDocPermissions";
+import { resetDoctypeMeta } from "../useDoctypeMeta";
+import { resetUserRoles } from "../useUserRoles";
+
+function reset() {
+  resetDoctypeMeta();
+  resetUserRoles();
+  vi.clearAllMocks();
+  state.roles = null;
+  state.permissions = undefined;
+  state.loading = false;
+}
+
+describe("useUserRoles' endpoint", () => {
+  beforeEach(reset);
+
+  // The composable is useless if this name drifts from the whitelisted method,
+  // and nothing else would notice: every other test here mocks the transport, so
+  // the URL is never resolved against a server. It was in fact wrong once — the
+  // method was left behind when this code was split out of its original branch.
+  it("asks the whitelisted method that returns the session user's roles", () => {
+    useDocPermissions("Note");
+
+    const urls = createResourceMock.mock.calls.map(([o]: any[]) => o.url);
+    expect(urls).toContain(ROLES_URL);
+  });
+
+  it("fetches the roles once, however many callers ask", () => {
+    useDocPermissions("Note");
+    useDocPermissions("ToDo");
+
+    const rolesCalls = createResourceMock.mock.calls.filter(
+      ([o]: any[]) => o.url === ROLES_URL
+    );
+    expect(rolesCalls).toHaveLength(1);
+  });
+});
+
+describe("field-level access", () => {
+  beforeEach(reset);
+
+  it("leaves permlevel 0 to the doc-level rights", () => {
+    state.roles = [];
+    state.permissions = [];
+    const { fieldAccess } = useDocPermissions("Note");
+
+    expect(fieldAccess({ permlevel: 0 })).toBe("write");
+    expect(fieldAccess({})).toBe("write");
+  });
+
+  it("grants write on a permlevel one of the user's roles writes", () => {
+    state.roles = ["Accounts Manager"];
+    state.permissions = [
+      { role: "Accounts Manager", permlevel: 1, read: 1, write: 1 },
+    ];
+
+    expect(useDocPermissions("Note").fieldAccess({ permlevel: 1 })).toBe(
+      "write"
+    );
+  });
+
+  it("grants read only, when the row reads but does not write", () => {
+    state.roles = ["Sales User"];
+    state.permissions = [{ role: "Sales User", permlevel: 2, read: 1 }];
+
+    expect(useDocPermissions("Note").fieldAccess({ permlevel: 2 })).toBe(
+      "read"
+    );
+  });
+
+  it("refuses a permlevel no role of the user's holds", () => {
+    state.roles = ["Sales User"];
+    state.permissions = [
+      { role: "Accounts Manager", permlevel: 1, read: 1, write: 1 },
+    ];
+
+    expect(useDocPermissions("Note").fieldAccess({ permlevel: 1 })).toBe(
+      "none"
+    );
+  });
+
+  it("ignores a DocPerm row for a role the user does not hold", () => {
+    state.roles = ["Sales User"];
+    state.permissions = [
+      { role: "Sales User", permlevel: 1, read: 1 },
+      { role: "Accounts Manager", permlevel: 1, read: 1, write: 1 },
+    ];
+
+    expect(useDocPermissions("Note").fieldAccess({ permlevel: 1 })).toBe(
+      "read"
+    );
+  });
+
+  // Better a field the server refuses to save than a form that flashes empty.
+  it("fails open while the roles are still loading", () => {
+    state.roles = null;
+    state.permissions = [
+      { role: "Accounts Manager", permlevel: 1, read: 1, write: 1 },
+    ];
+
+    expect(useDocPermissions("Note").fieldAccess({ permlevel: 1 })).toBe(
+      "write"
+    );
+  });
+});
+
+describe("allowedPermlevels", () => {
+  beforeEach(reset);
+
+  it("lists the permlevels the user's roles hold the right on, in order", () => {
+    state.roles = ["Sales User", "Accounts Manager"];
+    state.permissions = [
+      { role: "Accounts Manager", permlevel: 2, read: 1, write: 1 },
+      { role: "Sales User", permlevel: 1, read: 1 },
+      { role: "Sales User", permlevel: 0, read: 1, write: 1 },
+    ];
+    const { allowedPermlevels } = useDocPermissions("Note");
+
+    expect(allowedPermlevels("read")).toEqual([0, 1, 2]);
+    expect(allowedPermlevels("write")).toEqual([0, 2]);
+  });
+
+  it("is empty while the meta is still loading", () => {
+    expect(useDocPermissions("Note").allowedPermlevels("read")).toEqual([]);
+  });
+});
+
+describe("doc-level rights", () => {
+  beforeEach(reset);
+
+  it("reads the server-computed docinfo permissions", () => {
+    const { can } = useDocPermissions("Note", { write: 1, delete: 0 });
+
+    expect(can("write")).toBe(true);
+    expect(can("delete")).toBe(false);
+  });
+
+  it("refuses everything until docinfo provides them", () => {
+    expect(useDocPermissions("Note").can("write")).toBe(false);
+  });
+});


### PR DESCRIPTION
`ui/src/composables/useUserRoles.ts` calls `frappe.core.doctype.user.user.get_current_user_roles`. **That method does not exist on this branch**, so the request fails on every record page.

## How it got lost

It was written alongside the composable in `feat/saved-view-sidebar` (commit `beeef0f3a4`, six lines in `user.py`). When the walking skeleton was carved into the #42171 → #42174 stack, the JavaScript half was carried across and the Python half was not. #42173 then merged the caller here without its callee.

Nothing caught it. Every test around this code stubs `createResource` wholesale, so the URL is never resolved against a server and a wrong one costs exactly nothing.

## What breaks today

The roles resource errors, so `roles` stays `null`, so `permlevels` stays `null`, and `fieldAccess` takes its fail-open path:

```ts
if (permlevel === 0 || !permlevels.value) return "write";
```

Every permlevel'd field therefore renders as writable, for everyone. **Not a security hole** — enforcement is server-side and the save is still refused — but the permission feature is inert, and the failure is silent.

`get_all_roles` is not a substitute: it returns every role in the system, not the ones the session user holds.

## What is here

Two commits, cherry-picked unchanged from **#42208** (the same fix against `develop`, where these `ui/` files also live):

| | |
| --- | --- |
| `feat: whitelist an endpoint for the logged-in user's roles` | the six missing lines |
| `test(ui): cover useDocPermissions, including the roles endpoint's name` | 12 tests, one of which asserts the URL |

Both are byte-identical to their counterparts on #42208, so whichever branch merges first, the other merges cleanly rather than conflicting.

The endpoint takes no arguments deliberately — `frappe.get_roles()` accepts a username and will answer for any user, and `get_newargs` drops kwargs the function does not declare, so a caller cannot smuggle one in.

## Verification

- desk-v2's own suite: **14 files / 249 tests green**, unchanged.
- The new `ui/` test: **12 passed**, run against this branch.
- Confirmed the URL test earns its place by pointing the composable at `get_all_roles` and watching the suite go red.

>no-docs
