### PR TITLE
fix(contact): enforce one primary contact per party

### DIFF
--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -74,11 +74,62 @@ class Contact(Document):
 		self.set_user()
 
 		set_link_title(self)
+		deduplicate_dynamic_links(self)
+		self.validate_primary_contact()
 
 		if self.get("sync_with_google_contacts") and not self.get("google_contacts"):
 			frappe.throw(_("Select Google Contacts to which contact should be synced."))
 
-		deduplicate_dynamic_links(self)
+	def validate_primary_contact(self) -> None:
+		if not self.is_primary_contact:
+			return
+
+		links = {(link.link_doctype, link.link_name) for link in self.links}
+		if not links:
+			return
+
+		self._lock_linked_documents(links)
+		primary_contacts = self._get_linked_primary_contacts(links)
+
+		if primary_contacts:
+			frappe.db.set_value("Contact", {"name": ["in", primary_contacts]}, "is_primary_contact", 0)
+
+	def _lock_linked_documents(self, links: set[tuple[str, str]]) -> None:
+		links_by_doctype = {}
+		for doctype, name in links:
+			links_by_doctype.setdefault(doctype, set()).add(name)
+
+		# Lock in a stable order so concurrent primary-contact updates serialize without deadlocking.
+		for doctype, names in sorted(links_by_doctype.items()):
+			frappe.qb.get_query(
+				doctype,
+				fields=["name"],
+				filters={"name": ["in", sorted(names)]},
+				order_by="name",
+				for_update=True,
+			).run()
+
+	def _get_linked_primary_contacts(self, links: set[tuple[str, str]]) -> list[str]:
+		Contact = frappe.qb.DocType("Contact")
+		DynamicLink = frappe.qb.DocType("Dynamic Link")
+
+		link_filter = None
+		for doctype, name in links:
+			condition = (DynamicLink.link_doctype == doctype) & (DynamicLink.link_name == name)
+			link_filter = condition if link_filter is None else link_filter | condition
+
+		return (
+			frappe.qb.from_(Contact)
+			.join(DynamicLink)
+			.on(DynamicLink.parent == Contact.name)
+			.select(Contact.name)
+			.distinct()
+			.where(Contact.is_primary_contact == 1)
+			.where(Contact.name != self.name)
+			.where(DynamicLink.parenttype == "Contact")
+			.where(DynamicLink.parentfield == "links")
+			.where(link_filter)
+		).run(pluck=True)
 
 	def set_user(self):
 		if not self.user and self.email_id:

--- a/frappe/contacts/doctype/contact/test_contact.py
+++ b/frappe/contacts/doctype/contact/test_contact.py
@@ -3,7 +3,7 @@
 import frappe
 from frappe.contacts.doctype.contact.contact import get_full_name
 from frappe.email import get_contact_list
-from frappe.tests import IntegrationTestCase
+from frappe.tests import IntegrationTestCase, timeout
 
 EXTRA_TEST_RECORD_DEPENDENCIES = ["Contact", "Salutation"]
 
@@ -64,6 +64,59 @@ class TestContact(IntegrationTestCase):
 		self.assertEqual(results[0].label, "test_contact@example.com")
 		self.assertEqual(results[0].value, "test_contact@example.com")
 		self.assertEqual(results[0].description, "_Test Contact For _Test Supplier")
+
+	def test_only_one_primary_contact_per_link(self):
+		first_contact = create_contact("First Primary Contact", "Mr", save=False)
+		first_contact.is_primary_contact = 1
+		first_contact.append("links", {"link_doctype": "User", "link_name": "Administrator"})
+		first_contact.insert()
+
+		second_contact = create_contact("Second Primary Contact", "Mr", save=False)
+		second_contact.is_primary_contact = 1
+		second_contact.append("links", {"link_doctype": "User", "link_name": "Administrator"})
+		second_contact.insert()
+
+		self.assertFalse(first_contact.reload().is_primary_contact)
+		self.assertTrue(second_contact.is_primary_contact)
+
+	def test_promoting_contact_clears_existing_primary_contact(self):
+		first_contact = create_contact("Existing Primary Contact", "Mr", save=False)
+		first_contact.is_primary_contact = 1
+		first_contact.append("links", {"link_doctype": "User", "link_name": "Administrator"})
+		first_contact.insert()
+
+		second_contact = create_contact("Promoted Primary Contact", "Mr", save=False)
+		second_contact.append("links", {"link_doctype": "User", "link_name": "Administrator"})
+		second_contact.insert()
+		second_contact.is_primary_contact = 1
+		second_contact.save()
+
+		self.assertFalse(first_contact.reload().is_primary_contact)
+		self.assertTrue(second_contact.is_primary_contact)
+
+	@timeout(5, "Primary Contact validation did not lock the linked party")
+	def test_primary_contact_locks_linked_party(self):
+		contact = create_contact("Locking Primary Contact", "Mr", save=False)
+		contact.is_primary_contact = 1
+		contact.append("links", {"link_doctype": "User", "link_name": "Administrator"})
+
+		with self.primary_connection():
+			contact.insert()
+
+			with self.secondary_connection():
+				self.assertRaises(
+					frappe.QueryTimeoutError,
+					lambda: frappe.db.get_value("User", "Administrator", for_update=True, wait=False),
+				)
+
+	def test_primary_contact_fetches_existing_primaries_once(self):
+		contact = create_contact("Multi-link Primary Contact", "Mr", save=False)
+		contact.is_primary_contact = 1
+		contact.append("links", {"link_doctype": "User", "link_name": "Administrator"})
+		contact.append("links", {"link_doctype": "User", "link_name": "Guest"})
+
+		with self.assertQueryCount(2):
+			contact.validate_primary_contact()
 
 
 def create_contact(name, salutation, emails=None, phones=None, save=True):


### PR DESCRIPTION
  ### Issue

  Multiple contacts linked to the same party can be marked as primary. This makes the default contact selection ambiguous in transactions.

Fixes : [#18811](https://github.com/frappe/frappe/issues/42221)

  ### Steps to reproduce

  1. Create a party such as a Customer.
  2. Create a Contact linked to that party and enable **Is Primary Contact**.
  3. Create another Contact linked to the same party.
  4. Enable **Is Primary Contact** on the second Contact and save it.

  ### Actual behaviour

  Both contacts remain marked as primary so that ERPNext may select an unexpected contact in downstream transactions.

  ### Expected behaviour

  When a Contact is marked as primary, the primary flag should be cleared from other contacts linked to the same party.

  ### Backport needed For V15 and V16