### PR TITLE
fix: escape Attach/Img./Sign./Barcode field values in print format temp.

### DIFF
--- a/frappe/templates/print_format/macros/Attach.html
+++ b/frappe/templates/print_format/macros/Attach.html
@@ -2,6 +2,6 @@
 
 {%- block value -%}
 <div class="value">
-    <a href="{{ value }}">{{ value.rsplit('/', 1)[1] }}</a>
+    <a href="{{ value|e }}">{{ value.rsplit('/', 1)[1]|e }}</a>
 </div>
 {%- endblock -%}

--- a/frappe/templates/print_format/macros/AttachImage.html
+++ b/frappe/templates/print_format/macros/AttachImage.html
@@ -2,6 +2,6 @@
 
 {%- block value -%}
 <div class="value">
-    <img class="w-100" src="{{ value }}" alt="{{ _(df.label)|e }}">
+    <img class="w-100" src="{{ value|e }}" alt="{{ _(df.label)|e }}">
 </div>
 {%- endblock -%}

--- a/frappe/templates/print_format/macros/Image.html
+++ b/frappe/templates/print_format/macros/Image.html
@@ -1,6 +1,6 @@
 {%- set src = df.image_url or value -%}
 {%- if src -%}
 <div class="field print-image{% if df.align %} field-align-{{ df.align }}{% endif %}"{% if df.custom_style %} style="{{ df.custom_style|e }}"{% endif %} {{ field_attributes(df) }}>
-	<img src="{{ src }}" alt="{{ (_(df.label) if df.label else '')|e }}" style="max-width: 100%;{% if df.width %} width: {{ df.width|e }};{% endif %}">
+	<img src="{{ src|e }}" alt="{{ (_(df.label) if df.label else '')|e }}" style="max-width: 100%;{% if df.width %} width: {{ df.width|e }};{% endif %}">
 </div>
 {%- endif -%}

--- a/frappe/templates/print_format/macros/Signature.html
+++ b/frappe/templates/print_format/macros/Signature.html
@@ -2,6 +2,6 @@
 
 {%- block value -%}
 <div class="value">
-    <img src="{{ value }}" alt="{{ _(df.label)|e }}">
+    <img src="{{ value|e }}" alt="{{ _(df.label)|e }}">
 </div>
 {%- endblock -%}

--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -146,20 +146,20 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
 	{% elif df.fieldtype=="Check" and not doc[df.fieldname] %}
 		<!-- empty -->
 	{% elif df.fieldtype in ("Image", "Attach Image") and frappe.utils.is_image(doc[doc.meta.get_field(df.fieldname).options]) %}
-		<img src="{{ doc[doc.meta.get_field(df.fieldname).options] }}"
+		<img src="{{ doc[doc.meta.get_field(df.fieldname).options]|e }}"
 			class="img-responsive"
 			{%- if df.print_width %} style="width: {{ get_width(df) }};"{% endif %}>
 	{% elif df.fieldtype=="Attach Image" %}
-		<img src="{{ doc[df.fieldname] }}"
+		<img src="{{ doc[df.fieldname]|e }}"
 			class="img-responsive"
 			{%- if df.print_width %} style="width: {{ get_width(df) }};"{% endif %}>
 	{% elif df.fieldtype=="Signature" %}
-		<img src="{{ doc[df.fieldname] }}" class="signature-img img-responsive"
+		<img src="{{ doc[df.fieldname]|e }}" class="signature-img img-responsive"
 			{%- if df.print_width %} style="width: {{ get_width(df) }};"{% endif %}>
 	{% elif df.fieldtype=="Barcode" and not doc[df.fieldname].startswith("<svg") %}
-		<svg data-barcode-value="{{ doc[df.fieldname] }}" height="80" data-options='{{ df.options }}'></svg>
+		<svg data-barcode-value="{{ doc[df.fieldname]|e }}" height="80" data-options='{{ df.options|e }}'></svg>
 	{% elif df.fieldtype in ("Attach", "Attach Image") and frappe.utils.is_image(doc[df.fieldname]) %}
-		<img src="{{ doc[df.fieldname] }}" class="img-responsive"
+		<img src="{{ doc[df.fieldname]|e }}" class="img-responsive"
 			{%- if df.print_width %} style="width: {{ get_width(df) }};"{% endif %}>
 	{% elif df.fieldtype=="HTML" %}
 		{{ frappe.render_template(df.options, {"doc":doc}) }}

--- a/frappe/tests/test_printview.py
+++ b/frappe/tests/test_printview.py
@@ -19,6 +19,71 @@ class PrintViewTest(IntegrationTestCase):
 		# html should exist
 		self.assertTrue(bool(ret["html"]))
 
+	def _make_attachment_fields_doctype(self):
+		return new_doctype(
+			fields=[
+				{"label": "Attach Field", "fieldname": "attach_field", "fieldtype": "Attach"},
+				{
+					"label": "Attach Image Field",
+					"fieldname": "attach_image_field",
+					"fieldtype": "Attach Image",
+				},
+				{"label": "Signature Field", "fieldname": "signature_field", "fieldtype": "Signature"},
+				{"label": "Barcode Field", "fieldname": "barcode_field", "fieldtype": "Barcode"},
+			]
+		).insert()
+
+	def _make_doc(self, doctype, suffix):
+		return frappe.get_doc(
+			doctype=doctype,
+			attach_field="/files/doc" + suffix,
+			attach_image_field="/files/img" + suffix,
+			signature_field="/files/sig" + suffix,
+			barcode_field="1234" + suffix,
+		).insert()
+
+	def test_attach_image_signature_barcode_values_are_escaped(self):
+		"""Values reach src/data-* attributes; unescaped values break attribute
+		context. "Standard" resolves to the beta renderer (macros/*.html)."""
+		doctype = self._make_attachment_fields_doctype()
+
+		benign = self._make_doc(doctype.name, ".png")
+		html = get_html_and_style(doc=benign.as_json(), print_format="Standard", no_letterhead=1)["html"]
+		self.assertIn('src="/files/img.png"', html)
+		self.assertIn('data-barcode-value="1234.png"', html)
+
+		evil = self._make_doc(doctype.name, '.png" onerror="alert(1)')
+		html = get_html_and_style(doc=evil.as_json(), print_format="Standard", no_letterhead=1)["html"]
+		self.assertNotIn('onerror="alert(1)"', html)
+		self.assertIn("&#34;", html)
+
+	def test_classic_print_format_escapes_attachment_fields(self):
+		"""Same, for the older Jinja engine, still reachable via custom Print
+		Format docs whose stored html imports it directly."""
+		doctype = self._make_attachment_fields_doctype()
+		print_format = frappe.get_doc(
+			doctype="Print Format",
+			name=frappe.generate_hash(length=10),
+			doc_type=doctype.name,
+			custom_format=1,
+			html="""
+				{% import "templates/print_formats/standard_macros.html" as standard_macros %}
+				{% for df in meta.fields %}{{ standard_macros.print_value(df, doc) }}{% endfor %}
+			""",
+		).insert()
+
+		benign = self._make_doc(doctype.name, ".png")
+		html = get_html_and_style(doc=benign.as_json(), print_format=print_format.name, no_letterhead=1)[
+			"html"
+		]
+		self.assertIn('src="/files/img.png"', html)
+		self.assertIn('data-barcode-value="1234.png"', html)
+
+		evil = self._make_doc(doctype.name, '.png" onerror="alert(1)')
+		html = get_html_and_style(doc=evil.as_json(), print_format=print_format.name, no_letterhead=1)["html"]
+		self.assertNotIn('onerror="alert(1)"', html)
+		self.assertIn("&#34;", html)
+
 	def test_print_error(self):
 		"""Print failures shouldn't generate PDF with failure message but instead escalate the error"""
 		doctype = new_doctype(is_submittable=1).insert()


### PR DESCRIPTION
Escape Attach/Image/Signature/Barcode field values in print templates so they render as plain text.