### PR TITLE
fix: use espresso tokens in sidebar and dock

### DIFF
--- a/cypress/integration/awesome_bar.js
+++ b/cypress/integration/awesome_bar.js
@@ -12,8 +12,8 @@ context("Awesome Bar", () => {
 	beforeEach(() => {
 		cy.get("body").type("{esc}");
 		cy.wait(300);
-		// the global-search trigger moved from the page header into the workspace dock (icon only)
-		cy.get(".workspace-dock .navbar-modal-search-mobile").as("awesome_bar_search");
+		// the global-search trigger moved from the page header into the dock (icon only)
+		cy.get(".dock .navbar-modal-search-mobile").as("awesome_bar_search");
 		cy.get("@awesome_bar_search").click();
 		cy.get("#navbar-search").as("awesome_bar");
 		cy.get("#navbar-search").type("{selectall}");

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -281,7 +281,7 @@ def load_desktop_data(bootinfo):
 def get_app_data() -> list[dict]:
 	"""Return the apps the desk knows about, each with the ordered set of entries its dock offers.
 
-	This backs the apps (desktop) screen and the workspace dock: the dock renders
+	This backs the apps (desktop) screen and the dock, which renders
 	`app_data[app].dock` for whichever app is in context, ordered by the arrangement in
 	`frappe.boot.dock`. It is one typed list rather than the separate module and workspace lists
 	it replaces, which the client had to reconcile to render a single rail and where the pin

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -8,7 +8,7 @@ frappe.pages["desktop"].on_page_load = function (wrapper) {
 		title: "Desktop",
 		single_column: true,
 		hide_sidebar: true,
-		hide_workspace_dock: true,
+		hide_dock: true,
 	});
 
 	// Desktop Settings -> Desktop Page picks which grid renders here. `Desktop Icons` is the

--- a/frappe/public/js/frappe/ui/notifications/notifications.js
+++ b/frappe/public/js/frappe/ui/notifications/notifications.js
@@ -195,12 +195,12 @@ frappe.ui.Notifications = class Notifications {
 	setup_dropdown_events() {
 		const dropdown = this.dropdown;
 
-		// not a real Bootstrap dropdown -- sidebar.js and workspace_dock.js trigger
+		// not a real Bootstrap dropdown -- sidebar.js and dock.js trigger
 		// this event by hand when they un-hide the drawer, and it is the open signal
 		this.dropdown.on("show.bs.dropdown", () => this.on_open());
 
 		$(document).on("click", function (e) {
-			// the bell may live in the sidebar or the workspace dock; match either
+			// the bell may live in the sidebar or the dock; match either
 			const isInsideNotificationBtn =
 				$(e.target).closest(".sidebar-notification").length > 0;
 			const isInsideDropdown = $(e.target).closest(".notifications-list").length > 0;
@@ -436,7 +436,7 @@ class NotificationsView extends BaseNotificationsView {
 	update_count_badge(count) {
 		this.unread_count = count;
 		// the unread count is the only unread affordance any bell gets -- update it wherever a bell
-		// lives (sidebar, workspace dock, desktop navbar). Re-queried each call so it also covers
+		// lives (sidebar, dock, desktop navbar). Re-queried each call so it also covers
 		// bells created after this view (the dock).
 		const $count = $(".notification-count");
 		if (!$count.length) return;

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -59,9 +59,9 @@ frappe.ui.Page = class Page {
 
 		this.make();
 		if (!Object.keys(opts).includes("hide_sidebar")) this.hide_sidebar = false;
-		// pages can hide just the workspace dock (while keeping the body sidebar) via this option;
+		// pages can hide just the dock (while keeping the body sidebar) via this option;
 		// a page that hides the whole sidebar hides the dock too (see Sidebar.page_allows_dock)
-		if (!Object.keys(opts).includes("hide_workspace_dock")) this.hide_workspace_dock = false;
+		if (!Object.keys(opts).includes("hide_dock")) this.hide_dock = false;
 		frappe.ui.pages[frappe.get_route_str()] = this;
 	}
 

--- a/frappe/public/js/frappe/ui/sidebar/dock.js
+++ b/frappe/public/js/frappe/ui/sidebar/dock.js
@@ -1,4 +1,4 @@
-// Workspace dock: a slim vertical rail rendered to the left of the body sidebar. Its top slot says
+// Dock: a slim vertical rail rendered to the left of the body sidebar. Its top slot says
 // what you are inside and links back out of it, and below that it lists the modules you can switch
 // to. Both come from the only question app context answers: which app owns the sidebar on screen
 // (Sidebar.get_sidebar_app):
@@ -7,11 +7,11 @@
 //   standalone  logo = module icon   items = (empty)
 //
 // It is drawn only when the app on screen resolves to at least one visible entry
-// (Sidebar.workspace_dock_enabled) and the page on screen allows it (page_allows_dock; the desktop
+// (Sidebar.dock_enabled) and the page on screen allows it (page_allows_dock; the desktop
 // or apps screen does not). An app that resolves to no entries gets no rail rather than an empty
 // stripe: the user button moves back to the body sidebar and the sidebar header carries a switcher
 // instead.
-frappe.ui.WorkspaceDock = class WorkspaceDock {
+frappe.ui.Dock = class Dock {
 	constructor(sidebar) {
 		this.sidebar = sidebar;
 		this.make();
@@ -20,16 +20,16 @@ frappe.ui.WorkspaceDock = class WorkspaceDock {
 	make() {
 		// The body is a horizontal flex row (body-sidebar-container, then main-section). Insert the
 		// dock as the leftmost element so it sits to the left of the sidebar.
-		this.$dock = $(`<div class="workspace-dock hidden" role="navigation" aria-label="${__(
+		this.$dock = $(`<div class="dock hidden" role="navigation" aria-label="${__(
 			"Workspaces"
 		)}">
-			<div class="workspace-dock-logo"></div>
-			<div class="workspace-dock-divider" role="separator"></div>
-			<div class="workspace-dock-shortcuts"></div>
-			<div class="workspace-dock-divider" role="separator"></div>
-			<div class="workspace-dock-items"></div>
-			<div class="workspace-dock-divider" role="separator"></div>
-			<button class="workspace-dock-user" aria-label="${__("User Menu")}"></button>
+			<div class="dock-logo"></div>
+			<div class="dock-divider" role="separator"></div>
+			<div class="dock-shortcuts"></div>
+			<div class="dock-divider" role="separator"></div>
+			<div class="dock-items"></div>
+			<div class="dock-divider" role="separator"></div>
+			<button class="dock-user" aria-label="${__("User Menu")}"></button>
 		</div>`);
 
 		let $container = $(".body-sidebar-container");
@@ -42,7 +42,7 @@ frappe.ui.WorkspaceDock = class WorkspaceDock {
 		// collapsed and only the rail shows, clicking the rail's right edge reopens it. CSS shows it
 		// only in the collapsed state (body.sidebar-collapsed), so it does not compete with the
 		// sidebar handle while expanded.
-		let $resize = $(`<div class="workspace-dock-resize-handle" aria-hidden="true"></div>`);
+		let $resize = $(`<div class="dock-resize-handle" aria-hidden="true"></div>`);
 		$resize.on("click", () => this.sidebar.open());
 		this.$dock.append($resize);
 
@@ -50,17 +50,17 @@ frappe.ui.WorkspaceDock = class WorkspaceDock {
 		// the same circular button on the rail's right edge, with the chevron pointing right since
 		// it only expands. Like the handle, CSS keeps it to the collapsed state.
 		let $expand = $(`<button
-			class="expand-sidebar-link workspace-dock-toggle-btn"
+			class="expand-sidebar-link dock-toggle-btn"
 			aria-label="${__("Toggle Sidebar")}"
 			data-placement="right"
 		>${frappe.utils.icon("chevron-right", "sm", "", "", "", true)}</button>`);
 		$expand.on("click", () => this.sidebar.open());
 		this.$dock.append($expand);
 
-		this.$logo = this.$dock.find(".workspace-dock-logo");
-		this.$shortcuts = this.$dock.find(".workspace-dock-shortcuts");
-		this.$items = this.$dock.find(".workspace-dock-items");
-		this.$user = this.$dock.find(".workspace-dock-user");
+		this.$logo = this.$dock.find(".dock-logo");
+		this.$shortcuts = this.$dock.find(".dock-shortcuts");
+		this.$items = this.$dock.find(".dock-items");
+		this.$user = this.$dock.find(".dock-user");
 		this.render_shortcuts();
 		this.render_user();
 	}
@@ -125,7 +125,7 @@ frappe.ui.WorkspaceDock = class WorkspaceDock {
 			}
 
 			let $item = $(`<button
-				class="workspace-dock-item ${item.css_class || ""}"
+				class="dock-item ${item.css_class || ""}"
 				title="${frappe.utils.escape_html(item.label)}"
 				data-toggle="tooltip"
 				data-placement="right"
@@ -177,10 +177,10 @@ frappe.ui.WorkspaceDock = class WorkspaceDock {
 		this.app = this.sidebar.get_sidebar_app();
 		// It is drawn only if it has entries and the page on screen allows it. The desktop or apps
 		// screen, and any page that has not rendered yet, do not.
-		let enabled = this.sidebar.workspace_dock_enabled() && this.sidebar.page_allows_dock();
+		let enabled = this.sidebar.dock_enabled() && this.sidebar.page_allows_dock();
 		// Drives the CSS that hides the sidebar's own user button while the rail is active, so
 		// switching this off returns the user button to the sidebar.
-		$("body").toggleClass("workspace-dock-active", enabled);
+		$("body").toggleClass("dock-active", enabled);
 
 		if (!enabled) {
 			this.$dock.addClass("hidden");
@@ -301,7 +301,7 @@ frappe.ui.WorkspaceDock = class WorkspaceDock {
 
 		let is_active = this.sidebar.is_active_entry(entry);
 		let $item = $(`<button
-			class="workspace-dock-item ${is_active ? "active" : ""}"
+			class="dock-item ${is_active ? "active" : ""}"
 			title="${frappe.utils.escape_html(label)}"
 			data-toggle="tooltip"
 			data-placement="right"

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.html
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.html
@@ -18,7 +18,7 @@
 				<!-- The standard-items band: search, notifications and background tasks, as
 				     full-width rows directly under the header and above the module's own items.
 				     Only drawn on a dock-less app, where the rail is not there to carry them --
-				     see Sidebar.add_standard_items and body.workspace-dock-active. -->
+				     see Sidebar.add_standard_items and body.dock-active. -->
 				<div class="standard-items-band"></div>
 				<div class="sidebar-items">
 				</div>

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -1,5 +1,5 @@
 import "./sidebar_item";
-import "./workspace_dock";
+import "./dock";
 
 // The query parameter that carries the shell. Named `sidebar` because that is what the desk
 // already read here before anything wrote it.
@@ -315,7 +315,7 @@ frappe.ui.Sidebar = class Sidebar {
 			// change (e.g. navigating within the same workspace). Refresh the header here so it
 			// always reflects the module resolved above.
 			frappe.app.sidebar.refresh_header();
-			// Keep the workspace dock in sync with the shown module and the active workspace.
+			// Keep the dock in sync with the shown module and the active workspace.
 			frappe.app.sidebar.refresh_dock();
 		});
 
@@ -386,17 +386,17 @@ frappe.ui.Sidebar = class Sidebar {
 	// the sidebar, which is the pre-dock layout and still exists, and the sidebar header carries
 	// a switcher instead. The trade-off is that the layout shifts when moving between a docked
 	// app and a dock-less one.
-	workspace_dock_enabled() {
+	dock_enabled() {
 		return this.collect_dock_entries(this.get_sidebar_app()).length > 0;
 	}
 
-	// Render or re-render the workspace dock to match the current app context. It is created
+	// Render or re-render the dock to match the current app context. It is created
 	// lazily on first refresh and stays hidden unless the page allows it (see page_allows_dock).
 	refresh_dock() {
-		if (!this.workspace_dock) {
-			this.workspace_dock = new frappe.ui.WorkspaceDock(this);
+		if (!this.dock) {
+			this.dock = new frappe.ui.Dock(this);
 		}
-		this.workspace_dock.refresh();
+		this.dock.refresh();
 	}
 
 	// Fired on page change and form refresh. Handles visibility, then runs the same resolver as
@@ -415,8 +415,8 @@ frappe.ui.Sidebar = class Sidebar {
 	}
 
 	// -------------------------------------------------------------------------------------------
-	// Visibility. Both shells, the body sidebar and the workspace dock, are hidden by default
-	// (see make_dom and WorkspaceDock.make) and are shown only once the page on screen says it
+	// Visibility. Both shells, the body sidebar and the dock, are hidden by default
+	// (see make_dom and Dock.make) and are shown only once the page on screen says it
 	// allows them. Defaulting to hidden means a page that suppresses them, such as the desktop
 	// or apps screen and the setup wizard, never flashes them first, and a page that has not
 	// rendered yet, whose options are unknown, shows nothing rather than guessing.
@@ -433,13 +433,13 @@ frappe.ui.Sidebar = class Sidebar {
 		return !!page && !page.hide_sidebar;
 	}
 
-	// The dock is displayed unless the page opts out with `hide_workspace_dock`. That and
+	// The dock is displayed unless the page opts out with `hide_dock`. That and
 	// `hide_sidebar` are both standard frappe.ui.Page options, and a page picks either shell on
 	// its own: the print format builder keeps the dock while hiding the body sidebar, and the
 	// desktop or apps screen sets both.
 	page_allows_dock() {
 		const page = this.current_page();
-		return !!page && !page.hide_workspace_dock;
+		return !!page && !page.hide_dock;
 	}
 
 	// Resolve both shells against the current page's options. This is the only place that turns
@@ -496,7 +496,7 @@ frappe.ui.Sidebar = class Sidebar {
 	}
 
 	// Build the user dropdown (profile, workspaces, theme, logout and so on) on a trigger
-	// element. Shared by the sidebar's user button and the workspace dock's avatar so both open
+	// element. Shared by the sidebar's user button and the dock's avatar so both open
 	// the same menu. `button` is the element that gets the active-state class while the menu is
 	// open.
 	create_user_menu({ parent, button }) {
@@ -762,7 +762,7 @@ frappe.ui.Sidebar = class Sidebar {
 	//
 	// The band sits directly under the header, above the module's own items, behind a divider,
 	// rather than after the user button where the generic add-item helper put these two. The
-	// whole band is hidden when the rail is present (`body.workspace-dock-active` hides it),
+	// whole band is hidden when the rail is present (`body.dock-active` hides it),
 	// which is what a docked app's sidebar wants: all three off, including background tasks,
 	// which it used to show while hiding the bell next to it.
 	//
@@ -886,8 +886,8 @@ frappe.ui.Sidebar = class Sidebar {
 			.find("use")
 			.attr("href", `#icon-${chevron_icon}`);
 		this.sidebar_header.toggle_width(this.sidebar_expanded);
-		// While collapsed, the body sidebar is hidden and only the workspace dock (rail) shows.
-		// This gates the rail's edge handle that reopens the sidebar (see workspace_dock.scss).
+		// While collapsed, the body sidebar is hidden and only the dock (rail) shows.
+		// This gates the rail's edge handle that reopens the sidebar (see dock.scss).
 		$("body").toggleClass("sidebar-collapsed", !this.sidebar_expanded);
 		$(document).trigger("sidebar-expand", {
 			sidebar_expand: this.sidebar_expanded,

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
@@ -90,7 +90,7 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 	// you are reads as a status line, and a menu row is something you press.
 	switcher_items() {
 		const sidebar = this.sidebar;
-		if (sidebar.workspace_dock_enabled()) return [];
+		if (sidebar.dock_enabled()) return [];
 
 		const items = [];
 		const modules = sidebar.app_modules(sidebar.get_sidebar_app());

--- a/frappe/public/js/frappe/views/container.js
+++ b/frappe/public/js/frappe/views/container.js
@@ -84,7 +84,7 @@ frappe.views.Container = class Container {
 		return this.page;
 	}
 	toggle_sidebar() {
-		// The body sidebar and the workspace dock are hidden by default and shown only when the
+		// The body sidebar and the dock are hidden by default and shown only when the
 		// page now on screen allows them; the sidebar owns that decision (it reads the same page
 		// options for both shells), so just ask it to re-resolve.
 		frappe.app.sidebar.apply_page_visibility();

--- a/frappe/public/scss/desk/dock.scss
+++ b/frappe/public/scss/desk/dock.scss
@@ -1,11 +1,11 @@
 // Slim vertical rail left of the body sidebar listing the current app's workspaces as icons, with
-// the app logo pinned to the top corner. Rendered by frappe.ui.WorkspaceDock and opt-in per app.
+// the app logo pinned to the top corner. Rendered by frappe.ui.Dock and opt-in per app.
 //
 // Styles mirror the frappe-ui <Rail> / <RailItem> component so the dock renders identically to the
 // Vue rail. Values map straight across: 50px column on --surface-sidebar; 28px items; workspace
 // icons use the `tile` treatment (filled cell + left indicator bar when active) and the bell uses
 // the `ghost` treatment (transparent until hovered).
-.workspace-dock {
+.dock {
 	position: relative;
 	flex: 0 0 50px;
 	width: 50px;
@@ -26,7 +26,7 @@
 		display: none;
 	}
 
-	.workspace-dock-logo {
+	.dock-logo {
 		flex: 0 0 auto;
 		// match the navbar / sidebar-header band so the logo lines up with them
 		height: var(--navbar-height, 48px);
@@ -68,7 +68,7 @@
 		}
 	}
 
-	.workspace-dock-divider {
+	.dock-divider {
 		flex: 0 0 auto;
 		width: 24px;
 		height: 1px;
@@ -79,14 +79,14 @@
 	// The divider right below the logo hugs the navbar-height band -- the logo is already centred in
 	// its 48px band, so no extra top margin is stacked on top of it; its 8px bottom margin then
 	// matches the gap on every other divider, keeping the rhythm even.
-	.workspace-dock-logo + .workspace-dock-divider {
+	.dock-logo + .dock-divider {
 		margin-top: 0;
 	}
 
 	// Icon shortcuts (search, notifications) pinned under the logo, bracketed by a divider above and
 	// below. A centred icon column whose 8px gap matches the dividers' margins, so every gap in the
 	// top of the rail reads the same. Collapses to nothing when no shortcut is enabled.
-	.workspace-dock-shortcuts {
+	.dock-shortcuts {
 		flex: 0 0 auto;
 		width: 100%;
 
@@ -101,11 +101,11 @@
 	}
 
 	// with no shortcuts, drop the divider that would sit under them so two dividers don't stack up
-	.workspace-dock-shortcuts:empty + .workspace-dock-divider {
+	.dock-shortcuts:empty + .dock-divider {
 		display: none;
 	}
 
-	.workspace-dock-items {
+	.dock-items {
 		flex: 1 1 auto;
 		width: 100%;
 
@@ -122,7 +122,7 @@
 		}
 	}
 
-	.workspace-dock-user {
+	.dock-user {
 		flex: 0 0 auto;
 		padding: 0;
 		border: none;
@@ -143,7 +143,7 @@
 
 	// Workspace icon — mirrors <RailItem variant="tile">: a filled 28px cell (7px radius) that darkens
 	// on active, with a left indicator bar sitting flush against the rail's edge.
-	.workspace-dock-item {
+	.dock-item {
 		position: relative;
 		flex: 0 0 auto;
 		width: 28px;
@@ -209,7 +209,7 @@
 
 	// Search / notification shortcuts are not workspaces — mirror <RailItem variant="ghost">:
 	// transparent until hovered, 8px radius.
-	.workspace-dock-shortcuts .workspace-dock-item {
+	.dock-shortcuts .dock-item {
 		background: transparent;
 		border-radius: var(--radius-4);
 
@@ -223,7 +223,7 @@
 // sidebar's copies go. The whole standard-items band goes with them, which is what finally takes
 // background tasks off a docked app's sidebar: it was the one of the three that showed there,
 // while its sibling bell was hidden.
-body.workspace-dock-active .body-sidebar {
+body.dock-active .body-sidebar {
 	.dropdown-navbar-user,
 	.standard-items-band {
 		display: none;
@@ -239,7 +239,7 @@ body.workspace-dock-active .body-sidebar {
 // `.body-sidebar-container` is in the chain only to outweigh the expanded mixin, which sets
 // `display: flex` on the chevron from `.body-sidebar-container.expanded .body-sidebar
 // .collapse-sidebar-link` -- one class more specific than this rule would otherwise be.
-body:not(.workspace-dock-active) .body-sidebar-container .body-sidebar {
+body:not(.dock-active) .body-sidebar-container .body-sidebar {
 	.collapse-sidebar-link,
 	.sidebar-resize-handle {
 		display: none;
@@ -256,15 +256,15 @@ body:not(.workspace-dock-active) .body-sidebar-container .body-sidebar {
 //
 // The selector carries the whole `.standard-sidebar-item .item-anchor` chain only to outweigh the
 // rule that gives the span its `display: flex` in sidebar.scss -- two classes more specific than
-// `body.workspace-dock-active .body-sidebar .sidebar-item-icon` would be on its own.
-body.workspace-dock-active .body-sidebar .standard-sidebar-item .item-anchor .sidebar-item-icon {
+// `body.dock-active .body-sidebar .sidebar-item-icon` would be on its own.
+body.dock-active .body-sidebar .standard-sidebar-item .item-anchor .sidebar-item-icon {
 	display: none;
 }
 
 // The label's own left margin stands in for the icon when there isn't one. Where the icon is
 // drawn it already supplies that gap, so drop the margin rather than paying for it twice --
 // scoped by :has() so section breaks and icon-less rows keep theirs.
-body:not(.workspace-dock-active) .body-sidebar {
+body:not(.dock-active) .body-sidebar {
 	.item-anchor:has(.sidebar-item-icon) .sidebar-item-label {
 		margin-left: 0;
 	}
@@ -289,7 +289,7 @@ body:not(.workspace-dock-active) .body-sidebar {
 // Right-edge handle that reopens the collapsed body sidebar -- the mirror of the sidebar's own
 // .sidebar-resize-handle. Only present while collapsed (body.sidebar-collapsed), so it doesn't
 // offer an expand affordance when the sidebar is already open.
-.workspace-dock-resize-handle {
+.dock-resize-handle {
 	position: absolute;
 	top: 0;
 	right: -4px;
@@ -316,13 +316,13 @@ body:not(.workspace-dock-active) .body-sidebar {
 	}
 }
 
-body.sidebar-collapsed .workspace-dock-resize-handle {
+body.sidebar-collapsed .dock-resize-handle {
 	display: block;
 }
 
 // The visible twin of the handle above, mirroring .body-sidebar .sidebar-toggle-btn so the expand
 // affordance lands in the same spot and looks the same as the collapse one it replaces.
-.workspace-dock-toggle-btn {
+.dock-toggle-btn {
 	position: absolute;
 	right: -12px;
 	bottom: 80px;
@@ -352,18 +352,18 @@ body.sidebar-collapsed .workspace-dock-resize-handle {
 	}
 }
 
-body.sidebar-collapsed .workspace-dock-toggle-btn {
+body.sidebar-collapsed .dock-toggle-btn {
 	display: flex;
 }
 
-body.sidebar-collapsed .workspace-dock:hover .workspace-dock-toggle-btn {
+body.sidebar-collapsed .dock:hover .dock-toggle-btn {
 	opacity: 1;
 	visibility: visible;
 }
 
 // mirror the body sidebar: the rail collapses away on mobile
 @include media-breakpoint-down(sm) {
-	.workspace-dock {
+	.dock {
 		display: none;
 	}
 }

--- a/frappe/public/scss/desk/index.scss
+++ b/frappe/public/scss/desk/index.scss
@@ -33,7 +33,7 @@
 @import "../common/awesomeplete";
 @import "main";
 @import "sidebar";
-@import "workspace_dock";
+@import "dock";
 @import "list_sidebar";
 @import "form_sidebar";
 @import "filters";

--- a/frappe/public/scss/desk/menu.scss
+++ b/frappe/public/scss/desk/menu.scss
@@ -19,7 +19,7 @@
 	border-radius: var(--radius);
 
 	&:hover:has(a) {
-		background-color: var(--sidebar-hover-color);
+		background-color: var(--surface-gray-2);
 	}
 
 	a {

--- a/frappe/public/scss/desk/notification.scss
+++ b/frappe/public/scss/desk/notification.scss
@@ -38,7 +38,7 @@ $notification-dot-size: 8px;
 }
 
 // The unread count is the only unread affordance a bell gets. Where the bell has a label (the
-// sidebar) it reads as a pill next to it; on icon-only bells (desktop navbar, workspace dock) there
+// sidebar) it reads as a pill next to it; on icon-only bells (desktop navbar, dock) there
 // is no room for a number, so the same element is drawn as a dot on the icon's corner.
 .notification-count {
 	padding: 1px 7px;

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -1,26 +1,18 @@
 // clean-this-file
+// Colours, radii and shadows come from Espresso tokens, so the panel tracks the
+// theme the same way frappe-ui's <Sidebar> / <SidebarItem> do -- the hand-rolled
+// --sidebar-* colour variables this file used to define carried their own dark
+// values and drifted from them. Only the panel's width is still a local variable:
+// it is layout, not a design token, and the resize handle writes to it.
 :root {
-	--sidebar-hover-color: #f3f3f3;
-	--sidebar-active-color: rgba(255, 255, 255, 1);
-	--sidebar-border-color: #ededed;
-	--divider-color: rgba(237, 237, 237, 1);
 	--sidebar-width: 220px;
-	--sidebar-active-shadow: 0 0 1px 0 rgba(0, 0, 0, 0.14), 0 1px 3px 0 rgba(0, 0, 0, 0.14);
 }
 
-[data-theme="dark"] {
-	--sidebar-hover-color: rgba(43, 43, 43, 1);
-	--sidebar-active-color: rgba(66, 66, 66, 1);
-	--sidebar-border-color: #232323;
-	--divider-color: rgba(52, 52, 52, 1);
-	--sidebar-active-shadow: 0 0 1px 0 rgba(0, 0, 0, 0.5), 0 1px 3px 0 rgba(0, 0, 0, 0.4),
-		inset 0 1px 0 rgba(255, 255, 255, 0.06);
-}
-
-// sidebar-item states
+// sidebar-item states -- mirrors <SidebarItem>'s `hover:bg-surface-gray-2` on a
+// `rounded` (8px) row.
 @mixin hover-mixin {
-	background-color: var(--sidebar-hover-color);
-	border-radius: 8px;
+	background-color: var(--surface-gray-2);
+	border-radius: var(--radius);
 	text-decoration: none;
 }
 
@@ -44,7 +36,7 @@
 	position: absolute;
 	width: var(--sidebar-width);
 	background: var(--surface-sidebar);
-	border-right: 1px solid var(--sidebar-border-color);
+	border-right: 1px solid var(--outline-gray-1);
 	// the panel's own chrome fades with its contents when collapsing / expanding, but the element
 	// itself stays put -- see the collapsed state below for why
 	transition: background 0.2s ease, border-color 0.2s ease;
@@ -92,8 +84,8 @@
 	}
 
 	.divider {
-		margin: var(--margin-xs) 0;
-		border-top: 1px solid var(--gray-300);
+		margin: var(--spacing) 0;
+		border-top: 1px solid var(--outline-gray-2);
 		width: 100%;
 	}
 
@@ -124,7 +116,7 @@
 			align-items: center;
 			@include transition(all, 0.3s, cubic-bezier(0.4, 0, 0.2, 1));
 			cursor: pointer;
-			margin-left: var(--margin-sm);
+			margin-left: calc(var(--spacing) * 2);
 		}
 
 		.item-anchor {
@@ -152,7 +144,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: 4px;
-		margin: var(--margin-sm) 0;
+		margin: calc(var(--spacing) * 2) 0;
 	}
 
 	.onboarding-sidebar,
@@ -350,9 +342,9 @@
 }
 
 .active-sidebar {
-	background: var(--sidebar-active-color);
-	box-shadow: var(--sidebar-active-shadow);
-	border-radius: 8px;
+	background: var(--surface-elevation-3);
+	box-shadow: var(--shadow-sm);
+	border-radius: var(--radius);
 
 	:hover {
 		text-decoration: none;
@@ -369,10 +361,10 @@
 	bottom: 80px;
 	width: 24px;
 	height: 24px;
-	border-radius: 50%;
-	border: 1px solid var(--sidebar-border-color);
+	border-radius: var(--radius-full);
+	border: 1px solid var(--outline-gray-1);
 	background: var(--surface-sidebar);
-	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+	box-shadow: var(--shadow-sm);
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -389,7 +381,7 @@
 	}
 
 	&:hover {
-		background: var(--sidebar-hover-color);
+		background: var(--surface-gray-2);
 	}
 }
 
@@ -420,7 +412,7 @@
 	}
 
 	&:hover::after {
-		background: var(--ink-gray-2);
+		background: var(--outline-gray-2);
 	}
 }
 
@@ -447,11 +439,11 @@
 }
 
 .indent + .nested-container {
-	margin-left: calc(var(--margin-sm) + 1px);
-	border-left: 1px solid var(--border-color);
+	margin-left: calc(var(--spacing) * 2 + 1px);
+	border-left: 1px solid var(--outline-gray-1);
 
 	.sidebar-item-container {
-		margin-left: var(--margin-xs);
+		margin-left: var(--spacing);
 	}
 }
 
@@ -460,7 +452,7 @@
 	padding: 7px;
 
 	.keyboard-shortcut {
-		color: var(--ink-gray-4, #999999);
+		color: var(--ink-gray-4);
 		font-size: var(--text-sm);
 		line-height: 1.15;
 		letter-spacing: 0.02em;

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -254,7 +254,7 @@
 	@include body-sidebar-expanded();
 }
 
-// Collapsed: the workspace dock is the icon rail now, so the body sidebar leaves entirely rather
+// Collapsed: the dock is the icon rail now, so the body sidebar leaves entirely rather
 // than shrinking to a strip. The placeholder animates its reserved width to 0 (the main section
 // glides left to fill it) while the panel's contents fade and slide out behind the dock. Reopening is done
 // from the dock's right-edge handle. Driven by the container's `expanded` class -- set at render

--- a/frappe/public/scss/desk/sidebar_header.scss
+++ b/frappe/public/scss/desk/sidebar_header.scss
@@ -15,15 +15,15 @@
 		flex-shrink: 0;
 		display: flex;
 		align-items: center;
-		color: var(--text-muted);
+		color: var(--ink-gray-6);
 	}
 
 	&:hover .drop-icon {
-		color: var(--text-color);
+		color: var(--ink-gray-8);
 	}
 }
 .header-logo-container {
-	border-radius: 8px;
+	border-radius: var(--radius);
 	background-color: var(--surface-gray-3);
 	&:has(img) {
 		background-color: unset;
@@ -34,11 +34,11 @@
 	height: 32px;
 	display: flex;
 	align-items: center;
-	background-color: var(--ink-gray-2);
+	background-color: var(--surface-gray-4);
 	border-radius: var(--radius-3);
 	& .icon-container {
 		padding: 4px;
-		border-radius: 10px;
+		border-radius: var(--radius-5);
 		width: 100%;
 		height: 100%;
 		display: flex;
@@ -65,7 +65,7 @@
 	line-height: 1.2;
 	@include truncate();
 	overflow: unset;
-	margin-left: calc(var(--margin-xs) - 3px);
+	margin-left: 2px;
 }
 
 .header-subtitle {

--- a/frappe/public/scss/desk/workspace_dock.scss
+++ b/frappe/public/scss/desk/workspace_dock.scss
@@ -20,7 +20,7 @@
 	padding: 0 0 12px 0;
 
 	background: var(--surface-sidebar);
-	border-right: 1px solid var(--border-color);
+	border-right: 1px solid var(--outline-gray-1);
 
 	&.hidden {
 		display: none;
@@ -211,7 +211,7 @@
 	// transparent until hovered, 8px radius.
 	.workspace-dock-shortcuts .workspace-dock-item {
 		background: transparent;
-		border-radius: 8px;
+		border-radius: var(--radius-4);
 
 		&:hover {
 			background: var(--surface-gray-3);
@@ -312,7 +312,7 @@ body:not(.workspace-dock-active) .body-sidebar {
 	}
 
 	&:hover::after {
-		background: var(--ink-gray-2);
+		background: var(--outline-gray-2);
 	}
 }
 
@@ -328,10 +328,10 @@ body.sidebar-collapsed .workspace-dock-resize-handle {
 	bottom: 80px;
 	width: 24px;
 	height: 24px;
-	border-radius: 50%;
-	border: 1px solid var(--sidebar-border-color);
+	border-radius: var(--radius-full);
+	border: 1px solid var(--outline-gray-1);
 	background: var(--surface-sidebar);
-	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+	box-shadow: var(--shadow-sm);
 	align-items: center;
 	justify-content: center;
 	cursor: pointer;
@@ -348,7 +348,7 @@ body.sidebar-collapsed .workspace-dock-resize-handle {
 	}
 
 	&:hover {
-		background: var(--sidebar-hover-color);
+		background: var(--surface-gray-2);
 	}
 }
 


### PR DESCRIPTION
- **fix(styles): apply espresso tokens for sidebar and dock**
- **refactor: rename workspace dock to dock**
