### PR TITLE
feat: add a way for non desk apps to go desk page of the app

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -321,6 +321,7 @@ def get_app_data() -> list[dict]:
 						or (frappe.get_hooks("app_title", app_name=app_name) or [None])[0]
 						or app_name,
 						app_route="",
+						desk_route="",
 						app_logo_url=app_info.get("logo")
 						or frappe.get_hooks("app_logo_url", app_name=app_name)
 						or frappe.get_hooks("app_logo_url", app_name="frappe"),
@@ -367,6 +368,12 @@ def get_app_data() -> list[dict]:
 					and frappe.get_hooks("app_home", app_name=app_name)[0]
 				)
 				or "",
+				# A non-desk app's door back into the desk. Configuring such an app -- its roles,
+				# its custom fields, the workspace it ships -- stays a desk job, so the app may
+				# name a desk route here and the apps screen renders it under the app's icon as a
+				# second link. Passed through exactly as `app_route` is: a literal route the app
+				# author owns, neither resolved nor permission-checked here.
+				desk_route=app_info.get("desk_route") or "",
 				# Only the app's own logo (from add_to_apps_screen or its app_logo_url hook); left
 				# empty when it declares none, so the desk renders an alphabet icon instead.
 				app_logo_url=app_info.get("logo")

--- a/frappe/desk/page/desktop/desktop.css
+++ b/frappe/desk/page/desktop/desktop.css
@@ -186,6 +186,40 @@ body.apps-page .icon-subtitle {
   color: var(--ink-gray-5);
   line-height: var(--desktop-icon-line-height);
 }
+/* The tile is a <div> holding two destinations: the app itself (its logo and its title) and,
+   for an app whose own UI isn't the desk, the "Open in Desk" subtitle. They are separate
+   anchors because one cannot nest inside another, and they carry no link chrome of their own. */
+body.apps-page .icon-link,
+body.apps-page a.icon-title,
+body.apps-page a.icon-subtitle {
+  text-decoration: none;
+}
+body.apps-page .icon-link,
+body.apps-page a.icon-title {
+  color: inherit;
+}
+/* The tile used to be a single anchor, so its padding, the gap under the logo and the empty
+   space beside the title all opened the app. Stretching the logo's link back across the whole
+   tile keeps that click target after the split. The caption is lifted above the overlay so the
+   title keeps its tooltip and the subtitle stays a link of its own. */
+body.apps-page .icon-link::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 20px;
+}
+body.apps-page .icon-caption {
+  position: relative;
+}
+/* The overlay sits between the pointer and the logo, so the zoom is driven by the tile. */
+body.apps-page .desktop-icon:hover .icon-container {
+  transform: scale(1.05);
+  transition: transform 0.1s;
+}
+body.apps-page a.icon-subtitle:hover {
+  color: var(--ink-gray-7);
+  text-decoration: none;
+}
 body.apps-page .timeless-style {
   width: 100vw;
   max-width: 600px;

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -89,6 +89,10 @@ class DesktopPage {
 			const icon_data = {
 				label: app.app_title,
 				logo_url: app.app_logo_url,
+				// A route into the desk for an app whose own UI isn't the desk, declared as
+				// `desk_route` on its `add_to_apps_screen` hook. Empty for a desk-native app,
+				// which renders no subtitle.
+				desk_route: app.desk_route,
 			};
 			this.add_icon($grid, icon_data, app.route);
 		});
@@ -97,10 +101,13 @@ class DesktopPage {
 	}
 	add_icon($grid, icon_data, route) {
 		const $icon = $(frappe.render_template("desktop_icon", { icon: icon_data }));
+		// The tile is a <div> so the "Open in Desk" subtitle can be its own link; the logo and
+		// the title are the two anchors that lead to the app itself.
+		const $app_links = $icon.find(".icon-link, .icon-title");
 		if (route.startsWith("http")) {
-			$icon.attr("target", "_blank");
+			$app_links.attr("target", "_blank");
 		}
-		$icon.attr("href", route);
+		$app_links.attr("href", route);
 		$grid.append($icon);
 	}
 	setup() {

--- a/frappe/public/js/frappe/ui/desktop_icon.html
+++ b/frappe/public/js/frappe/ui/desktop_icon.html
@@ -1,12 +1,20 @@
-<a href="#" class="desktop-icon" style="text-decoration:none">
-    {% if (icon.logo_url) { %}
-        <div class="icon-container">
-            <img class="app-icon" src="{{ frappe.utils.escape_html(icon.logo_url) }}" alt="{{ frappe.utils.escape_html(icon.label) }}" />
-        </div>
-    {% } else { %}
-        {%= frappe.utils.desktop_icon(icon.label, "gray", "md", "Solid") %}
-    {% } %}
+<div class="desktop-icon">
+    <!-- The logo and the title are two anchors to the same place, because the subtitle below is a
+         link of its own and an anchor cannot nest inside another. The logo is hidden from the
+         accessibility tree so the tile offers one link to the app, not two. -->
+    <a class="icon-link" href="#" tabindex="-1" aria-hidden="true">
+        {% if (icon.logo_url) { %}
+            <div class="icon-container">
+                <img class="app-icon" src="{{ frappe.utils.escape_html(icon.logo_url) }}" alt="{{ frappe.utils.escape_html(icon.label) }}" />
+            </div>
+        {% } else { %}
+            {%= frappe.utils.desktop_icon(icon.label, "gray", "md", "Solid") %}
+        {% } %}
+    </a>
     <div class="icon-caption">
-        <div class="icon-title" data-toggle="tooltip" data-original-title="{{ frappe.utils.escape_html(__(icon.label)) }}">{{ frappe.utils.escape_html(__(icon.label)) }}</div>
+        <a class="icon-title" href="#" data-toggle="tooltip" data-original-title="{{ frappe.utils.escape_html(__(icon.label)) }}">{{ frappe.utils.escape_html(__(icon.label)) }}</a>
+        {% if (icon.desk_route) { %}
+        <a class="icon-subtitle" href="{{ frappe.utils.escape_html(icon.desk_route) }}">{{ frappe.utils.escape_html(__("Open in Desk")) }}</a>
+        {% } %}
     </div>
-</a>
+</div>

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
@@ -48,10 +48,13 @@ frappe.ui.sidebar_item.get_route = function (item, edit_mode = false) {
 			name: item.link_to,
 			tab: item.tab,
 		};
-		if (item.filters) {
-			let filters_json = JSON.parse(
-				frappe.utils.get_filter_as_json(JSON.parse(item.filters))
-			);
+		// get_filter_as_json() returns null for an empty filter array, so an item stored
+		// with `filters` of "[]" lands here with nothing to convert.
+		const filters_as_json = item.filters
+			? frappe.utils.get_filter_as_json(JSON.parse(item.filters))
+			: null;
+		if (filters_as_json) {
+			let filters_json = JSON.parse(filters_as_json);
 			for (const [key, value] of Object.entries(filters_json)) {
 				if (Array.isArray(value)) {
 					filters_json[key] = value[0] === "=" ? value[1] : JSON.stringify(value);

--- a/frappe/tests/test_dock_preferences.py
+++ b/frappe/tests/test_dock_preferences.py
@@ -2157,3 +2157,62 @@ class TestTheExportRoad(IntegrationTestCase):
 
 				self.assertTrue(doc.standard)
 				frappe.delete_doc("Dock", doc.name, force=True, ignore_permissions=True)
+
+
+class TestTheDeskDoor(IntegrationTestCase):
+	"""An app whose own UI is not the desk can still name a door back into it.
+
+	Configuring such an app -- its roles, its custom fields, the workspace it ships -- stays a desk
+	job, so `add_to_apps_screen` carries a `desk_route` and the apps screen renders it under the
+	app's icon as a second link. It is a literal route, passed through exactly as `route` is: the
+	app author owns the string, and nothing here resolves or permission-checks it.
+	"""
+
+	def app_entry(self, app_name: str) -> dict:
+		from frappe.boot import get_app_data
+
+		return next(app for app in get_app_data() if app["app_name"] == app_name)
+
+	def test_a_declared_desk_route_is_carried(self):
+		"""The whole feature: an app names a desk route and the boot payload hands it to the apps
+		screen unchanged."""
+		with patch.object(frappe, "get_hooks", _with_desk_route("/desk/crm")):
+			self.assertEqual(self.app_entry("frappe")["desk_route"], "/desk/crm")
+
+	def test_an_app_that_declares_no_desk_route_gets_an_empty_one(self):
+		"""A desk-native app has no door to name -- it is already the desk -- so the key is empty
+		and the apps screen renders no second link. Empty rather than missing, so every entry in
+		the payload has the same shape, exactly as `app_route` does."""
+		self.assertEqual(self.app_entry("frappe")["desk_route"], "")
+
+	def test_an_app_this_user_cannot_access_still_carries_an_empty_desk_route(self):
+		"""The denied branch withholds an app's routes but keeps its entry, so anything that
+		references the app can still label it. `desk_route` is withheld the way `app_route` is --
+		emptied, not dropped -- so every entry in the payload has one shape and a client reading
+		`desk_route` off one never gets `undefined`."""
+		with patch.object(frappe, "get_hooks", _with_desk_route("/desk/crm", denied=True)):
+			self.assertEqual(self.app_entry("frappe")["desk_route"], "")
+
+
+def _with_desk_route(route: str, denied: bool = False):
+	"""`frappe.get_hooks` with a `desk_route` added to frappe's own apps-screen entry, standing in
+	for the non-desk app that would really ship one. `denied` also points the entry's
+	`has_permission` at a hook that turns everyone away, to reach the branch that keeps an app in
+	the payload while withholding its routes."""
+	real = frappe.get_hooks
+
+	def patched(hook=None, default="_KEEP_DEFAULT_LIST", app_name=None):
+		hooks = real(hook, default, app_name)
+		if hook == "add_to_apps_screen" and app_name == "frappe":
+			entry = dict(hooks[0]) | {"desk_route": route}
+			if denied:
+				entry["has_permission"] = "frappe.tests.test_dock_preferences._denies_access"
+			return [entry]
+		return hooks
+
+	return patched
+
+
+def _denies_access() -> bool:
+	"""Stands in for an app's `has_permission` hook turning this user away."""
+	return False

--- a/hooks.md
+++ b/hooks.md
@@ -38,7 +38,12 @@ A disable or an enable is one transaction. If a hook fails, the site keeps the s
 
 1. `get_desktop_icons` - method to get list of desktop icons
 1. `awesomebar_search` - method(txt) returning extra Awesome Bar results (`label`, `description`, `route`, `index`). `route` may be a desk route list, an in-app path (`/desk/...`), or an `http(s)://` URL.
-1. `add_to_apps_screen` - list of dicts, one per app to place on the apps screen
+1. `add_to_apps_screen` - list of dicts, one per app to place on the apps screen. An app whose
+   own UI is not the desk may add `desk_route`, a route back into the desk -- the workspace where
+   it is configured, say. The apps screen renders it under the app's icon as a second link
+   labelled "Open in Desk". It is passed through exactly as `route` is: a literal route the app
+   owns, neither resolved nor permission-checked, so a workspace that gets renamed leaves a link
+   that no longer lands.
 
 #### Navigation an app ships
 


### PR DESCRIPTION
Add a way to go to desk for non desk based apps as well

<img width="148" height="158" alt="Screenshot 2026-08-29 at 12 43 38 AM" src="https://github.com/user-attachments/assets/7433783a-4338-43b3-b09d-3dc5a28a1f0d" />

`no-docs` for now