### PR TITLE
fix: allow export when report exceeds max_report_rows

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1172,6 +1172,11 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				[cstr(format_number(data.length, null, 0)).bold(), __("export").bold()]
 			);
 
+			if (this.datatable) {
+				this.datatable.destroy();
+				this.datatable = null;
+			}
+
 			this.toggle_message(true, `${frappe.utils.icon("triangle-alert")} ${msg}`);
 			return;
 		}

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1819,7 +1819,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	}
 
 	export_report() {
-		let visible_idx = this.get_validated_visible_indexes();
+		const has_datatable = !!this.datatable;
+		let visible_idx = has_datatable ? this.get_validated_visible_indexes() : [];
 
 		const extra_fields = [];
 		const applied_filters = this.get_applied_filters(this.get_filter_values());
@@ -1896,7 +1897,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				const totalRows = this.data.length - (this.raw_data.add_total_row ? 1 : 0);
 				const isIdentityOrder =
 					visible_idx.length === totalRows && visible_idx.every((idx, i) => idx === i);
-				const ignore_visible_idx = isIdentityOrder;
+				const ignore_visible_idx = !has_datatable || isIdentityOrder;
 				visible_idx = ignore_visible_idx ? [] : visible_idx;
 
 				const args = {

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1824,9 +1824,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	}
 
 	export_report() {
-		const has_datatable = !!this.datatable;
-		let visible_idx = has_datatable ? this.get_validated_visible_indexes() : [];
-
 		const extra_fields = [];
 		const applied_filters = this.get_applied_filters(this.get_filter_values());
 
@@ -1886,6 +1883,9 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				csv_decimal_sep,
 			}) => {
 				this.make_access_log("Export", file_format);
+
+				const has_datatable = !!this.datatable;
+				let visible_idx = has_datatable ? this.get_validated_visible_indexes() : [];
 
 				const filters = this.get_filter_values(true);
 				const applied_filters = this.get_applied_filters(filters);


### PR DESCRIPTION
## Problem

A query report with more rows than `max_report_rows` renders no table, only:

> This report contains 1,04,019 rows and is too big to display in browser, you can **export** this report instead.

Clicking Actions > Export throws:

> No data to perform this action
> Please adjust filters to include some data

The one action the UI recommends for a large report is the one it refuses to do.

## Cause

`render_datatable()` returns early over the limit, so `this.datatable` is never constructed. `export_report()` starts with `get_validated_visible_indexes()`, which reads `this.datatable?.bodyRenderer.visibleRowIndices` (`[]` when there is no datatable) and throws.

Nothing in the export actually needs the rendered table: the rows are in `this.data`, and `frappe.desk.query_report.export_query` re-runs the report server-side anyway.

## Fix

Skip the visible-row check when no datatable was rendered, and export every row in that case (`ignore_visible_idx = true`). Report View's export already behaves this way, tolerating a missing datatable rather than erroring.

Reports that do render a table are unaffected: sort/filter order is still sent as before.

<img width="1280" height="577" alt="76852_v3_dialog" src="https://github.com/user-attachments/assets/c0d2eb9f-d9e1-47a1-a908-bb3cec1d7b37" />


