### PR TITLE
fix: calendar view breaks for users in a different timezone than the system

### DIFF
--- a/frappe/desk/calendar.py
+++ b/frappe/desk/calendar.py
@@ -6,6 +6,7 @@ from datetime import date
 import frappe
 from frappe import _
 from frappe.query_builder import functions
+from frappe.utils import get_datetime, getdate
 
 
 @frappe.whitelist()
@@ -32,13 +33,15 @@ def get_event_conditions(doctype, filters=None):
 @frappe.whitelist()
 def get_events(
 	doctype: str,
-	start: date,
-	end: date,
+	start: str | date,
+	end: str | date,
 	field_map: str | dict,
 	filters: str | list | dict | None = None,
 	fields: str | list[str] | None = None,
 	order_by: str | None = None,
 ):
+	start, end = getdate(start), get_datetime(end)
+
 	field_map = frappe._dict(frappe.parse_json(field_map))
 	fields = frappe.parse_json(fields)
 

--- a/frappe/desk/test_calendar.py
+++ b/frappe/desk/test_calendar.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+
+import frappe
+from frappe.desk.calendar import get_events
+from frappe.tests import IntegrationTestCase
+
+
+class TestCalendar(IntegrationTestCase):
+	def test_get_events_accepts_range_from_a_different_timezone(self):
+		todo = frappe.get_doc(doctype="ToDo", description="Renew SSL certificate", date="2026-05-10").insert()
+
+		events = get_events(
+			doctype="ToDo",
+			start="2026-04-30 23:00:00",
+			end="2026-06-10 23:00:00",
+			field_map={"start": "date", "end": "date", "title": "description"},
+		)
+
+		self.assertIn(todo.name, [event.name for event in events])
+
+	def test_get_events_keeps_the_last_day_of_a_datetime_range(self):
+		maintenance_window = frappe.get_doc(
+			doctype="Event",
+			subject="Line 3 maintenance window",
+			event_type="Public",
+			starts_on="2026-05-10 10:00:00",
+			ends_on="2026-05-10 12:00:00",
+		).insert()
+
+		events = get_events(
+			doctype="Event",
+			start="2026-04-30 23:00:00",
+			end="2026-05-10 23:00:00",
+			field_map={"start": "starts_on", "end": "ends_on", "title": "subject"},
+		)
+
+		self.assertIn(maintenance_window.name, [event.name for event in events])


### PR DESCRIPTION
## Description

Calendar views failed for users in a different timezone because the date range could contain a time value, while `get_events` expected a `date`.

This affected generic calendar views such as ToDo, Task, Work Order, Job Card, and Production Plan Schedule.

The date range is now handled explicitly:

* `start` is converted to the start of the day.
* `end` keeps its time to avoid excluding records on the last day.

Users in the system timezone are unaffected. Tests cover both Date and Datetime fields.

---

Ref: https://support.frappe.io/helpdesk/tickets/76630?view=VIEW-HD+Ticket-1242