### PR TITLE
fix: show print format field only for query/script reports

### DIFF
--- a/frappe/public/js/frappe/form/print_utils.js
+++ b/frappe/public/js/frappe/form/print_utils.js
@@ -3,7 +3,7 @@ frappe.ui.get_print_settings = function (
 	callback,
 	letter_head,
 	pick_columns,
-	has_filters = false,
+	is_query_report = false,
 	title = null,
 	default_print_format = null
 ) {
@@ -31,24 +31,6 @@ frappe.ui.get_print_settings = function (
 			default: "Landscape",
 		},
 		{
-			fieldtype: "Link",
-			fieldname: "print_format",
-			label: __("Print Format"),
-			options: "Print Format",
-			default: default_print_format,
-			description: __(
-				"If no Print Format is selected, the default template for this report will be used."
-			),
-			get_query: () => ({
-				filters: {
-					print_format_for: "Report",
-					print_format_type: "JS",
-					report: frappe.query_report ? frappe.query_report.report_name : "",
-					disabled: 0,
-				},
-			}),
-		},
-		{
 			fieldtype: "Check",
 			fieldname: "with_letter_head",
 			label: __("With Letter Head"),
@@ -72,7 +54,29 @@ frappe.ui.get_print_settings = function (
 		},
 	];
 
-	if (has_filters) {
+	// Print format and include-filters only apply to query/script reports.
+	if (is_query_report) {
+		columns.splice(1, 0, {
+			fieldtype: "Link",
+			fieldname: "print_format",
+			label: __("Print Format"),
+			options: "Print Format",
+			default: default_print_format,
+			description: __(
+				"If no Print Format is selected, the default template for this report will be used."
+			),
+			get_query: () => ({
+				filters: {
+					print_format_for: "Report",
+					print_format_type: "JS",
+					report: frappe.query_report ? frappe.query_report.report_name : "",
+					disabled: 0,
+				},
+			}),
+		});
+	}
+
+	if (is_query_report) {
 		columns.push({
 			label: __("Include filters"),
 			fieldtype: "Check",

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -2057,7 +2057,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 						this.report_doc.letter_head,
 						this.get_visible_columns(),
 						true,
-						"PDF Settings"
+						"PDF Settings",
+						this.report_doc.default_print_format
 					);
 					this.add_portrait_warning(dialog);
 				},


### PR DESCRIPTION
**Issue:** The report Print Settings dialog rendered the Print Format field and Include Filters toggle even in the doctype report view and treeview, where a Report-scoped print format does not apply.

Before:
<img width="873" height="385" alt="Screenshot 2026-08-29 at 1 33 14 PM" src="https://github.com/user-attachments/assets/83ab4db4-ed3a-4b35-a5ff-9bd0c9ba889c" />

**Fix:** Gate those fields behind a single `is_query_report` flag so they appear only for query/script reports. Report view and treeview now show just Orientation and Letter Head.