### PR TITLE
fix(integration): Add connect timeout for requests to frappecloud

### DIFF
--- a/frappe/integrations/frappe_providers/frappecloud_billing.py
+++ b/frappe/integrations/frappe_providers/frappecloud_billing.py
@@ -42,7 +42,9 @@ def post(method: str, json: dict | None = None):
 	"""POST to a whitelisted method on Frappe Cloud with this site's credentials."""
 	import requests
 
-	return requests.post(f"{get_base_url()}/api/method/{method}", headers=get_headers(), json=json)
+	return requests.post(
+		f"{get_base_url()}/api/method/{method}", headers=get_headers(), json=json, timeout=(5, 10)
+	)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Frappe Cloud integration sends outbound request to cloud.frappe.io.
In case of network issues, the request can stuck and cause timeout issue. It can eventually block gunicorn workers for long time and prevent serving legitimate requests.

Set a lower connect timeout and read timeout to fail early.