### PR TITLE
fix: rename Server Script 'disabled' field to 'enabled' for consistent

### DIFF
--- a/frappe/core/doctype/server_script/server_script.json
+++ b/frappe/core/doctype/server_script/server_script.json
@@ -16,7 +16,7 @@
   "allow_guest",
   "column_break_3",
   "module",
-  "disabled",
+  "enabled",
   "section_break_8",
   "script",
   "rate_limiting_section",
@@ -75,7 +75,7 @@
   },
   {
    "default": "0",
-   "fieldname": "disabled",
+   "fieldname": "enabled",
    "fieldtype": "Check",
    "label": "Disabled"
   },

--- a/frappe/core/doctype/server_script/server_script.py
+++ b/frappe/core/doctype/server_script/server_script.py
@@ -36,7 +36,7 @@ class ServerScript(Document):
 		allow_guest: DF.Check
 		api_method: DF.Data | None
 		cron_format: DF.Data | None
-		disabled: DF.Check
+		enabled: DF.Check
 		doctype_event: DF.Literal[
 			"Before Insert",
 			"Before Validate",
@@ -144,7 +144,7 @@ class ServerScript(Document):
 			self.has_value_changed("event_frequency")
 			or self.has_value_changed("cron_format")
 			or self.has_value_changed("queue")
-			or self.has_value_changed("disabled")
+			or self.has_value_changed("enabled")
 			or self.has_value_changed("script_type")
 		):
 			return
@@ -155,7 +155,7 @@ class ServerScript(Document):
 				"frequency": self.event_frequency,
 				"cron_format": self.cron_format if self.event_frequency == "Cron" else "",
 				"queue": self.queue,
-				"stopped": self.disabled,
+				"stopped": not self.enabled,
 			}
 		).save()
 

--- a/frappe/core/doctype/server_script/server_script_utils.py
+++ b/frappe/core/doctype/server_script/server_script_utils.py
@@ -71,7 +71,7 @@ def get_server_script_map():
 		enabled_server_scripts = frappe.get_all(
 			"Server Script",
 			fields=("name", "reference_doctype", "doctype_event", "api_method", "script_type"),
-			filters={"disabled": 0},
+			filters={"enabled": 1},
 		)
 		for script in enabled_server_scripts:
 			if script.script_type == "DocType Event":

--- a/frappe/core/doctype/server_script/test_server_script.py
+++ b/frappe/core/doctype/server_script/test_server_script.py
@@ -70,7 +70,7 @@ frappe.method_that_doesnt_exist("do some magic")
 		script_type="DocType Event",
 		doctype_event="Before Save",
 		reference_doctype="ToDo",
-		disabled=1,
+		enabled=0,
 		script="""
 frappe.db.commit()
 """,
@@ -80,7 +80,7 @@ frappe.db.commit()
 		script_type="DocType Event",
 		doctype_event="Before Save",
 		reference_doctype="ToDo",
-		disabled=1,
+		enabled=0,
 		script="""
 frappe.db.add_index("Todo", ["color", "date"])
 """,
@@ -101,7 +101,7 @@ doc.save()
 		doctype_event="After Rename",
 		reference_doctype="Role",
 		script="""
-doc.disabled =1
+doc.enabled = 0
 doc.save()
 """,
 	),
@@ -179,22 +179,22 @@ class TestServerScript(IntegrationTestCase):
 
 	def test_commit_in_doctype_event(self):
 		server_script = frappe.get_doc("Server Script", "test_todo_commit")
-		server_script.disabled = 0
+		server_script.enabled = 1
 		server_script.save()
 
 		self.assertRaises(AttributeError, frappe.get_doc(doctype="ToDo", description="test me").insert)
 
-		server_script.disabled = 1
+		server_script.enabled = 0
 		server_script.save()
 
 	def test_add_index_in_doctype_event(self):
 		server_script = frappe.get_doc("Server Script", "test_add_index")
-		server_script.disabled = 0
+		server_script.enabled = 1
 		server_script.save()
 
 		self.assertRaises(AttributeError, frappe.get_doc(doctype="ToDo", description="test me").insert)
 
-		server_script.disabled = 1
+		server_script.enabled = 0
 		server_script.save()
 
 	def test_restricted_qb(self):
@@ -385,10 +385,10 @@ frappe.qb.from_(todo).select(todo.name).where(todo.name == "{todo.name}").run()
 
 		# manually disable
 
-		script.disabled = 1
+		script.enabled = 0
 		script.save()
 		self.assertTrue(job.reload().stopped)
 
-		script.disabled = 0
+		script.enabled = 1
 		script.save()
 		self.assertFalse(job.reload().stopped)

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -274,3 +274,4 @@ frappe.patches.v16_0.keep_existing_sites_on_desktop_icons
 frappe.patches.v16_0.repair_converted_print_formats
 frappe.patches.v16_0.repair_converted_print_formats #2026-08-02 section-spacing
 execute:frappe.db.set_single_value("Contact Us Settings", "send_acknowledgement_email", 1)
+frappe.patches.v16_0.rename_server_script_disabled_to_enabled

--- a/frappe/patches/v16_0/rename_server_script_disabled_to_enabled.py
+++ b/frappe/patches/v16_0/rename_server_script_disabled_to_enabled.py
@@ -1,0 +1,16 @@
+import frappe
+
+
+def execute():
+	"""Migrate Server Script's `disabled` field data to the new `enabled` field."""
+	if not frappe.db.has_column("Server Script", "disabled"):
+		return
+
+	frappe.reload_doctype("Server Script")
+
+	frappe.db.sql(
+		"""
+		UPDATE `tabServer Script`
+		SET enabled = IF(disabled = 1, 0, 1)
+		"""
+	)


### PR DESCRIPTION
Problem :

Client Script and Server Script are two very similar doctypes, but their
"active/inactive" checkbox is inconsistent:

- Client Script uses an "Enabled" checkbox, checked by default (positive framing)
- Server Script uses a "Disabled" checkbox, unchecked by default (negative framing)

This inconsistency is confusing for users who work with both doctypes side by side.

Solution :

Renamed Server Script's `disabled` field to `enabled` (default checked) to match
Client Script's UX pattern. Added a migration patch so existing sites' saved
Server Scripts correctly preserve their enabled/disabled state after upgrade.

Screenshots :

Before (Server Script - "Disabled" checkbox):
<img width="2466" height="1340" alt="image" src="https://github.com/user-attachments/assets/725c1207-ad5c-4c29-9673-999ff9c28142" />

After (Server Script - "Enabled" checkbox, matching Client Script):
<img width="2721" height="1548" alt="image" src="https://github.com/user-attachments/assets/a00607d2-fee2-4fad-9ae6-1d66efe8e380" />

For comparison, Client Script's existing "Enabled" field:
<img width="2769" height="1470" alt="image" src="https://github.com/user-attachments/assets/a36d7552-c7dd-4aee-b6b4-3524ca822693" />