### PR TITLE
fix(pfb): print format onboarding follow-ups

### DIFF
--- a/frappe/printing/doctype/print_format/print_format.json
+++ b/frappe/printing/doctype/print_format/print_format.json
@@ -149,21 +149,21 @@
    "fieldname": "align_labels_right",
    "fieldtype": "Check",
    "label": "Align Labels to the Right",
-   "hidden": 1
+   "depends_on": "eval:!doc.print_format_builder_beta"
   },
   {
    "default": "0",
    "fieldname": "show_section_headings",
    "fieldtype": "Check",
    "label": "Show Section Headings",
-   "hidden": 1
+   "depends_on": "eval:!doc.print_format_builder_beta"
   },
   {
    "default": "0",
    "fieldname": "line_breaks",
    "fieldtype": "Check",
    "label": "Show Line Breaks after Sections",
-   "hidden": 1
+   "depends_on": "eval:!doc.print_format_builder_beta"
   },
   {
    "fieldname": "column_break_11",

--- a/frappe/printing/doctype/print_format/print_format_list.js
+++ b/frappe/printing/doctype/print_format/print_format_list.js
@@ -48,6 +48,7 @@ frappe.listview_settings["Print Format"] = {
 				fieldname: "report",
 				fieldtype: "Link",
 				options: "Report",
+				default: active.report || "",
 				depends_on: 'eval:doc.print_format_for === "Report"',
 				mandatory_depends_on: 'eval:doc.print_format_for === "Report"',
 			},

--- a/frappe/printing/doctype/print_format/test_print_format.py
+++ b/frappe/printing/doctype/print_format/test_print_format.py
@@ -932,6 +932,15 @@ class TestPrintFormatDraft(IntegrationTestCase):
 		self.assertEqual(live.margin_top, 30)
 		self.assertEqual(live.disabled, 0)
 
+	def test_css_rides_the_draft_pipeline(self):
+		from frappe.printing.doctype.print_format.print_format import apply_draft, save_draft
+
+		save_draft(self.pf.name, {"css": ".print-format p { margin: 0; }"}, self.stamp())
+		self.assertIn("css", frappe.parse_json(self.live("draft_data").draft_data))
+
+		apply_draft(self.pf.name, self.stamp(), {"css": ".print-format p { margin: 0; }"})
+		self.assertEqual(self.live("css").css, ".print-format p { margin: 0; }")
+
 	def test_a_stale_write_cannot_clobber_a_newer_draft(self):
 		"""db_set skips the timestamp check save() runs, so the endpoints do it."""
 		from frappe.printing.doctype.print_format.print_format import (

--- a/frappe/public/js/print_format_builder/components/PrintSettingsPanel.vue
+++ b/frappe/public/js/print_format_builder/components/PrintSettingsPanel.vue
@@ -118,10 +118,16 @@ let { typst_blockers, has_typst_block } = store;
 
 // ── custom css ─────────────────────────────────────────────
 let css_enabled = ref(!!print_format.value.css);
-// a discarded draft or re-fetch replaces the doc — the toggle follows it
+// a discarded draft or re-fetch replaces the doc — the toggle follows it,
+// except a toggle the user opened themselves stays open through a doc swap
+// (a save with an empty box must not close the panel under them)
+let css_manual = false;
 watch(
 	() => print_format.value,
-	(pf) => (css_enabled.value = !!pf?.css)
+	(pf) => {
+		if (pf?.css) css_enabled.value = true;
+		else if (!css_manual) css_enabled.value = false;
+	}
 );
 watch(
 	() => print_format.value?.css,
@@ -134,6 +140,7 @@ watch(
 let stashed_css = "";
 
 function toggle_css(on) {
+	css_manual = on;
 	css_enabled.value = on;
 	if (on) {
 		if (stashed_css && !print_format.value.css) {

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -20,7 +20,11 @@
 		     and the empty header drop-zone only surfaces while a drag is in progress. -->
 		<div class="pfb-header-area">
 			<LetterHeadZoneEditor zone="header" />
-			<div class="pfb-header-fields" :style="bodyStyles">
+			<div
+				class="pfb-header-fields"
+				:class="{ 'pfb-header-fields--empty': header_is_empty }"
+				:style="bodyStyles"
+			>
 				<PrintFormatSection :section="layout.header" :is_header="true" zone="header" />
 			</div>
 		</div>
@@ -83,6 +87,14 @@ import { useStore } from "../../stores";
 import { computed, inject, watch, nextTick, onMounted, onUnmounted, ref } from "vue";
 
 let { layout, letterhead, print_format } = useStore();
+
+// one definition of "the header holds no fields" — the tree and the canvas
+// both key off it, so a deleted field (kept in the DOM as a tombstone) can't
+// make them disagree
+let header_is_empty = computed(
+	() =>
+		!(layout.value.header?.columns || []).some((c) => (c.fields || []).some((f) => !f.remove))
+);
 let store = inject("$store");
 
 const PAGE_SIZES_MM = { A4: [210, 297], Letter: [216, 279.4] };

--- a/frappe/public/js/print_format_builder/inspector.css
+++ b/frappe/public/js/print_format_builder/inspector.css
@@ -293,10 +293,10 @@
    render at all (display beats the section's data-driven inline margins), and
    surfaces as a drop target the moment a drag starts. Fields dropped there
    render right under the letterhead — same region. */
-.pfb-header-area:has(.letter-head) .pfb-header-fields:not(:has([data-field-uid])) {
+.pfb-header-area:has(.letter-head) .pfb-header-fields.pfb-header-fields--empty {
 	display: none;
 }
-body.pfb-dragging .pfb-header-area:has(.letter-head) .pfb-header-fields {
+body.pfb-dragging .pfb-header-area:has(.letter-head) .pfb-header-fields.pfb-header-fields--empty {
 	display: block;
 }
 

--- a/frappe/templates/print_format/print_format_doc.css
+++ b/frappe/templates/print_format/print_format_doc.css
@@ -483,7 +483,8 @@
    classic formats. Builder layouts space the letterhead through their own
    section margins, so neutralise it here. body. outranks the print style's
    .print-format .letter-head, which is injected after this bundle. */
-body.print-format-doc .letter-head {
+body.print-format-doc .letter-head,
+.wrapper.print-format-doc .letter-head {
 	margin-bottom: 0;
 }
 

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -706,6 +706,12 @@ class PrintFormatGenerator:
 	}
 
 	def get_layout(self, print_format):
+		if not print_format.format_data:
+			# a format created without a layout (the New dialog inserts a bare row)
+			# prints the default layout instead of a blank page until its first save
+			from frappe.printing.doctype.print_format.classic_converter import create_default_layout
+
+			return self.get_processed_layout(create_default_layout(frappe.get_meta(print_format.doc_type)))
 		try:
 			layout = frappe.parse_json(print_format.format_data) or copy.deepcopy(self.EMPTY_LAYOUT)
 		except Exception:
@@ -719,6 +725,9 @@ class PrintFormatGenerator:
 			)
 			if not print_format.page_number or print_format.page_number == "Hide":
 				print_format.page_number = "Bottom Center"
+		return self.get_processed_layout(layout)
+
+	def get_processed_layout(self, layout):
 		layout = self.normalise_layout(layout)
 		layout = self.apply_permlevel_access(layout)
 		layout = self.set_field_renderers(layout)


### PR DESCRIPTION
Follow-ups to #41715:

- Empty-header check unified: the canvas hid the header zone by probing the DOM (`:has([data-field-uid])`) while the Layers tree checked `!f.remove` — deleting the last header field left a stray band on the canvas. One computed drives both now
- The letterhead bottom-margin reset missed the Chrome PDF header overlay (letterhead sits under `div.wrapper.print-format-doc`, not `body`) — preview showed 0px, PDF 30px
- Formats created from the New dialog carried no `format_data` and printed a blank page until the first Save & Apply — the renderer now falls back to the default layout
- The three classic-only checks (`align_labels_right`, `show_section_headings`, `line_breaks`) were hidden outright but classic formats and the classic→beta converter still read them — hidden only for beta formats now
- The Custom CSS toggle collapsed on every doc refetch when the box was empty; a toggle the user opened stays open
- The New dialog prefills the `report` list filter like it already did `doc_type`
- Test: `css` rides the draft save/apply pipeline

no-docs