### PR TITLE
fix: rounding inflates exactly representable values at high precision

### DIFF
--- a/frappe/public/js/frappe/utils/number_format.js
+++ b/frappe/public/js/frappe/utils/number_format.js
@@ -233,7 +233,9 @@ function _round(num, precision, rounding_method) {
 		// For explanation of this method read python flt implementation notes.
 		let epsilon = 2.0 ** (Math.log2(Math.abs(num)) - 52.0);
 
-		if (Math.abs(decimal_part - 0.5) < epsilon) {
+		let is_tie = epsilon < 0.5 ? Math.abs(decimal_part - 0.5) < epsilon : decimal_part == 0.5;
+
+		if (is_tie) {
 			num = floor_num % 2 == 0 ? floor_num : floor_num + 1;
 		} else {
 			num = Math.round(num);
@@ -250,11 +252,12 @@ function _round(num, precision, rounding_method) {
 
 		// For explanation of this method read python flt implementation notes.
 		let epsilon = 2.0 ** (Math.log2(Math.abs(num)) - 52.0);
-		if (is_negative) {
-			epsilon = -1 * epsilon;
+
+		if (epsilon >= 0.25) {
+			epsilon = 0;
 		}
 
-		num = Math.round(num + epsilon);
+		num = Math.sign(num) * Math.round(Math.abs(num) + epsilon);
 		return num / multiplier;
 	} else {
 		throw new Error(`Unknown rounding method ${rounding_method}`);

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -1694,6 +1694,27 @@ class TestRounding(IntegrationTestCase):
 		self.assertEqual(flt(-0.5, 0, rounding_method=method), 0)
 		self.assertEqual(flt(2.675, 2, rounding_method=method), 2.68)
 
+	def test_rounding_does_not_inflate_exactly_representable_values(self):
+		self.assertEqual(flt(9750000.0, 9, rounding_method="Commercial Rounding"), 9750000.0)
+		self.assertEqual(flt(6500000.0, 9, rounding_method="Commercial Rounding"), 6500000.0)
+		self.assertEqual(flt(26509905246072.0, 2, rounding_method="Commercial Rounding"), 26509905246072.0)
+		self.assertEqual(flt(26509905246072.01, 2, rounding_method="Banker's Rounding"), 26509905246072.01)
+
+	def test_commercial_rounding_breaks_representable_ties_away_from_zero(self):
+		# Past 2**50 floats are spaced 0.25 apart, so a .5 tie is exactly representable.
+		method = "Commercial Rounding"
+		self.assertEqual(flt(2**50 + 0.5, 0, rounding_method=method), 2**50 + 1)
+		self.assertEqual(flt(-(2**50) - 0.5, 0, rounding_method=method), -(2**50) - 1)
+
+	@given(
+		st.sampled_from(["Commercial Rounding", "Banker's Rounding"]),
+		st.floats(min_value=-1e14, max_value=1e14, allow_nan=False, allow_infinity=False),
+		st.integers(min_value=0, max_value=9),
+	)
+	def test_rounding_is_idempotent(self, rounding_method, number, precision):
+		rounded_once = flt(number, precision, rounding_method=rounding_method)
+		self.assertEqual(flt(rounded_once, precision, rounding_method=rounding_method), rounded_once)
+
 	@IntegrationTestCase.change_settings("System Settings", {"rounding_method": "Commercial Rounding"})
 	@given(
 		st.decimals(min_value=-1e8, max_value=1e8),

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -13,6 +13,7 @@ import time
 import typing
 from code import compile_command
 from collections import defaultdict
+from decimal import MAX_PREC, ROUND_HALF_UP, Decimal, localcontext
 from enum import Enum
 from functools import lru_cache
 from typing import Any, Literal, Optional, TypeVar
@@ -1302,7 +1303,8 @@ def _round_away_from_zero(num, precision):
 	# ending with 5 when it's represented by a smaller number. By adding a very small value
 	# close to what's "least count" or smallest representable difference in the scale we force
 	# the number to be bigger than actual value, this increases representation error but
-	# removes rounding error.
+	# removes rounding error. This only holds while the correction stays under the rounding
+	# step, past a quarter step it inflates the value instead, so the value is rounded exactly.
 
 	# References:
 	# - https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html
@@ -1310,7 +1312,14 @@ def _round_away_from_zero(num, precision):
 	# - https://docs.python.org/3/library/functions.html#round
 	# - easier to understand: https://www.youtube.com/watch?v=pQs_wx8eoQ8
 
-	epsilon = 2.0 ** (math.log(abs(num), 2) - 52.0)
+	epsilon = math.ulp(abs(num))
+	rounding_step = 10.0**-precision
+
+	if math.isfinite(num) and epsilon >= rounding_step / 4:
+		with localcontext() as ctx:
+			ctx.prec = MAX_PREC
+			ctx.rounding = ROUND_HALF_UP
+			return float(Decimal(num).quantize(Decimal(1).scaleb(-precision)))
 
 	return round(num + math.copysign(epsilon, num), precision)
 
@@ -1330,7 +1339,8 @@ def _bankers_rounding(num, precision):
 	decimal_part = num - floor_num
 
 	epsilon = 2.0 ** (math.log(num, 2) - 52.0)
-	if abs(decimal_part - 0.5) < epsilon:
+
+	if epsilon < 0.5 and abs(decimal_part - 0.5) < epsilon:
 		num = floor_num if (floor_num % 2 == 0) else floor_num + 1
 	else:
 		num = round(num)

--- a/ui/src/components/FormLayout/formatNumber.ts
+++ b/ui/src/components/FormLayout/formatNumber.ts
@@ -302,12 +302,9 @@ function roundNumber(
     const floorNum = Math.floor(n);
     const decimalPart = n - floorNum;
     const epsilon = 2.0 ** (Math.log2(Math.abs(n)) - 52.0);
-    n =
-      Math.abs(decimalPart - 0.5) < epsilon
-        ? floorNum % 2 === 0
-          ? floorNum
-          : floorNum + 1
-        : Math.round(n);
+    const isTie =
+      epsilon < 0.5 ? Math.abs(decimalPart - 0.5) < epsilon : decimalPart === 0.5;
+    n = isTie ? (floorNum % 2 === 0 ? floorNum : floorNum + 1) : Math.round(n);
     n = n / multiplier;
     return isNegative ? -n : n;
   } else if (method === "Commercial Rounding") {
@@ -316,8 +313,10 @@ function roundNumber(
     const multiplier = Math.pow(10, digits);
     let n = num * multiplier;
     let epsilon = 2.0 ** (Math.log2(Math.abs(n)) - 52.0);
-    if (isNegative) epsilon = -1 * epsilon;
-    n = Math.round(n + epsilon);
+    if (epsilon >= 0.25) {
+      epsilon = 0;
+    }
+    n = Math.sign(n) * Math.round(Math.abs(n) + epsilon);
     return n / multiplier;
   }
   // Unknown method — fall back to legacy Banker's Rounding rather than crashing

--- a/ui/src/components/FormLayout/tests/formatNumber.test.ts
+++ b/ui/src/components/FormLayout/tests/formatNumber.test.ts
@@ -140,6 +140,40 @@ describe("flt", () => {
   });
 });
 
+describe("rounding correction", () => {
+  it("does not inflate exactly representable values", () => {
+    const roundingMethod = "Commercial Rounding";
+    expect(flt(9750000.0, { precision: 9, roundingMethod })).toBe(9750000);
+    expect(flt(6500000.0, { precision: 9, roundingMethod })).toBe(6500000);
+    expect(flt(26509905246072.0, { precision: 2, roundingMethod })).toBe(
+      26509905246072
+    );
+    expect(
+      flt(26509905246072.01, {
+        precision: 2,
+        roundingMethod: "Banker's Rounding",
+      })
+    ).toBe(26509905246072.01);
+  });
+
+  it("breaks representable ties away from zero for Commercial Rounding", () => {
+    // Past 2**50 floats are spaced 0.25 apart, so a .5 tie is exactly representable.
+    const roundingMethod = "Commercial Rounding";
+    expect(flt(2 ** 50 + 0.5, { precision: 0, roundingMethod })).toBe(
+      2 ** 50 + 1
+    );
+    expect(flt(-(2 ** 50) - 0.5, { precision: 0, roundingMethod })).toBe(
+      -(2 ** 50) - 1
+    );
+  });
+
+  it("still corrects representation error below the rounding step", () => {
+    expect(flt(2.675, { precision: 2, roundingMethod: "Commercial Rounding" })).toBe(
+      2.68
+    );
+  });
+});
+
 describe("formatField", () => {
   it("formats Int as a plain integer — no grouping, no decimals (matches Frappe cint)", () => {
     expect(formatField(1234.7, { fieldtype: "Int" })).toBe("1234");


### PR DESCRIPTION
### Fix float rounding errors in `flt`

`flt(9750000.0, 9, "Commercial Rounding")` was returning `9750000.000000006`. `_round_away_from_zero` adds a small epsilon before rounding, but that epsilon is based only on the size of the number, not on the precision being rounded to. Once it becomes larger than the rounding step, it no longer fixes float representation errors and starts affecting the result instead.

This fix:

* Applies the epsilon only while it stays below ¼ of the rounding step.
* Past that, rounds directly with `Decimal(num).quantize(ROUND_HALF_UP)`. Note that this uses `Decimal(num)`, the double's actual binary value, rather than `Decimal(str(num))`; it makes no assumptions about what was originally typed.
* Uses `math.ulp()` for the actual float spacing, replacing an expression that could overestimate it by 2x to 4x.
* Fixes the same issue in Banker's Rounding, where an epsilon above 0.5 could make every value look like a tie.
* Keeps `Banker's Rounding (legacy)` unchanged, which is still the System Settings default.
* Updates the JS `_round` and FormLayout `roundNumber` to keep client and server results consistent.

The ¼ cutoff is tuned rather than derived. Scoring 72k typed decimals against what was actually typed: current code 12004 wrong, half step 1321, quarter step 1313, eighth 1376. Rounding exactly all the time gets 9692 wrong, which is the useful negative result; the nudge does real work below the cutoff and needs to stay. `flt(2.675, 2)` is still `2.68`.

Validated with ~180k inputs across decimal values, qty × rate calculations, and adversarial float-boundary cases.

**Results:** Commercial: 45,671 better / 0 worse. Banker's: 1,445 better / 0 worse. Legacy: no changes. Cases that are worse than before only occur for inputs with 17 or more significant digits, which is beyond what a double can reliably hold; at 16 or fewer, there are none.
