### PR TITLE
feat(printing): render Jinja in Letter Head previews

### DIFF
--- a/frappe/printing/doctype/letter_head/letter_head.js
+++ b/frappe/printing/doctype/letter_head/letter_head.js
@@ -4,6 +4,12 @@
 frappe.ui.form.on("Letter Head", {
 	setup(frm) {
 		frm.get_field("instructions").html(INSTRUCTIONS);
+
+		["content", "footer"].forEach((fieldname) => {
+			const field = frm.get_field(fieldname);
+			field.preview_renderer = (value, $preview) =>
+				render_letter_head_preview(frm, field, value, $preview);
+		});
 	},
 
 	refresh(frm) {
@@ -40,6 +46,69 @@ frappe.ui.form.on("Letter Head", {
 		});
 	},
 });
+
+async function render_letter_head_preview(frm, field, value, $preview) {
+	if (frm.is_new()) {
+		$preview.html(
+			`<div class="text-muted p-3">${__("Save the Letter Head to preview it")}</div>`
+		);
+		return;
+	}
+
+	const request_id = (field.preview_request_id || 0) + 1;
+	field.preview_request_id = request_id;
+	$preview.html(`<div class="text-muted p-3">${__("Rendering preview...")}</div>`);
+
+	try {
+		const { message } = await frappe.call({
+			method: "frappe.printing.doctype.letter_head.letter_head.render_preview",
+			args: {
+				letter_head: frm.doc.name,
+				fieldname: field.df.fieldname,
+				content: value,
+			},
+		});
+
+		if (request_id !== field.preview_request_id) return;
+		render_isolated_preview(message || "", $preview);
+	} catch (error) {
+		if (request_id !== field.preview_request_id) return;
+		$preview.html(
+			`<div class="text-danger p-3">${__("Unable to render Letter Head preview")}</div>`
+		);
+	}
+}
+
+function render_isolated_preview(value, $preview) {
+	const iframe = document.createElement("iframe");
+	iframe.setAttribute("sandbox", "allow-same-origin");
+	iframe.setAttribute("referrerpolicy", "no-referrer");
+	iframe.setAttribute("title", __("Letter Head Preview"));
+	iframe.style.cssText = "width: 100%; min-height: 180px; border: 0; background: #fff;";
+
+	iframe.addEventListener("load", () => {
+		const resize = () => {
+			const height = iframe.contentDocument?.documentElement?.scrollHeight || 180;
+			iframe.style.height = `${Math.max(height, 180)}px`;
+		};
+
+		resize();
+		iframe.contentDocument?.querySelectorAll("img").forEach((image) => {
+			image.addEventListener("load", resize, { once: true });
+		});
+	});
+
+	iframe.srcdoc = `<!doctype html>
+		<html>
+			<head>
+				<base href="${window.location.origin}/">
+				<style>html, body { margin: 0; padding: 0; }</style>
+			</head>
+			<body><div class="letter-head">${value}</div></body>
+		</html>`;
+
+	$preview.empty().append(iframe);
+}
 
 const INSTRUCTIONS = `<h4>${__("Letter Head Scripts")}</h4>
 <p>${__("Header/Footer scripts can be used to add dynamic behaviours.")}</p>

--- a/frappe/printing/doctype/letter_head/letter_head.py
+++ b/frappe/printing/doctype/letter_head/letter_head.py
@@ -5,7 +5,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.modules.utils import export_module_json
-from frappe.utils import flt, is_image
+from frappe.utils import flt, is_image, nowdate
 
 
 class LetterHead(Document):
@@ -175,3 +175,41 @@ class LetterHead(Document):
 
 			if not self.module:
 				frappe.throw(_("Module is required when Standard is set to 'Yes'"))
+
+
+@frappe.whitelist(methods=["POST"])
+def render_preview(letter_head: str, fieldname: str, content: str | None = None) -> str:
+	"""Render Letter Head HTML with the same Jinja renderer used for printing."""
+	if fieldname not in {"content", "footer"}:
+		frappe.throw(_("Invalid Letter Head field for preview"))
+
+	letter_head_doc = frappe.get_doc("Letter Head", letter_head)
+	letter_head_doc.check_permission("read")
+
+	stored_content = letter_head_doc.get(fieldname) or ""
+	if content is None:
+		content = stored_content
+	elif content != stored_content:
+		letter_head_doc.check_permission("write")
+
+	doc = _get_preview_document()
+	return frappe.utils.jinja.render_template(content, {"doc": doc})
+
+
+def _get_preview_document() -> frappe._dict:
+	"""Build an extensible document context for the Letter Head form preview."""
+	preview_date = nowdate()
+	doc = frappe._dict(
+		{
+			"doctype": "Document",
+			"name": _("PREVIEW"),
+			"transaction_date": preview_date,
+			"posting_date": preview_date,
+			"date": preview_date,
+		}
+	)
+
+	for method in frappe.get_hooks("get_letter_head_preview_context"):
+		doc.update(frappe.get_attr(method)(doc) or {})
+
+	return doc

--- a/frappe/printing/doctype/letter_head/test_letter_head.py
+++ b/frappe/printing/doctype/letter_head/test_letter_head.py
@@ -2,9 +2,11 @@
 # License: MIT. See LICENSE
 import os
 import shutil
+from unittest.mock import patch
 
 import frappe
 from frappe.tests import IntegrationTestCase
+from frappe.utils import nowdate
 
 
 class TestLetterHead(IntegrationTestCase):
@@ -43,3 +45,58 @@ class TestLetterHead(IntegrationTestCase):
 
 		dir_path = os.path.dirname(os.path.dirname(final_path))
 		self.addCleanup(shutil.rmtree, dir_path)
+
+	def test_render_preview_uses_hook_context(self):
+		from frappe.printing.doctype.letter_head.letter_head import render_preview
+
+		letter_head = frappe.new_doc("Letter Head")
+		letter_head.letter_head_for = "DocType"
+		letter_head.letter_head_name = "Preview Test"
+		letter_head.module = "Core"
+		letter_head.standard = "No"
+		letter_head.source = "HTML"
+		letter_head.content = (
+			"<h1>{{ doc.company }}</h1>"
+			"<div>{{ doc.doctype }}</div>"
+			"<strong>{{ doc.name }}</strong>"
+			"<time>{{ doc.posting_date }}</time>"
+		)
+		letter_head.insert()
+
+		original_get_hooks = frappe.get_hooks
+
+		def get_hooks(hook_name=None, *args, **kwargs):
+			if hook_name == "get_letter_head_preview_context":
+				return [f"{__name__}.get_test_letter_head_preview_context"]
+			return original_get_hooks(hook_name, *args, **kwargs)
+
+		with patch("frappe.get_hooks", side_effect=get_hooks):
+			preview = render_preview(letter_head.name, "content")
+
+		self.assertNotIn("{{", preview)
+		self.assertIn("Test Company", preview)
+		self.assertIn("Sales Invoice", preview)
+		self.assertIn("PREVIEW", preview)
+		self.assertIn(nowdate(), preview)
+
+	def test_rendering_modified_content_requires_write_permission(self):
+		from frappe.printing.doctype.letter_head.letter_head import render_preview
+
+		letter_head = frappe.new_doc("Letter Head")
+		letter_head.letter_head_for = "DocType"
+		letter_head.letter_head_name = "Preview Permission Test"
+		letter_head.module = "Core"
+		letter_head.standard = "No"
+		letter_head.source = "HTML"
+		letter_head.content = "<p>Stored content</p>"
+		letter_head.insert()
+
+		with patch.object(letter_head.__class__, "check_permission") as check_permission:
+			render_preview(letter_head.name, "content", "<p>Modified content</p>")
+
+		check_permission.assert_any_call("read")
+		check_permission.assert_any_call("write")
+
+
+def get_test_letter_head_preview_context(_doc):
+	return {"doctype": "Sales Invoice", "company": "Test Company"}

--- a/frappe/public/js/frappe/form/controls/html_editor.js
+++ b/frappe/public/js/frappe/form/controls/html_editor.js
@@ -8,8 +8,13 @@ frappe.ui.form.ControlHTMLEditor = class ControlHTMLEditor extends (
 	}
 	update_preview() {
 		if (!this.markdown_preview) return;
-		let value = this.get_value() || "";
-		value = frappe.dom.remove_script_and_style(value);
-		this.markdown_preview.html(value);
+		const value = this.get_value() || "";
+
+		if (this.preview_renderer) {
+			return this.preview_renderer(value, this.markdown_preview);
+		}
+
+		const safe_value = frappe.dom.remove_script_and_style(value);
+		this.markdown_preview.html(safe_value);
 	}
 };


### PR DESCRIPTION
## Problem

The HTML Editor preview inserts the stored HTML directly into the form. As a result, Letter Head templates show raw `{% ... %}` / `{{ ... }}` expressions, discard embedded styles, and do not match the output produced by the print pipeline.

## Changes

- add an optional `preview_renderer` extension point to `ControlHTMLEditor`
- render Letter Head `content` and `footer` with the server-side Jinja renderer used by printing
- provide a framework-neutral preview document and a `get_letter_head_preview_context` hook for installed apps
- isolate rendered HTML and styles in a sandboxed iframe
- ignore stale asynchronous preview responses
- require write permission when submitted HTML differs from the stored Letter Head; read-only users can only render stored content

Frappe works standalone with a generic `Document / PREVIEW` context. ERPNext can enrich the same context with company and address data through the hook.

## Validation

- Letter Head integration tests: 3 passed on a version-16 bench
- Ruff format and lint checks passed on the develop branch
- JavaScript syntax checks and `git diff --check` passed
- `bench build --app frappe` passed
- manually verified Jinja control blocks, localized document labels, number, date, company details, and iframe isolation

## Related ERPNext implementation

The companion ERPNext hook is ready for review at:
https://github.com/frappe/erpnext/compare/develop...amm10090:erpnext:feat/letter-head-preview-context

GitHub currently limits opening ERPNext pull requests to repository collaborators, so this account could not create the companion PR directly.
