### PR TITLE
fix(sms_settings): add roles table to sms settings

### DIFF
--- a/frappe/core/doctype/sms_settings/sms_settings.json
+++ b/frappe/core/doctype/sms_settings/sms_settings.json
@@ -10,7 +10,9 @@
   "receiver_parameter",
   "static_parameters_section",
   "parameters",
-  "use_post"
+  "use_post",
+  "allowed_roles_section",
+  "allowed_roles"
  ],
  "fields": [
   {
@@ -54,13 +56,24 @@
    "fieldname": "use_post",
    "fieldtype": "Check",
    "label": "Use POST"
+  },
+  {
+   "fieldname": "allowed_roles_section",
+   "fieldtype": "Section Break"
+  },
+  {
+   "description": "Only users with one of these roles can send SMS. Leave empty to allow only System Manager.",
+   "fieldname": "allowed_roles",
+   "fieldtype": "Table",
+   "label": "Allowed Roles",
+   "options": "Has Role"
   }
  ],
  "icon": "fa fa-cog",
  "idx": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-03-23 16:03:38.762589",
+ "modified": "2026-08-31 10:48:45.735288",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "SMS Settings",
@@ -74,6 +87,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/core/doctype/sms_settings/sms_settings.py
+++ b/frappe/core/doctype/sms_settings/sms_settings.py
@@ -16,9 +16,11 @@ class SMSSettings(Document):
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
+		from frappe.core.doctype.has_role.has_role import HasRole
 		from frappe.core.doctype.sms_parameter.sms_parameter import SMSParameter
 		from frappe.types import DF
 
+		allowed_roles: DF.Table[HasRole]
 		message_parameter: DF.Data
 		parameters: DF.Table[SMSParameter]
 		receiver_parameter: DF.Data
@@ -70,8 +72,23 @@ def get_contact_number(contact_name: str, ref_doctype: str, ref_name: str):
 	return (contact and (contact.mobile_no or contact.phone)) or ""
 
 
+def check_sms_permission():
+	user_roles = set(frappe.get_roles())
+	if "System Manager" in user_roles:
+		return
+
+	allowed_roles = {d.role for d in frappe.get_single("SMS Settings").get("allowed_roles") if d.role}
+	if not user_roles & allowed_roles:
+		frappe.throw(_("You are not permitted to send SMS"), frappe.PermissionError)
+
+
 @frappe.whitelist()
 def send_sms(receiver_list: str | list[str], msg: str, sender_name: str = "", success_msg: bool = True):
+	check_sms_permission()
+	return _send_sms(receiver_list, msg, sender_name, success_msg)
+
+
+def _send_sms(receiver_list: str | list[str], msg: str, sender_name: str = "", success_msg: bool = True):
 	send_sms_hook_methods = frappe.get_hooks("send_sms")
 	if send_sms_hook_methods:
 		return frappe.get_attr(send_sms_hook_methods[-1])(receiver_list, msg, sender_name, success_msg)

--- a/frappe/core/doctype/sms_settings/test_sms_settings.py
+++ b/frappe/core/doctype/sms_settings/test_sms_settings.py
@@ -1,7 +1,50 @@
 # Copyright (c) 2017, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
+import frappe
+from frappe.core.doctype.sms_settings.sms_settings import check_sms_permission
 from frappe.tests import IntegrationTestCase
 
 
 class TestSMSSettings(IntegrationTestCase):
-	pass
+	def setUp(self):
+		self.sms_settings = frappe.get_single("SMS Settings")
+		self._allowed_roles = self.sms_settings.get("allowed_roles")
+		self.sms_settings.set("allowed_roles", [])
+		self.sms_settings.flags.ignore_mandatory = True
+		self.sms_settings.save()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		self.sms_settings.set("allowed_roles", self._allowed_roles)
+		self.sms_settings.flags.ignore_mandatory = True
+		self.sms_settings.save()
+
+	def test_user_without_allowed_role_is_blocked(self):
+		frappe.set_user("test@example.com")
+		self.assertRaises(frappe.PermissionError, check_sms_permission)
+
+	def test_system_manager_is_always_allowed(self):
+		frappe.set_user("Administrator")
+		check_sms_permission()
+
+	def test_user_with_configured_role_is_allowed(self):
+		self.sms_settings.append("allowed_roles", {"role": "System Manager"})
+		self.sms_settings.flags.ignore_mandatory = True
+		self.sms_settings.save()
+
+		frappe.set_user("test@example.com")
+		frappe.get_doc(
+			{
+				"doctype": "Has Role",
+				"parent": "test@example.com",
+				"parenttype": "User",
+				"parentfield": "roles",
+				"role": "System Manager",
+			}
+		).db_insert()
+		frappe.clear_cache(user="test@example.com")
+
+		check_sms_permission()
+
+		frappe.db.delete("Has Role", {"parent": "test@example.com", "role": "System Manager"})
+		frappe.clear_cache(user="test@example.com")

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -9,7 +9,7 @@ from functools import partial
 import frappe
 from frappe import _
 from frappe.core.doctype.role.role import get_info_based_on_role, get_user_info
-from frappe.core.doctype.sms_settings.sms_settings import send_sms
+from frappe.core.doctype.sms_settings.sms_settings import _send_sms as send_via_sms_gateway
 from frappe.desk.doctype.notification_log.notification_log import enqueue_create_notification
 from frappe.integrations.doctype.slack_webhook_url.slack_webhook_url import send_slack_message
 from frappe.model.document import Document
@@ -566,7 +566,7 @@ def get_context(context):
 		)
 
 	def send_sms(self, doc, context):
-		send_sms(
+		send_via_sms_gateway(
 			receiver_list=self.get_receiver_list(doc, context, "mobile_no", self.get_mobile_no),
 			msg=frappe.utils.strip_html_tags(
 				frappe.render_template(self.message, context, restrict_globals=True)

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -274,6 +274,7 @@ frappe.patches.v16_0.keep_existing_sites_on_desktop_icons
 frappe.patches.v16_0.repair_converted_print_formats
 frappe.patches.v16_0.repair_converted_print_formats #2026-08-02 section-spacing
 execute:frappe.db.set_single_value("Contact Us Settings", "send_acknowledgement_email", 1)
+frappe.patches.v16_0.seed_sms_settings_allowed_roles
 
 
 [post_fixture_sync]

--- a/frappe/patches/v16_0/seed_sms_settings_allowed_roles.py
+++ b/frappe/patches/v16_0/seed_sms_settings_allowed_roles.py
@@ -1,0 +1,14 @@
+import frappe
+
+
+def execute():
+	"""Seed SMS Settings.allowed_roles with System Manager on existing sites."""
+	frappe.reload_doctype("SMS Settings")
+
+	sms_settings = frappe.get_single("SMS Settings")
+	if sms_settings.get("allowed_roles"):
+		return
+
+	sms_settings.append("allowed_roles", {"role": "System Manager"})
+	sms_settings.flags.ignore_mandatory = True
+	sms_settings.save()


### PR DESCRIPTION
This PR adds a Roles Table to SMS Settings Doctype. This configurable allows System Managers to configure which roles are allowed to send SMS.

closes Ticket 75346 & 77057

to minimize breaking behavior, this patch has also been written (frappe/erpnext#58586)