### PR TITLE
fix: defer File disk deletion until transaction commit

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -243,9 +243,14 @@ class File(Document):
 		self.validate_empty_folder()
 		self.validate_protected_file()
 		self.validate_not_referenced_in_attach_field()
-		self._delete_file_on_disk()
+		frappe.db.after_commit.add(self._delete_file_on_disk_after_commit)
 		if not self.is_folder:
 			self.add_comment_in_reference_doc("Attachment Removed", self.file_name)
+
+	def _delete_file_on_disk_after_commit(self):
+		if frappe.db.exists("File", self.name):
+			return
+		self._delete_file_on_disk()
 
 	def on_rollback(self):
 		rollback_flags = ("new_file", "original_content", "original_path")

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -250,7 +250,15 @@ class File(Document):
 	def _delete_file_on_disk_after_commit(self):
 		if frappe.db.exists("File", self.name):
 			return
-		self._delete_file_on_disk()
+		try:
+			self._delete_file_on_disk()
+		except Exception:
+			# The delete is already committed; a filesystem error here must not
+			# surface post-commit or abort sibling after_commit callbacks.
+			frappe.log_error(
+				title="File cleanup after commit failed",
+				message=f"Could not remove {self.file_url} from disk",
+			)
 
 	def on_rollback(self):
 		rollback_flags = ("new_file", "original_content", "original_path")

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -1567,6 +1567,7 @@ class TestGuestFileAndAttachments(IntegrationTestCase):
 
 		self.assertEqual(doc_pri.get_content(), content)
 		doc_pri.delete()
+		frappe.db.after_commit.run()
 		self.assertFalse(os.path.exists(doc_pri.get_full_path()))
 
 	def test_toggling_is_private_does_not_leak_shared_file(self):
@@ -1626,6 +1627,7 @@ class TestGuestFileAndAttachments(IntegrationTestCase):
 		# B's private copy must survive because B still references it.
 		doc_a_path = doc_a.get_full_path()
 		doc_a.delete()
+		frappe.db.after_commit.run()
 		self.assertFalse(
 			os.path.exists(doc_a_path),
 			"Public copy not cleaned up after A's deletion",
@@ -1639,6 +1641,7 @@ class TestGuestFileAndAttachments(IntegrationTestCase):
 		# Deleting B removes the last reference to the private copy.
 		doc_b_path = doc_b.get_full_path()
 		doc_b.delete()
+		frappe.db.after_commit.run()
 		self.assertFalse(
 			os.path.exists(doc_b_path),
 			"Private copy not cleaned up after B's deletion",


### PR DESCRIPTION
- `File.on_trash` unlinked the file from disk immediately; nothing restored it if the transaction later rolled back, leaving the File row intact with its bytes gone (private file URLs then 404 from nginx instead of 403)
- Disk deletion is now queued on `frappe.db.after_commit` and skipped if the row still exists at commit time
- The post-commit unlink is best-effort: a filesystem error is logged, not raised, so it can't surface after an already-committed delete or abort sibling `after_commit` callbacks

Why: any request that trashes a File and then errors — e.g. a web form re-uploading an attachment, where `remove_file_by_url` runs before the new File is saved — silently destroyed the stored file.

Needs backport to version-15 and version-16 (`on_trash` is identical there).
