### PR TITLE
fix: use postgres-compatible quoting in SQL strings and aliases

### DIFF
--- a/frappe/desk/doctype/sidebar/test_sidebar.py
+++ b/frappe/desk/doctype/sidebar/test_sidebar.py
@@ -504,8 +504,11 @@ class TestSidebarIsNamedByItsTitle(IntegrationTestCase):
 		"""
 		make_sidebar(self.MODULE, title=self.LEADS)
 
+		# postgres aborts the transaction on a failed statement, so recover to a savepoint
+		frappe.db.savepoint("duplicate_title")
 		with self.assertRaises(frappe.DuplicateEntryError):
 			make_sidebar(self.MODULE, title=self.LEADS)
+		frappe.db.rollback(save_point="duplicate_title")
 
 	def test_the_title_index_catches_a_row_whose_name_has_drifted(self):
 		"""What `unique` on `title` buys over the primary key, which already forbids two records of
@@ -519,8 +522,10 @@ class TestSidebarIsNamedByItsTitle(IntegrationTestCase):
 		drifted = make_sidebar(self.MODULE)
 		frappe.db.set_value("Sidebar", drifted.name, "title", self.LEADS, update_modified=False)
 
+		frappe.db.savepoint("drifted_title")
 		with self.assertRaises(frappe.UniqueValidationError):
 			make_sidebar(self.MODULE, title=self.LEADS)
+		frappe.db.rollback(save_point="drifted_title")
 
 	def test_module_is_neither_required_nor_unique(self):
 		module = frappe.get_meta("Sidebar").get_field("module")

--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, Optional
+from typing import TYPE_CHECKING, Literal
 
 import frappe
 

--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -78,7 +78,7 @@ def relink(name: str, reference_doctype: str | None = None, reference_name: str 
 		set
 			reference_doctype = %s,
 			reference_name = %s,
-			status = "Linked"
+			status = 'Linked'
 		where
 			name = %s""",
 		(reference_doctype, reference_name, name),

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -266,7 +266,7 @@ class DatabaseQuery:
 			for idx, field in enumerate(self.fields):
 				# handle aliases (e.g. `tabSI`.`posting_date` as posting_date)
 				if " as " in field.lower():
-					alias = field.split(" as ")[1].strip(" '`")
+					alias = re.split(r"\s+as\s+", field, flags=re.IGNORECASE)[1].strip(" '`")
 					field_index_map[alias] = idx
 				else:
 					# extract last part after `.`

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -266,7 +266,7 @@ class DatabaseQuery:
 			for idx, field in enumerate(self.fields):
 				# handle aliases (e.g. `tabSI`.`posting_date` as posting_date)
 				if " as " in field.lower():
-					alias = field.split(" as ")[1].strip(" '")
+					alias = field.split(" as ")[1].strip(" '`")
 					field_index_map[alias] = idx
 				else:
 					# extract last part after `.`
@@ -368,7 +368,7 @@ from {tables}
 		if self.with_childnames:
 			for t in self.tables:
 				if t != f"`tab{self.doctype}`":
-					self.fields.append(f"{t}.name as '{t[4:-1]}:name'")
+					self.fields.append(f"{t}.name as `{t[4:-1]}:name`")
 
 		# query dict
 		assert self.tables, "extract_tables must have populated at least the primary table"

--- a/frappe/tests/test_api_v2.py
+++ b/frappe/tests/test_api_v2.py
@@ -302,6 +302,14 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 		self.post(self.method("login"), {"sid": self.sid})
 		return super().setUp()
 
+	def cleanup_docs(self, docs: list, job_id: str | None = None):
+		"""Delete `docs`, waiting for `job_id` first: the job touches these same rows."""
+		if job_id:
+			wait_for_job(job_id)
+		for doc in docs:
+			frappe.delete_doc_if_exists(self.DOCTYPE, doc.name)
+		frappe.db.commit()  # nosemgrep
+
 	def test_bulk_delete_docs_single_doctype_v2(self):
 		# Create docs to delete
 		doc1 = frappe.get_doc({"doctype": self.DOCTYPE, "description": "To delete 1"}).insert()
@@ -544,12 +552,7 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 			self.assertIn("job_id", response.json["data"])
 			job_id = response.json["data"]["job_id"]
 		finally:
-			# Clean up. Wait first: the job touches these same rows.
-			if job_id:
-				wait_for_job(job_id)
-			for doc in docs:
-				frappe.delete_doc_if_exists(self.DOCTYPE, doc.name)
-			frappe.db.commit()  # nosemgrep
+			self.cleanup_docs(docs, job_id)
 
 	def test_bulk_update_enqueue_v2(self):
 		# Create 25 docs
@@ -572,12 +575,7 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 			self.assertIn("job_id", response.json["data"])
 			job_id = response.json["data"]["job_id"]
 		finally:
-			# Clean up. Wait first: the job touches these same rows.
-			if job_id:
-				wait_for_job(job_id)
-			for doc in docs:
-				frappe.delete_doc_if_exists(self.DOCTYPE, doc.name)
-			frappe.db.commit()  # nosemgrep
+			self.cleanup_docs(docs, job_id)
 
 
 class TestDocTypeAPIV2(FrappeAPITestCase):

--- a/frappe/tests/test_api_v2.py
+++ b/frappe/tests/test_api_v2.py
@@ -8,7 +8,7 @@ import frappe
 from frappe.api import discovery
 from frappe.installer import update_site_config
 from frappe.tests.test_api import FrappeAPITestCase, suppress_stdout
-from frappe.tests.utils import toggle_test_mode, whitelist_for_tests
+from frappe.tests.utils import toggle_test_mode, wait_for_job, whitelist_for_tests
 
 authorization_token = None
 
@@ -531,6 +531,7 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 		]
 		frappe.db.commit()  # nosemgrep
 
+		job_id = None
 		try:
 			# Bulk delete > 20 docs
 			names = [doc.name for doc in docs]
@@ -541,8 +542,11 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 
 			self.assertEqual(response.status_code, 202)
 			self.assertIn("job_id", response.json["data"])
+			job_id = response.json["data"]["job_id"]
 		finally:
-			# Clean up
+			# Clean up. Wait first: the job touches these same rows.
+			if job_id:
+				wait_for_job(job_id)
 			for doc in docs:
 				frappe.delete_doc_if_exists(self.DOCTYPE, doc.name)
 			frappe.db.commit()  # nosemgrep
@@ -555,6 +559,7 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 		]
 		frappe.db.commit()  # nosemgrep
 
+		job_id = None
 		try:
 			# Bulk update > 20 docs
 			updates = [{"name": doc.name, "description": "Updated"} for doc in docs]
@@ -565,8 +570,11 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 
 			self.assertEqual(response.status_code, 202)
 			self.assertIn("job_id", response.json["data"])
+			job_id = response.json["data"]["job_id"]
 		finally:
-			# Clean up
+			# Clean up. Wait first: the job touches these same rows.
+			if job_id:
+				wait_for_job(job_id)
 			for doc in docs:
 				frappe.delete_doc_if_exists(self.DOCTYPE, doc.name)
 			frappe.db.commit()  # nosemgrep

--- a/frappe/tests/test_api_v2.py
+++ b/frappe/tests/test_api_v2.py
@@ -539,20 +539,20 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 		]
 		frappe.db.commit()  # nosemgrep
 
+		# Late-bound on purpose: cleanup sees the job_id assigned below.
 		job_id = None
-		try:
-			# Bulk delete > 20 docs
-			names = [doc.name for doc in docs]
-			response = self.post(
-				self.resource(self.DOCTYPE, "bulk_delete"),
-				{"names": names, "sid": self.sid},
-			)
+		self.addCleanup(lambda: self.cleanup_docs(docs, job_id))
 
-			self.assertEqual(response.status_code, 202)
-			self.assertIn("job_id", response.json["data"])
-			job_id = response.json["data"]["job_id"]
-		finally:
-			self.cleanup_docs(docs, job_id)
+		# Bulk delete > 20 docs
+		names = [doc.name for doc in docs]
+		response = self.post(
+			self.resource(self.DOCTYPE, "bulk_delete"),
+			{"names": names, "sid": self.sid},
+		)
+
+		self.assertEqual(response.status_code, 202)
+		self.assertIn("job_id", response.json["data"])
+		job_id = response.json["data"]["job_id"]
 
 	def test_bulk_update_enqueue_v2(self):
 		# Create 25 docs
@@ -562,20 +562,20 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 		]
 		frappe.db.commit()  # nosemgrep
 
+		# Late-bound on purpose: cleanup sees the job_id assigned below.
 		job_id = None
-		try:
-			# Bulk update > 20 docs
-			updates = [{"name": doc.name, "description": "Updated"} for doc in docs]
-			response = self.post(
-				self.resource(self.DOCTYPE, "bulk_update"),
-				{"docs": updates, "sid": self.sid},
-			)
+		self.addCleanup(lambda: self.cleanup_docs(docs, job_id))
 
-			self.assertEqual(response.status_code, 202)
-			self.assertIn("job_id", response.json["data"])
-			job_id = response.json["data"]["job_id"]
-		finally:
-			self.cleanup_docs(docs, job_id)
+		# Bulk update > 20 docs
+		updates = [{"name": doc.name, "description": "Updated"} for doc in docs]
+		response = self.post(
+			self.resource(self.DOCTYPE, "bulk_update"),
+			{"docs": updates, "sid": self.sid},
+		)
+
+		self.assertEqual(response.status_code, 202)
+		self.assertIn("job_id", response.json["data"])
+		job_id = response.json["data"]["job_id"]
 
 
 class TestDocTypeAPIV2(FrappeAPITestCase):

--- a/frappe/tests/test_dock_preferences.py
+++ b/frappe/tests/test_dock_preferences.py
@@ -699,7 +699,10 @@ class TestDockSiteLayer(DockTestCase):
 
 		duplicate = frappe.new_doc("Dock")
 		duplicate.app = APP
+		# postgres aborts the transaction on a failed statement, so recover to a savepoint
+		frappe.db.savepoint("duplicate_layer")
 		self.assertRaises(frappe.UniqueValidationError, duplicate.insert)
+		frappe.db.rollback(save_point="duplicate_layer")
 
 
 class TestTheAppLayer(DockTestCase):

--- a/frappe/tests/test_mask_fields.py
+++ b/frappe/tests/test_mask_fields.py
@@ -525,7 +525,7 @@ class TestMaskFieldsInChildTable(IntegrationTestCase):
 		from frappe.model.db_query import DatabaseQuery
 
 		rows = DatabaseQuery(self.dt).execute(
-			fields=["name", "items.rate", f"`tab{self.child_dt}`.`secret_note` as 'child:secret_note'"],
+			fields=["name", "items.rate", f"`tab{self.child_dt}`.`secret_note` as `child:secret_note`"],
 			filters={"name": self.docname},
 		)
 		self.assertEqual(rows[0]["rate"], "XXXXXXXX")

--- a/frappe/tests/utils/__init__.py
+++ b/frappe/tests/utils/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import time
 from functools import wraps
 
 import frappe
@@ -60,6 +61,24 @@ def toggle_test_mode(enable: bool):
 	"""Enable or disable `frappe.in_test` (and related deprecated flag)"""
 	frappe.in_test = enable
 	frappe.local.flags.in_test = enable
+
+
+def wait_for_job(job_id: str, tries: int = 50):
+	"""Wait for an enqueued job to stop running, so a test does not race the worker.
+
+	A worker holds a row lock on everything it touches, and frappe asks for those locks with
+	NOWAIT, so a test that writes the same rows fails instead of queueing. Returns quietly if
+	the job never runs, e.g. when no worker is up.
+	"""
+	from frappe.utils.background_jobs import is_job_enqueued
+
+	# job_id may be "site||abc123"; is_job_enqueued wants just "abc123"
+	job_id = job_id.split("||", 1)[-1]
+
+	for _ in range(tries):  # 0.2s each
+		if not is_job_enqueued(job_id):
+			return
+		time.sleep(0.2)
 
 
 from frappe.deprecation_dumpster import (

--- a/frappe/tests/utils/__init__.py
+++ b/frappe/tests/utils/__init__.py
@@ -63,19 +63,21 @@ def toggle_test_mode(enable: bool):
 	frappe.local.flags.in_test = enable
 
 
-def wait_for_job(job_id: str, tries: int = 50):
+def wait_for_job(job_id: str, wait_timeout: float = 10):
 	"""Wait for an enqueued job to stop running, so a test does not race the worker.
 
 	A worker holds a row lock on everything it touches, and frappe asks for those locks with
-	NOWAIT, so a test that writes the same rows fails instead of queueing. Returns quietly if
-	the job never runs, e.g. when no worker is up.
+	NOWAIT, so a test that writes the same rows fails instead of queueing. Returns quietly after
+	`wait_timeout` seconds if the job never runs, e.g. when no worker is up.
 	"""
 	from frappe.utils.background_jobs import is_job_enqueued
 
 	# job_id may be "site||abc123"; is_job_enqueued wants just "abc123"
 	job_id = job_id.split("||", 1)[-1]
 
-	for _ in range(tries):  # 0.2s each
+	deadline = time.monotonic() + wait_timeout
+
+	while time.monotonic() < deadline:
 		if not is_job_enqueued(job_id):
 			return
 		time.sleep(0.2)

--- a/frappe/website/doctype/help_article/help_article.py
+++ b/frappe/website/doctype/help_article/help_article.py
@@ -104,7 +104,7 @@ def get_sidebar_items():
 	def _get():
 		return frappe.db.sql(
 			"""select
-				concat(category_name, " (", help_articles, ")") as title,
+				concat(category_name, ' (', help_articles, ')') as title,
 				concat('/', route) as route
 			from
 				`tabHelp Category`


### PR DESCRIPTION
Postgres reads `"x"` as an identifier, so double-quoted string literals and single-quoted aliases fail there. MariaDB accepts both, so these went unnoticed.

Fixes the `test_communication`, `test_portal` and `test_mask_fields` errors on the postgres CI job.