### PR TITLE
fix: add link for partner discovery

### DIFF
--- a/frappe/integrations/frappe_providers/frappecloud_billing.py
+++ b/frappe/integrations/frappe_providers/frappecloud_billing.py
@@ -22,6 +22,38 @@ def get_site_name():
 	return site_name
 
 
+def mock_billing_enabled() -> bool:
+	"""True when a developer asked for fake Frappe Cloud billing data.
+
+	Put both of these in site_config.json to see the trial/upgrade banner on a
+	local site that has no Frappe Cloud credentials:
+
+	    "developer_mode": 1,
+	    "mock_fc_billing": 1
+
+	Optionally set "mock_fc_trial_days" (default 7) to move the trial end date.
+	"""
+	return bool(frappe.conf.developer_mode and frappe.conf.get("mock_fc_billing"))
+
+
+def mock_site_info() -> dict:
+	"""Stand-in for what Frappe Cloud would report for a site on a trial plan."""
+	from frappe.utils import add_days, cint, nowdate
+
+	trial_days = cint(frappe.conf.get("mock_fc_trial_days")) or 7
+	site_name = get_site_name()
+
+	return {
+		"name": site_name,
+		"site_name": site_name,
+		"base_url": get_base_url(),
+		"trial_end_date": add_days(nowdate(), trial_days),
+		"plan": {"is_trial_plan": True},
+		"is_fc_user": True,
+		"setup_complete": cint(frappe.get_system_settings("setup_complete")),
+	}
+
+
 def get_headers():
 	# check if user is system manager
 	if frappe.get_roles(frappe.session.user).count("System Manager") == 0:
@@ -50,6 +82,10 @@ def current_site_info():
 	from frappe.utils import cint
 
 	frappe.only_for("System Manager")
+
+	if mock_billing_enabled():
+		# not cached, so tweaking site_config shows up on the next reload
+		return mock_site_info()
 
 	cache_key = f"fc_current_site_info:{frappe.local.site}"
 	cached_data = frappe.cache().get_value(cache_key)
@@ -89,7 +125,10 @@ def api(method: str, data: str | dict[str, Any] | None = None):
 @frappe.whitelist()
 def is_fc_site() -> bool:
 	is_system_manager = frappe.get_roles(frappe.session.user).count("System Manager")
-	return bool(is_system_manager and frappe.conf.get("fc_communication_secret"))
+	if not is_system_manager:
+		return False
+
+	return bool(mock_billing_enabled() or frappe.conf.get("fc_communication_secret"))
 
 
 # login to frappe cloud dashboard

--- a/frappe/public/js/billing.bundle.js
+++ b/frappe/public/js/billing.bundle.js
@@ -14,8 +14,10 @@ $(document).ready(function () {
 		const trial_end_string =
 			trial_end_days > 1 ? `${trial_end_days} days` : `${trial_end_days} day`;
 
+		// the card template renders the message as-is, so the link can sit inside the sentence
+		const partners_link = `<a class="frappe-card-link" href="${getFrappePartnersUrl()}" target="_blank" rel="noopener noreferrer">partners</a>`;
 		const banner_message = isFCUser
-			? "Please upgrade for uninterrupted services"
+			? `Please upgrade for uninterrupted services. Take help from our ${partners_link} to get started.`
 			: "Please contact your system administrator to upgrade your plan.";
 		let card_args = {
 			title: `Your trial ends in ${trial_end_string}`,
@@ -91,6 +93,15 @@ function openFrappeCloudDashboard() {
 		`${frappeCloudBaseEndpoint}/dashboard/sites/${frappe.boot.site_info.name}`,
 		"_blank"
 	);
+}
+
+function getFrappePartnersUrl() {
+	// the partner list filters on country names from the Country doctype,
+	// which is what System Settings stores as the system default
+	const country = frappe.boot.sysdefaults?.country;
+	return country
+		? `https://frappe.io/partners/list?country=${encodeURIComponent(country)}`
+		: "https://frappe.io/partners/regions";
 }
 
 function addChatBubble() {

--- a/frappe/public/scss/desk/card.scss
+++ b/frappe/public/scss/desk/card.scss
@@ -37,6 +37,14 @@
 	@include get_textstyle("sm", "regular");
 	white-space: wrap;
 }
+.frappe-card-link {
+	color: var(--ink-gray-8);
+	text-decoration: underline;
+	white-space: nowrap;
+	&:hover {
+		color: var(--ink-gray-9);
+	}
+}
 .frappe-card-header-slot {
 	align-items: flex-start;
 }


### PR DESCRIPTION
Billing card now has a link to partners page

<img width="1440" height="900" alt="Screenshot 2026-08-31 at 3 01 19 PM" src="https://github.com/user-attachments/assets/6f6275e5-ded3-4825-87cb-625a1294a6ab" />
