### PR TITLE
fix(perm): Apply field level permision on activity

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -245,7 +245,12 @@ class File(Document):
 		self.validate_not_referenced_in_attach_field()
 		self._delete_file_on_disk()
 		if not self.is_folder:
-			self.add_comment_in_reference_doc("Attachment Removed", self.file_name)
+			fieldname = escape_html(self.attached_to_field or "")
+			file_name = escape_html(self.file_name)
+			self.add_comment_in_reference_doc(
+				"Attachment Removed",
+				f"<span data-fieldname='{fieldname}'>{file_name}</span>",
+			)
 
 	def on_rollback(self):
 		rollback_flags = ("new_file", "original_content", "original_path")
@@ -972,10 +977,13 @@ class File(Document):
 		icon = ' <i class="fa fa-lock text-warning"></i>' if self.is_private else ""
 		file_url = quote(frappe.safe_encode(self.file_url), safe="/:") if self.file_url else self.file_name
 		file_name = escape_html(self.file_name or self.file_url)
+		# fieldname is embedded so the timeline can drop this entry for users without permlevel
+		# access to the field, without needing a structured Comment field of its own
+		fieldname = escape_html(self.attached_to_field or "")
 
 		self.add_comment_in_reference_doc(
 			"Attachment",
-			f"<a href='{file_url}' target='_blank'>{file_name}</a>{icon}",
+			f"<a href='{file_url}' target='_blank' data-fieldname='{fieldname}'>{file_name}</a>{icon}",
 		)
 
 	def add_comment_in_reference_doc(self, comment_type, text):

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 
 import json
+import re
 import typing
 from typing import Any
 from urllib.parse import quote
@@ -139,6 +140,9 @@ def get_docinfo(
 	frappe.response["docinfo"] = docinfo
 
 
+ATTACHMENT_FIELDNAME_RE = re.compile(r"data-fieldname=['\"]([^'\"]*)['\"]")
+
+
 def add_comments(doc, docinfo):
 	# divide comments into separate lists
 	docinfo.comments = []
@@ -155,6 +159,8 @@ def add_comments(doc, docinfo):
 		filters={"reference_doctype": doc.doctype, "reference_name": doc.name},
 	)
 
+	restricted_fieldnames = None
+
 	for c in comments:
 		match c.comment_type:
 			case "Comment":
@@ -165,6 +171,11 @@ def add_comments(doc, docinfo):
 			case "Assignment Completed" | "Assigned":
 				docinfo.assignment_logs.append(c)
 			case "Attachment" | "Attachment Removed":
+				if restricted_fieldnames is None:
+					restricted_fieldnames = get_permlevel_restricted_fieldnames(doc.doctype)
+				m = ATTACHMENT_FIELDNAME_RE.search(c.content or "")
+				if m and m.group(1) in restricted_fieldnames:
+					continue
 				docinfo.attachment_logs.append(c)
 			case "Info" | "Edit" | "Label":
 				docinfo.info_logs.append(c)
@@ -204,6 +215,36 @@ def get_attachments(dt, dn):
 		],
 		filters={"attached_to_name": str(dn), "attached_to_doctype": dt},
 	)
+
+
+def get_permlevel_restricted_fieldnames(dt) -> set:
+	"""Fieldnames (top-level and child table) whose permlevel the current user can't read."""
+	from frappe.desk.form.activity import readable_permlevels
+
+	if frappe.session.user == "Administrator":
+		return set()
+
+	meta = frappe.get_meta(dt)
+	all_fields = meta.fields.copy()
+	for table_field in meta.get_table_fields(include_computed=True):
+		all_fields += frappe.get_meta(table_field.options).fields or []
+
+	if all(df.permlevel == 0 for df in all_fields):
+		return set()
+
+	def restricted_fieldnames(field_meta, permitted):
+		if permitted is None:
+			return set()
+		return {df.fieldname for df in field_meta.fields or [] if df.permlevel not in permitted}
+
+	# a fieldname restricted in any table it appears in fails closed (dropped everywhere), since
+	# attached_to_field alone can't identify which table a given file's field actually came from
+	restricted = restricted_fieldnames(meta, readable_permlevels(meta))
+	for table_field in meta.get_table_fields(include_computed=True):
+		child_meta = frappe.get_meta(table_field.options)
+		restricted |= restricted_fieldnames(child_meta, readable_permlevels(child_meta, parenttype=dt))
+
+	return restricted
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Similar to #42292, but on activity and comments side where we are rendering the attachment that the user don't have access too. 

While the fix can apply on the upcoming doctypes created, for fixing the existing ones, we will need to edit the html tags stored in Comments doctype. As its a huge one, I am not sure what would be the best way to handle it. Let me know if you have any input/suggestions on this part.

cc: @AarDG10 @ankush 