### PR TITLE
ci: use Python 3.10 for version-15-hotfix POT generation

### DIFF
--- a/.github/workflows/generate-pot-file.yml
+++ b/.github/workflows/generate-pot-file.yml
@@ -12,7 +12,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ["develop", "version-16-hotfix", "version-15-hotfix"]
+        include:
+          - branch: "develop"
+            python: "3.14"
+          - branch: "version-16-hotfix"
+            python: "3.14"
+          - branch: "version-15-hotfix"
+            python: "3.10"
     permissions:
       contents: write
 
@@ -25,7 +31,7 @@ jobs:
         - name: Setup Python
           uses: actions/setup-python@v7
           with:
-            python-version: "3.14"
+            python-version: ${{ matrix.python }}
 
         - name: Setup Node
           uses: actions/setup-node@v7


### PR DESCRIPTION
The `version-15-hotfix` job of the weekly POT regeneration workflow has been failing, while `develop` and `version-16-hotfix` pass. ([run 33385067081](https://github.com/frappe/frappe/actions/runs/33385067081))

The job fails in "Run script to update POT file" with:

```
File "babel/messages/extract.py", line 643, in _parse_python_string
    if isinstance(body, ast.Str):
AttributeError: module 'ast' has no attribute 'Str'
```

The workflow hardcodes `python-version: "3.14"` for every branch in the matrix. `ast.Str` was removed in CPython 3.12. `develop` and `version-16-hotfix` pin `Babel~=2.16.0` and are fine; `version-15-hotfix` pins `Babel~=2.13.1`, which still uses `ast.Str` and so crashes on 3.14.

This moves the Python version into the matrix so v15 gets `3.10` — the same interpreter its own `server-tests.yml` uses, and within its `requires-python = ">=3.10,<3.15"`. `develop` and `version-16-hotfix` stay on 3.14. No changes to v15's `pyproject.toml` or Babel pin.

Note: this workflow runs from the default branch on schedule/dispatch, so the fix takes effect once it is on `develop`.