### PR TITLE
ci: fix pot generation workflow for v16

### DIFF
--- a/.github/workflows/generate-pot-file.yml
+++ b/.github/workflows/generate-pot-file.yml
@@ -1,8 +1,5 @@
 name: Regenerate POT file (translatable strings)
 on:
-  schedule:
-    # 9:30 UTC => 3 PM IST Sunday
-    - cron: "30 9 * * 0"
   workflow_dispatch:
 
 jobs:
@@ -12,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ["develop"]
+        branch: ["version-16-hotfix"]
     permissions:
       contents: write
 


### PR DESCRIPTION
- schedule only works on default branch (`develop`)
- branch this workflow runs against needs to be `version-16-hotfix`