### PR TITLE
test: replace datetime.now() with now_datetime()

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/test_dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/test_dashboard_chart.py
@@ -10,7 +10,7 @@ import frappe
 from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.desk.doctype.dashboard_chart.dashboard_chart import get
 from frappe.tests import IntegrationTestCase
-from frappe.utils import formatdate, get_last_day, getdate
+from frappe.utils import formatdate, get_last_day, getdate, now_datetime
 from frappe.utils.dateutils import get_period, get_period_ending
 
 
@@ -72,7 +72,8 @@ class TestDashboardChart(IntegrationTestCase):
 			timeseries=1,
 		).insert()
 
-		cur_date = datetime.now() - relativedelta(years=1)
+		# site timezone, same clock the chart uses; datetime.now() drifts a month at midnight
+		cur_date = now_datetime() - relativedelta(years=1)
 
 		result = get(chart_name="Test Dashboard Chart", refresh=1)
 		uncached_result = get(chart_name="Test Dashboard Chart", no_cache=1)
@@ -102,7 +103,8 @@ class TestDashboardChart(IntegrationTestCase):
 			timeseries=1,
 		).insert()
 
-		cur_date = datetime.now() - relativedelta(years=1)
+		# site timezone, same clock the chart uses; datetime.now() drifts a month at midnight
+		cur_date = now_datetime() - relativedelta(years=1)
 
 		result = get(chart_name="Test Empty Dashboard Chart", refresh=1)
 
@@ -152,7 +154,8 @@ class TestDashboardChart(IntegrationTestCase):
 			timeseries=1,
 		).insert()
 
-		cur_date = datetime.now() - relativedelta(years=1)
+		# site timezone, same clock the chart uses; datetime.now() drifts a month at midnight
+		cur_date = now_datetime() - relativedelta(years=1)
 
 		result = get(chart_name="Test Empty Dashboard Chart 2", refresh=1)
 


### PR DESCRIPTION
`test_dashboard_chart`, `test_empty_dashboard_chart` and `test_chart_wih_one_value` fail on CI at the end of every month with errors like:

```
AssertionError: 'Aug 2025' != 'Sep 2025'
```

**Cause**

The tests build their expected month labels from `datetime.now()`, which reads the machine clock. The chart itself builds its labels from `now_datetime()` (see `get_chart_config` in `dashboard_chart.py`), which reads the site time zone. The two clocks are not the same.

On CI they are 5.5 hours apart:

- GitHub runners are UTC.
- `bench new-site` does not run the setup wizard, and `time_zone` has no default in `system_settings.json`. The field stays empty, so `get_system_timezone()` falls back to `Asia/Kolkata`.

On the last day of a month, every run between 18:30 and 24:00 UTC puts the chart in the next month while the test expectation is still in the current one. That is 5.5 hours of guaranteed failure per month. The same drift occurs on any machine whose local time zone differs from the site time zone.

**Fix**

Read the expected date from `now_datetime()`, so the test and the chart use the same clock. This holds for any combination of runner and site time zone.
