### PR TITLE
fix(chromium): Make headless_shell executable on linux arm64 (v16 backport)

### DIFF
--- a/frappe/utils/print_utils.py
+++ b/frappe/utils/print_utils.py
@@ -292,9 +292,11 @@ def download_chromium():
 					os.rename(executable_shell, os.path.join(renamed_dir, "headless_shell"))
 				else:
 					raise RuntimeError("Failed to rename executable. Expected chrome-headless-shell.")
-			# Make the `headless_shell` executable
-			exec_path = os.path.join(renamed_dir, executable_path[1])
-			make_chromium_executable(exec_path)
+
+		# zipfile.extractall() does not restore permissions, so the binary always needs a chmod.
+		# Keep this outside the rename branch: the linux-arm64 build already extracts to
+		# chrome-linux/headless_shell and would otherwise be left non-executable.
+		make_chromium_executable(os.path.join(chromium_dir, *executable_path))
 
 		click.echo(f"Chromium is ready to use at: {chromium_dir}")
 	except requests.Timeout:


### PR DESCRIPTION
Manual backport of #41661 to `version-16-hotfix`.

## Problem

`download_chromium()` extracts with `zipfile.extractall()`, which does not restore permissions, and the `chmod` runs only inside the `if extracted != chrome_folder_name:` rename branch.

On linux-arm64 we pull Playwright's `chromium-headless-shell-linux-arm64.zip`, which already unpacks to `chrome-linux/headless_shell`. The rename branch is skipped, so the binary is left at 0644 and callers get `Chromium not executable at <path>` with the file sitting exactly where it is expected.

## Fix

Move the `chmod` out of the rename branch — `extractall()` never restores permissions for either build, so the binary always needs it. Same change as #41661, reapplied by hand: develop has since moved these helpers to `frappe/utils/chromium/download.py`, so mergify had nothing to backport onto and v16 has been carrying the bug since 964dd6c03 (2025-09-25).

## Impact

This is what makes headless PDF generation fail after a fresh Chromium download on arm64 hosts. Frappe Cloud benches also bake Chromium into the image via `bench setup-chrome`, so the bad mode gets baked in and every container of the bench inherits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
