### PR TITLE
fix: give the calendar and date picker the locale they are already asked for

### DIFF
--- a/frappe/public/js/calendar.bundle.js
+++ b/frappe/public/js/calendar.bundle.js
@@ -3,6 +3,11 @@ import dayGridPlugin from "@fullcalendar/daygrid";
 import listPlugin from "@fullcalendar/list";
 import timeGridPlugin from "@fullcalendar/timegrid";
 import interactionPlugin from "@fullcalendar/interaction";
+import allLocales from "@fullcalendar/core/locales-all";
 
 frappe.FullCalendar = FullCalendar;
 frappe.FullCalendar.Plugins = [listPlugin, dayGridPlugin, timeGridPlugin, interactionPlugin];
+// The view passes `locale: frappe.boot.lang`, but FullCalendar can only honour a
+// locale it has been given. Without this the option is accepted and ignored, and
+// every calendar renders its month names, day names and buttons in English.
+frappe.FullCalendar.Locales = allLocales;

--- a/frappe/public/js/frappe/form/controls/datepicker_i18n.js
+++ b/frappe/public/js/frappe/form/controls/datepicker_i18n.js
@@ -423,3 +423,44 @@ import "air-datepicker/dist/js/i18n/datepicker.zh.js";
 		firstDay: 1,
 	};
 })(jQuery);
+
+(function ($) {
+	$.fn.datepicker.language["ja"] = {
+		days: ["日曜日", "月曜日", "火曜日", "水曜日", "木曜日", "金曜日", "土曜日"],
+		daysShort: ["日", "月", "火", "水", "木", "金", "土"],
+		daysMin: ["日", "月", "火", "水", "木", "金", "土"],
+		months: [
+			"1月",
+			"2月",
+			"3月",
+			"4月",
+			"5月",
+			"6月",
+			"7月",
+			"8月",
+			"9月",
+			"10月",
+			"11月",
+			"12月",
+		],
+		monthsShort: [
+			"1月",
+			"2月",
+			"3月",
+			"4月",
+			"5月",
+			"6月",
+			"7月",
+			"8月",
+			"9月",
+			"10月",
+			"11月",
+			"12月",
+		],
+		today: "今日",
+		clear: "クリア",
+		dateFormat: "yyyy/mm/dd",
+		timeFormat: "hh:ii",
+		firstDay: 0,
+	};
+})(jQuery);

--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -320,10 +320,13 @@ frappe.views.Calendar = class Calendar {
 			plugins: frappe.FullCalendar.Plugins,
 			initialView: defaults.initialView || "dayGridMonth",
 			locale: frappe.boot.lang,
+			locales: frappe.FullCalendar.Locales,
 			eventTimeFormat: {
 				hour: "numeric",
 				minute: "2-digit",
-				hour12: true,
+				// Follow the site's Time Format rather than assuming a 12-hour
+				// clock, which most locales do not use.
+				hour12: (frappe.boot.sysdefaults?.time_format || "").includes("hh"),
 			},
 			firstDay: frappe.datetime.get_first_day_of_the_week_index(),
 			eventDisplay: "block",


### PR DESCRIPTION
## Description

Three small omissions leave every non-English desk showing an English calendar. All three are in code that already intends to be localised.

**1. The date picker has no Japanese definition.** `datepicker_i18n.js` defines 25 languages — including Chinese and Thai — but not Japanese. `date.js` falls back to English for any language it cannot find:

```js
if (!$.fn.datepicker.language[lang]) {
    lang = "en";
}
```

so a Japanese user sees English month and day names in every date field. The block added here follows the same shape as the existing ones.

**2. FullCalendar is given a locale it was never taught.** The calendar view already passes `locale: frappe.boot.lang`, but `calendar.bundle.js` imports no locales at all, so FullCalendar has nothing to resolve the code against and silently renders in English. The translations are already in the package we depend on — `@fullcalendar/core/locales/ja.js` carries 前 / 次 / 今日 / 終日 / 予定リスト — they were simply never loaded.

**3. `eventTimeFormat` hard-codes `hour12: true`.** Most locales do not use a 12-hour clock, and the site already records the answer in **System Settings → Time Format**.

## Cost

`calendar.bundle.js` grows from **258 KB to 293 KB** (measured with `bench build`). That bundle is only fetched when a calendar view is opened, so it does not affect desk load.

The date picker addition is a few hundred bytes.

## Risk

Low, and confined to non-English languages:

- A language with no date picker definition still falls back to English exactly as before.
- `locales` is additive; FullCalendar continues to use English when `frappe.boot.lang` is `en`.
- `hour12` now follows Time Format. Sites set to a 12-hour format are unchanged; sites set to 24-hour previously showed 12-hour times in the calendar regardless, which is the bug.

## Verification

Built with `bench build --app frappe` and confirmed the locale data reaches the output bundles (esbuild escapes the strings, so grep for `\uXXXX` rather than the characters).

## Motivation

Reported by a user at LUSH Japan during a Japanese localisation project, who asked simply for the calendar to follow Japanese conventions. It turned out not to be a translation issue at all — no amount of work on `ja.csv` can reach these libraries.