### PR TITLE
fix: let moment follow the user's language

### DIFF
--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -651,12 +651,15 @@ frappe.Application = class Application {
 	}
 
 	setup_moment() {
-		moment.updateLocale("en", {
+		// moment resolves a locale it does not have by falling back to English, so
+		// an unknown code is safe here.
+		const lang = (frappe.boot.lang || "en").toLowerCase();
+		moment.updateLocale(lang, {
 			week: {
 				dow: frappe.datetime.get_first_day_of_the_week_index(),
 			},
 		});
-		moment.locale("en");
+		moment.locale(lang);
 		moment.user_utc_offset = moment().utcOffset();
 		if (frappe.boot.timezone_info) {
 			moment.tz.add(frappe.boot.timezone_info);

--- a/frappe/public/js/lib/moment.js
+++ b/frappe/public/js/lib/moment.js
@@ -2,4 +2,8 @@
 // before the bundle finishes loading, due to imports (datetime.js) in the bundle
 // that depend on `moment`.
 import momentTimezone from "moment-timezone/builds/moment-timezone-with-data-10-year-range.min.js";
+// The timezone build ships no locale data, so moment.locale() silently keeps
+// English. Without these, relative dates ("3 days ago") stay English in every
+// language.
+import "moment/min/locales";
 window.moment = momentTimezone;


### PR DESCRIPTION
## Description

`setup_moment()` hard-codes the locale:

```js
moment.updateLocale("en", { week: { dow: ... } });
moment.locale("en");
```

so relative dates — "3 days ago", "in 2 hours" — stay English on every desk regardless of the user's language.

Changing that line alone does nothing, because the timezone build we import ships no locale data:

```js
import momentTimezone from "moment-timezone/builds/moment-timezone-with-data-10-year-range.min.js";
```

`moment.locale("ja")` against that build silently keeps English. So the locales have to be imported as well.

## The cost, stated plainly

`moment/min/locales` adds **298 KB to `libs.bundle.js`** — 739 KB → 1,038 KB, measured with `bench build --app frappe`. That bundle loads on every desk page.

That is a lot for "3 days ago", which is why this is a separate PR from #42343 (calendar and date picker locales). That one is cheap and self-contained; this one is a judgement call, and it is yours to make. Three ways I can see:

1. **Take it as is** — every language gets correct relative dates, at 298 KB on the shared bundle.
2. **Dynamic import** of the single locale in use, so English sites pay nothing. More moving parts, and needs the chunk to be served correctly.
3. **Close it** — #42343 stands on its own and does not depend on this.

Happy to rework it as (2) if that is the preferred direction, or to close it.

## Risk

Low. `moment.locale()` falls back to English for a code it does not have, so an unrecognised `frappe.boot.lang` behaves exactly as today. The language code is lower-cased first, since moment uses `zh-tw` where Frappe uses `zh-TW`.

## Motivation

Found while localising a Frappe site into Japanese for LUSH Japan.