### PR TITLE
feat: extend Sidebar for desk v2 with an address, layers and Navigation Item rows

### DIFF
--- a/frappe/desk/doctype/navigation_item_type/navigation_item_type.json
+++ b/frappe/desk/doctype/navigation_item_type/navigation_item_type.json
@@ -3,7 +3,7 @@
  "allow_rename": 0,
  "autoname": "field:type_name",
  "creation": "2026-09-01 10:00:00.000000",
- "description": "The kinds of thing a `Navigation Item` can be. Code-owned: a row is shipped as a file in an app and arrives on a site by migrate, never by someone filling in this form. An app adds a kind by shipping one of these rows and a renderer beside it, which is the same mechanism the framework's own kinds use.",
+ "description": "The kinds of thing a `Navigation Item` can be. Code-owned: a row is shipped as a file in an app and arrives on a site by migrate, never by someone filling in this form. An app adds a kind by shipping one of these rows and a renderer beside it, which is the same mechanism the framework's own kinds use. The framework ships eight: `DocType`, `Record`, `Module`, `Module Contents`, `Page`, `Link`, `Section` and `Sidebar`.",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
@@ -18,7 +18,7 @@
  ],
  "fields": [
   {
-   "description": "What this kind is called, on screen and as its record name. Named for its destination, which is the rule the whole set follows: `DocType`, `Record`, `Module`, `Page`, `Link`.",
+   "description": "What this kind is called, on screen and as its record name. Named for its destination, which is the rule the whole set follows: a `DocType` row opens a doctype, a `Sidebar` row opens a sidebar, a `Module` row opens a module's page. The two exceptions are named for what they hold rather than for where they go, because they go nowhere themselves: `Section`, a heading with rows under it, and `Module Contents`, the overflow row that expands into whatever of a module is left.",
    "fieldname": "type_name",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -53,7 +53,7 @@
    "reqd": 1
   },
   {
-   "description": "The doctype an item of this kind points into, copied onto the item's `link_doctype` so a row of this kind cannot name a destination in the wrong table. Left blank by the one kind that lets the item choose — `Record`, where the user picks the doctype as well as the document — and by the kinds that point nowhere at all.",
+   "description": "The doctype an item of this kind points into, copied onto the item's `link_doctype` so a row of this kind cannot name a destination in the wrong table. Left blank by the one kind that lets the item choose -- `Record`, where the user picks the doctype as well as the document -- and by the kinds that point nowhere at all. Two kinds may share a target and still be two kinds: `Module` and `Module Contents` both name a `Module Def`, and what tells them apart is what they do with it, which is their renderer's business and not a column here.",
    "fieldname": "target_doctype",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -61,7 +61,7 @@
    "options": "DocType"
   },
   {
-   "description": "Which rule decides whether a user sees an item of this kind. Filtering navigation is a courtesy and never a control — hiding the way to a document is not hiding the document — so a rule may skip an expensive case and be wrong in the safe direction. Declaring a bucket is what keeps a new kind to two files and no framework change; `Custom` is the door for a kind that genuinely needs its own answer, and almost none should.\n\n`Readable DocType`: visible when the user can read the doctype it points at, whether by role or by a share.\n`Module Contents`: visible when any doctype in the module is readable, less an administrator's block.\n`Derived From Children`: visible when anything under it survives, and dropped when nothing does.\n`Permitted Page`: visible when the page is in the user's page set.\n`Always Visible`: never filtered; for a kind that points outside the site.\n`Custom`: answered by the type's own batched `can_see`, contributed alongside its renderer.",
+   "description": "Which rule decides whether a user sees an item of this kind. Filtering navigation is a courtesy and never a control \u2014 hiding the way to a document is not hiding the document \u2014 so a rule may skip an expensive case and be wrong in the safe direction. Declaring a bucket is what keeps a new kind to two files and no framework change; `Custom` is the door for a kind that genuinely needs its own answer, and almost none should.\n\n`Readable DocType`: visible when the user can read the doctype it points at, whether by role or by a share.\n`Module Contents`: visible when any doctype in the module is readable, less an administrator's block. Named for the question it asks and not for the kind of the same name, which does not use it.\n`Derived From Children`: visible when anything under it survives, and dropped when nothing does.\n`Permitted Page`: visible when the page is in the user's page set.\n`Always Visible`: never filtered; for a kind that points outside the site.\n`Custom`: answered by the type's own batched `can_see`, contributed alongside its renderer.",
    "fieldname": "permission_rule",
    "fieldtype": "Select",
    "label": "Permission Rule",
@@ -72,11 +72,11 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-09-01 10:00:00.000000",
+ "modified": "2026-09-01 18:00:00.000000",
  "modified_by": "Administrator",
  "module": "Desk",
- "naming_rule": "By fieldname",
  "name": "Navigation Item Type",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {

--- a/frappe/desk/doctype/navigation_item_type/navigation_item_type.py
+++ b/frappe/desk/doctype/navigation_item_type/navigation_item_type.py
@@ -58,7 +58,7 @@ class NavigationItemType(Document):
 
 		The permission rows already withhold create and write from every role, so this only has to
 		catch what permissions cannot see: a write made with `ignore_permissions`, and Administrator,
-		who is exempt from permission checks entirely. `Dock`'s equivalent guard is conditional
+		who is exempt from permission checks entirely. `Rail`'s equivalent guard is conditional
 		because its three layers share one table and two of them must stay writable at runtime.
 		This one is unconditional, because every row here is app content and there is no second
 		layer to protect.

--- a/frappe/desk/doctype/rail/rail.json
+++ b/frappe/desk/doctype/rail/rail.json
@@ -2,7 +2,7 @@
  "actions": [],
  "autoname": "hash",
  "creation": "2026-09-01 10:00:00.000000",
- "description": "One layer of one app's rail. Three of them share this table, told apart by `app`, `user` and `standard`: the app's own rail, which it ships as an exported document and a developer authors; the site's arrangement of it, curated by a Workspace Manager and applying to everyone; and one person's own, applied last and winning. The order is strict -- app, then site, then user -- and there is no role layer, because a user with three roles would get three competing arrangements and a precedence rule the framework has nowhere else. A rail belongs to an app, so arranging ERPNext's does not touch CRM's. The container is named for where it is and its rows for what they do, which is the only arrangement in which one row type can honestly serve both this and a sidebar.",
+ "description": "One layer of one app's rail. Three of them share this table, told apart by `app`, `user` and `standard`: the app's own rail, which it ships as an exported document and a developer authors; the site's arrangement of it, curated by a System Manager and applying to everyone; and one person's own, applied last and winning. The order is strict -- app, then site, then user -- and there is no role layer, because a user with three roles would get three competing arrangements and a precedence rule the framework has nowhere else. A rail belongs to an app, so arranging ERPNext's does not touch CRM's. The container is named for where it is and its rows for what they do, which is the only arrangement in which one row type can honestly serve both this and a sidebar.",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
@@ -68,7 +68,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-09-01 16:30:00.000000",
+ "modified": "2026-09-01 18:00:00.000000",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Rail",
@@ -81,7 +81,7 @@
    "email": 1,
    "print": 1,
    "read": 1,
-   "role": "Workspace Manager",
+   "role": "System Manager",
    "share": 1,
    "write": 1
   },

--- a/frappe/desk/doctype/rail/rail.py
+++ b/frappe/desk/doctype/rail/rail.py
@@ -3,7 +3,6 @@
 
 import frappe
 from frappe import _
-from frappe.desk.doctype.workspace.workspace import is_workspace_manager
 from frappe.model.document import Document
 
 # Blank, not `None`: the column is not nullable so that one spelling of "not a user's own layer"
@@ -167,25 +166,28 @@ def on_doctype_update():
 
 
 def has_permission(doc, ptype="read", user=None, debug=False):
-	"""Allow a Workspace Manager to curate the site and the apps; everyone else gets only their own.
+	"""Allow a System Manager to curate the site and the apps; everyone else gets only their own.
 
 	This is the document-level half of the gate the endpoints hold. A `Desk User` has `read` and
 	nothing more: rearranging a rail goes through an endpoint that writes one person's own layer
 	with `ignore_permissions`, so no write permission is needed or granted. This stops the read
 	they do have from being a read of everyone else's layers.
 
-	The manager check is the same one the sidebar's layers use. A second role for "may rearrange
-	what everyone sees" would be two ways to grant one capability.
+	`System Manager`, not `Workspace Manager`: this table is not about workspaces, and `Sidebar`,
+	the other container desk v2 uses, has always granted `System Manager` and has never had a
+	`Workspace Manager` row. Reaching for the narrower role here made the branch disagree with
+	itself about who may curate. The cost is real and accepted: curating the site layer can no
+	longer be delegated without full site administration.
 	"""
 	user = user or frappe.session.user
-	if user == "Administrator" or is_workspace_manager(user):
+	if user == "Administrator" or "System Manager" in frappe.get_roles(user):
 		return True
 
 	return bool(doc.user) and doc.user == user
 
 
 def get_permission_query_conditions(user=None):
-	"""Restrict list queries so everyone but a Workspace Manager sees only their own layer.
+	"""Restrict list queries so everyone but a System Manager sees only their own layer.
 
 	This pairs with `has_permission` and is not redundant: reports, the API and the desk's export
 	go through this rather than through the document-level check.
@@ -197,7 +199,7 @@ def get_permission_query_conditions(user=None):
 	left alone.
 	"""
 	user = user or frappe.session.user
-	if user == "Administrator" or is_workspace_manager(user):
+	if user == "Administrator" or "System Manager" in frappe.get_roles(user):
 		return None
 
 	return frappe.qb.DocType("Rail").user == user

--- a/frappe/desk/doctype/rail/test_rail.py
+++ b/frappe/desk/doctype/rail/test_rail.py
@@ -46,17 +46,18 @@ def item(**kwargs):
 
 
 class TestRail(IntegrationTestCase):
-	def test_the_seven_shipped_types_are_present(self):
+	def test_the_eight_shipped_types_are_present(self):
 		"""The framework's own kinds arrive by migrate, as records rather than through a seeder.
 
-		`Sidebar` and `View` are deliberately absent: each points at a doctype that does not exist
-		on this branch yet, and a type row with a wrong target is worse than a missing one.
+		`Sidebar` joined them once desk v2 had a sidebar container for it to point at. `View` is
+		still deliberately absent: the doctype it points at is a separate effort, and a type row
+		with a wrong target is worse than a missing one.
 		"""
 		shipped = set(frappe.get_all("Navigation Item Type", pluck="name"))
 		self.assertTrue(
-			{"DocType", "Record", "Module", "Module Contents", "Page", "Link", "Section"} <= shipped
+			{"DocType", "Record", "Module", "Module Contents", "Page", "Link", "Section", "Sidebar"}
+			<= shipped
 		)
-		self.assertNotIn("Sidebar", shipped)
 		self.assertNotIn("View", shipped)
 
 	def test_a_type_declares_its_permission_bucket(self):
@@ -68,6 +69,18 @@ class TestRail(IntegrationTestCase):
 		self.assertEqual(buckets["Module"], "Module Contents")
 		self.assertEqual(buckets["Section"], "Derived From Children")
 		self.assertEqual(buckets["Link"], "Always Visible")
+
+	def test_module_and_module_contents_are_two_kinds(self):
+		"""They share a target doctype and are told apart by what they do with it. `Module` opens a
+		module's page and is visible when anything in the module is readable; `Module Contents` is
+		the overflow row that expands into what is left, so it drops when nothing survives under
+		it, exactly as a `Section` does.
+		"""
+		buckets = dict(
+			frappe.get_all("Navigation Item Type", fields=["name", "permission_rule"], as_list=True)
+		)
+		self.assertEqual(buckets["Module"], "Module Contents")
+		self.assertEqual(buckets["Module Contents"], "Derived From Children")
 
 	def test_nobody_may_author_a_type_outside_developer_mode(self):
 		"""A kind is code, so minting one is a developer act and not a permission a role carries."""
@@ -152,7 +165,7 @@ class TestRail(IntegrationTestCase):
 		self.assertEqual(rail.name, APP)
 
 	def test_app_content_is_not_writable_outside_developer_mode(self):
-		"""Otherwise a Workspace Manager could take an app's rail and turn it into a site row."""
+		"""Otherwise anyone who may curate the site could take an app's rail and turn it into a site row."""
 		with developer_mode(False):
 			self.assertRaises(frappe.ValidationError, make_rail(standard=1).insert)
 

--- a/frappe/desk/doctype/sidebar/sidebar.json
+++ b/frappe/desk/doctype/sidebar/sidebar.json
@@ -11,8 +11,12 @@
   "header_icon",
   "column_break_defn",
   "app",
+  "link_doctype",
+  "link_to",
+  "user",
   "items_section",
   "items",
+  "navigation_items",
   "provenance_section",
   "standard",
   "column_break_prov",
@@ -20,21 +24,20 @@
  ],
  "fields": [
   {
+   "description": "What this sidebar is called, on screen and -- on desk v1's sidebars -- as its record name (`autoname: field:title`). Defaults to the module's name there, and the default is stored, so a module's own sidebar keeps the name it has always had and a second sidebar under that module is told apart by being called something else. On a desk v2 sidebar the name comes from the address instead and this is only the label, which is why uniqueness is enforced in the controller for v1's rows rather than by an index over both.",
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Title",
+   "reqd": 1
+  },
+  {
    "description": "The module this sidebar belongs to. Neither required nor unique: one module may own several sidebars, and which of them answers for the module itself is decided by the name -- the one called after the module -- rather than by a column here. May also be blank, which means the sidebar belongs to its app rather than to any one of the app's modules; such a sidebar is exported to the app's own folder and says which app in `app`.",
    "fieldname": "module",
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Module",
    "options": "Module Def"
-  },
-  {
-   "description": "What this sidebar is called, on screen and as its record name (`autoname: field:title`). Defaults to the module's name, and the default is stored -- so a module's own sidebar keeps the name it has always had, and a second sidebar under that module is told apart by being called something else. `unique` on top of that adds one thing the primary key does not: it refuses a second sidebar claiming the title of a row whose name has drifted away from it -- a legacy row, or one written straight to the table.",
-   "fieldname": "title",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Title",
-   "reqd": 1,
-   "unique": 1
   },
   {
    "fieldname": "header_icon",
@@ -54,6 +57,28 @@
    "options": "Installed Applications"
   },
   {
+   "description": "Desk v2 only. The doctype half of the address this sidebar hangs on -- `Module Def` for a module's sidebar, a doctype for a doctype's. Blank on desk v1's sidebars, which are addressed by `module` and named by `title` instead. A Link rather than Data so that renaming a doctype repairs the pointer through ordinary link renaming, matching `Navigation Item.link_doctype`.",
+   "fieldname": "link_doctype",
+   "fieldtype": "Link",
+   "label": "Link DocType",
+   "options": "DocType"
+  },
+  {
+   "description": "The record this sidebar belongs to. With `link_doctype` this is the whole address, and it is what a rail item of type `Sidebar` points at: a linked rail item names the sidebar the address produced. A real Dynamic Link, so `rename_dynamic_links` repairs every pointer on the site in one statement.",
+   "fieldname": "link_to",
+   "fieldtype": "Dynamic Link",
+   "label": "Link To",
+   "options": "link_doctype"
+  },
+  {
+   "description": "The person whose own arrangement this is. Blank means the app's own sidebar or the site's arrangement of it, told apart by `standard` -- the same three layers, in the same strict order, that `Rail` holds for the rail. Not nullable, so that one spelling of \"not a user's own layer\" reaches the index: every `NULL` is distinct to an index, so a nullable column would let one address hold two site layers that both look like one address.",
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "label": "User",
+   "not_nullable": 1,
+   "options": "User"
+  },
+  {
    "fieldname": "items_section",
    "fieldtype": "Section Break",
    "label": "Items"
@@ -63,6 +88,13 @@
    "fieldtype": "Table",
    "label": "Items",
    "options": "Sidebar Item"
+  },
+  {
+   "description": "Desk v2's rows, in the same table type the rail holds -- one row model serving both surfaces. Beside v1's `items` rather than replacing them: v1's sidebars keep rendering from `Sidebar Item` untouched, and a row can only be read by the desk that understands its columns. Order is per parent and sparse, so an item this layer never names keeps its shipped position.",
+   "fieldname": "navigation_items",
+   "fieldtype": "Table",
+   "label": "Navigation Items",
+   "options": "Navigation Item"
   },
   {
    "collapsible": 1,
@@ -92,7 +124,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-08-27 14:57:28.772713",
+ "modified": "2026-09-01 18:45:00.000000",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Sidebar",

--- a/frappe/desk/doctype/sidebar/sidebar.py
+++ b/frappe/desk/doctype/sidebar/sidebar.py
@@ -238,7 +238,26 @@ class Sidebar(Document, DeskViews):
 		if not self.title:
 			self.title = self.link_to if self.is_addressed else self.module
 
-	def validate_title_is_unique(self):
+	def before_import(self):
+		"""Run the title check on the one path that skips `validate`.
+
+		`import_doc` sets `ignore_validate`, so nothing in `validate` runs when an app's sidebar
+		arrives by migrate. That did not matter while uniqueness was an index, because the database
+		held it whatever the caller skipped, and it is the half of the old constraint that moving
+		the check into the controller would otherwise drop.
+
+		The title checked is the record name, not the title in the file: `_sync_autoname_field`
+		copies the name over the column on the way in, so the name is what the row will end up
+		carrying. That is also why this is narrow in practice -- an imported row's title is its own
+		unique name -- and it leaves exactly one way to collide, which is a row whose stored title
+		has drifted away from its name.
+		"""
+		if self.is_addressed:
+			return
+
+		self.validate_title_is_unique(self.name)
+
+	def validate_title_is_unique(self, title: str | None = None):
 		"""Refuse a desk v1 sidebar claiming another v1 sidebar's title.
 
 		This used to be `unique: 1` on the column. It cannot stay there, because desk v2's three
@@ -253,13 +272,14 @@ class Sidebar(Document, DeskViews):
 		if self.is_addressed:
 			return
 
+		title = title or self.title
 		twin = frappe.db.get_value(
-			"Sidebar", {"title": self.title, "link_doctype": ("is", "not set"), "name": ("!=", self.name)}
+			"Sidebar", {"title": title, "link_doctype": ("is", "not set"), "name": ("!=", self.name)}
 		)
 		if twin:
 			frappe.throw(
 				_("{0} is already the title of the sidebar {1}.").format(
-					frappe.bold(self.title), frappe.bold(twin)
+					frappe.bold(title), frappe.bold(twin)
 				),
 				title=_("Pick another title"),
 			)

--- a/frappe/desk/doctype/sidebar/sidebar.py
+++ b/frappe/desk/doctype/sidebar/sidebar.py
@@ -39,6 +39,7 @@ from frappe.app_state import get_disabled_modules
 from frappe.desk.desk_views import DeskViews
 from frappe.desk.utils import is_item_allowed
 from frappe.model.document import Document
+from frappe.model.naming import make_autoname
 from frappe.model.rename_doc import rename_doc
 from frappe.utils.modules import get_module_placement
 
@@ -90,8 +91,28 @@ LINKED_IDENTITY_FIELDS = ("type", "link_type", "link_to", "url", "filters")
 # sidebar would fail on every customer site.
 SYSTEM_WRITE_FLAGS = ("in_import", "in_fixtures", "in_migrate", "in_install", "in_patch")
 
+# Blank, not `None`: the column is not nullable so that one spelling of "not a user's own layer"
+# reaches the index. Every `NULL` is distinct to an index, so a nullable column would let one
+# address hold two site layers that both look like one address. `Rail.SITE_LAYER` is the same
+# constant for the same reason; the two containers hold the same three layers.
+SITE_LAYER = ""
+
 
 class Sidebar(Document, DeskViews):
+	"""A sidebar, in either desk.
+
+	One table holds two things, told apart by whether the row carries an address. Desk v1's
+	sidebar belongs to a module, is named after its title, and renders from `Sidebar Item` rows.
+	Desk v2's is addressed by a `link_doctype`/`link_to` pair -- the module or doctype it hangs
+	on -- is named after that address, and renders from `Navigation Item` rows, the same row type
+	the rail holds. `app` and `standard` mean the same thing on both, so neither is duplicated.
+
+	Extending in place rather than authoring a second container is a choice about names, not
+	about build order: `Rail` was a free name and `Sidebar` is not. A second doctype would have
+	had to be called something other than what it is, and every reader would then have had to
+	know which of the two spellings meant a sidebar.
+	"""
+
 	_DOCTYPE_NAME = "Sidebar"
 
 	# begin: auto-generated types
@@ -100,31 +121,104 @@ class Sidebar(Document, DeskViews):
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
+		from frappe.desk.doctype.navigation_item.navigation_item import NavigationItem
 		from frappe.desk.doctype.sidebar_item.sidebar_item import SidebarItem
 		from frappe.types import DF
 
 		app: DF.Autocomplete | None
 		header_icon: DF.Icon | None
 		items: DF.Table[SidebarItem]
+		link_doctype: DF.Link | None
+		link_to: DF.DynamicLink | None
 		merged_from: DF.LongText | None
 		module: DF.Link | None
+		navigation_items: DF.Table[NavigationItem]
 		standard: DF.Check
 		title: DF.Data
+		user: DF.Link
 	# end: auto-generated types
+
+	@property
+	def is_addressed(self) -> bool:
+		"""Whether this is a desk v2 sidebar, which is to say whether it has an address.
+
+		The address is the whole test. Desk v1's sidebars carry none and never will: nothing
+		writes `link_doctype` on them, and the fixture conversion does not either. So one column
+		decides which desk a row belongs to, and no migration has to stamp the existing rows.
+		"""
+		return bool(self.link_doctype)
+
+	def autoname(self):
+		"""Name a desk v2 sidebar after its address, and leave desk v1's to `field:title`.
+
+		Returning early is what leaves v1 alone: `set_new_name` runs this first and falls back to
+		the doctype's own rule only when the controller left the name empty.
+
+		An app layer is named from the address because the export path is the record name, and a
+		hash-named standard record would write a folder a re-export from a fresh bench could not
+		find again -- `Rail.autoname` names the app layer for the same reason. It is also what lets
+		a rail item of type `Sidebar` name the sidebar it opens: the address is authored, so the
+		name it produces is known before the row exists.
+
+		The other two layers fall through to the doctype's `hash`, since a layer is looked up by
+		filter and never by name, and two people arranging one sidebar must not claim one name.
+		"""
+		if not self.is_addressed:
+			return
+
+		self.name = (
+			frappe.scrub(f"{self.link_doctype} {self.link_to}")
+			if self.standard
+			else make_autoname("hash", self.doctype)
+		)
+
+	def _sync_autoname_field(self):
+		"""Keep `field:title` from copying a desk v2 sidebar's name over its label.
+
+		The framework does this for every `field:` doctype, and desk v1 depends on it: it is what
+		corrects the title of an imported row whose file names it one thing and titles it another.
+		A v2 sidebar is named after its address instead, so the same pass would overwrite the label
+		it shows with a hash.
+
+		Overriding the framework's own pass is what `Dock` and `Custom Sidebar` already do to
+		`_validate_links` in this family, and it is narrower than the alternative: dropping
+		`field:title` from the doctype takes the correction away from v1's rows as well, and there
+		is no public hook that runs where this one does -- after `before_save`, and on an import,
+		which skips validation entirely.
+		"""
+		if self.is_addressed:
+			return
+
+		super()._sync_autoname_field()
 
 	def before_naming(self):
 		# the name is the title, so the default has to be in place before naming reads it
 		self.set_default_title()
 
 	def validate(self):
+		self.user = self.user or SITE_LAYER
+		self.blank_the_empty_address()
 		self.validate_app_content()
 		self.set_default_title()
 		self.validate_title_is_its_own()
+		self.validate_title_is_unique()
 		self.validate_standard()
 		self.clear_stored_keys()
 
 	def before_save(self):
 		self.rename_to_title()
+
+	def blank_the_empty_address(self):
+		"""Store a missing address as `NULL` rather than as two empty strings.
+
+		The unique index over the address has to let desk v1's rows through, and it does that on
+		`NULL` being distinct from every other `NULL`. A row saved from the form sends `""` for a
+		Link it never filled in, and two of those would collide on an index that a hundred `NULL`
+		rows sit under happily.
+		"""
+		if not self.link_doctype:
+			self.link_doctype = None
+			self.link_to = None
 
 	def set_default_title(self):
 		"""Title an untitled sidebar after its module.
@@ -135,9 +229,40 @@ class Sidebar(Document, DeskViews):
 
 		Called from `before_naming` as well as `validate` because `field:` autoname reads the
 		column directly, before `validate` has filled it in.
+
+		A desk v2 sidebar falls back to what it is addressed to instead of to a module it does
+		not have. There the title is only a label -- the name comes from the address -- but it is
+		still required, so a sensible default is what keeps an app from having to repeat the
+		module's name to ship a sidebar for it.
 		"""
 		if not self.title:
-			self.title = self.module
+			self.title = self.link_to if self.is_addressed else self.module
+
+	def validate_title_is_unique(self):
+		"""Refuse a desk v1 sidebar claiming another v1 sidebar's title.
+
+		This used to be `unique: 1` on the column. It cannot stay there, because desk v2's three
+		layers of one sidebar all carry the label that sidebar shows, so an index over both desks
+		would refuse the second layer. Moving the check here narrows it to the rows it was written
+		for, which is the same narrowing `validate_title_is_its_own` already does.
+
+		What it buys over the primary key is unchanged: it refuses a second sidebar claiming the
+		title of a row whose name has drifted away from it -- a legacy row, or one written
+		straight to the table.
+		"""
+		if self.is_addressed:
+			return
+
+		twin = frappe.db.get_value(
+			"Sidebar", {"title": self.title, "link_doctype": ("is", "not set"), "name": ("!=", self.name)}
+		)
+		if twin:
+			frappe.throw(
+				_("{0} is already the title of the sidebar {1}.").format(
+					frappe.bold(self.title), frappe.bold(twin)
+				),
+				title=_("Pick another title"),
+			)
 
 	def validate_title_is_its_own(self):
 		"""Refuse a title that is another module's name.
@@ -147,8 +272,13 @@ class Sidebar(Document, DeskViews):
 		sidebar titled after another module would claim the same key and one of the two would
 		be dropped silently. We refuse it here, while the user can still pick another title.
 
-		Titling a sidebar after its own module is the default and is allowed.
+		Titling a sidebar after its own module is the default and is allowed. A desk v2 sidebar is
+		skipped outright: its name is its address, not its title, so a v2 sidebar for the Accounts
+		module is titled "Accounts" as a matter of course and claims no key by doing so.
 		"""
+		if self.is_addressed:
+			return
+
 		if self.title == self.module:
 			return
 
@@ -176,7 +306,13 @@ class Sidebar(Document, DeskViews):
 		`ignore_validate`, so an import never reaches here, but it also leaves the flag set to
 		`False` instead of restoring the previous value, and a rename here moves a folder inside
 		an app.
+
+		A desk v2 sidebar never renames on a title edit, because its name is its address. Relabelling
+		one is an ordinary field change, and moving its record would strand every rail item naming it.
 		"""
+		if self.is_addressed:
+			return
+
 		if frappe.flags.in_import or self.is_new() or not self.title or self.title == self.name:
 			return
 
@@ -222,7 +358,18 @@ class Sidebar(Document, DeskViews):
 		Deleting is not blocked. A delete cannot turn site intent into app content, and the
 		things that delete one, such as a module going away or orphan cleanup, have to keep
 		working on a customer site.
+
+		Desk v2's sidebars are guarded conditionally instead, the way `Rail` guards its own three
+		layers: only the app layer is app content, and the site's and each person's arrangements
+		have to stay writable at runtime. The `is_new()` check matters there -- on an unsaved
+		document `has_value_changed` returns `True` for every field, so without it every site- and
+		user-layer row would be refused outside developer mode.
 		"""
+		if self.is_addressed and not (
+			self.standard or (not self.is_new() and self.has_value_changed("standard"))
+		):
+			return
+
 		if frappe.conf.developer_mode:
 			return
 
@@ -379,6 +526,61 @@ class Sidebar(Document, DeskViews):
 # `standard` means an app ships this sidebar as a JSON file. The two actions below turn the
 # flag on and off, and both move the file as well.
 # ---------------------------------------------------------------------------------------
+
+
+def on_doctype_update():
+	"""Enforce one layer per address in the schema rather than in a `validate` hook.
+
+	A hook is bypassed by `db_insert`, a bulk write, or anything that skips the document, and two
+	documents at one address would give the merge two answers for the same layer.
+
+	The index is composite because an address is four columns, not two. `user` is in it because
+	each person arranges a sidebar for themselves, and `standard` because an app's own sidebar and
+	the site's arrangement of it are two documents at the same `(address, user)`: one shipped, one
+	curated, and resetting the site's must not touch the app's.
+
+	Desk v1's sidebars sit under this index without being constrained by it: they carry no address,
+	and a `NULL` is distinct from every other `NULL` to a unique index. `blank_the_empty_address`
+	is what keeps that true for a row saved from the form, which sends `""` rather than nothing.
+	"""
+	frappe.db.add_unique(
+		"Sidebar", ("link_doctype", "link_to", "user", "standard"), constraint_name="unique_layer_address"
+	)
+
+
+def has_permission(doc, ptype="read", user=None, debug=False):
+	"""Let a System Manager see every layer, and everyone else only their own and the shared ones.
+
+	Desk v1's rows are all app content, which is why this doctype needed no such hook until now.
+	A `user` column changes that: `Desk User` has read on this table, so without this hook one
+	person's arrangement of a sidebar would be readable by everyone on the site.
+
+	A row with no `user` -- an app layer, a site layer, or any of desk v1's -- stays readable by
+	everyone who can read the doctype, because that is the navigation the site shares.
+
+	`System Manager`, not `Workspace Manager`: curating what everyone sees is site administration
+	here, and a second role for it would be two ways to grant one capability.
+	"""
+	user = user or frappe.session.user
+	if user == "Administrator" or "System Manager" in frappe.get_roles(user):
+		return True
+
+	return not doc.user or doc.user == user
+
+
+def get_permission_query_conditions(user=None):
+	"""Restrict list queries the same way, since reports and the API do not go through the document.
+
+	Returns a query-builder term rather than a SQL string -- the hook accepts either, and the term
+	keeps identifier quoting out of this file. The two older hooks beside this one still build
+	strings; they are desk v1's and are left alone.
+	"""
+	user = user or frappe.session.user
+	if user == "Administrator" or "System Manager" in frappe.get_roles(user):
+		return None
+
+	sidebar = frappe.qb.DocType("Sidebar")
+	return sidebar.user.isnull() | (sidebar.user == "") | (sidebar.user == user)
 
 
 @frappe.whitelist()

--- a/frappe/desk/doctype/sidebar/test_sidebar.py
+++ b/frappe/desk/doctype/sidebar/test_sidebar.py
@@ -528,6 +528,34 @@ class TestSidebarIsNamedByItsTitle(IntegrationTestCase):
 		with self.assertRaises(frappe.ValidationError):
 			make_sidebar(self.MODULE, title=self.LEADS)
 
+	def test_an_import_cannot_land_on_a_title_that_has_drifted(self):
+		"""The half of the old index that `validate` alone would not have covered.
+
+		`import_doc` sets `ignore_validate`, so an app's sidebar arriving by migrate runs none of
+		the checks above. What the row will store is its name, since the autoname sync copies it
+		over the column, so the collision it can still cause is with a row whose stored title has
+		drifted away from its own name.
+		"""
+		from frappe.modules.import_file import import_doc
+
+		# `import_doc` clears `in_import` after the insert and not in a `finally`, so a refused
+		# import leaves the flag set for whatever runs next
+		self.addCleanup(lambda: frappe.flags.update({"in_import": False}))
+
+		drifted = make_sidebar(self.MODULE)
+		frappe.db.set_value("Sidebar", drifted.name, "title", self.LEADS, update_modified=False)
+
+		with self.assertRaises(frappe.ValidationError):
+			import_doc(
+				{
+					"doctype": "Sidebar",
+					"name": self.LEADS,
+					"title": self.LEADS,
+					"module": self.MODULE,
+					"items": [],
+				}
+			)
+
 	def test_module_is_neither_required_nor_unique(self):
 		module = frappe.get_meta("Sidebar").get_field("module")
 		self.assertFalse(module.reqd)

--- a/frappe/desk/doctype/sidebar/test_sidebar.py
+++ b/frappe/desk/doctype/sidebar/test_sidebar.py
@@ -2,13 +2,16 @@
 # License: MIT. See LICENSE
 
 import json
+import typing
 from contextlib import contextmanager
+from unittest.mock import patch
 
 import frappe
 from frappe.desk.doctype.sidebar.sidebar import (
 	COMPUTED_BASE_CACHE_KEY,
 	MODULE_CONTENT_DOCTYPES,
 	SYSTEM_WRITE_FLAGS,
+	Sidebar,
 	clear_computed_base_cache,
 	filter_sidebar_items,
 	get_computed_base,
@@ -507,19 +510,22 @@ class TestSidebarIsNamedByItsTitle(IntegrationTestCase):
 		with self.assertRaises(frappe.DuplicateEntryError):
 			make_sidebar(self.MODULE, title=self.LEADS)
 
-	def test_the_title_index_catches_a_row_whose_name_has_drifted(self):
-		"""What `unique` on `title` buys over the primary key, which already forbids two records of
-		one name.
+	def test_a_title_a_row_has_drifted_onto_is_still_refused(self):
+		"""What the title check buys over the primary key, which already forbids two records of one
+		name.
 
 		A row written straight to the table, such as a legacy row or a raw update that skips
-		`_sync_autoname_field`, can carry a title its name does not match. The index refuses to let a
-		second sidebar claim that title, and nothing else would.
+		`_sync_autoname_field`, can carry a title its name does not match. Nothing else refuses a
+		second sidebar claiming that title.
 
+		This used to be `unique: 1` on the column and is now a check in the controller, because desk
+		v2's three layers of one sidebar all carry the label that sidebar shows, and an index over
+		both desks would refuse the second layer.
 		"""
 		drifted = make_sidebar(self.MODULE)
 		frappe.db.set_value("Sidebar", drifted.name, "title", self.LEADS, update_modified=False)
 
-		with self.assertRaises(frappe.UniqueValidationError):
+		with self.assertRaises(frappe.ValidationError):
 			make_sidebar(self.MODULE, title=self.LEADS)
 
 	def test_module_is_neither_required_nor_unique(self):
@@ -531,9 +537,11 @@ class TestSidebarIsNamedByItsTitle(IntegrationTestCase):
 		"""`unique: 1` was silently indexing `module`, and nothing takes its place. Neither
 		`Custom Sidebar.module` nor `Workspace.module` declares one, and `Custom Sidebar` runs the
 		same access pattern on a larger table.
+
+		The index this doctype does declare is desk v2's, over the address rather than the module.
 		"""
 		self.assertFalse(frappe.get_meta("Sidebar").get_field("module").search_index)
-		self.assertFalse(hasattr(frappe.new_doc("Sidebar"), "on_doctype_update"))
+		self.assertFalse(frappe.get_meta("Sidebar").get_field("title").unique)
 
 	def test_a_module_lands_on_the_sidebar_named_after_it(self):
 		"""The naming rule, and why no `is_default` column is needed: which of a module's sidebars
@@ -1613,3 +1621,180 @@ class TestComputedSidebarBase(IntegrationTestCase):
 				frappe.cache.hget(COMPUTED_BASE_CACHE_KEY, self.module),
 				f"{doctype}.clear_cache() does not bust the computed sidebar base",
 			)
+
+
+class TestSidebarForDeskV2(IntegrationTestCase):
+	"""Desk v2's sidebars, which share this table with desk v1's and are told apart by an address.
+
+	Everything here turns on one column. A row with a `link_doctype` is desk v2's: named from its
+	address, layered per user, and rendering from `Navigation Item` rows. A row without one is desk
+	v1's and behaves exactly as it did, which is what the tests above still assert.
+	"""
+
+	ADDRESS: typing.ClassVar[dict] = {"link_doctype": "Module Def", "link_to": "Desk"}
+
+	def layer(self, **kwargs):
+		"""A desk v2 sidebar at the shared address, defaulting to the site layer.
+
+		The export is patched out rather than allowed to run: authoring and shipping are one step
+		for a standard row, and in a test that is a fixture leaking into the repo, since the
+		database is rolled back afterwards and the file is not.
+		"""
+		doc = frappe.new_doc("Sidebar")
+		doc.update(self.ADDRESS | kwargs)
+		doc.append("navigation_items", {"item_type": "DocType", "link_to": "User", "label": "Users"})
+		with developer_mode(), patch.object(Sidebar, "export_sidebar"):
+			doc.insert(ignore_permissions=True)
+		self.addCleanup(frappe.delete_doc, "Sidebar", doc.name, force=True, ignore_permissions=True)
+		return doc
+
+	def test_an_app_layer_names_the_app_that_ships_it(self):
+		"""`app` is shared with desk v1 rather than duplicated, and a standard row still needs one:
+		it is the whole address of the file, since a v2 sidebar has no module to be written under.
+		"""
+		with developer_mode():
+			doc = frappe.new_doc("Sidebar")
+			doc.update(self.ADDRESS | {"standard": 1, "title": "Desk"})
+			self.assertRaises(frappe.ValidationError, doc.insert, ignore_permissions=True)
+
+	def test_an_app_layer_is_named_after_its_address(self):
+		"""The record name is the export path, and it is also what a rail item points at.
+
+		Both need the name to be knowable before the row exists, which a hash is not.
+		"""
+		doc = self.layer(standard=1, app="frappe", title="Desk")
+		self.assertEqual(doc.name, "module_def_desk")
+
+	def test_the_name_is_what_the_export_writes(self):
+		"""Orphan cleanup builds a record's path from `scrub(name)`, so a name that scrubs to
+		something else would have its file deleted on the next migrate."""
+		doc = self.layer(standard=1, app="frappe", title="Desk")
+		self.assertEqual(frappe.scrub(doc.name), doc.name)
+
+	def test_the_other_layers_get_a_hash(self):
+		"""A layer is looked up by filter and never by name, so two people arranging one sidebar
+		must not both reach for the name the address makes."""
+		site = self.layer(title="Desk")
+		self.assertNotEqual(site.name, "module_def_desk")
+
+	def test_three_layers_of_one_sidebar_may_share_a_title(self):
+		"""They all carry the label the sidebar shows, which is why `unique` came off `title`."""
+		app = self.layer(standard=1, app="frappe", title="Desk")
+		site = self.layer(title="Desk")
+		mine = self.layer(title="Desk", user="Administrator")
+
+		self.assertEqual(len({app.name, site.name, mine.name}), 3)
+
+	def test_two_layers_cannot_share_one_address(self):
+		"""The database holds this, not a hook, because a bulk write skips the document entirely."""
+		self.layer()
+
+		with self.assertRaises(frappe.UniqueValidationError):
+			self.layer()
+
+	def test_desk_v1s_sidebars_all_sit_under_the_index(self):
+		"""Every one of them has an empty address, and a `NULL` is distinct from every other `NULL`.
+
+		`blank_the_empty_address` is what keeps that true for a row saved from the form, which sends
+		`""` for a Link it never filled in. Two such rows storing `""` would collide on an index a
+		hundred `NULL` rows sit under happily.
+		"""
+		first = self.v1_sidebar("Test V2 Neighbour One")
+		second = self.v1_sidebar("Test V2 Neighbour Two")
+
+		self.assertIsNone(frappe.db.get_value("Sidebar", first.name, "link_doctype"))
+		self.assertIsNone(frappe.db.get_value("Sidebar", second.name, "link_doctype"))
+
+	def v1_sidebar(self, title: str):
+		"""A desk v1 sidebar written the way the form writes one, with a blank rather than no
+		address."""
+		doc = frappe.new_doc("Sidebar")
+		doc.update({"module": "Desk", "title": title, "link_doctype": "", "link_to": ""})
+		with developer_mode():
+			doc.insert(ignore_permissions=True)
+		self.addCleanup(frappe.delete_doc, "Sidebar", doc.name, force=True, ignore_permissions=True)
+		return doc
+
+	def test_a_v2_sidebar_may_be_titled_after_a_module(self):
+		"""It is titled after one as a matter of course, and claims no key by doing so: its name is
+		its address, so v1's rule that a title must not be another module's name does not apply."""
+		self.assertEqual(self.layer(title="Desk").title, "Desk")
+
+	def test_the_title_defaults_to_what_the_sidebar_is_addressed_to(self):
+		"""`reqd` stays, so an app shipping a sidebar for a module should not have to repeat its
+		name to satisfy it."""
+		self.assertEqual(self.layer().title, "Desk")
+
+	def test_editing_the_title_does_not_rename_the_record(self):
+		"""Relabelling is an ordinary field change; moving the record would strand every rail item
+		naming it."""
+		doc = self.layer(standard=1, app="frappe", title="Desk")
+		name = doc.name
+		doc.title = "Workbench"
+		with developer_mode(), patch.object(Sidebar, "export_sidebar"):
+			doc.save(ignore_permissions=True)
+
+		self.assertEqual(doc.name, name)
+
+	def test_a_layer_is_writable_outside_developer_mode(self):
+		"""Only the app layer is app content. The other two are written at runtime, on a customer
+		site, by people rearranging their own navigation."""
+		with no_developer_mode():
+			doc = frappe.new_doc("Sidebar")
+			doc.update(self.ADDRESS | {"user": "Administrator"})
+			doc.insert(ignore_permissions=True)
+			self.addCleanup(frappe.delete_doc, "Sidebar", doc.name, force=True, ignore_permissions=True)
+
+		self.assertTrue(doc.name)
+
+	def test_the_app_layer_is_still_app_content(self):
+		"""Otherwise anyone who may write a layer could turn a git-versioned sidebar into a site
+		row they own."""
+		with no_developer_mode():
+			doc = frappe.new_doc("Sidebar")
+			doc.update(self.ADDRESS | {"standard": 1, "app": "frappe", "title": "Desk"})
+			self.assertRaises(frappe.ValidationError, doc.insert, ignore_permissions=True)
+
+	def test_a_layer_with_no_user_is_the_site_layer(self):
+		"""One spelling of "not a user's own", so two site layers cannot look like one address."""
+		self.assertEqual(self.layer().user, "")
+
+	def test_the_type_fixes_the_destination_doctype(self):
+		"""`link_doctype` comes off the type, so a row cannot point into the wrong table. The same
+		row model the rail holds, behaving the same way in a sidebar."""
+		self.assertEqual(self.layer().navigation_items[0].link_doctype, "DocType")
+
+	def test_the_sidebar_item_type_ships_now_that_it_has_a_target(self):
+		"""Held back when it was authored, because a type row with a wrong target is worse than a
+		missing one. There is a container for it to point at now."""
+		self.assertEqual(frappe.db.get_value("Navigation Item Type", "Sidebar", "target_doctype"), "Sidebar")
+
+	def test_a_person_lists_only_their_own_layer_and_the_shared_ones(self):
+		"""A `Desk User` has read on this table, so without the query condition one person's
+		arrangement of a sidebar would be readable by everyone on the site.
+
+		Rows with no `user` stay visible to all of them: that is the navigation the site shares, and
+		it is every one of desk v1's sidebars.
+		"""
+		site = self.layer()
+
+		person = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": "sidebar-layer-tester@example.com",
+				"first_name": "Sidebar",
+				"roles": [{"role": "Desk User"}],
+			}
+		).insert(ignore_permissions=True)
+		self.addCleanup(person.delete)
+
+		mine = self.layer(user=person.name)
+		theirs = self.layer(user="Administrator")
+
+		# `get_list`, not `get_all`: the latter bypasses permissions by design.
+		with self.set_user(person.name):
+			visible = frappe.get_list("Sidebar", filters={"link_doctype": "Module Def"}, pluck="name")
+
+		self.assertIn(site.name, visible)
+		self.assertIn(mine.name, visible)
+		self.assertNotIn(theirs.name, visible)

--- a/frappe/desk/navigation_item_type/sidebar/sidebar.json
+++ b/frappe/desk/navigation_item_type/sidebar/sidebar.json
@@ -1,15 +1,15 @@
 {
- "creation": "2026-09-01 10:00:00.000000",
+ "creation": "2026-09-01 18:00:00.000000",
  "docstatus": 0,
  "doctype": "Navigation Item Type",
  "idx": 0,
- "label": "Module Contents",
+ "label": "Sidebar",
  "modified": "2026-09-01 18:00:00.000000",
  "modified_by": "Administrator",
  "module": "Desk",
- "name": "Module Contents",
+ "name": "Sidebar",
  "owner": "Administrator",
  "permission_rule": "Derived From Children",
- "target_doctype": "Module Def",
- "type_name": "Module Contents"
+ "target_doctype": "Sidebar",
+ "type_name": "Sidebar"
 }

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -166,6 +166,7 @@ permission_query_conditions = {
 	"Custom Sidebar": "frappe.desk.doctype.custom_sidebar.custom_sidebar.get_permission_query_conditions",
 	"Dock": "frappe.desk.doctype.dock.dock.get_permission_query_conditions",
 	"Rail": "frappe.desk.doctype.rail.rail.get_permission_query_conditions",
+	"Sidebar": "frappe.desk.doctype.sidebar.sidebar.get_permission_query_conditions",
 	"DocType": "frappe.app_state.get_module_permission_query_conditions",
 	"Page": "frappe.app_state.get_module_permission_query_conditions",
 	"Workspace": "frappe.app_state.get_module_permission_query_conditions",
@@ -202,6 +203,7 @@ has_permission = {
 	"Custom Sidebar": "frappe.desk.doctype.custom_sidebar.custom_sidebar.has_permission",
 	"Dock": "frappe.desk.doctype.dock.dock.has_permission",
 	"Rail": "frappe.desk.doctype.rail.rail.has_permission",
+	"Sidebar": "frappe.desk.doctype.sidebar.sidebar.has_permission",
 }
 
 has_website_permission = {"Address": "frappe.contacts.doctype.address.address.has_website_permission"}


### PR DESCRIPTION
Builds what [What is desk v2's sidebar container, now that Sidebar is desk v1's?](https://github.com/frappe/frappe/issues/42353) settled, on top of [PR #42352](https://github.com/frappe/frappe/pull/42352). Closes the build ticket [Extend Sidebar for desk v2](https://github.com/frappe/frappe/issues/42355).

## What this does

Desk v1's `Sidebar` is extended in place rather than a second container being authored, because `Rail` was a free name and `Sidebar` is not. It gains:

- a `link_doctype`/`link_to` Dynamic Link pair, which is the sidebar's address;
- a `user` Link, which makes a row a layer, with the same three layers `Rail` holds;
- a `navigation_items` table of `Navigation Item` rows beside v1's `items`;
- a controller `autoname()` naming v2 rows from their address, leaving v1's to `field:title`;
- a unique index on `(link_doctype, link_to, user, standard)`.

`app` and `standard` are shared with v1, not duplicated. `title`, `module`, `header_icon`, `merged_from`, `items` and the permissions are untouched.

The `Sidebar` navigation item type ships too, held back when the registry was authored because it had no real target. `View` stays held.

## Two things the ticket did not anticipate

**`field:title` does more than name.** `_sync_autoname_field` copies the record name back over the title column on every save, including on an import that skips validation, which is how an imported v1 row whose file names it one thing and titles it another gets corrected. On a v2 row it overwrote the label with a hash. Dropping `field:title` from the doctype fixed v2 and broke that correction for v1, so the pass is narrowed in the controller instead — the same override `Dock` and `Custom Sidebar` already do to `_validate_links` in this family.

**`unique: 1` on `title` cannot survive layering.** An app layer, a site layer and each person's layer all carry the label the sidebar shows, so an index over both desks refuses the second one. The column loses `unique` and the check it bought — refusing a second sidebar claiming the title of a row whose name has drifted — moves into the controller, narrowed to v1's rows.

## One thing added beyond the ticket

A `has_permission`/`get_permission_query_conditions` pair for `Sidebar`. `Desk User` has read on this table and every row on it was app content until now; a `user` column without these hooks means one person's arrangement is readable by everyone. Rows with no `user` stay readable by all, which is every one of desk v1's.

## Riding along

- **The role move from [Does Workspace Manager get renamed for desk v2?](https://github.com/frappe/frappe/issues/42354)**, which that ticket handed to this one: `Rail`'s site-layer gate becomes `System Manager`. The role keeps its name and desk v1's endpoints.
- **The `Navigation Item Type` tidy** the ticket asked for: the description named five kinds while seven shipped, `Module` and `Module Contents` were column-identical, and the authoring guard cited `Dock` where it meant `Rail`.

## Verification

`bench migrate` on a real site, then nine suites, all green: sidebar (94), custom sidebar (60), rail (15), dock preferences (121), module sidebar boot (63), v16 upgrade (29), module def (21), sidebar fixture conversion (20), v15 upgrade (14), module home and onboarding (12).

The index was checked on the site rather than assumed, since `on_doctype_update` only fires when a doctype's JSON changes — which is how `Rail`'s index shipped unenforced at first.

>no-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
