### PR TITLE
fix: tables in markdown editor (backport #25935)

### DIFF
--- a/frappe/public/js/frappe/utils/tools.js
+++ b/frappe/public/js/frappe/utils/tools.js
@@ -107,7 +107,7 @@ function sanitize_markdown_html(html) {
 
 frappe.markdown = function (txt) {
 	if (!frappe.md2html) {
-		frappe.md2html = new showdown.Converter();
+		frappe.md2html = new showdown.Converter({ tables: true });
 	}
 
 	while (txt.substr(0, 1) === "\n") {

--- a/frappe/public/scss/common/controls.scss
+++ b/frappe/public/scss/common/controls.scss
@@ -387,6 +387,17 @@ textarea.form-control {
 	min-height: 300px;
 	max-height: 600px;
 	overflow: auto;
+
+	table {
+		width: 100%;
+		border-collapse: collapse;
+
+		th,
+		td {
+			border: 1px solid var(--border-color);
+			padding: var(--padding-sm);
+		}
+	}
 }
 
 .markdown-toggle,


### PR DESCRIPTION
**Before:**
![CleanShot 2024-04-12 at 15 15 54@2x](https://github.com/frappe/frappe/assets/25369014/1d1a5059-13d4-4592-a543-aac080b94ae1)

**After:**
![CleanShot 2024-04-12 at 15 15 42@2x](https://github.com/frappe/frappe/assets/25369014/b79c57c6-dfe9-401b-adca-d70a107c74be)
