### PR TITLE
fix(Contact): use query builder for contact search

### DIFF
--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -9,7 +9,7 @@ from frappe.core.doctype.access_log.access_log import make_access_log
 from frappe.core.doctype.dynamic_link.dynamic_link import deduplicate_dynamic_links
 from frappe.model.document import Document
 from frappe.model.naming import append_number_if_name_exists
-from frappe.query_builder.functions import Coalesce
+from frappe.query_builder.functions import Coalesce, Locate, NullIf
 from frappe.utils import cstr
 
 
@@ -400,40 +400,29 @@ def update_contact(doc, method):
 def contact_query(
 	doctype: str, txt: str, searchfield: str, start: int, page_len: int, filters: dict[str, Any]
 ):
-	from frappe.desk.reportview import get_match_cond
-
 	doctype = "Contact"
 	if not frappe.get_meta(doctype).get_field(searchfield) and searchfield not in frappe.db.DEFAULT_COLUMNS:
 		return []
 
-	link_doctype = filters.pop("link_doctype", None)
-	link_name = filters.pop("link_name", None)
-
-	return frappe.db.sql(
-		f"""select
-			`tabContact`.name, `tabContact`.full_name, `tabContact`.company_name
-		from
-			`tabContact`, `tabDynamic Link`
-		where
-			`tabDynamic Link`.parent = `tabContact`.name and
-			`tabDynamic Link`.parenttype = 'Contact' and
-			`tabDynamic Link`.link_doctype = %(link_doctype)s and
-			`tabDynamic Link`.link_name = %(link_name)s and
-			`tabContact`.`{searchfield}` like %(txt)s
-			{get_match_cond(doctype)}
-		order by
-			if(locate(%(_txt)s, `tabContact`.full_name), locate(%(_txt)s, `tabContact`.company_name), 99999),
-			`tabContact`.idx desc, `tabContact`.full_name
-		limit %(page_len)s offset %(start)s """,
-		{
-			"txt": "%" + txt + "%",
-			"_txt": txt.replace("%", ""),
-			"start": start,
-			"page_len": page_len,
-			"link_name": link_name,
-			"link_doctype": link_doctype,
-		},
+	Contact = frappe.qb.DocType(doctype)
+	query = frappe.qb.get_query(
+		Contact,
+		fields=[Contact.name, Contact.full_name, Contact.company_name],
+		filters=[
+			[Contact[searchfield], "like", f"%{txt}%"],
+			["Dynamic Link", "link_doctype", "=", filters.get("link_doctype")],
+			["Dynamic Link", "link_name", "=", filters.get("link_name")],
+		],
+		limit=page_len,
+		offset=start,
+		ignore_permissions=False,
 	)
+
+	if txt:
+		relevance = Coalesce(NullIf(Locate(txt.replace("%", ""), Contact.full_name), 0), 99999)
+		query = query.orderby(relevance)
+
+	return query.orderby(Contact.idx, order=frappe.qb.desc).orderby(Contact.full_name).run()
 
 
 @frappe.whitelist()

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -420,10 +420,14 @@ def contact_query(
 
 	if txt:
 		search_text = txt.replace("%", "")
-		relevance = Coalesce(
-			NullIf(Locate(search_text, Contact.full_name), 0),
-			NullIf(Locate(search_text, Contact.company_name), 0),
-			99999,
+		full_name_position = NullIf(Locate(search_text, Contact.full_name), 0)
+		company_name_position = NullIf(Locate(search_text, Contact.company_name), 0)
+		relevance = (
+			frappe.qb.terms.Case()
+			.when(full_name_position.isnull(), Coalesce(company_name_position, 99999))
+			.when(company_name_position.isnull(), full_name_position)
+			.when(full_name_position <= company_name_position, full_name_position)
+			.else_(company_name_position)
 		)
 		query = query.orderby(relevance)
 

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -419,7 +419,12 @@ def contact_query(
 	)
 
 	if txt:
-		relevance = Coalesce(NullIf(Locate(txt.replace("%", ""), Contact.full_name), 0), 99999)
+		search_text = txt.replace("%", "")
+		relevance = Coalesce(
+			NullIf(Locate(search_text, Contact.full_name), 0),
+			NullIf(Locate(search_text, Contact.company_name), 0),
+			99999,
+		)
 		query = query.orderby(relevance)
 
 	return query.orderby(Contact.idx, order=frappe.qb.desc).orderby(Contact.full_name).run()

--- a/frappe/contacts/doctype/contact/test_contact.py
+++ b/frappe/contacts/doctype/contact/test_contact.py
@@ -63,6 +63,27 @@ class TestContact(IntegrationTestCase):
 		results = contact_query("Contact", "Contact Query Match", "name", 0, 10, filters)
 		self.assertEqual(results[0][0], contact.name)
 
+	def test_contact_query_ranks_company_name_matches(self):
+		later_match = create_contact("A Company Contact", "Mr", save=False)
+		later_match.company_name = "Supplier Company Match"
+		later_match.append("links", {"link_doctype": "User", "link_name": "Administrator"})
+		later_match.insert()
+
+		prefix_match = create_contact("Z Company Contact", "Mr", save=False)
+		prefix_match.company_name = "Company Match Supplier"
+		prefix_match.append("links", {"link_doctype": "User", "link_name": "Administrator"})
+		prefix_match.insert()
+
+		results = contact_query(
+			"Contact",
+			"Company Match",
+			"company_name",
+			0,
+			1,
+			{"link_doctype": "User", "link_name": "Administrator"},
+		)
+		self.assertEqual(results[0][0], prefix_match.name)
+
 	def test_get_contact_list(self):
 		# First time from database
 		results = get_contact_list("_Test Supplier")

--- a/frappe/contacts/doctype/contact/test_contact.py
+++ b/frappe/contacts/doctype/contact/test_contact.py
@@ -84,6 +84,27 @@ class TestContact(IntegrationTestCase):
 		)
 		self.assertEqual(results[0][0], prefix_match.name)
 
+	def test_contact_query_uses_best_name_match(self):
+		full_name_match = create_contact("A Match Contact", "Mr", save=False)
+		full_name_match.company_name = "Supplier Match"
+		full_name_match.append("links", {"link_doctype": "User", "link_name": "Administrator"})
+		full_name_match.insert()
+
+		company_name_match = create_contact("Z Supplier Match", "Mr", save=False)
+		company_name_match.company_name = "Match Supplier"
+		company_name_match.append("links", {"link_doctype": "User", "link_name": "Administrator"})
+		company_name_match.insert()
+
+		results = contact_query(
+			"Contact",
+			"Match",
+			"company_name",
+			0,
+			1,
+			{"link_doctype": "User", "link_name": "Administrator"},
+		)
+		self.assertEqual(results[0][0], company_name_match.name)
+
 	def test_get_contact_list(self):
 		# First time from database
 		results = get_contact_list("_Test Supplier")

--- a/frappe/contacts/doctype/contact/test_contact.py
+++ b/frappe/contacts/doctype/contact/test_contact.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import frappe
-from frappe.contacts.doctype.contact.contact import get_full_name
+from frappe.contacts.doctype.contact.contact import contact_query, get_full_name
 from frappe.email import get_contact_list
 from frappe.tests import IntegrationTestCase, timeout
 
@@ -51,6 +51,17 @@ class TestContact(IntegrationTestCase):
 		# links as a native list of dicts instead of a JSON string (frappe.parse_json passthrough)
 		result = address_query(links=[{"link_doctype": "User", "link_name": "Administrator"}])
 		self.assertIsInstance(result, list)
+
+	def test_contact_query_for_linked_contact(self):
+		contact = create_contact("Contact Query Match", "Mr", save=False)
+		contact.append("links", {"link_doctype": "User", "link_name": "Administrator"})
+		contact.insert()
+
+		filters = {"link_doctype": "User", "link_name": "Administrator"}
+		self.assertIsInstance(contact_query("Contact", "", "name", 0, 10, filters), list | tuple)
+
+		results = contact_query("Contact", "Contact Query Match", "name", 0, 10, filters)
+		self.assertEqual(results[0][0], contact.name)
 
 	def test_get_contact_list(self):
 		# First time from database


### PR DESCRIPTION
## Problem

The Contact link query uses the MySQL IF function. PostgreSQL rewrites LOCATE to STRPOS but cannot execute the resulting IF call with integer arguments.

This error prevents users from selecting a linked Contact in forms such as Request for Quotation.

## Changes

- Build the Contact link query with the permission-aware query builder.
- Filter linked contacts through the Dynamic Link child table.
- Rank full-name matches with portable Locate, NullIf, and Coalesce expressions.
- Skip relevance sorting when the search text is empty.
- Add a regression test for empty and non-empty linked Contact searches.

## Tests

- Ran the full Contact integration test module on PostgreSQL: 10 tests passed.
- Ran the repository pre-commit checks for both changed files.