### PR TITLE
fix: dashboard count and connection filter use the wrong child table with a duplicate link field

### DIFF
--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -343,10 +343,17 @@ def has_external_link_field(doctype, links):
 	fieldname = get_external_link_fieldname(doctype, links)
 	if not fieldname:
 		return False
-	meta = frappe.get_meta(doctype)
-	return meta.has_field(fieldname) or any(
-		frappe.get_meta(df.options).has_field(fieldname) for df in meta.get_table_fields()
+	return frappe.get_meta(doctype).has_field(fieldname) or bool(
+		get_child_doctypes_with_field(doctype, fieldname)
 	)
+
+
+def get_child_doctypes_with_field(doctype, fieldname):
+	"""Child tables of `doctype` carrying `fieldname`, empty when the parent itself has it."""
+	meta = frappe.get_meta(doctype)
+	if meta.has_field(fieldname):
+		return []
+	return [df.options for df in meta.get_table_fields() if frappe.get_meta(df.options).has_field(fieldname)]
 
 
 def get_external_links(doctype, name, links):
@@ -355,13 +362,8 @@ def get_external_links(doctype, name, links):
 	# updating filters based on dynamic_links
 	filters = get_dynamic_link_filters(doctype, links, fieldname) or {}
 
-	meta = frappe.get_meta(doctype)
-	if not meta.has_field(fieldname):
-		child_doctypes = [
-			df.options for df in meta.get_table_fields() if frappe.get_meta(df.options).has_field(fieldname)
-		]
-		if len(child_doctypes) > 1:
-			return get_external_links_via_child_tables(doctype, name, fieldname, child_doctypes, filters)
+	if len(child_doctypes := get_child_doctypes_with_field(doctype, fieldname)) > 1:
+		return get_external_links_in_child_tables(doctype, name, fieldname, child_doctypes, filters)
 
 	filters[fieldname] = name
 
@@ -375,16 +377,14 @@ def get_external_links(doctype, name, links):
 	return {"doctype": doctype, "count": total_count, "open_count": open_count}
 
 
-def get_external_links_via_child_tables(doctype, name, fieldname, child_doctypes, filters):
-	"""A filter on a fieldname that several child tables share resolves to whichever
-	of them is scanned first, so match the link in any of them."""
-	or_filters = [[child_doctype, fieldname, "=", name] for child_doctype in child_doctypes]
-
+def get_external_links_in_child_tables(doctype, name, fieldname, child_doctypes, filters):
+	"""A filter on a fieldname that several child tables share resolves to whichever of them
+	is scanned first, so match the link in any of them and let the client route by name."""
 	try:
-		names = frappe.get_all(
+		names = frappe.get_list(
 			doctype,
 			filters=filters,
-			or_filters=or_filters,
+			or_filters=[[child_doctype, fieldname, "=", name] for child_doctype in child_doctypes],
 			limit=100,
 			distinct=True,
 			ignore_ifnull=True,

--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -351,11 +351,19 @@ def has_external_link_field(doctype, links):
 
 def get_external_links(doctype, name, links):
 	fieldname = get_external_link_fieldname(doctype, links)
-	filters = {fieldname: name}
 
 	# updating filters based on dynamic_links
-	if dynamic_link_filters := get_dynamic_link_filters(doctype, links, fieldname):
-		filters.update(dynamic_link_filters)
+	filters = get_dynamic_link_filters(doctype, links, fieldname) or {}
+
+	meta = frappe.get_meta(doctype)
+	if not meta.has_field(fieldname):
+		child_doctypes = [
+			df.options for df in meta.get_table_fields() if frappe.get_meta(df.options).has_field(fieldname)
+		]
+		if len(child_doctypes) > 1:
+			return get_external_links_via_child_tables(doctype, name, fieldname, child_doctypes, filters)
+
+	filters[fieldname] = name
 
 	total_count = get_doc_count(doctype, filters)
 
@@ -365,6 +373,34 @@ def get_external_links(doctype, name, links):
 		open_count = get_doc_count(doctype, filters)
 
 	return {"doctype": doctype, "count": total_count, "open_count": open_count}
+
+
+def get_external_links_via_child_tables(doctype, name, fieldname, child_doctypes, filters):
+	"""A filter on a fieldname that several child tables share resolves to whichever
+	of them is scanned first, so match the link in any of them."""
+	or_filters = [[child_doctype, fieldname, "=", name] for child_doctype in child_doctypes]
+
+	try:
+		names = frappe.get_all(
+			doctype,
+			filters=filters,
+			or_filters=or_filters,
+			limit=100,
+			distinct=True,
+			ignore_ifnull=True,
+			order_by=None,
+			pluck="name",
+		)
+	except Exception as e:
+		if frappe.db.is_statement_timeout(e):
+			return {"doctype": doctype, "count": "?", "open_count": 0}
+		raise
+
+	open_count = 0
+	if names and (open_count_filters := get_filters_for(doctype)):
+		open_count = get_doc_count(doctype, {"name": ("in", names), **open_count_filters})
+
+	return {"doctype": doctype, "count": len(names), "open_count": open_count, "names": names}
 
 
 def get_doc_count(doctype, filters) -> int | Literal["?"]:

--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -488,12 +488,7 @@ frappe.ui.form.Dashboard = class FormDashboard {
 		);
 
 		this.set_badge_count_common(open_count, count, $link);
-
-		if (names && names.length) {
-			$link.attr("data-names", names.join(","));
-		} else {
-			$link.removeAttr("data-names");
-		}
+		$link.attr("data-names", names ? names.join(",") : "");
 	}
 
 	set_badge_count_for_internal_link(doctype, open_count, count, names) {
@@ -504,9 +499,8 @@ frappe.ui.form.Dashboard = class FormDashboard {
 		this.set_badge_count_common(open_count, count, $link);
 
 		if (names && names.length) {
-			$link.attr("data-names", names.join(","));
+			$link.attr("data-names", names ? names.join(",") : "");
 		} else {
-			$link.removeAttr("data-names");
 			$link.find("a").attr("disabled", true);
 		}
 	}

--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -383,15 +383,13 @@ frappe.ui.form.Dashboard = class FormDashboard {
 			(this.data.non_standard_fieldnames && this.data.non_standard_fieldnames[doctype]) ||
 			this.data.fieldname;
 
-		if (
+		if (names.length) {
+			frappe.route_options = { name: ["in", names] };
+		} else if (
 			this.internal_links_found &&
 			this.internal_links_found.find((d) => d.doctype === doctype)
 		) {
-			if (names.length) {
-				frappe.route_options = { name: ["in", names] };
-			} else {
-				return false;
-			}
+			return false;
 		} else if (fieldname) {
 			frappe.route_options = this.get_document_filter(doctype, fieldname);
 			if (show_open && frappe.ui.notifications) {
@@ -475,16 +473,27 @@ frappe.ui.form.Dashboard = class FormDashboard {
 		});
 
 		$.each(count.external_links_found, function (i, d) {
-			me.frm.dashboard.set_badge_count_for_external_link(d.doctype, d.open_count, d.count);
+			me.frm.dashboard.set_badge_count_for_external_link(
+				d.doctype,
+				d.open_count,
+				d.count,
+				d.names
+			);
 		});
 	}
 
-	set_badge_count_for_external_link(doctype, open_count, count) {
+	set_badge_count_for_external_link(doctype, open_count, count, names) {
 		let $link = $(this.transactions_area).find(
 			'.document-link[data-doctype="' + doctype + '"]'
 		);
 
 		this.set_badge_count_common(open_count, count, $link);
+
+		if (names && names.length) {
+			$link.attr("data-names", names.join(","));
+		} else {
+			$link.removeAttr("data-names");
+		}
 	}
 
 	set_badge_count_for_internal_link(doctype, open_count, count, names) {
@@ -495,8 +504,9 @@ frappe.ui.form.Dashboard = class FormDashboard {
 		this.set_badge_count_common(open_count, count, $link);
 
 		if (names && names.length) {
-			$link.attr("data-names", names ? names.join(",") : "");
+			$link.attr("data-names", names.join(","));
 		} else {
+			$link.removeAttr("data-names");
 			$link.find("a").attr("disabled", true);
 		}
 	}

--- a/frappe/tests/test_dashboard_connections.py
+++ b/frappe/tests/test_dashboard_connections.py
@@ -377,6 +377,7 @@ def create_test_doctype_c_with_duplicate_link_to_doctype_a():
 		"Test Doctype C With Duplicate Link To Doctype A",
 		fields=[
 			{"fieldname": "title", "fieldtype": "Data", "label": "Title", "unique": 1},
+			# scanned before `child_table`, so a filter on the shared fieldname lands here
 			{
 				"fieldname": "unrelated_child_table",
 				"fieldtype": "Table",

--- a/frappe/tests/test_dashboard_connections.py
+++ b/frappe/tests/test_dashboard_connections.py
@@ -122,6 +122,45 @@ class TestDashboardConnections(IntegrationTestCase):
 				expected_open_count,
 			)
 
+	def test_external_link_count_with_shared_link_field_in_child_tables(self):
+		jupiter = frappe.get_doc(
+			doctype="Test Doctype A With Child Table With Link To Doctype B", title="Jupiter"
+		).insert()
+
+		voyager = frappe.get_doc(doctype="Test Doctype C With Duplicate Link To Doctype A", title="Voyager")
+		voyager.append(
+			"child_table",
+			{
+				"title": "Voyager",
+				"test_doctype_a_with_test_child_table_with_link_to_doctype_b": "Jupiter",
+			},
+		)
+		voyager.insert()
+
+		dashboard = frappe._dict(
+			fieldname="test_doctype_a_with_test_child_table_with_link_to_doctype_b",
+			transactions=[
+				{"label": "Reference", "items": ["Test Doctype C With Duplicate Link To Doctype A"]}
+			],
+		)
+
+		with patch.object(jupiter.meta, "get_dashboard_data", return_value=dashboard):
+			connections = get_open_count("Test Doctype A With Child Table With Link To Doctype B", "Jupiter")[
+				"count"
+			]
+
+		self.assertEqual(
+			connections["external_links_found"],
+			[
+				{
+					"doctype": "Test Doctype C With Duplicate Link To Doctype A",
+					"open_count": 0,
+					"count": 1,
+					"names": ["Voyager"],
+				}
+			],
+		)
+
 	def test_internal_link_without_external_field_reports_zero(self):
 		venus = frappe.get_doc(
 			{
@@ -195,6 +234,7 @@ def create_test_data():
 	create_test_doctype_b_with_test_child_table_with_link_to_doctype_a()
 	create_linked_doctypes()
 	add_links_in_child_tables()
+	create_test_doctype_c_with_duplicate_link_to_doctype_a()
 
 
 def delete_test_data():
@@ -205,6 +245,8 @@ def delete_test_data():
 		"Test Doctype B With Child Table With Link To Doctype A",
 		"Test Doctype D",
 		"Test Doctype E",
+		"Test Doctype C With Duplicate Link To Doctype A",
+		"Test Unrelated Child Table With Link To Doctype A",
 	]
 	for doctype in doctypes:
 		if frappe.db.table_exists(doctype):
@@ -308,6 +350,44 @@ def create_test_doctype_b_with_test_child_table_with_link_to_doctype_a():
 				"fieldtype": "Tab Break",
 				"label": "Connections",
 				"show_dashboard": 1,
+			},
+		],
+		custom=False,
+		autoname="field:title",
+		naming_rule="By fieldname",
+	).insert(ignore_if_duplicate=True)
+
+
+def create_test_doctype_c_with_duplicate_link_to_doctype_a():
+	new_doctype(
+		"Test Unrelated Child Table With Link To Doctype A",
+		istable=1,
+		fields=[
+			{
+				"fieldname": "test_doctype_a_with_test_child_table_with_link_to_doctype_b",
+				"fieldtype": "Link",
+				"label": "Test Doctype A With Child Table With Link To Doctype B",
+				"options": "Test Doctype A With Child Table With Link To Doctype B",
+			}
+		],
+		custom=False,
+	).insert(ignore_if_duplicate=True)
+
+	new_doctype(
+		"Test Doctype C With Duplicate Link To Doctype A",
+		fields=[
+			{"fieldname": "title", "fieldtype": "Data", "label": "Title", "unique": 1},
+			{
+				"fieldname": "unrelated_child_table",
+				"fieldtype": "Table",
+				"label": "Unrelated Child Table",
+				"options": "Test Unrelated Child Table With Link To Doctype A",
+			},
+			{
+				"fieldname": "child_table",
+				"fieldtype": "Table",
+				"label": "Child Table",
+				"options": "Test Child Table With Link To Doctype A",
 			},
 		],
 		custom=False,


### PR DESCRIPTION
When a dashboard connection points at a doctype that links back through a child table, the count filters on the bare fieldname. That field is not on the parent, so the query builder binds to whichever child table it scans first; with two child tables sharing the field, DocField order decides which. The count is computed against the wrong table and the connection opens a list filtered on it.

The count now matches the link in any child table carrying the field and returns the names it matched, and the click routes by those names. Links that resolve to a field on the parent, or to a single child table, are unchanged.

#39716 fixed the same bug in `get_linked_docs`; the dashboard badge and the connection filter never went through that path.

---

Ref: https://support.frappe.io/helpdesk/tickets/76220?view=VIEW-HD+Ticket-1252