### PR TITLE
fix(web_page): force render_safe_globals context

### DIFF
--- a/frappe/website/doctype/web_page/web_page.py
+++ b/frappe/website/doctype/web_page/web_page.py
@@ -127,7 +127,9 @@ class WebPage(WebsiteGenerator):
 			frappe.flags.web_block_scripts = {}
 			frappe.flags.web_block_styles = {}
 			try:
-				context["main_section"] = render_template(context.main_section, context)
+				context["main_section"] = render_template(
+					context.main_section, context, restrict_globals=True
+				)
 				if "<!-- static -->" not in context.main_section:
 					context["no_cache"] = 1
 			except TemplateSyntaxError:


### PR DESCRIPTION
There should be no need to parse `exec_safe_globals` for this, `render_safe_globals` is sufficient for this use case.

closes Ticket 74677