### PR TITLE
fix(safe_exec): remove request completely

### DIFF
--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -600,9 +600,7 @@ def exec_safe_globals():
 			),
 		),
 	)
-	result = _update_namespace(render_safe, exec_safe)
-	result["frappe"]["request"] = getattr(frappe.local, "request", {})
-	return result
+	return _update_namespace(render_safe, exec_safe)
 
 
 def get_keys_for_autocomplete(


### PR DESCRIPTION
Seeing as nobody most likely uses this, removing `request` completely.