### PR TITLE
fix(user): correct typo. in cache invalidation key

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -633,7 +633,7 @@ class User(Document):
 		# delete notification settings
 		frappe.delete_doc("Notification Settings", self.name, ignore_permissions=True)
 
-		if self.get("allow_in_mentions"):
+		if self.get("allowed_in_mentions"):
 			frappe.cache.delete_key("users_for_mentions")
 
 		frappe.cache.delete_key("enabled_users")

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -356,7 +356,7 @@ class User(Document):
 		if self.has_value_changed("enabled"):
 			frappe.cache.delete_key("users_for_mentions")
 			frappe.cache.delete_key("enabled_users")
-		elif self.has_value_changed("allow_in_mentions") or self.has_value_changed("user_type"):
+		elif self.has_value_changed("allowed_in_mentions") or self.has_value_changed("user_type"):
 			frappe.cache.delete_key("users_for_mentions")
 
 		if self.has_value_changed("user_type"):

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -79,8 +79,8 @@ class TestSearch(IntegrationTestCase):
 				"allowed_in_mentions": True,
 			}
 		)
+		# saved when roles are added
 		user.add_roles("System Manager")
-		user.insert()
 
 		# Populate the users_for_mentions cache.
 		names_for_mention = [user.get("id") for user in get_names_for_mentions("")]

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -66,6 +66,35 @@ class TestSearch(IntegrationTestCase):
 		names_for_mention = [user.get("id") for user in get_names_for_mentions("")]
 		self.assertNotIn(email, names_for_mention)
 
+	def test_allowed_in_mentions_cache_invalidation(self):
+		email = "test_allowed_in_mentions@example.com"
+		frappe.delete_doc("User", email, ignore_missing=True)
+
+		user = frappe.new_doc("User")
+		user.update(
+			{
+				"email": email,
+				"first_name": email.split("@", 1)[0],
+				"enabled": True,
+				"allowed_in_mentions": True,
+			}
+		)
+		user.add_roles("System Manager")
+		user.insert()
+
+		# Populate the users_for_mentions cache.
+		names_for_mention = [user.get("id") for user in get_names_for_mentions("")]
+		self.assertIn(email, names_for_mention)
+
+		# Changing Allowed In Mentions should invalidate the cache.
+		user.allowed_in_mentions = False
+		user.save()
+
+		names_for_mention = [user.get("id") for user in get_names_for_mentions("")]
+		self.assertNotIn(email, names_for_mention)
+
+		frappe.delete_doc("User", email)
+
 	def test_link_field_order(self):
 		# Making a request to the search_link with the tree doctype
 		results = search_link(


### PR DESCRIPTION
Raising PR on behalf of @DaizyModi 


**Issue**

Allowed In Mentions changes are not reflected in mention suggestions

Updating the Allowed In Mentions field on a User does not invalidate the cached list of users available for mentions. As a result, enabling or disabling the option does not immediately reflect in @mentions until the cache is cleared manually.

The User on_update handler checks the incorrect field name allow_in_mentions instead of allowed_in_mentions, so the users_for_mentions cache is not invalidated when the setting changes.

Issue Link: https://github.com/frappe/frappe/issues/42388

**Fix**

Use the correct field name allowed_in_mentions when checking whether the value has changed, so the users_for_mentions cache is invalidated after updating the User.

elif self.has_value_changed("allowed_in_mentions") or self.has_value_changed("user_type"):
    frappe.cache.delete_key("users_for_mentions")
This ensures that changes to Allowed In Mentions are reflected immediately in subsequent mention searches. The mention search itself filters users using allowed_in_mentions.


closes #42388