### PR TITLE
feat: resolve desk v2 navigation into boot

### DIFF
--- a/frappe/desk/doctype/navigation_item/navigation_item.py
+++ b/frappe/desk/doctype/navigation_item/navigation_item.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2026, Frappe Technologies and contributors
 # For license information, please see license.txt
 
+import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
@@ -41,3 +43,37 @@ class NavigationItem(Document):
 	# end: auto-generated types
 
 	pass
+
+
+def validate_item_keys(items):
+	"""Refuse a shipped list whose rows are not addressable, one by one.
+
+	A `key` is what every site and user edit is filed against, so a missing or duplicated one
+	is not a cosmetic slip: the deltas naming it go inert and the site quietly loses its
+	arrangement while the navigation still renders correctly. Navigation that breaks quietly
+	gets misdiagnosed as a permission problem, so this fails at write time instead.
+
+	Both containers call it, because both hold these rows and the resolver reads them by key
+	from either. Only the app layer is ever checked: a layer's rows are addressed by the base
+	key they name, and a row a layer *added* is minted a key when it is written.
+	"""
+	seen = set()
+
+	for item in items:
+		if not item.key:
+			frappe.throw(
+				_("Row {0} ({1}) has no key. Every item an app ships needs one, frozen for good.").format(
+					item.idx, frappe.bold(item.label or item.link_to or item.item_type)
+				),
+				title=_("Missing Key"),
+			)
+
+		if item.key in seen:
+			frappe.throw(
+				_("Row {0} repeats the key {1}. Two rows with one address cannot both be customized.").format(
+					item.idx, frappe.bold(item.key)
+				),
+				title=_("Duplicate Key"),
+			)
+
+		seen.add(item.key)

--- a/frappe/desk/doctype/rail/rail.py
+++ b/frappe/desk/doctype/rail/rail.py
@@ -3,6 +3,7 @@
 
 import frappe
 from frappe import _
+from frappe.desk.doctype.navigation_item.navigation_item import validate_item_keys
 from frappe.model.document import Document
 
 # Blank, not `None`: the column is not nullable so that one spelling of "not a user's own layer"
@@ -99,38 +100,15 @@ class Rail(Document):
 		)
 
 	def validate_item_keys(self):
-		"""Refuse a shipped rail whose rows are not addressable, one by one.
+		"""The shared rule, in `navigation_item.py`: an app's rows must each carry a unique key.
 
-		A `key` is what every site and user edit is filed against, so a missing or duplicated one
-		is not a cosmetic slip: the deltas naming it go inert and the site quietly loses its
-		arrangement while the rail still renders correctly. Navigation that breaks quietly gets
-		misdiagnosed as a permission problem, so this fails at write time instead.
-
-		Only the app layer is checked. A layer's rows are addressed by the base key they name, and
-		a row the layer *added* is minted a key on export alongside the rest.
+		Only the app layer is checked. A layer's rows are addressed by the base key they name,
+		and a row the layer *added* is minted a key on export alongside the rest.
 		"""
 		if not self.standard:
 			return
 
-		seen = set()
-		for item in self.items:
-			if not item.key:
-				frappe.throw(
-					_("Row {0} ({1}) has no key. Every item an app ships needs one, frozen for good.").format(
-						item.idx, frappe.bold(item.label or item.link_to or item.item_type)
-					),
-					title=_("Missing Key"),
-				)
-
-			if item.key in seen:
-				frappe.throw(
-					_(
-						"Row {0} repeats the key {1}. Two rows with one address cannot both be customized."
-					).format(item.idx, frappe.bold(item.key)),
-					title=_("Duplicate Key"),
-				)
-
-			seen.add(item.key)
+		validate_item_keys(self.items)
 
 	def on_update(self):
 		self.export_rail()

--- a/frappe/desk/doctype/sidebar/sidebar.py
+++ b/frappe/desk/doctype/sidebar/sidebar.py
@@ -37,6 +37,7 @@ import frappe
 from frappe import _
 from frappe.app_state import get_disabled_modules
 from frappe.desk.desk_views import DeskViews
+from frappe.desk.doctype.navigation_item.navigation_item import validate_item_keys
 from frappe.desk.utils import is_item_allowed
 from frappe.model.document import Document
 from frappe.model.naming import make_autoname
@@ -204,6 +205,7 @@ class Sidebar(Document, DeskViews):
 		self.validate_title_is_unique()
 		self.validate_standard()
 		self.clear_stored_keys()
+		self.validate_navigation_item_keys()
 
 	def before_save(self):
 		self.rename_to_title()
@@ -348,6 +350,21 @@ class Sidebar(Document, DeskViews):
 		from frappe.desk.doctype.dock.dock import rename_sidebar_rows
 
 		rename_sidebar_rows(old_name, new_name)
+
+	def validate_navigation_item_keys(self):
+		"""Hold desk v2's rows to the same rule `Rail` holds its own to: an app's rows each carry
+		a unique key.
+
+		Desk v1's `items` are exempt, and `clear_stored_keys` above blanks their key column
+		outright -- a v1 base row is identified by its own columns, so a stored key there would be
+		a second, possibly stale answer. Desk v2 reversed that: the key *is* the identity, so it
+		has to exist and it has to be unique, or the deltas filed against it go inert and the site
+		silently loses its arrangement.
+		"""
+		if not self.standard:
+			return
+
+		validate_item_keys(self.navigation_items)
 
 	def clear_stored_keys(self):
 		"""Blank the `key` column on every item.

--- a/frappe/desk/doctype/sidebar/test_sidebar.py
+++ b/frappe/desk/doctype/sidebar/test_sidebar.py
@@ -1670,7 +1670,13 @@ class TestSidebarForDeskV2(IntegrationTestCase):
 		"""
 		doc = frappe.new_doc("Sidebar")
 		doc.update(self.ADDRESS | kwargs)
-		doc.append("navigation_items", {"item_type": "DocType", "link_to": "User", "label": "Users"})
+		# `key` on every row, because an app layer is held to the same rule `Rail` holds its own
+		# to: the key is what a site or user delta is filed against, so a shipped row without one
+		# is a row nobody can ever customize.
+		doc.append(
+			"navigation_items",
+			{"item_type": "DocType", "link_to": "User", "label": "Users", "key": "user"},
+		)
 		with developer_mode(), patch.object(Sidebar, "export_sidebar"):
 			doc.insert(ignore_permissions=True)
 		self.addCleanup(frappe.delete_doc, "Sidebar", doc.name, force=True, ignore_permissions=True)
@@ -1684,6 +1690,35 @@ class TestSidebarForDeskV2(IntegrationTestCase):
 			doc = frappe.new_doc("Sidebar")
 			doc.update(self.ADDRESS | {"standard": 1, "title": "Desk"})
 			self.assertRaises(frappe.ValidationError, doc.insert, ignore_permissions=True)
+
+	def test_an_app_layer_needs_a_key_on_every_row(self):
+		"""The same rule `Rail` holds its own rows to, and it lives in one place now.
+
+		The key is the identity of a shipped row: every site and user delta is filed against it,
+		so a row without one renders correctly and can never be arranged, which is the quiet
+		failure that gets misdiagnosed as a permission problem. This is the reverse of desk v1's
+		rule for `items`, whose keys `clear_stored_keys` blanks outright.
+		"""
+		doc = frappe.new_doc("Sidebar")
+		doc.update(self.ADDRESS | {"standard": 1, "app": "frappe", "title": "Desk"})
+		doc.append("navigation_items", {"item_type": "DocType", "link_to": "User"})
+
+		with developer_mode(), patch.object(Sidebar, "export_sidebar"):
+			self.assertRaises(frappe.ValidationError, doc.insert, ignore_permissions=True)
+
+	def test_an_app_layer_refuses_two_rows_with_one_key(self):
+		doc = frappe.new_doc("Sidebar")
+		doc.update(self.ADDRESS | {"standard": 1, "app": "frappe", "title": "Desk"})
+		for link_to in ("User", "Role"):
+			doc.append("navigation_items", {"item_type": "DocType", "link_to": link_to, "key": "same"})
+
+		with developer_mode(), patch.object(Sidebar, "export_sidebar"):
+			self.assertRaises(frappe.ValidationError, doc.insert, ignore_permissions=True)
+
+	def test_a_layer_is_not_asked_for_keys(self):
+		"""A layer's rows are addressed by the base key they name, and a row a layer added is
+		minted one when it is written."""
+		self.assertTrue(self.layer().name)
 
 	def test_an_app_layer_is_named_after_its_address(self):
 		"""The record name is the export path, and it is also what a rail item points at.

--- a/frappe/shell/boot.py
+++ b/frappe/shell/boot.py
@@ -12,6 +12,7 @@ from frappe.utils import get_system_timezone
 
 from . import SHELL_ROOT
 from .doctypes import metadata_version
+from .navigation import resolve_navigation
 from .permissions import has_app_permission
 from .registry import get_prefix_registry, prefix_map, shell_base, split_shell_path
 
@@ -158,6 +159,17 @@ def get_boot(path: str | None = None) -> dict:
 		**core_boot(),
 		"shell_base": shell_base(prefix),
 		"app": app,
+		# The rail and every sidebar in this prefix, resolved server-side. A framework key
+		# and not an `app_boot` contribution: apps shape navigation through the rows and
+		# the item types they ship, and a code-level second route in would be two
+		# mechanisms for one thing (#42232).
+		#
+		# It rides boot because #42070 already makes boot a blocking pre-mount fetch, so a
+		# separate navigation request would be a second blocking round trip for the same
+		# wait — and because a rail click that costs a request is the thing this payload
+		# exists to prevent. What an app *contains* is still fetched, by the app home and
+		# the module page that show it (`doctypes.get_contents`, #42357).
+		"navigation": resolve_navigation(app),
 		# No `doctype_slugs` here any more. It was prefix-scoped and sat in boot
 		# because it was small; the lens made it full-bench, which broke the 40 KB
 		# budget — and byte-identical for every user and every prefix, which is what

--- a/frappe/shell/doctypes.py
+++ b/frappe/shell/doctypes.py
@@ -161,46 +161,66 @@ def get_addresses(v: str | None = None) -> dict:
 	return get_address_table()
 
 
-def navigation_for_app(app: str, module: str | None = None) -> list[dict]:
-	"""What an app's chrome LISTS — curated per app and permission-filtered.
+def get_readable_doctypes() -> set[str]:
+	"""Every doctype this user may read, in ONE pass. The single input both filters share.
 
-	The counterpart of the address table, and deliberately a different list. #42210
-	split what `boot.doctype_slugs` conflated: **addressability** is full-bench and
-	permission-independent, **navigation** is per-app and filtered. A doctype you
-	cannot read is still addressable (you get refused at the record, by ordinary
-	doctype permissions); it is simply not offered to you.
+	Measured on this bench for an ordinary System User: **3,594 ms** for 553 per-doctype
+	`has_permission` calls against **25 ms** for this. The per-doctype loop looked free
+	only because it was first measured as Administrator, who short-circuits every check
+	— 6 ms, and nothing like what a real user pays. The rail loads on every page, so that
+	was 3.6 s of worker time per load.
 
-	`module` narrows it further, for the module landing page a modular app's address
-	space now walks up to (#42211 §6).
+	It also removes a failure mode outright rather than guarding it: `has_permission`
+	imports each doctype's controller, so one app's un-importable module took down the
+	rail for *every* app. This reads DocPerm and Custom DocPerm and imports nothing.
+
+	Roles are not the whole answer. `has_permission(doctype, "read")` returns True with
+	**no doc passed** when at least one document of that type is shared with the user
+	(`permissions.py:206`), so a role-only set silently drops every doctype a user
+	reaches purely by sharing. `get_shared_doctypes` is the framework's own bulk answer
+	to that question — one query, `user = me OR everyone = 1` — so it costs a query
+	rather than a per-doctype check.
+
+	The two sets agree for a user with no shares, which is why the first measurement
+	missed this. They differ for Administrator by three doctypes carrying *zero* DocPerm
+	rows, which nobody but Administrator could ever read; not offering those is the
+	intended reading of "what is offered", and they stay fully addressable.
+
+	This lives here, and `shell/navigation.py` derives an unconverted app's rail from it,
+	because two answers to "may this user read this doctype" is exactly the divergence
+	#42231 exists to close. Filtering an app's *authored* rows against their declared
+	permission bucket is the other half of that rule and belongs to the walking skeleton
+	(#42233), which is where authored rows first exist to be filtered.
 	"""
 	from frappe.permissions import get_doctypes_with_read
 	from frappe.share import get_shared_doctypes
 
+	return set(get_doctypes_with_read()) | set(get_shared_doctypes())
+
+
+def contents_for_app(app: str, module: str | None = None) -> list[dict]:
+	"""What an app CONTAINS — its own doctypes, permission-filtered.
+
+	The counterpart of the address table, and deliberately a different list. #42210
+	split what `boot.doctype_slugs` conflated: **addressability** is full-bench and
+	permission-independent, **contents** are per-app and filtered. A doctype you cannot
+	read is still addressable (you get refused at the record, by ordinary doctype
+	permissions); it is simply not offered to you.
+
+	`module` narrows it further, for the module landing page a modular app's address
+	space now walks up to (#42211 §6).
+
+	This used to be called `navigation_for_app`, and it used to feed the rail. It no
+	longer does: the rail is authored navigation, resolved into boot by
+	`shell/navigation.py`, while this stays the derived list of what is *in* an app.
+	#42357 settled that those are two lists and nothing reconciles them — measured
+	across ERPNext, 107 doctypes sit on a module page and not in that module's sidebar
+	while 101 sidebar links point outside the module. The app home and the module page
+	answer *what does this contain*; the rail answers *what do you do here*.
+	"""
 	table = get_address_table()
 	owners = get_doctype_owners()
-
-	# ONE role-based pass, not `has_permission` per doctype. Measured on this bench for
-	# an ordinary System User: **3,594 ms** for 553 per-doctype checks against **25 ms**
-	# for this. The per-doctype loop looked free only because it was first measured as
-	# Administrator, who short-circuits every check — 6 ms, and nothing like what a real
-	# user pays. The rail loads on every page, so that was 3.6 s of worker time per load.
-	#
-	# It also removes the failure mode outright rather than guarding it: `has_permission`
-	# imports each doctype's controller, so one app's un-importable module took down the
-	# rail for *every* app. This reads DocPerm and Custom DocPerm and imports nothing.
-	#
-	# Roles are not the whole answer. `has_permission(doctype, "read")` returns True with
-	# **no doc passed** when at least one document of that type is shared with the user
-	# (`permissions.py:206`), so a role-only set silently drops every doctype a user
-	# reaches purely by sharing. `get_shared_doctypes` is the framework's own bulk answer
-	# to that question — one query, `user = me OR everyone = 1` — so it costs a query
-	# rather than a per-doctype check.
-	#
-	# The two sets agree for a user with no shares, which is why the first measurement
-	# missed this. They differ for Administrator by three doctypes carrying *zero*
-	# DocPerm rows, which nobody but Administrator could ever read; not offering those is
-	# the intended reading of "what is offered", and they stay fully addressable.
-	readable = set(get_doctypes_with_read()) | set(get_shared_doctypes())
+	readable = get_readable_doctypes()
 	entries = []
 
 	for doctype, owner in owners.items():
@@ -221,7 +241,13 @@ def navigation_for_app(app: str, module: str | None = None) -> list[dict]:
 
 
 @frappe.whitelist(methods=["GET"])
-def get_navigation(app: str, module: str | None = None) -> list[dict]:
+def get_contents(app: str, module: str | None = None) -> list[dict]:
+	"""An app's contents, or one module's, fetched on arrival at the page that shows them.
+
+	Kept as a fetch rather than folded into boot, where the rail went. A module page is a
+	destination, and paying one request on arrival is ordinary; a rail click must cost
+	none, which is why only the rail moved (#42357).
+	"""
 	from .permissions import has_app_permission
 	from .registry import get_prefix_registry
 
@@ -232,7 +258,7 @@ def get_navigation(app: str, module: str | None = None) -> list[dict]:
 
 	# And validate it against the registry BEFORE it reaches `has_app_permission`,
 	# which passes it to `get_hooks(app_name=)` — an importlib call on a
-	# caller-supplied name. An app that serves no prefix has no navigation to ask
+	# caller-supplied name. An app that serves no prefix has no contents to ask
 	# about, so this costs nothing real.
 	if app not in set(get_prefix_registry().values()):
 		frappe.throw(_("No app named {0} is installed").format(app), frappe.DoesNotExistError)
@@ -240,4 +266,4 @@ def get_navigation(app: str, module: str | None = None) -> list[dict]:
 	if not has_app_permission(app):
 		frappe.throw(_("You are not permitted to access this page."), frappe.PermissionError)
 
-	return navigation_for_app(app, module)
+	return contents_for_app(app, module)

--- a/frappe/shell/navigation.py
+++ b/frappe/shell/navigation.py
@@ -242,6 +242,13 @@ def _promote_orphans(items: list[dict]) -> list[dict]:
 	`parent_key` naming a row that is no longer there promotes the child instead of taking it
 	with it, so an app removing a section never silently removes everything under it. It also
 	matches #42230's rule for a user who has reparented into a section the site later withdrew.
+
+	It runs after hidden items are dropped, so hiding a section currently promotes its children
+	rather than taking them with it. That is the rule above applied to a case nobody has decided:
+	an app *removing* a section should not remove what was under it, but a person *hiding* one
+	may well mean the whole branch. Nothing exercises it -- no app ships a section and nothing
+	writes a hide -- and #42363 owns the editor that would first produce one, so it is recorded
+	here rather than settled by whichever line happened to be written first.
 	"""
 	present = {item_key(item) for item in items}
 	return [
@@ -365,7 +372,11 @@ def _sidebar_layers(addresses: list[tuple[str, str]]) -> dict[tuple[str, str], d
 		},
 		fields=["name", "standard", "user", "link_doctype", "link_to"],
 	)
-	records = [record for record in records if (record.link_doctype, record.link_to) in set(addresses)]
+	# The query filters on `link_doctype` alone, since a tuple is not a filter; the pair is
+	# checked here. A row at an address this app does not ship is another app's, or a delta over
+	# an address nobody ships, and neither belongs in this payload.
+	wanted = set(addresses)
+	records = [record for record in records if (record.link_doctype, record.link_to) in wanted]
 
 	# `navigation_items`, never `items`. One `Sidebar` document holds both tables — desk v1's
 	# rows and desk v2's — so naming the parentfield is what keeps a v2 resolver from silently

--- a/frappe/shell/navigation.py
+++ b/frappe/shell/navigation.py
@@ -1,0 +1,428 @@
+# NAVIGATION — the rail and the sidebars of one prefix, resolved for one user.
+#
+# #42356: resolution spans both containers, so it belongs to neither controller. It cannot
+# live on `Sidebar` either, whose class is desk v1's `Sidebar(Document, DeskViews)` — v1's
+# boot builder — and hanging desk v2's resolution off that would couple the new path to the
+# old one on its first day. It lives beside its only caller instead, `shell/boot.py`, since
+# #42232 made navigation a framework boot key.
+#
+# One entry point. #42232 decided the server sends one resolved tree that the browser never
+# restacks, so composing the payload is this module's job and not the caller's — the moment a
+# second caller appears (the overlay write endpoints, #42363) it would compose it slightly
+# differently.
+#
+# Nothing here is whitelisted. `get_boot` has already checked the prefix registry and
+# `has_app_permission` before it composes any key, so a second trust boundary inside the
+# resolver would duplicate a check no caller can skip. Desk v1 does the same: `resolve_dock`
+# and `resolve_sidebar` are both unwhitelisted with one caller each.
+
+import json
+
+import frappe
+from frappe.desk.layers import resolve_layers
+
+# What a stored row carries. Read as columns rather than as a document, because `Sidebar`'s
+# document is desk v1's: the class subclasses `DeskViews` and the record holds v1's `items`
+# beside desk v2's `navigation_items`, so a `get_doc` here would put v1's rows one attribute
+# away from the ones we want.
+ITEM_FIELDS = (
+	"key",
+	"parent_key",
+	"item_type",
+	"link_doctype",
+	"link_to",
+	"url",
+	"payload",
+	"label",
+	"icon",
+	"collapsible",
+	"keep_closed",
+	"hidden",
+	"added",
+	"overrides",
+)
+
+# What reaches the browser. `hidden`, `added` and `overrides` are how a layer was *stored*;
+# once the layers are merged they say nothing about the item on screen, and #42232's payload
+# is for rendering.
+WIRE_FIELDS = (
+	"key",
+	"parent_key",
+	"item_type",
+	"link_doctype",
+	"link_to",
+	"url",
+	"payload",
+	"label",
+	"icon",
+	"collapsible",
+	"keep_closed",
+)
+
+# `Rail.SITE_LAYER` and `Sidebar.SITE_LAYER`, which are both the empty string for the same
+# reason: one spelling of "not a person's own layer" has to reach the unique index.
+SITE_LAYER = ""
+
+
+def resolve_navigation(app: str) -> dict:
+	"""The whole navigation payload for one prefix, as the session user sees it.
+
+	`{"rail": [...], "sidebars": {address: [...]}}` — the rail plus *every* sidebar in the
+	prefix, because #42232 decided no rail click may cost a request.
+
+	The sidebars are keyed by their **scrubbed address**, not by the name of any record. A
+	resolved sidebar is the merge of up to three rows with three different names: #42355 names a
+	standard row after its address and hash-names the site and user layers, so no one row's name
+	identifies the sidebar. The address is what all three share, and for a shipped sidebar the
+	scrubbed address is byte-identical to the standard row's name — which is the string a rail
+	item of type `Sidebar` already carries in `link_to`, so the browser still does one dictionary
+	lookup on a value it is holding.
+	"""
+	return {"rail": _resolve_rail(app), "sidebars": _resolve_sidebars(app)}
+
+
+def _resolve_rail(app: str) -> list[dict]:
+	"""One app's rail: its own layer, then the site's, then this user's.
+
+	When the app ships no `Rail` record the base is *derived* from the address table, and it goes
+	through the same merge as any other base rather than short-circuiting past it. That is not a
+	corner case: no app ships a `Rail` record today, so every app takes this path until the
+	walking skeleton (#42233) converts one. Short-circuiting would make the per-user overlay
+	(#42230) work on converted apps only, so whether a person may reorder their own rail would
+	depend on something they cannot see.
+	"""
+	layers = _rail_layers(app)
+	base = layers.pop("standard", None)
+	if base is None:
+		base = _derive_rail(app)
+
+	return _merge(base, [layers.get("site", []), layers.get("user", [])])
+
+
+def _resolve_sidebars(app: str) -> dict[str, list[dict]]:
+	"""Every sidebar this app ships, resolved and keyed by scrubbed address.
+
+	Empty until an app ships rows, and deliberately so: derivation produces a rail and nothing
+	else (#42356). A derived *doctype* sidebar would be saved views, which this map put out of
+	scope, and deriving only *module* sidebars would make the fallback behave differently for a
+	doctype-primary app and a module-primary one — the asymmetry charter point 2 exists to
+	prevent. #42357 confirmed it from the other side: desk v2's one module-contents computation
+	yields doctypes, which is the module *page's* list, and the module page and the module
+	sidebar are two lists on purpose.
+	"""
+	addresses = _sidebar_addresses(app)
+	if not addresses:
+		return {}
+
+	layers = _sidebar_layers(addresses)
+	resolved = {}
+
+	for address in addresses:
+		by_layer = layers.get(address, {})
+		base = by_layer.get("standard", [])
+		items = _merge(base, [by_layer.get("site", []), by_layer.get("user", [])])
+		if items:
+			# An address that resolves to nothing is absent rather than empty. The payload is read
+			# by key, so the two mean the same thing to the browser, and a linked rail item whose
+			# sidebar has no rows renders as an independent one (#42357).
+			resolved[frappe.scrub(f"{address[0]} {address[1]}")] = items
+
+	return resolved
+
+
+def _merge(base: list[dict], layers: list[list[dict]]) -> list[dict]:
+	"""Fold the layers into the base and return what the browser renders.
+
+	The merge itself is `frappe.desk.layers`, imported rather than copied. It is 165 lines that
+	do not import `frappe` at all, and it takes identity and row application as parameters, so
+	desk v2 passes its own `key` and `apply_row` exactly as the dock and the sidebar each pass
+	theirs.
+
+	Hidden items are dropped here. `resolve_layers` returns `(resolved, hidden)` as two values and
+	deliberately leaves the flag unapplied, because the surface decides: desk v1's dock keeps a
+	hidden entry so its manager can list it under Hidden. Desk v2's payload has no manager UI to
+	feed, so shipping a row the client cannot use would spend bytes against the budget boot
+	already manages. Nothing is foreclosed — when the overlay editor lands (#42363) it calls the
+	resolver with the flag kept, which the engine already takes as a parameter.
+	"""
+	resolved, hidden = resolve_layers(
+		base,
+		layers,
+		key=item_key,
+		apply_row=apply_item_row,
+		# An item no layer named survives, after the ones a layer did name. This is the sidebar's
+		# side of that flag rather than the dock's, so an item an app ships later still reaches a
+		# person who has already arranged their rail instead of waiting in a manager that does not
+		# exist yet.
+		#
+		# It is not the whole of #42229's sparse move-list, which asks that a newly-shipped item
+		# land at its *shipped position* rather than after the arranged rows. Today's engine has
+		# no third option between "keep, at the end" and "drop", and with no writer on the branch
+		# the two behave identically. #42363 owns what a drag saves, and that decides whether the
+		# engine needs the position or whether a saved layer names every row anyway.
+		keep_unnamed=True,
+	)
+
+	return [
+		on_the_wire(item)
+		for item in _promote_orphans([item for item in resolved if not hidden.get(item_key(item))])
+	]
+
+
+def item_key(row) -> str | None:
+	"""What identifies a navigation item: its authored, frozen `key` and nothing else.
+
+	#42229 made the key the identity of every row an app ships, in the same sense a `fieldname`
+	is: every site and user edit is filed against it, so changing one is a breaking change. That
+	replaces desk v1's *computed* identity, which the client reimplemented and got wrong —
+	`sidebar_manager.js:167-174` leaves `filters` out of a key the server includes.
+
+	A row with no key names nothing. `Rail.validate_item_keys` only checks the app layer, on
+	purpose, because a layer row is addressed by the base key it names; a row a *layer* added has
+	its key minted when it is written, which is #42363's endpoint. Until that exists, a keyless
+	row is a malformed row and `apply_item_row` drops it rather than merging every keyless row in
+	a layer into one.
+	"""
+	return row.get("key") or None
+
+
+def apply_item_row(row, entry: dict | None) -> dict | None:
+	"""What one layer row does to the item it names.
+
+	Two kinds of row, which #42229 tells apart by a stored flag rather than by inference. An
+	**added** row is the item: it brings something no layer below it holds, and is rendered as it
+	stands. A **delta** row states an opinion about an item already in the list, and `overrides`
+	says which fields that opinion covers.
+
+	`overrides` is an explicit list of fieldnames rather than "whatever is non-blank", and that is
+	the whole point of it: a site clearing a value the app shipped — removing an icon, blanking a
+	label — is not expressible in an empty-means-inherit encoding, and it also makes "did a human
+	author this label" answerable at render time.
+
+	A delta naming an item the list does not hold returns `None` and is skipped. That is #42229's
+	*deltas whose base is gone are left inert*: an app can remove an item without a site's stored
+	arrangement resurrecting it as an unlabelled button, and reinstalling the app restores the
+	layout because the delta was never deleted.
+	"""
+	if not item_key(row):
+		return None
+
+	if row.get("added"):
+		return {field: row.get(field) for field in ITEM_FIELDS}
+
+	if entry is None:
+		return None
+
+	return {**entry, **{field: row.get(field) for field in _overridden(row)}}
+
+
+def _overridden(row) -> list[str]:
+	"""The fieldnames a delta row has an opinion about.
+
+	Stored as JSON on the row. A row whose `overrides` will not parse is treated as having no
+	opinion rather than as having an opinion about everything: the second reading would let one
+	malformed row blank an item's whole presentation, which is a worse failure than a delta that
+	quietly does nothing.
+	"""
+	try:
+		overrides = json.loads(row.get("overrides") or "[]")
+	except (TypeError, ValueError):
+		return []
+
+	if not isinstance(overrides, list):
+		return []
+
+	return [field for field in overrides if field in ITEM_FIELDS]
+
+
+def _promote_orphans(items: list[dict]) -> list[dict]:
+	"""Move an item whose parent is gone up to the top level rather than dropping it.
+
+	`parent_key` is the whole of hierarchy, and its own description already fixes this: a
+	`parent_key` naming a row that is no longer there promotes the child instead of taking it
+	with it, so an app removing a section never silently removes everything under it. It also
+	matches #42230's rule for a user who has reparented into a section the site later withdrew.
+	"""
+	present = {item_key(item) for item in items}
+	return [
+		item if not item.get("parent_key") or item["parent_key"] in present else {**item, "parent_key": None}
+		for item in items
+	]
+
+
+def on_the_wire(item: dict) -> dict:
+	"""One resolved item as the browser gets it: the fields it renders, and only those set.
+
+	Blank fields are omitted rather than sent as `null`. Navigation is the largest thing in a
+	payload #42232 measured at 5,684 B against a 40 KB ceiling, and most fields on most rows are
+	blank — a derived rail row sets four of eleven.
+
+	`payload` is parsed here rather than sent as the string it is stored as, so the type-specific
+	tail is a JSON object on both sides of the wire and no renderer parses it again. A payload
+	that will not parse is dropped and logged: it is authored by whoever shipped the row, so it
+	is a bug in an app rather than something a reader can act on.
+	"""
+	wire = {field: item.get(field) for field in WIRE_FIELDS if item.get(field)}
+
+	if wire.get("payload"):
+		wire["payload"] = _parse_payload(item)
+
+	return {field: value for field, value in wire.items() if value}
+
+
+def _parse_payload(item: dict) -> dict:
+	try:
+		payload = json.loads(item["payload"])
+	except (TypeError, ValueError):
+		payload = None
+
+	if isinstance(payload, dict):
+		return payload
+
+	frappe.log_error(
+		title="Navigation item has an unreadable payload",
+		message=f"{item.get('item_type')} item {item.get('key')!r}: {item.get('payload')!r}",
+	)
+	return {}
+
+
+# The stored layers
+#
+# Every read below is `frappe.get_all`, which does not apply permissions — and that is the point
+# rather than an oversight. Both containers carry a `has_permission` hook that stops one person
+# reading another's layer through the API, and `Rail`'s also withholds the app and site layers
+# from a `Desk User`. Resolution is the server reading those layers *on that person's behalf* to
+# build what they are allowed to see, so applying the hook here would resolve everyone's rail
+# down to their own delta rows over nothing.
+
+
+def _rail_layers(app: str) -> dict[str, list[dict]]:
+	"""One app's three rail layers, by role, in one pair of queries.
+
+	`standard` is absent rather than empty when the app ships no rail, because the two mean
+	different things: an app that ships an empty rail has said something, and an app that ships
+	none has not, and only the second derives a base.
+	"""
+	records = frappe.get_all(
+		"Rail",
+		filters={"app": app, "user": ("in", (SITE_LAYER, frappe.session.user))},
+		fields=["name", "standard", "user"],
+	)
+
+	rows = _rows_by_parent("Rail", "items", [record.name for record in records])
+	layers = {}
+
+	for record in records:
+		layers[_layer_role(record)] = rows.get(record.name, [])
+
+	# `mount_on` is read by nothing here, deliberately. #42364 took the question up and answered
+	# it against the column: a scalar cannot say what an app extending two hosts needs, so `Rail`
+	# gains `extends` and `mount_on` comes off. That is #42398's build, and it merges into this
+	# derived-and-shipped rail rather than replacing it.
+	return layers
+
+
+def _layer_role(record) -> str:
+	if record.standard:
+		return "standard"
+	return "site" if record.user == SITE_LAYER else "user"
+
+
+def _sidebar_addresses(app: str) -> list[tuple[str, str]]:
+	"""The addresses of the sidebars this app ships.
+
+	Read from the standard rows, because an app layer is what makes a sidebar exist: a site or a
+	user delta over an address no app ships is inert under #42229, and a *sidebar* added by a
+	layer is an addition nothing authors yet (#42363).
+
+	`link_doctype` set is the whole test for a desk v2 row. Desk v1's sidebars carry no address
+	and never will, so this one filter separates the two desks with no migration stamping rows.
+	"""
+	return [
+		(record.link_doctype, record.link_to)
+		for record in frappe.get_all(
+			"Sidebar",
+			filters={"app": app, "standard": 1, "link_doctype": ("is", "set")},
+			fields=["link_doctype", "link_to"],
+			order_by="name",
+		)
+		if record.link_to
+	]
+
+
+def _sidebar_layers(addresses: list[tuple[str, str]]) -> dict[tuple[str, str], dict[str, list[dict]]]:
+	"""Every layer of every one of those addresses, in one pair of queries.
+
+	Not one query per sidebar: a modular app has one sidebar per module, so per-address reads
+	would put two queries per module into the blocking pre-mount path (#42070).
+	"""
+	doctypes = {address[0] for address in addresses}
+	records = frappe.get_all(
+		"Sidebar",
+		filters={
+			"link_doctype": ("in", doctypes),
+			"user": ("in", (SITE_LAYER, frappe.session.user)),
+		},
+		fields=["name", "standard", "user", "link_doctype", "link_to"],
+	)
+	records = [record for record in records if (record.link_doctype, record.link_to) in set(addresses)]
+
+	# `navigation_items`, never `items`. One `Sidebar` document holds both tables — desk v1's
+	# rows and desk v2's — so naming the parentfield is what keeps a v2 resolver from silently
+	# rendering v1's sidebar.
+	rows = _rows_by_parent("Sidebar", "navigation_items", [record.name for record in records])
+	layers: dict[tuple[str, str], dict[str, list[dict]]] = {}
+
+	for record in records:
+		address = (record.link_doctype, record.link_to)
+		layers.setdefault(address, {})[_layer_role(record)] = rows.get(record.name, [])
+
+	return layers
+
+
+def _rows_by_parent(parenttype: str, parentfield: str, parents: list[str]) -> dict[str, list[dict]]:
+	if not parents:
+		return {}
+
+	rows: dict[str, list[dict]] = {}
+
+	for row in frappe.get_all(
+		"Navigation Item",
+		filters={"parent": ("in", parents), "parenttype": parenttype, "parentfield": parentfield},
+		fields=["parent", *ITEM_FIELDS],
+		order_by="parent asc, idx asc",
+	):
+		rows.setdefault(row.pop("parent"), []).append(row)
+
+	return rows
+
+
+# Deriving a rail for an app that ships none
+
+
+def _derive_rail(app: str) -> list[dict]:
+	"""An app's rail when it ships no `Rail` record: its own doctypes, permission-filtered.
+
+	This is what `frappe.shell.doctypes` has been serving the rail all along, in the item shape
+	the rest of this module speaks. It is the honest default for an app that has no opinions yet,
+	and it is what keeps five apps' rails from going blank on the day the resolver lands.
+
+	The key is the doctype name. Derived items need a stable one to file deltas against, and the
+	doctype name is already what the address table is keyed on, so it stays stable through a slug
+	change and through the app's eventual conversion to shipped rows.
+
+	No label and no icon, because nobody authored either. A renderer falls back to the destination
+	for a row that carries no label, which is what the rail shows today — so the appearance
+	changes when an app ships rows, not when this lands.
+	"""
+	from .doctypes import get_address_table, get_doctype_owners, get_readable_doctypes
+
+	addressable = get_address_table()["doctypes"]
+	readable = get_readable_doctypes()
+	owners = get_doctype_owners()
+
+	return [
+		{"key": doctype, "item_type": "DocType", "link_doctype": "DocType", "link_to": doctype}
+		for doctype in sorted(owners)
+		if owners[doctype] == app and doctype in addressable and doctype in readable
+	]

--- a/frappe/tests/test_shell.py
+++ b/frappe/tests/test_shell.py
@@ -555,24 +555,24 @@ class TestShellBoot(IntegrationTestCase):
 		# The table takes no prefix and cannot: there is nothing to vary by.
 		self.assertNotIn("app", get_address_table())
 
-	def test_navigation_is_filtered_where_addressing_is_not(self):
+	def test_the_contents_list_is_filtered_where_addressing_is_not(self):
 		"""The other half of the split #42210 made.
 
-		Addressability is full-bench and permission-independent; navigation is per app
-		and permission-filtered. A doctype you cannot read is still addressable — you
+		Addressability is full-bench and permission-independent; an app's contents are
+		per app and permission-filtered. A doctype you cannot read is still addressable — you
 		are refused at the record — it is simply not offered to you.
 		"""
-		from frappe.shell.doctypes import get_address_table, navigation_for_app
+		from frappe.shell.doctypes import get_address_table, contents_for_app
 
 		self.assertIn("User", get_address_table()["doctypes"])
-		self.assertIn("User", {entry["doctype"] for entry in navigation_for_app("frappe")})
+		self.assertIn("User", {entry["doctype"] for entry in contents_for_app("frappe")})
 
 		frappe.set_user("Guest")
 		self.addCleanup(frappe.set_user, "Administrator")
 		# Still addressable...
 		self.assertIn("User", get_address_table()["doctypes"])
 		# ...and not offered.
-		self.assertNotIn("User", {entry["doctype"] for entry in navigation_for_app("frappe")})
+		self.assertNotIn("User", {entry["doctype"] for entry in contents_for_app("frappe")})
 
 	def test_the_slug_table_tracks_doctypes_being_added_and_removed(self):
 		"""A new doctype must be addressable, and a deleted one must stop being so.
@@ -826,7 +826,7 @@ class TestModularAddresses(IntegrationTestCase):
 
 		`has_permission(doctype, "read")` returns True with **no doc passed** when at
 		least one document of that type is shared with the user (`permissions.py:206`).
-		A navigation list built from roles alone hides every doctype a user reaches
+		A contents list built from roles alone hides every doctype a user reaches
 		purely by sharing — invisible on a bench where nobody shares anything, which is
 		why the first version of this shipped wrong.
 
@@ -838,7 +838,7 @@ class TestModularAddresses(IntegrationTestCase):
 		assertion mean something.
 		"""
 		import frappe.share
-		from frappe.shell.doctypes import navigation_for_app
+		from frappe.shell.doctypes import contents_for_app
 
 		email = "shell-share-probe@example.com"
 		if frappe.db.exists("User", email):
@@ -856,7 +856,7 @@ class TestModularAddresses(IntegrationTestCase):
 		self.addCleanup(lambda: frappe.delete_doc("Role", role.name, force=True, ignore_missing=True))
 
 		def offered():
-			return {entry["doctype"] for entry in navigation_for_app("frappe")}
+			return {entry["doctype"] for entry in contents_for_app("frappe")}
 
 		frappe.set_user(email)
 		self.addCleanup(frappe.set_user, "Administrator")
@@ -869,19 +869,19 @@ class TestModularAddresses(IntegrationTestCase):
 		self.assertIn("Role", offered())
 
 	def test_the_module_landing_page_is_permission_filtered(self):
-		"""#42210's line, held exactly: addressability is not filtered, navigation is.
+		"""#42210's line, held exactly: addressability is not filtered, contents are.
 
 		Nobody pastes a module page as a record link, so filtering it changes no
 		address's shape.
 		"""
-		from frappe.shell.doctypes import navigation_for_app
+		from frappe.shell.doctypes import contents_for_app
 
-		self.assertTrue(navigation_for_app("frappe", "core"))
-		self.assertFalse(navigation_for_app("frappe", "no-such-module"))
+		self.assertTrue(contents_for_app("frappe", "core"))
+		self.assertFalse(contents_for_app("frappe", "no-such-module"))
 
 		frappe.set_user("Guest")
 		self.addCleanup(frappe.set_user, "Administrator")
-		self.assertFalse(navigation_for_app("frappe", "core"))
+		self.assertFalse(contents_for_app("frappe", "core"))
 
 
 class TestNoHandBuiltDoctypeUrls(IntegrationTestCase):

--- a/frappe/tests/test_shell.py
+++ b/frappe/tests/test_shell.py
@@ -562,7 +562,7 @@ class TestShellBoot(IntegrationTestCase):
 		per app and permission-filtered. A doctype you cannot read is still addressable — you
 		are refused at the record — it is simply not offered to you.
 		"""
-		from frappe.shell.doctypes import get_address_table, contents_for_app
+		from frappe.shell.doctypes import contents_for_app, get_address_table
 
 		self.assertIn("User", get_address_table()["doctypes"])
 		self.assertIn("User", {entry["doctype"] for entry in contents_for_app("frappe")})

--- a/frappe/tests/test_shell_navigation.py
+++ b/frappe/tests/test_shell_navigation.py
@@ -1,0 +1,421 @@
+# Copyright (c) 2026, Frappe Technologies and Contributors
+# License: MIT. See LICENSE
+
+"""The desk v2 navigation resolver: `frappe/shell/navigation.py`.
+
+Every test here is about the merge and the payload, not about anyone's real navigation, so
+which app the layers belong to does not matter. They belong to `frappe` because it is
+certainly installed wherever this runs.
+"""
+
+import contextlib
+import json
+from unittest.mock import patch
+
+import frappe
+from frappe.shell.navigation import resolve_navigation
+from frappe.tests import IntegrationTestCase
+from frappe.tests.classes.context_managers import set_user
+from frappe.utils import set_request
+
+APP = "frappe"
+
+# The address of the sidebar these tests ship. `Core` is a module on every site, and the
+# name its address produces is `module_def_core` — which is both the standard record's name
+# and the key the payload uses, and the test below is that those two agree by construction
+# rather than by luck.
+ADDRESS = ("Module Def", "Core")
+ADDRESS_KEY = "module_def_core"
+
+
+@contextlib.contextmanager
+def shipping():
+	"""Place app content on the site the way an install does.
+
+	Developer mode, because `Sidebar.validate_standard` refuses a standard row it could not
+	write a file for, and it asks that question outright rather than through the flags. And
+	`in_import`, which is what makes both `export_rail` and `export_sidebar` return early --
+	otherwise the fixture writes a JSON file into the working tree, where the database
+	rollback cannot reach it.
+	"""
+	developer_mode = frappe.conf.get("developer_mode")
+	frappe.conf.developer_mode = 1
+	frappe.flags.in_import = True
+	try:
+		yield
+	finally:
+		frappe.flags.in_import = False
+		frappe.conf.developer_mode = developer_mode
+
+
+class NavigationTestCase(IntegrationTestCase):
+	"""Roll the database back after every test, not after the class.
+
+	`IntegrationTestCase` rolls back once the whole class has run, which is enough for tests
+	that read. These write layers, and a standard `Rail` is named after its app -- so a
+	second test in the same class would collide on the primary key instead of starting from
+	a site with no rails, which is the state every one of them assumes.
+	"""
+
+	def setUp(self):
+		super().setUp()
+		frappe.db.savepoint("navigation_test")
+		self.addCleanup(lambda: frappe.db.rollback(save_point="navigation_test"))
+
+
+def item(key: str, **kwargs) -> dict:
+	return {"doctype": "Navigation Item", "item_type": "DocType", "key": key, **kwargs}
+
+
+def doctype_item(key: str, doctype: str, **kwargs) -> dict:
+	return item(key, link_doctype="DocType", link_to=doctype, **kwargs)
+
+
+def make_rail(items: list[dict], *, standard: int = 0, user: str | None = None):
+	doc = frappe.get_doc(doctype="Rail", app=APP, standard=standard, user=user or "", items=items)
+	with shipping():
+		return doc.insert(ignore_permissions=True)
+
+
+def make_sidebar(items: list[dict], *, standard: int = 0, user: str | None = None, **kwargs):
+	doc = frappe.get_doc(
+		doctype="Sidebar",
+		app=APP,
+		standard=standard,
+		user=user or "",
+		link_doctype=kwargs.pop("link_doctype", ADDRESS[0]),
+		link_to=kwargs.pop("link_to", ADDRESS[1]),
+		navigation_items=items,
+		**kwargs,
+	)
+	with shipping():
+		return doc.insert(ignore_permissions=True)
+
+
+def keys(items: list[dict]) -> list[str]:
+	return [entry["key"] for entry in items]
+
+
+class TestDerivedRail(NavigationTestCase):
+	"""An app that ships no `Rail` record still gets one.
+
+	Not a corner case: no app on the branch ships a `Rail` record, so this is the path every
+	app takes until the walking skeleton converts one. Without it, landing the resolver
+	would have blanked five apps' rails at once.
+	"""
+
+	def test_an_app_with_no_rail_gets_its_own_doctypes(self):
+		rail = resolve_navigation(APP)["rail"]
+
+		self.assertTrue(rail)
+		self.assertTrue(all(entry["item_type"] == "DocType" for entry in rail))
+		self.assertIn("User", keys(rail))
+
+	def test_a_derived_item_is_keyed_on_the_doctype_name(self):
+		"""The key is what a delta is filed against, so it has to survive a slug change and
+		the app's eventual conversion to shipped rows. The doctype name is already what the
+		address table is keyed on."""
+		entry = next(entry for entry in resolve_navigation(APP)["rail"] if entry["key"] == "User")
+
+		self.assertEqual(entry["link_to"], "User")
+		self.assertEqual(entry["link_doctype"], "DocType")
+
+	def test_a_derived_item_carries_no_label(self):
+		"""Nobody authored one. A renderer falls back to the destination, which is what the
+		rail showed before this landed — so the appearance changes when an app ships rows,
+		not when the resolver does."""
+		entry = next(entry for entry in resolve_navigation(APP)["rail"] if entry["key"] == "User")
+
+		self.assertNotIn("label", entry)
+		self.assertNotIn("icon", entry)
+
+	def test_a_derived_rail_is_permission_filtered(self):
+		with set_user("Guest"):
+			self.assertNotIn("User", keys(resolve_navigation(APP)["rail"]))
+
+	def test_derivation_produces_a_rail_and_no_sidebars(self):
+		"""A derived doctype sidebar would be saved views, which are out of this map's
+		scope, and deriving only module sidebars would make the fallback behave differently
+		for a doctype-primary app and a module-primary one."""
+		self.assertEqual(resolve_navigation(APP)["sidebars"], {})
+
+	def test_a_derived_rail_goes_through_the_merge(self):
+		"""The decision with the widest blast radius: derivation synthesizes a base layer and
+		passes it through `resolve_layers` rather than short-circuiting.
+
+		Under a short-circuit an unconverted app's rail could not be reordered or hidden by
+		anyone, so the whole per-user overlay would apply to converted apps only — and
+		whether a person may arrange their own rail would depend on their app's conversion
+		status rather than on anything they can see.
+		"""
+		make_rail([item("User", added=1, link_to="User", label="Everyone")], user=frappe.session.user)
+
+		entry = next(entry for entry in resolve_navigation(APP)["rail"] if entry["key"] == "User")
+		self.assertEqual(entry["label"], "Everyone")
+
+
+class TestShippedRail(NavigationTestCase):
+	def test_a_shipped_rail_replaces_derivation(self):
+		make_rail([doctype_item("user", "User", label="People")], standard=1)
+
+		rail = resolve_navigation(APP)["rail"]
+		self.assertEqual(keys(rail), ["user"])
+		self.assertEqual(rail[0]["label"], "People")
+
+	def test_an_app_that_ships_an_empty_rail_gets_an_empty_rail(self):
+		"""Shipping no rail and shipping an empty one are different statements, and only the
+		first derives a base."""
+		make_rail([], standard=1)
+
+		self.assertEqual(resolve_navigation(APP)["rail"], [])
+
+	def test_the_site_layer_then_the_users(self):
+		make_rail(
+			[doctype_item("user", "User"), doctype_item("role", "Role")],
+			standard=1,
+		)
+		make_rail([item("role"), item("user")])
+		self.assertEqual(keys(resolve_navigation(APP)["rail"]), ["role", "user"])
+
+		make_rail([item("user"), item("role")], user=frappe.session.user)
+		self.assertEqual(keys(resolve_navigation(APP)["rail"]), ["user", "role"])
+
+	def test_a_hidden_item_never_reaches_the_payload(self):
+		"""`resolve_layers` returns the hidden map unapplied because the surface decides.
+		Desk v2's payload is for rendering and has no manager UI, so a row the client cannot
+		use would be bytes spent against boot's budget."""
+		make_rail([doctype_item("user", "User"), doctype_item("role", "Role")], standard=1)
+		make_rail([item("role", hidden=1)])
+
+		self.assertEqual(keys(resolve_navigation(APP)["rail"]), ["user"])
+
+	def test_a_user_can_unhide_what_the_site_hid(self):
+		"""Which is why hiding is resolved across every layer before anything acts on it: a
+		user's `hidden: 0` has to find the item the site hid still in the list."""
+		make_rail([doctype_item("user", "User"), doctype_item("role", "Role")], standard=1)
+		make_rail([item("role", hidden=1)])
+		make_rail([item("role", hidden=0)], user=frappe.session.user)
+
+		self.assertIn("role", keys(resolve_navigation(APP)["rail"]))
+
+	def test_a_delta_naming_an_item_the_app_removed_is_inert(self):
+		"""#42229: a delta whose base is gone is left inert rather than deleted, so
+		reinstalling an app restores the layout. What it must not do is reappear as an
+		unlabelled button, since a delta need carry no label at all."""
+		make_rail([doctype_item("user", "User")], standard=1)
+		make_rail([item("gone"), item("user")])
+
+		self.assertEqual(keys(resolve_navigation(APP)["rail"]), ["user"])
+
+	def test_a_layer_added_row_is_the_item(self):
+		make_rail([doctype_item("user", "User")], standard=1)
+		make_rail([item("note", added=1, link_to="Note", label="Notes")])
+
+		rail = resolve_navigation(APP)["rail"]
+		self.assertIn("note", keys(rail))
+		self.assertEqual(next(e for e in rail if e["key"] == "note")["label"], "Notes")
+
+	def test_a_row_with_no_key_names_nothing(self):
+		"""Until the write endpoints mint one, a keyless layer row is malformed. Merging
+		every keyless row under one key would let two of them silently become one."""
+		make_rail([doctype_item("user", "User")], standard=1)
+		make_rail([item(None, added=1, link_to="Note", label="Notes")])
+
+		self.assertEqual(keys(resolve_navigation(APP)["rail"]), ["user"])
+
+
+class TestOverrides(NavigationTestCase):
+	"""`overrides` names the fields a delta has an opinion about, explicitly.
+
+	The whole reason it is a list rather than "whatever is non-blank" is that a site
+	clearing a value the app shipped — removing an icon, blanking a label — cannot be said
+	in an empty-means-inherit encoding.
+	"""
+
+	def setUp(self):
+		super().setUp()
+		make_rail(
+			[doctype_item("user", "User", label="People", icon="user")],
+			standard=1,
+		)
+
+	def resolved(self) -> dict:
+		return next(e for e in resolve_navigation(APP)["rail"] if e["key"] == "user")
+
+	def test_only_the_named_fields_are_overridden(self):
+		make_rail([item("user", label="Staff", icon="crown", overrides=json.dumps(["label"]))])
+
+		entry = self.resolved()
+		self.assertEqual(entry["label"], "Staff")
+		self.assertEqual(entry["icon"], "user")
+
+	def test_a_named_field_can_be_blanked(self):
+		make_rail([item("user", icon="", overrides=json.dumps(["icon"]))])
+
+		self.assertNotIn("icon", self.resolved())
+
+	def test_a_row_that_names_nothing_changes_nothing(self):
+		make_rail([item("user", label="Staff")])
+
+		self.assertEqual(self.resolved()["label"], "People")
+
+	def test_an_unreadable_overrides_list_is_read_as_no_opinion(self):
+		"""Rather than as an opinion about everything, which would let one malformed row
+		blank an item's whole presentation."""
+		make_rail([item("user", label="Staff", overrides="not json")])
+
+		self.assertEqual(self.resolved()["label"], "People")
+
+
+class TestTheWire(NavigationTestCase):
+	def test_the_stored_flags_do_not_travel(self):
+		"""`hidden`, `added` and `overrides` say how a layer was stored. Once the layers are
+		merged they say nothing about the item on screen."""
+		make_rail([doctype_item("user", "User")], standard=1)
+		make_rail([item("user", added=0, overrides="[]")])
+
+		entry = next(e for e in resolve_navigation(APP)["rail"] if e["key"] == "user")
+		for field in ("hidden", "added", "overrides"):
+			self.assertNotIn(field, entry)
+
+	def test_a_blank_field_is_omitted_rather_than_sent_as_null(self):
+		make_rail([doctype_item("user", "User")], standard=1)
+
+		entry = next(e for e in resolve_navigation(APP)["rail"] if e["key"] == "user")
+		self.assertEqual(set(entry), {"key", "item_type", "link_doctype", "link_to"})
+
+	def test_a_payload_arrives_parsed(self):
+		"""So the type-specific tail is an object on both sides of the wire and no renderer
+		parses it a second time."""
+		make_rail([doctype_item("user", "User", payload=json.dumps({"open_in_new_tab": 1}))], standard=1)
+
+		entry = next(e for e in resolve_navigation(APP)["rail"] if e["key"] == "user")
+		self.assertEqual(entry["payload"], {"open_in_new_tab": 1})
+
+	def test_an_unreadable_payload_is_dropped_and_logged(self):
+		make_rail([doctype_item("user", "User", payload="{not json")], standard=1)
+
+		with patch("frappe.log_error") as log_error:
+			entry = next(e for e in resolve_navigation(APP)["rail"] if e["key"] == "user")
+
+		self.assertNotIn("payload", entry)
+		self.assertTrue(log_error.called)
+
+	def test_an_item_whose_parent_is_gone_is_promoted(self):
+		"""A `parent_key` naming a row that is no longer there promotes the child rather than
+		taking it with it, so an app removing a section never silently removes everything
+		under it."""
+		make_rail([doctype_item("user", "User", parent_key="people")], standard=1)
+
+		entry = next(e for e in resolve_navigation(APP)["rail"] if e["key"] == "user")
+		self.assertNotIn("parent_key", entry)
+
+	def test_a_parent_that_is_present_is_kept(self):
+		make_rail(
+			[
+				item("people", item_type="Section", label="People"),
+				doctype_item("user", "User", parent_key="people"),
+			],
+			standard=1,
+		)
+
+		entry = next(e for e in resolve_navigation(APP)["rail"] if e["key"] == "user")
+		self.assertEqual(entry["parent_key"], "people")
+
+
+class TestSidebars(NavigationTestCase):
+	def test_a_sidebar_is_keyed_by_its_scrubbed_address(self):
+		"""Not by the name of any record. A resolved sidebar merges up to three rows with
+		three different names, since a standard row is named after its address and the site
+		and user layers are hash-named. The address is what all three share — and it is the
+		string a rail item of type `Sidebar` already carries in `link_to`.
+		"""
+		shipped = make_sidebar([doctype_item("user", "User")], standard=1)
+		mine = make_sidebar(
+			[item("user", label="Me", overrides=json.dumps(["label"]))], user=frappe.session.user
+		)
+
+		sidebars = resolve_navigation(APP)["sidebars"]
+
+		# The standard record's own name agrees with the key by construction...
+		self.assertEqual(shipped.name, ADDRESS_KEY)
+		# ...and the user's layer, which is hash-named, still merges into it.
+		self.assertNotEqual(mine.name, ADDRESS_KEY)
+		self.assertEqual(sidebars[ADDRESS_KEY][0]["label"], "Me")
+
+	def test_a_v2_resolver_never_reads_v1s_rows(self):
+		"""One `Sidebar` document holds desk v1's `items` beside desk v2's
+		`navigation_items`, so a resolver reading the document rather than the child table it
+		wants gets v1's sidebar. This is the live hazard that read-by-column exists for."""
+		sidebar = make_sidebar([doctype_item("user", "User")], standard=1)
+		with shipping():
+			sidebar.append("items", {"type": "Link", "label": "A desk v1 row", "link_type": "DocType"})
+			sidebar.save(ignore_permissions=True)
+
+		items = resolve_navigation(APP)["sidebars"][ADDRESS_KEY]
+		self.assertEqual(keys(items), ["user"])
+
+	def test_an_address_that_resolves_to_nothing_is_absent(self):
+		"""The payload is read by key, so an absent key and an empty list mean the same thing
+		— and a linked rail item whose sidebar has no rows renders as an independent one."""
+		make_sidebar([], standard=1)
+
+		self.assertNotIn(ADDRESS_KEY, resolve_navigation(APP)["sidebars"])
+
+	def test_a_sidebar_nobody_ships_is_not_resolved(self):
+		"""An app layer is what makes a sidebar exist. A site delta over an address no app
+		ships is inert, the same rule as a delta over an item the app removed."""
+		make_sidebar([item("user", added=1, link_to="User")])
+
+		self.assertEqual(resolve_navigation(APP)["sidebars"], {})
+
+	def test_desk_v1s_own_sidebars_are_not_in_the_payload(self):
+		"""They carry no address, and never will. That one column separates the two desks
+		with no migration having to stamp the rows."""
+		make_sidebar([doctype_item("user", "User")], standard=1)
+
+		self.assertEqual(list(resolve_navigation(APP)["sidebars"]), [ADDRESS_KEY])
+
+
+class TestNavigationInBoot(NavigationTestCase):
+	def setUp(self):
+		super().setUp()
+		frappe.set_user("Administrator")
+		set_request(method="GET", path="/apps/desk")
+
+	def tearDown(self):
+		if hasattr(frappe.local, "request"):
+			delattr(frappe.local, "request")
+
+	def test_boot_carries_the_resolved_navigation(self):
+		from frappe.shell.boot import get_boot
+
+		boot = get_boot("/apps/desk")
+
+		self.assertIn("navigation", boot)
+		self.assertIn("User", keys(boot["navigation"]["rail"]))
+		self.assertEqual(boot["navigation"]["sidebars"], {})
+
+	def test_the_index_has_no_navigation(self):
+		"""It belongs to no app, so there is no prefix whose navigation it could carry."""
+		from frappe.shell.boot import get_boot
+
+		self.assertNotIn("navigation", get_boot("/apps"))
+
+	def test_navigation_is_a_framework_key_a_contribution_cannot_overwrite(self):
+		"""Apps shape navigation through the rows and item types they ship. A code-level
+		second route in would be two mechanisms for one thing."""
+		from frappe.shell.boot import get_boot
+
+		with patch("frappe.shell.boot.app_boot", return_value={"navigation": "mine"}):
+			boot = get_boot("/apps/desk")
+
+		self.assertIsInstance(boot["navigation"], dict)
+
+	def test_boot_stays_under_the_ceiling_with_navigation_in_it(self):
+		"""The framework's own prefix is the biggest one, and Administrator is the worst
+		case: every doctype on the site is readable, so the derived rail is as long as it
+		can get."""
+		from frappe.shell.boot import get_boot
+
+		self.assertLess(len(json.dumps(get_boot("/apps/desk"), default=str)), 40_000)

--- a/frontend/CONTEXT.md
+++ b/frontend/CONTEXT.md
@@ -49,6 +49,14 @@ A new, small per-prefix payload — deliberately *not* `frappe.sessions.get()`. 
 (the keys every prefix gets) plus app boot (the declaring app's contribution, merged
 under core). `location.pathname` is its only input; the document carries nothing.
 
+**`boot.navigation`**:
+This prefix's rail and *every* sidebar in it, already resolved: the app's rows, the site's
+arrangement and this person's, merged server-side. The browser never restacks those layers.
+It rides boot so that no rail click costs a request; what an app *contains* is a different
+list and is still fetched by the pages that show it (`contents.ts`).
+_Avoid_: navigation as a word for an app's contents — the rail is authored, the contents
+list is derived, and the two disagree on purpose.
+
 **`app_order`**:
 The site's ordered array of **active** apps, used to order contributions. Deliberately not
 `installed_apps` — that name is taken client-side for a permission-filtered list, and only
@@ -70,7 +78,10 @@ The shell-owned navigation strip that never disappears, and the `Rail` doctype b
 one record per app per layer. Its contents are **declared rows**, not derived doctypes, and
 they are not limited to doctypes — a rail item may be a doctype, a module, a page, a record,
 a link or a section. Permission filters that declaration; it does not produce it. A rail item
-is *independent* or *linked*, and it is linked exactly when it opens a sidebar.
+is *independent* or *linked*, and it is linked exactly when it opens a sidebar. An app that
+ships **no** `Rail` record still gets a rail, derived from its own doctypes and permission-
+filtered — which is every app until one converts, and it goes through the same layer merge
+as a declared one, so a person can arrange a derived rail too.
 _Avoid_: dock (that is desk v1's, and a live doctype of its own).
 
 **Sidebar**:

--- a/frontend/src/boot.ts
+++ b/frontend/src/boot.ts
@@ -4,6 +4,47 @@
 // furniture. That is why CRM and Gameplan each rebuilt the generic keys by hand. This
 // one starts small; v1's is left untouched and retires with v1.
 
+/**
+ * One resolved navigation item, on the rail or in a sidebar. The SAME shape in both:
+ * they are two presentations of one model, not two models (charter point 1).
+ *
+ * Everything but `key` and `item_type` is optional because the server omits a blank
+ * field rather than sending `null` — navigation is the largest thing in a payload with
+ * a 40 KB ceiling, and most fields on most rows are blank.
+ *
+ * `item_type` decides what the item does; the client does not branch on it beyond
+ * picking a renderer (#42228). An item with no `label` was never labelled by anyone, so
+ * a renderer falls back to its destination.
+ */
+export type NavigationItem = {
+	key: string;
+	item_type: string;
+	parent_key?: string;
+	link_doctype?: string;
+	link_to?: string;
+	url?: string;
+	payload?: Record<string, unknown>;
+	label?: string;
+	icon?: string;
+	collapsible?: 1;
+	keep_closed?: 1;
+};
+
+export type Navigation = {
+	rail: NavigationItem[];
+	/**
+	 * Every sidebar in this prefix, keyed by SCRUBBED ADDRESS — `module_def_accounts`,
+	 * not a record name. A resolved sidebar is the merge of up to three records with
+	 * three different names, so no one name identifies it; the address is what they
+	 * share. A rail item of type `Sidebar` already carries that string in `link_to`, so
+	 * opening one is a dictionary lookup on a value the item is holding (#42356).
+	 *
+	 * An address that resolved to nothing is absent rather than empty, and a linked rail
+	 * item whose sidebar is absent renders as an independent one (#42357).
+	 */
+	sidebars: Record<string, NavigationItem[]>;
+};
+
 export type Boot = {
 	// --- framework core ---
 	frappe_version: string;
@@ -36,6 +77,18 @@ export type Boot = {
 	// not in here -- it went full-bench when the prefix became a lens and broke the
 	// 40 KB budget (#42210). Same treatment as `translations_version`.
 	metadata_version: string;
+
+	// --- navigation ---
+	//
+	// The rail and every sidebar in this prefix, already resolved: the app's own rows,
+	// then the site's arrangement, then this person's, merged server-side. The browser
+	// never restacks those layers and never re-filters the list (#42232).
+	//
+	// It is here rather than fetched because a rail click must cost no request. What an
+	// app CONTAINS is still fetched, by the pages that show it -- see `contents.ts`.
+	//
+	// Absent on the index, which belongs to no app.
+	navigation?: Navigation;
 
 	// Present on the index only (#42124).
 	apps?: {

--- a/frontend/src/contents.ts
+++ b/frontend/src/contents.ts
@@ -1,24 +1,24 @@
-// NAVIGATION -- what an app's chrome offers you. Deliberately a different list from
-// the address table beside it.
+// CONTENTS -- what an app CONTAINS. Deliberately a different list from the address
+// table beside it, and a different list from the rail.
 //
 // #42210 split what `boot.doctype_slugs` conflated. ADDRESSABILITY is full-bench and
 // permission-independent: two colleagues must resolve a pasted URL identically, so
-// the address space cannot change shape per user. NAVIGATION is per app and
+// the address space cannot change shape per user. CONTENTS are per app and
 // permission-filtered: a doctype you cannot read is still addressable -- you are
 // refused at the record by ordinary permissions -- it is simply not offered to you.
 //
-// The rail derived from the address space before this, and its "permission, not
-// declaration" comment was already false. It is true now.
-//
-// What this is NOT is the navigation MODEL. #42211 §8 retired `Navigation Section`
-// without naming a replacement; a single item kind used in both rail and sidebar is
-// the direction, and it is a data model rather than a decision, so it is not this
-// ticket's. This is the smallest honest thing that keeps the chrome rendering now
-// that the table it read has moved: the owning app's doctypes, filtered.
+// The rail read this until #42357, and no longer does. The rail is AUTHORED
+// navigation, resolved server-side and delivered in boot, because a rail click must
+// not cost a request. This list is DERIVED, and it is fetched by the two pages that
+// show it -- the app home and a module page -- because arriving somewhere and paying
+// one request for what is there is ordinary. The two lists disagree on purpose:
+// measured across ERPNext, 107 doctypes sit on a module page and not in that module's
+// sidebar, while 101 sidebar links point outside their module. The page answers what
+// does this contain; the rail answers what do you do here.
 
 import { ref, watchEffect, type Ref } from "vue";
 
-export type NavigationEntry = { doctype: string; slug: string; module: string };
+export type ContentEntry = { doctype: string; slug: string; module: string };
 
 /**
  * THROWS rather than answering empty. A swallowed failure is indistinguishable from
@@ -26,33 +26,33 @@ export type NavigationEntry = { doctype: string; slug: string; module: string };
  * confident, false "0 doctypes you can read" over a request that never landed, and an
  * empty rail that looks like an empty app.
  */
-export async function fetchNavigation(
+export async function fetchContents(
 	app: string,
 	module?: string
-): Promise<NavigationEntry[]> {
+): Promise<ContentEntry[]> {
 	const params = new URLSearchParams({ app });
 	if (module) params.set("module", module);
 
 	const res = await fetch(
-		`/api/method/frappe.shell.doctypes.get_navigation?${params}`
+		`/api/method/frappe.shell.doctypes.get_contents?${params}`
 	);
-	if (!res.ok) throw new Error(`Navigation failed with ${res.status}`);
+	if (!res.ok) throw new Error(`Contents failed with ${res.status}`);
 	return (await res.json()).message ?? [];
 }
 
 /**
- * Reactive navigation for a prefix, optionally narrowed to one module.
+ * Reactive contents for a prefix, optionally narrowed to one module.
  *
  * `loading` and `failed` are not decoration. An empty list is a REAL answer here — a
  * module you can read nothing in — so a caller that cannot tell "none" from "not yet"
  * or from "the request failed" has to assert one of them, and "0 doctypes you can
  * read" is a false statement to put under either.
  */
-export function useNavigation(
+export function useContents(
 	app: string | null,
 	module?: Ref<string | undefined>
 ) {
-	const entries = ref<NavigationEntry[]>([]);
+	const entries = ref<ContentEntry[]>([]);
 	const loading = ref(false);
 	const failed = ref(false);
 
@@ -82,7 +82,7 @@ export function useNavigation(
 		// Reading it after the await would register no dependency and the list would
 		// never update again.
 		try {
-			const fetched = await fetchNavigation(app, module?.value);
+			const fetched = await fetchContents(app, module?.value);
 			if (mine !== generation) return;
 			entries.value = fetched;
 		} catch {

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -74,13 +74,13 @@ import { RouterLink } from "vue-router";
 import type { Boot } from "@/boot";
 import type { Addresses } from "@/addresses";
 import { routeFor, routeForModule, isModular } from "@/router/routeFor";
-import { useNavigation } from "@/navigation";
+import { useContents } from "@/contents";
 
 const boot = inject<Boot>("boot")!;
 const addresses = inject<Addresses>("addresses")!;
 
 const modular = computed(() => isModular(boot));
-const { entries, failed } = useNavigation(boot.app);
+const { entries, failed } = useContents(boot.app);
 
 // The modules a user can reach, derived from what they can read rather than from the
 // module list -- an empty module is a tile that leads nowhere.

--- a/frontend/src/pages/Module.vue
+++ b/frontend/src/pages/Module.vue
@@ -42,14 +42,14 @@ import { RouterLink, useRoute } from "vue-router";
 import type { Boot } from "@/boot";
 import type { Addresses } from "@/addresses";
 import { routeFor } from "@/router/routeFor";
-import { useNavigation } from "@/navigation";
+import { useContents } from "@/contents";
 
 const boot = inject<Boot>("boot")!;
 const addresses = inject<Addresses>("addresses")!;
 const route = useRoute();
 
 const moduleSlug = computed(() => String(route.params.module ?? ""));
-const { entries, loading, failed } = useNavigation(boot.app, moduleSlug);
+const { entries, loading, failed } = useContents(boot.app, moduleSlug);
 // The slug is the address; the name is what a human reads. The server sends both, so
 // neither side has to guess the other.
 const title = computed(() => addresses.moduleName(moduleSlug.value) ?? moduleSlug.value);

--- a/frontend/src/public.ts
+++ b/frontend/src/public.ts
@@ -19,4 +19,4 @@ export {
 	urlFor,
 	type RouteOptions,
 } from "@/router/routeFor";
-export type { NavigationEntry } from "@/navigation";
+export type { ContentEntry } from "@/contents";

--- a/frontend/src/shell/AppRail.vue
+++ b/frontend/src/shell/AppRail.vue
@@ -1,17 +1,25 @@
 <!--
   The rail. Shell-owned, and it never disappears.
 
-  It shows the doctypes of the app serving this prefix that the user can READ --
-  permission, not declaration. A per-app `rail_doctypes` hook was rejected as strictly
-  narrower than what already exists, moving a runtime user choice to a build-time
-  author guess (#42102).
+  It renders `boot.navigation.rail` — the app's own rows, the site's arrangement and
+  this person's, already merged by the server (#42232). The browser never restacks
+  those layers and holds no permission logic: an item that reached this list is one
+  this person may be offered.
 
-  It used to derive that list from `boot.doctype_slugs`, which was the ADDRESS space,
-  so the comment above was false: it listed what was addressable, unfiltered. The
-  address table is full-bench since #42210 -- 553 doctypes -- so deriving a rail from
-  it is no longer merely wrong, it is unusable. It now reads `get_navigation`, which
-  is per-app and filtered. See `navigation.ts` for what this is still NOT: the
-  navigation model itself, which #42211 left unnamed.
+  Two data sources have gone before this one. It first derived from
+  `boot.doctype_slugs`, which was the ADDRESS space, so "permission, not declaration"
+  was false — it listed what was addressable, unfiltered. It then fetched the endpoint
+  now called `get_contents`, which was per-app and filtered, and made the claim true.
+  It is in boot for a reason neither of those had: a rail click must cost no request,
+  which a fetched rail cannot promise. What an app CONTAINS is still fetched, by the app home
+  and the module page that show it (`contents.ts`, #42357).
+
+  There is no "could not load" state left. Navigation arrives with boot, and a boot
+  that fails never mounts a shell for this to render in.
+
+  An app that ships no rail rows still gets a rail: its own doctypes, permission-
+  filtered, exactly the list this showed before. So the rail's appearance changes when
+  an app ships rows and not when this lands (#42356).
 -->
 <template>
 	<nav class="flex w-52 shrink-0 flex-col gap-1 border-r border-outline-gray-2 p-2">
@@ -23,18 +31,15 @@
 		</RouterLink>
 
 		<div class="mt-2 overflow-y-auto">
-			<!-- An empty rail and a rail that failed to load look identical, and one of
-					 them is a lie about the app. -->
-			<p v-if="failed" class="px-2 py-1 text-sm text-ink-gray-5">
-				Could not load navigation.
-			</p>
 			<RouterLink
-				v-for="entry in entries"
-				:key="entry.doctype"
-				:to="routeFor(entry.doctype)"
+				v-for="item in doctypeItems"
+				:key="item.key"
+				:to="routeFor(item.link_to!)"
 				class="block truncate rounded px-2 py-1 text-sm text-ink-gray-7 hover:bg-surface-gray-2"
 			>
-				{{ entry.doctype }}
+				<!-- An item nobody labelled falls back to its destination, which is what a
+						 derived rail row is: an address and no authored presentation. -->
+				{{ item.label ?? item.link_to }}
 			</RouterLink>
 		</div>
 
@@ -48,12 +53,21 @@
 </template>
 
 <script setup lang="ts">
-import { inject } from "vue";
+import { computed, inject } from "vue";
 import { RouterLink } from "vue-router";
 import type { Boot } from "@/boot";
 import { routeFor } from "@/router/routeFor";
-import { useNavigation } from "@/navigation";
 
 const boot = inject<Boot>("boot")!;
-const { entries, failed } = useNavigation(boot.app);
+
+// `DocType` only, for now. A kind is two files — a type record and the JS that says
+// what an item of that kind does on click (#42228) — and none of the other seven kinds
+// has its half yet, so a row of one is a row this cannot render. Skipping it is what
+// #42228 chose for a missing renderer, and no app ships such a row today: every rail on
+// the branch is derived, and derivation produces `DocType` items and nothing else.
+// Renderers, and a rail that draws sections and opens sidebars, are the walking
+// skeleton's (#42233).
+const doctypeItems = computed(() =>
+	(boot.navigation?.rail ?? []).filter((item) => item.item_type === "DocType" && item.link_to)
+);
 </script>


### PR DESCRIPTION
Builds what [Where does desk v2 resolve navigation layers, and what calls it?](https://github.com/frappe/frappe/issues/42356) decided, amended by [The module page and the module sidebar: one list or two?](https://github.com/frappe/frappe/issues/42357). Ticket: [Author frappe/shell/navigation.py and put navigation in boot](https://github.com/frappe/frappe/issues/42362).

## What this does

**New `frappe/shell/navigation.py`** — one unwhitelisted `resolve_navigation(app)` returning `{"rail": [...], "sidebars": {...}}`, called only from `frappe/shell/boot.py`, which gains `navigation` as a framework key merged with the other framework keys after the contributed ones.

Resolution spans both containers, so it belongs to neither controller. `Sidebar`'s class is `Sidebar(Document, DeskViews)` — `DeskViews` is desk v1's boot builder — so hanging desk v2's resolution off it would couple the new path to the old one on its first day. `frappe/desk/layers.py` is imported rather than copied; it takes identity and row application as parameters and never names a doctype, so desk v2 passes its own `key` and `apply_row` exactly as the dock and the sidebar each pass theirs.

Points worth reviewing:

- **An app with no `Rail` record still gets a rail**, derived from the address table exactly as before, and it goes through `resolve_layers` like any other base rather than short-circuiting. No app ships a `Rail` record, so every app takes this path until the walking skeleton converts one; a short-circuit would have made the per-user overlay apply to converted apps only.
- **Derivation produces a rail only.** `sidebars` is empty until an app ships rows.
- **Sidebars are keyed by scrubbed address**, not by a record name: a resolved sidebar merges up to three rows with three different names, since a standard row is named after its address and the site and user layers are hash-named. For a shipped sidebar that key is byte-identical to the standard row's name, which is the string a rail item of type `Sidebar` already carries in `link_to`.
- **`Sidebar`'s child rows are read with `frappe.get_all` on the `navigation_items` parentfield, never through `get_doc`** — one document holds v1's `items` beside v2's rows, so a document read would silently get v1's sidebar. There is a test for exactly that.
- **Hidden items drop before boot.** `resolve_layers` returns `(resolved, hidden)` and deliberately leaves the flag unapplied because the surface decides; desk v2's payload is for rendering and has no manager UI to feed.
- **The 3,594 ms vs 25 ms comment moves with the technique**, into a `get_readable_doctypes()` helper both filters now call, rather than being copied into a second place.
- **`mount_on` stays inert**, with a comment. It comes off the doctype in #42398.

## What changes for a reader

The rail's data source, not the rail. `AppRail.vue` now renders `boot.navigation.rail` instead of fetching. Because every rail is derived today and a derived item carries no authored label, the rail looks exactly the same as before — the appearance changes when an app ships rows, not here.

`get_navigation` does not die, which is where this departs from #42356's decision 11: #42357 reversed that half. A module page is a destination and paying one request on arrival is ordinary, where a rail click must cost none. So the endpoint loses its rail caller and is renamed `contents_for_app` / `get_contents` (`navigation.ts` → `contents.ts`, `NavigationEntry` → `ContentEntry` on the `@shell` public surface), and the app home and the module page keep it. That also removes the duplicate fetch on the app home, where the rail and the page were asking for the same list independently.

## Measured, not estimated

On `migrate-check.localhost` at `/apps/desk`, the framework's own prefix and the largest one:

| | items | navigation | whole boot |
|---|---|---|---|
| Administrator | 194 | 20,618 B | 23,557 B |
| an ordinary System Manager | 174 | 18,504 B | — |

Warm, resolution is 8–25 ms. Boot stays under the 40 KB ceiling and there is a test asserting it, but navigation is now 88% of the payload — most of that is the derived rail, and it shrinks when an app ships a curated one. If it ever bites, the lever is `link_doctype`: it is `fetch_from: item_type.target_doctype`, so it is implied by the type for every kind except `Record`, and it is 4.8 KB of the 20 KB above. Not taken here, because a compression rule the client has to understand is worth more than 4.8 KB only once something is actually over budget.

## Tests

449 python tests green across five suites on a real site — 33 new in `frappe/tests/test_shell_navigation.py`, plus `test_shell` (46), `test_rail` (15), `test_sidebar` (95) and `test_custom_sidebar` (60). 249 frontend vitest tests green, and `vue-tsc` clean over `frontend/src`.

The new tests roll back per test rather than per class, which `IntegrationTestCase` does not do: a standard `Rail` is named after its app, so two tests writing one collide on the primary key instead of each starting from a site with no rails.

>no-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
