### PR TITLE
feat: let an app extend another app's rail, and drop mount_on

### DIFF
--- a/frappe/desk/doctype/navigation_item/navigation_item.json
+++ b/frappe/desk/doctype/navigation_item/navigation_item.json
@@ -27,7 +27,11 @@
   "customization_section",
   "hidden",
   "added",
-  "overrides"
+  "overrides",
+  "contribution_section",
+  "anchors",
+  "column_break_contrib",
+  "switches_app"
  ],
  "fields": [
   {
@@ -164,13 +168,38 @@
    "fieldtype": "Code",
    "label": "Overrides",
    "options": "JSON"
+  },
+  {
+   "collapsible": 1,
+   "description": "Only meaningful on a row one app contributes to another app's rail — a `Rail` layer with `extends` set. An app's own rows are already where their author put them, and a site or user layer says where a row goes by the order it lists it in.",
+   "fieldname": "contribution_section",
+   "fieldtype": "Section Break",
+   "label": "Contribution"
+  },
+  {
+   "description": "Where this row wants to land in the host's list, as an ordered JSON list of attempts. Each attempt is an object naming at most one of `after` and `before`, a sibling to sit next to, and optionally `parent_key`, a row to nest under; every key it names has to be in the merged list for the attempt to resolve. The first that resolves wins and the rest are ignored, which is how an app says \"beside Customers, or failing that beside Contacts, or failing that anywhere\" without knowing which version of the host is installed. None resolving means the row is appended at the top level and never dropped, because a contributed item that lands in the wrong place is a cosmetic problem and one that vanishes is a bug report. Keys are written as the host wrote them, unprefixed; the merge namespaces contributed keys but never the anchors that name them.",
+   "fieldname": "anchors",
+   "fieldtype": "Code",
+   "label": "Anchors",
+   "options": "JSON"
+  },
+  {
+   "fieldname": "column_break_contrib",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "description": "Whether following this row leaves the host app for the app that contributed it. Off by default, and that default needs no code: a contributed row is an ordinary prefix-relative link, so clicking it keeps you where you are — addresses are bench-wide, so a foreign doctype opens under the host's prefix. On, the server sends the finished absolute URL, because the client resolves routes through the router it is standing in and cannot build one into another prefix. A column rather than a corner of `payload`, so that `overrides` can name it: a site that wants a contributed item to stay put, or to leave, is stating an opinion about a field, and `payload` sits inside the row's identity.",
+   "fieldname": "switches_app",
+   "fieldtype": "Check",
+   "label": "Switches App"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-09-01 10:00:00.000000",
+ "modified": "2026-09-02 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Navigation Item",

--- a/frappe/desk/doctype/navigation_item/navigation_item.py
+++ b/frappe/desk/doctype/navigation_item/navigation_item.py
@@ -24,6 +24,7 @@ class NavigationItem(Document):
 		from frappe.types import DF
 
 		added: DF.Check
+		anchors: DF.Code | None
 		collapsible: DF.Check
 		hidden: DF.Check
 		icon: DF.Icon | None
@@ -39,6 +40,7 @@ class NavigationItem(Document):
 		parentfield: DF.Data
 		parenttype: DF.Data
 		payload: DF.Code | None
+		switches_app: DF.Check
 		url: DF.Data | None
 	# end: auto-generated types
 

--- a/frappe/desk/doctype/rail/rail.json
+++ b/frappe/desk/doctype/rail/rail.json
@@ -2,14 +2,14 @@
  "actions": [],
  "autoname": "hash",
  "creation": "2026-09-01 10:00:00.000000",
- "description": "One layer of one app's rail. Three of them share this table, told apart by `app`, `user` and `standard`: the app's own rail, which it ships as an exported document and a developer authors; the site's arrangement of it, curated by a System Manager and applying to everyone; and one person's own, applied last and winning. The order is strict -- app, then site, then user -- and there is no role layer, because a user with three roles would get three competing arrangements and a precedence rule the framework has nowhere else. A rail belongs to an app, so arranging ERPNext's does not touch CRM's. The container is named for where it is and its rows for what they do, which is the only arrangement in which one row type can honestly serve both this and a sidebar.",
+ "description": "One layer of one app's rail. Four kinds of row share this table, told apart by `app`, `extends`, `user` and `standard`: the app's own rail, which it ships as an exported document and a developer authors; the site's arrangement of it, curated by a System Manager and applying to everyone; and one person's own, applied last and winning. The order is strict -- app, then site, then user -- and there is no role layer, because a user with three roles would get three competing arrangements and a precedence rule the framework has nowhere else. A rail belongs to an app, so arranging ERPNext's does not touch CRM's. The fourth kind is another app's contribution to this one's rail, which names its host in `extends` and is merged into the base before any of those three are laid over it. The container is named for where it is and its rows for what they do, which is the only arrangement in which one row type can honestly serve both this and a sidebar.",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
   "app",
+  "extends",
   "user",
   "standard",
-  "mount_on",
   "items_section",
   "items"
  ],
@@ -23,6 +23,16 @@
    "label": "App",
    "options": "Installed Applications",
    "reqd": 1
+  },
+  {
+   "depends_on": "eval:doc.standard == 1",
+   "description": "The app whose rail this layer joins, for an app that adds entries to somebody else's. Blank on an app's own rail, which is what nearly every row is. This replaces `mount_on`, which was desk v1's arrangement and a different claim: there, a companion app surrendered its own rail and its apps-screen tile to live inside a host, and one column could only ever name one host. An app that extends ERPNext *or* CRM *or* Helpdesk ships one row per host and keeps its own, which is why this belongs to the address rather than to the app. An **app name** rather than a Link to a `Rail`, because a pin aimed at a record would be a pin aimed at one of that app's three layers, which means nothing. Not nullable, for the reason `user` is not: one spelling of \"extends nobody\" has to reach the unique index. App-layer only -- `depends_on` hides it elsewhere and `validate` blanks it, because hiding a field does not stop an API write, and a site or user layer naming a host would be one person's arrangement of a rail they do not own.",
+   "fieldname": "extends",
+   "fieldtype": "Autocomplete",
+   "in_standard_filter": 1,
+   "label": "Extends",
+   "not_nullable": 1,
+   "options": "Installed Applications"
   },
   {
    "description": "The person whose own arrangement this is. Blank means the app's own rail or the site's arrangement of it, told apart by `standard`. Not nullable, so that one spelling of \"not a user's own layer\" reaches the index: a blank column stored as `NULL` is distinct from every other `NULL`, and an app could then hold two site layers that both look like one address.",
@@ -45,14 +55,6 @@
    "read_only_depends_on": "eval: !frappe.boot.developer_mode"
   },
   {
-   "depends_on": "eval:doc.standard == 1",
-   "description": "The app this one mounts on, for a companion app -- one with no rail of its own, whose entries live on a host's. Blank on every ordinary rail. An **app name** rather than a Link to a `Rail`: every consumer wants a string, and a pin aimed at a record would be a pin aimed at one of that app's three layers, which means nothing. App-layer only: `depends_on` hides it elsewhere and `validate` blanks it, because hiding a field does not stop an API write.",
-   "fieldname": "mount_on",
-   "fieldtype": "Autocomplete",
-   "label": "Mount On",
-   "options": "Installed Applications"
-  },
-  {
    "fieldname": "items_section",
    "fieldtype": "Section Break",
    "label": "Items"
@@ -68,7 +70,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-09-01 18:00:00.000000",
+ "modified": "2026-09-02 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Rail",

--- a/frappe/desk/doctype/rail/rail.py
+++ b/frappe/desk/doctype/rail/rail.py
@@ -3,6 +3,7 @@
 
 import frappe
 from frappe import _
+from frappe.database.utils import drop_index_if_exists
 from frappe.desk.doctype.navigation_item.navigation_item import validate_item_keys
 from frappe.model.document import Document
 
@@ -10,6 +11,10 @@ from frappe.model.document import Document
 # reaches the index. Every `NULL` is distinct to an index, so a nullable column would let one app
 # hold two site layers that both look like one address.
 SITE_LAYER = ""
+
+# Blank, for the same reason and read the same way: "this layer extends nobody, it is the app's
+# own rail". A nullable column would not reach the unique index below.
+NO_HOST = ""
 
 # The writes that are an app's content arriving on a site rather than a person editing it. Each is
 # a real route by which a shipped rail reaches a site, and without them, installing or updating an
@@ -20,7 +25,7 @@ SYSTEM_WRITE_FLAGS = ("in_install", "in_patch", "in_migrate", "in_import", "in_s
 class Rail(Document):
 	"""One layer of one app's rail.
 
-	The document holds the layer; how three of them resolve into the list a person sees is not
+	The document holds the layer; how they resolve into the list a person sees is not
 	here. That resolution is one engine shared with the sidebar -- the rail and the sidebar are two
 	presentations of one model, not two models -- and it runs at read time, against the whole of a
 	prefix, on the way into boot.
@@ -36,39 +41,92 @@ class Rail(Document):
 		from frappe.types import DF
 
 		app: DF.Autocomplete
+		extends: DF.Autocomplete
 		items: DF.Table[NavigationItem]
-		mount_on: DF.Autocomplete | None
 		standard: DF.Check
 		user: DF.Link
 	# end: auto-generated types
 
 	def autoname(self):
-		"""Name an app's own rail after the app; everything else gets a hash.
+		"""Name a shipped rail after what it arranges; everything else gets a hash.
 
 		The export path requires it, because the record name is the file path. A hash-named
 		standard record would write `<app>/rail/6a1f9c2e/6a1f9c2e.json`, and a re-export from a
 		fresh bench would create a second file, leaving the first as a permanent orphan.
 
+		An app ships more than one of these once it extends somebody: its own rail, plus a record
+		per host. So the name is the address and not the app alone — `telephony` for its own,
+		`telephony-erpnext` for what it adds to ERPNext's. A hyphen separates them because an app
+		name is a Python module name and can never contain one.
+
 		An opaque name costs the other two layers nothing, because a layer is looked up by filter
 		and never by name.
 		"""
-		if self.standard:
-			self.name = self.app
+		if not self.standard:
+			return
+
+		self.name = f"{self.app}-{self.extends}" if self.extends else self.app
 
 	def validate(self):
 		self.user = self.user or SITE_LAYER
+		self.extends = self.extends or NO_HOST
 		self.validate_app_content()
-		self.blank_the_mount()
+		self.blank_the_host()
+		self.refuse_extending_itself()
+		self.refuse_a_second_record_at_this_address()
 		self.validate_item_keys()
 
-	def blank_the_mount(self):
-		"""Clear `mount_on` outside the app layer, because mounting is an app-layer claim.
+	def blank_the_host(self):
+		"""Clear `extends` outside the app layer, because extending is an app-layer claim.
 
 		`depends_on` hides the field on the two writable layers but does not stop an API write, and
-		a site row carrying a mount would put a user's arrangement on another app's rail.
+		a site or user row naming a host would be one person's arrangement of a rail they do not
+		own — which is also the row that already exists, since a person arranges a host rail
+		through the host's own address and gets every contributed item in the same list.
 		"""
 		if not self.standard:
-			self.mount_on = None
+			self.extends = NO_HOST
+
+	def refuse_extending_itself(self):
+		"""An app extending itself is its own rail written twice, and the two would both merge.
+
+		Cheap to state and impossible to mean: the second record would be appended to the first
+		with its keys namespaced `<app>:<key>`, so every item would appear once addressable and
+		once not.
+		"""
+		if self.extends and self.extends == self.app:
+			frappe.throw(
+				_("{0} cannot extend its own rail. Ship the items on its own rail instead.").format(
+					frappe.bold(self.app)
+				),
+				title=_("Extends Itself"),
+			)
+
+	def refuse_a_second_record_at_this_address(self):
+		"""Say plainly that a shipped rail is already there, rather than letting the insert fail.
+
+		The unique index below is the guarantee and stays the guarantee — it holds against a bulk
+		write and against anything that skips the document. This is about the message. A shipped
+		rail's name *is* its address, while the doctype autonames by `hash` for the sake of the
+		other two layers, so `db_insert` reads the primary-key collision as a hash collision and
+		retries. `autoname` puts the same name back each time, so it retries five times and then
+		re-raises the driver's own `IntegrityError`, which names a column and no cause.
+
+		Only shipped rows have a deterministic name, so only they can reach that path. Everything
+		else keeps its hash and meets the index, which reports itself properly.
+
+		In `validate` rather than `before_insert`, which runs before the name exists: `insert`
+		calls `before_insert`, then `set_new_name`, then the before-save methods.
+		"""
+		if not self.is_new() or not self.standard or not frappe.db.exists("Rail", self.name):
+			return
+
+		frappe.throw(
+			_("{0} already has a rail at this address. Edit {1} rather than shipping a second.").format(
+				frappe.bold(self.app), frappe.bold(self.name)
+			),
+			title=_("Already Shipped"),
+		)
 
 	def validate_app_content(self):
 		"""Allow only developer mode to set or clear the standard flag, because it is app content.
@@ -116,10 +174,11 @@ class Rail(Document):
 	def export_rail(self):
 		"""Write this rail to its file, so authoring it and shipping it are one step.
 
-		The path is `<app>/rail/<app>/<app>.json`: the usual per-record folder, rooted at the app
-		instead of a module, because an app has one rail and no module owns it. The import walk and
-		the orphan sweep both work on that shape unchanged, because the filename and the record
-		name agree.
+		The path is `<app>/rail/<name>/<name>.json`: the usual per-record folder, rooted at the app
+		instead of a module, because no module owns a rail. The import walk and the orphan sweep
+		both work on that shape unchanged, because the filename and the record name agree — which
+		is why `autoname` makes the name the address, so an app that extends two hosts writes three
+		files rather than overwriting one.
 		"""
 		from frappe.modules.export_file import export_to_files
 
@@ -135,12 +194,22 @@ def on_doctype_update():
 	A hook is bypassed by `db_insert`, a bulk write, or anything that skips the document, and two
 	documents at one address would give the merge two answers for the same layer.
 
-	The index is composite because an address is three columns. `user` alone would let one person
+	The index is composite because an address is four columns. `user` alone would let one person
 	arrange only one app's rail. `standard` is in it because an app's own rail and the site's
 	arrangement of it are two documents at the same `(app, user)`: one shipped, one curated, and
-	resetting the site's must not touch the app's.
+	resetting the site's must not touch the app's. `extends` is in it because an app ships one
+	record per rail it joins and one for its own, and the three-column form made extending
+	unstorable rather than merely unresolvable: `telephony` already owns `(telephony, "", 1)`, so
+	its second record collided with its first.
+
+	The old three-column index is dropped by name. `add_unique` is keyed on the constraint name
+	and does nothing when one already exists, so widening the columns under the same name would
+	have been a silent no-op on every bench that has already migrated this branch.
 	"""
-	frappe.db.add_unique("Rail", ("app", "user", "standard"), constraint_name="unique_layer_address")
+	drop_index_if_exists("tabRail", "unique_layer_address")
+	frappe.db.add_unique(
+		"Rail", ("app", "extends", "user", "standard"), constraint_name="unique_rail_address"
+	)
 
 
 def has_permission(doc, ptype="read", user=None, debug=False):

--- a/frappe/desk/doctype/rail/test_rail.py
+++ b/frappe/desk/doctype/rail/test_rail.py
@@ -13,6 +13,13 @@ from frappe.tests.classes.context_managers import set_user
 # matter: these tests are about the layers and the rows, not about anyone's actual navigation.
 APP = "frappe"
 
+# Hosts an extension names. Neither has to be installed: `Rail.app` and `Rail.extends` are
+# `Autocomplete` columns over installed apps rather than Links, so nothing on the document
+# resolves them. Resolution is where an uninstalled app stops counting, and that is tested
+# against the resolver in `frappe/tests/test_shell_navigation.py`.
+HOST = "erpnext"
+OTHER_HOST = "helpdesk"
+
 
 @contextlib.contextmanager
 def authoring():
@@ -143,11 +150,73 @@ class TestRail(IntegrationTestCase):
 		self.assertEqual(rail.items[0].link_doctype, "User")
 
 	def test_a_site_layer_cannot_claim_another_apps_rail(self):
-		"""`mount_on` is an app-layer claim, and hiding the field does not stop an API write."""
-		rail = make_rail(mount_on="crm")
+		"""`extends` is an app-layer claim, and hiding the field does not stop an API write.
+
+		A site or user row naming a host would be one person's arrangement filed onto a rail
+		they do not own — and it is unnecessary besides, since arranging a host rail is one row
+		at the host's own address covering every contributed item in the list.
+		"""
+		rail = make_rail(extends=HOST)
 		rail.insert()
 		self.addCleanup(rail.delete)
-		self.assertFalse(rail.mount_on)
+		self.assertFalse(rail.extends)
+
+	def test_an_app_cannot_extend_itself(self):
+		"""It is its own rail written twice, and both copies would merge into one list."""
+		rail = make_rail(standard=1, extends=APP, items=[item(key="users", link_to="User")])
+		with authoring():
+			self.assertRaises(frappe.ValidationError, rail.insert)
+
+	def test_an_extension_is_named_after_the_address_and_not_the_app(self):
+		"""An app ships its own rail and one record per host, so the app name is not enough.
+
+		The record name is the export path, so two records sharing a name would overwrite one
+		file — which is exactly what `mount_on`'s single column made unavoidable.
+		"""
+		own = make_rail(standard=1, items=[item(key="users", link_to="User")])
+		extension = make_rail(standard=1, extends=HOST, items=[item(key="users", link_to="User")])
+		with authoring():
+			own.insert()
+			self.addCleanup(own.delete)
+			extension.insert()
+			self.addCleanup(extension.delete)
+
+		self.assertEqual(own.name, APP)
+		self.assertEqual(extension.name, f"{APP}-{HOST}")
+
+	def test_one_app_may_extend_two_hosts_and_keep_its_own_rail(self):
+		"""The whole reason `mount_on` came off: a scalar could name one host, and Payments and
+		Telephony each extend ERPNext *or* CRM *or* Helpdesk, choosing per site.
+
+		This is also what the old three-column index made unstorable rather than merely
+		unresolvable — every one of these rows is `(app, "", 1)` under it.
+		"""
+		with authoring():
+			for extends in ("", HOST, OTHER_HOST):
+				rail = make_rail(standard=1, extends=extends, items=[item(key="users", link_to="User")])
+				rail.insert()
+				self.addCleanup(rail.delete)
+
+		self.assertEqual(
+			frappe.db.count("Rail", {"app": APP, "standard": 1}),
+			3,
+		)
+
+	def test_two_extensions_of_one_host_by_one_app_are_still_refused(self):
+		"""The index widened; it did not stop enforcing one layer per address.
+
+		A shipped row is refused by name rather than by the index, and says so: its name is its
+		address, so the second one collides on the primary key — which `db_insert` reads as a
+		hash collision, retries five times against an `autoname` that keeps returning the same
+		string, and then re-raises the driver's own error naming a column and no cause.
+		"""
+		with authoring():
+			first = make_rail(standard=1, extends=HOST, items=[item(key="users", link_to="User")])
+			first.insert()
+			self.addCleanup(first.delete)
+
+			with self.assertRaises(frappe.ValidationError):
+				make_rail(standard=1, extends=HOST, items=[item(key="roles", link_to="Role")]).insert()
 
 	def test_a_layer_with_no_user_is_the_site_layer(self):
 		"""One spelling of "not a user's own", so two site layers cannot look like one address."""

--- a/frappe/shell/extensions.py
+++ b/frappe/shell/extensions.py
@@ -1,0 +1,276 @@
+# EXTENSION — how one app's rows join another app's rail.
+#
+# #42364 settled this after taking `mount_on` apart. Desk v1's arrangement was that a
+# companion app surrendered its own rail and its apps-screen tile to live inside a host,
+# named by one scalar column. That could never say what Payments and Telephony need, since
+# each extends ERPNext *or* CRM *or* Helpdesk, and it was unnecessary besides: addresses
+# are bench-wide, so a foreign item is an ordinary in-prefix link and nothing has to be
+# surrendered to make it work. So an app keeps its own rail and ships one `Rail` record per
+# host, each naming that host in `extends` and each able to offer it a different list.
+#
+# Nothing here reads the database. Every query in this family lives in `navigation.py`, and
+# what is left once they are taken out is a list operation: given a host's list and some
+# other apps' rows, produce one list. That is worth having on its own, because the ordering
+# rules below are where the design actually is.
+#
+# Two rules carry most of the weight:
+#
+# 1. Contributed keys are namespaced at merge, `<app>:<key>`, and host keys are untouched.
+#    The key is what every user edit is filed against (#42229), so an identity that changed
+#    when a second app was installed would silently detach a person's arrangement. Letting
+#    the host win and dropping the collision has the same fault from the other side.
+#
+# 2. An item that cannot be placed is appended, never dropped. An app writes its anchors
+#    against a host it does not ship and cannot pin, so a missing anchor is the expected
+#    case rather than a broken one. Landing in the wrong place is cosmetic; vanishing is a
+#    bug report against the wrong app.
+
+import json
+
+# `<app>:<key>`. A colon because it cannot occur in an app name, which is a Python module
+# name, and because it reads as a qualifier rather than as part of a slug — `telephony:leads`
+# is visibly two things where `telephony-leads` is one.
+NAMESPACE = ":"
+
+
+def namespaced(app: str, key: str) -> str:
+	return f"{app}{NAMESPACE}{key}"
+
+
+def extend(base: list[dict], contributions: list[tuple[str, list[dict]]], *, anchorable: bool) -> list[dict]:
+	"""The host's list with every other app's rows merged in.
+
+	`contributions` is `(app, rows)` in installation order, and `base` is the host's own
+	list — shipped or derived. The result is the base of the layer merge, not its output:
+	the site's arrangement and each person's are laid over this, so a person who reorders a
+	host rail gets one row covering the contributed items too (#42364), rather than one row
+	per app whose contributions they happened to move.
+
+	`anchorable` says whether the base's keys may be named by an anchor. It is False for a
+	*derived* base, whose keys are doctype names nobody authored — an app cannot write an
+	anchor against a list the host never wrote down, and a key that looks stable but is a
+	side effect of what the reader may see is worse than no key at all. Contributed keys are
+	always anchorable, because a contributed row is a shipped row and its key is authored.
+
+	Two passes, and the reason is install order. Placing and anchoring in one pass would
+	make an anchor that names another extender's item resolve or not depending on which app
+	was installed first, which is a property of a bench and not of either app. So every row
+	is placed first, and only then does anything look for a key.
+	"""
+	merged = [dict(item) for item in base]
+	placed = []
+
+	for app, rows in contributions:
+		for row in rows:
+			item = _contributed(app, row)
+			if item is None:
+				continue
+			merged.append(item)
+			placed.append(item)
+
+	if not placed:
+		return merged
+
+	targets = {item["key"] for item in placed}
+	if anchorable:
+		targets |= {item["key"] for item in base if item.get("key")}
+
+	return _anchor(merged, placed, targets)
+
+
+def _contributed(app: str, row: dict) -> dict | None:
+	"""One contributed row, keyed for the merged list.
+
+	`parent_key` is namespaced with the key, so a contributed subtree keeps its own shape and
+	travels as a unit. It names a sibling in the app's own list and never a host row: nesting
+	*into* the host is what an anchor's `parent_key` is for, and reading one column as
+	sometimes-mine-sometimes-theirs would make an app's own hierarchy break the day a host
+	happened to ship a row with the same key.
+
+	A row with no key is skipped. `validate_item_keys` already refuses one on any standard
+	record, and an extension record is standard — but a keyless row here would namespace to a
+	bare `<app>:` that every other keyless row also produced, so it is worth being explicit.
+	"""
+	key = row.get("key")
+	if not key:
+		return None
+
+	item = {**row, "key": namespaced(app, key), "app": app}
+
+	if row.get("parent_key"):
+		item["parent_key"] = namespaced(app, row["parent_key"])
+
+	return item
+
+
+def _anchor(merged: list[dict], placed: list[dict], targets: set[str]) -> list[dict]:
+	"""Move each contributed root to the first position it asks for that resolves.
+
+	Roots only. A row with a `parent_key` of its own is inside a contributed subtree, and
+	where that subtree sits is its root's business — an anchor on a child would tear the
+	subtree apart to satisfy a row that never had a say in the first place.
+
+	`anchored` is the cycle guard and the whole of it: it records what each moved row was
+	moved next to, so an anchor whose target chain leads back to the row being placed is
+	refused and the next anchor is tried. Two apps naming each other is the case, and neither
+	an exception nor an arbitrary winner would be right — falling through to the next anchor,
+	and then to the append, is the same answer the design gives every other unresolvable one.
+	"""
+	anchored: dict[str, str] = {}
+
+	for item in placed:
+		if item.get("parent_key"):
+			continue
+
+		attempt = _first_resolving(item, targets, anchored)
+		if attempt is None:
+			continue
+
+		_place(merged, item, attempt)
+		anchored[item["key"]] = attempt["target"]
+
+	return merged
+
+
+def _first_resolving(item: dict, targets: set[str], anchored: dict[str, str]) -> dict | None:
+	"""The first of this row's anchors whose every named key is present and not circular."""
+	for anchor in _attempts(item):
+		resolved = _resolve(item, anchor, targets, anchored)
+		if resolved:
+			return resolved
+
+	return None
+
+
+def _attempts(item: dict) -> list[dict]:
+	"""This row's anchors, as an ordered list of well-formed attempts.
+
+	A malformed list is no anchors rather than an error. The rows are authored by an app
+	against a host it cannot see, so the reader of any complaint would be the wrong person;
+	the row still appears, at the end, which is what an app with no anchors gets anyway.
+
+	An attempt naming both `after` and `before` names two positions and so names none. It is
+	dropped rather than resolved by precedence, because picking one would make a typo into a
+	silent placement nobody wrote.
+	"""
+	try:
+		anchors = json.loads(item.get("anchors") or "[]")
+	except (TypeError, ValueError):
+		return []
+
+	if not isinstance(anchors, list):
+		return []
+
+	attempts = []
+
+	for anchor in anchors:
+		if not isinstance(anchor, dict):
+			continue
+
+		after, before, parent = anchor.get("after"), anchor.get("before"), anchor.get("parent_key")
+		if after and before:
+			continue
+		if not (after or before or parent):
+			continue
+
+		attempts.append({"after": after, "before": before, "parent_key": parent})
+
+	return attempts
+
+
+def _resolve(item: dict, anchor: dict, targets: set[str], anchored: dict[str, str]) -> dict | None:
+	"""One attempt against the finished list, or None if any key it names is not there.
+
+	A key is read as written first and as this app's own second. Written-first is what makes
+	an anchor aimed at a host resolve to the host, which is the case an app is nearly always
+	writing; the own-namespace fallback is what lets an app anchor to a row it shipped itself
+	without having to write its own name into its own file. It can never shadow a host key,
+	because it is only reached when the host has no such key.
+	"""
+	app = item["app"]
+	resolved = {"after": None, "before": None, "parent_key": None, "target": None}
+
+	for field in ("after", "before", "parent_key"):
+		name = anchor.get(field)
+		if not name:
+			continue
+
+		key = _target_key(app, name, targets)
+		if key is None:
+			return None
+
+		if _leads_back(key, item["key"], anchored):
+			return None
+
+		resolved[field] = key
+
+	resolved["target"] = resolved["after"] or resolved["before"] or resolved["parent_key"]
+	return resolved
+
+
+def _target_key(app: str, name: str, targets: set[str]) -> str | None:
+	if name in targets:
+		return name
+
+	own = namespaced(app, name)
+	return own if own in targets else None
+
+
+def _leads_back(target: str, key: str, anchored: dict[str, str]) -> bool:
+	"""Whether following what each row was anchored to gets back to `key`."""
+	seen = set()
+
+	while target and target not in seen:
+		if target == key:
+			return True
+		seen.add(target)
+		target = anchored.get(target)
+
+	return False
+
+
+def _place(merged: list[dict], item: dict, anchor: dict):
+	"""Move `item` to where the anchor says, and give it the parent that implies.
+
+	`after` and `before` put a row beside another, so it takes that row's parent: beside
+	means beside, and a sibling that landed at a different depth would be somewhere else
+	entirely. An explicit `parent_key` wins over that, for the app that means *under this
+	section, next to that row*.
+
+	A `parent_key` with no `after` or `before` lands the row after the last child that parent
+	already has, or immediately after the parent when it has none — the position an app would
+	get by appending to that section, which is what it asked for.
+	"""
+	merged.remove(item)
+	beside = anchor["after"] or anchor["before"]
+	parent = anchor["parent_key"]
+
+	if beside:
+		at = _index_of(merged, beside)
+		if parent is None:
+			parent = _entry(merged, beside).get("parent_key")
+		item["parent_key"] = parent
+		merged.insert(at + 1 if anchor["after"] else at, item)
+		return
+
+	item["parent_key"] = parent
+	merged.insert(_last_child(merged, parent) + 1, item)
+
+
+def _index_of(merged: list[dict], key: str) -> int:
+	return next(index for index, entry in enumerate(merged) if entry.get("key") == key)
+
+
+def _entry(merged: list[dict], key: str) -> dict:
+	return merged[_index_of(merged, key)]
+
+
+def _last_child(merged: list[dict], parent: str) -> int:
+	"""The index of `parent`'s last child, or of `parent` itself when it has none."""
+	at = _index_of(merged, parent)
+
+	for index, entry in enumerate(merged):
+		if entry.get("parent_key") == parent:
+			at = index
+
+	return at

--- a/frappe/shell/extensions.py
+++ b/frappe/shell/extensions.py
@@ -241,28 +241,37 @@ def _place(merged: list[dict], item: dict, anchor: dict):
 	already has, or immediately after the parent when it has none — the position an app would
 	get by appending to that section, which is what it asked for.
 	"""
-	merged.remove(item)
 	beside = anchor["after"] or anchor["before"]
-	parent = anchor["parent_key"]
+	target = _index_of(merged, beside or anchor["parent_key"])
+	if target is None:
+		# Unreachable as long as an anchor only ever resolves against a key that is in the list,
+		# which is what `targets` is. Checked anyway because the caller is boot: an exception here
+		# would blank the shell over a misplaced navigation row.
+		return
+
+	merged.pop(_position_of(merged, item))
 
 	if beside:
 		at = _index_of(merged, beside)
+		parent = anchor["parent_key"]
 		if parent is None:
-			parent = _entry(merged, beside).get("parent_key")
+			parent = merged[at].get("parent_key")
 		item["parent_key"] = parent
 		merged.insert(at + 1 if anchor["after"] else at, item)
 		return
 
-	item["parent_key"] = parent
-	merged.insert(_last_child(merged, parent) + 1, item)
+	item["parent_key"] = anchor["parent_key"]
+	merged.insert(_last_child(merged, anchor["parent_key"]) + 1, item)
 
 
-def _index_of(merged: list[dict], key: str) -> int:
-	return next(index for index, entry in enumerate(merged) if entry.get("key") == key)
+def _index_of(merged: list[dict], key: str) -> int | None:
+	return next((index for index, entry in enumerate(merged) if entry.get("key") == key), None)
 
 
-def _entry(merged: list[dict], key: str) -> dict:
-	return merged[_index_of(merged, key)]
+def _position_of(merged: list[dict], item: dict) -> int:
+	"""Where this exact row is. By identity, not by equality: `list.remove` takes the first row
+	that compares equal, which is the right one only for as long as no two rows can match."""
+	return next(index for index, entry in enumerate(merged) if entry is item)
 
 
 def _last_child(merged: list[dict], parent: str) -> int:

--- a/frappe/shell/navigation.py
+++ b/frappe/shell/navigation.py
@@ -76,6 +76,10 @@ SITE_LAYER = ""
 # nobody, and one spelling of that has to reach the unique index — and this filter.
 NO_HOST = ""
 
+# #42231's bucket for a kind whose destination is a doctype, and the one bucket this module
+# applies. The other five are #42233's, along with every authored row that is not contributed.
+READABLE_DOCTYPE = "Readable DocType"
+
 
 def resolve_navigation(app: str) -> dict:
 	"""The whole navigation payload for one prefix, as the session user sees it.
@@ -455,7 +459,59 @@ def _rail_contributions(host: str) -> list[tuple[str, list[dict]]]:
 	)
 	rows = _rows_by_parent("Rail", "items", [record.name for record in records])
 
-	return [(record.app, rows.get(record.name, [])) for record in records]
+	return [(record.app, _readable(rows.get(record.name, []))) for record in records]
+
+
+def _readable(rows: list[dict]) -> list[dict]:
+	"""Drop a contributed row pointing at a doctype this person cannot read.
+
+	#42364's rule 6: doctype read is the only filter on a contribution, and the target app's
+	`app_permission` door does **not** run — that gate is about entering a prefix, and following
+	a foreign item does not leave the host.
+
+	It is here rather than waiting for #42233, which owns filtering authored rows generally,
+	because the host is the one party that cannot refuse: an app's own rows are its own problem,
+	while these arrive on somebody else's rail. The narrowness is the point — this is #42231's
+	`Readable DocType` bucket and only that one, read off the type table rather than hardcoded,
+	so #42233 replaces it with the full dispatch rather than finding a second rule to reconcile.
+
+	Which column names the doctype depends on the type: a `DocType` item's destination *is* the
+	doctype, in `link_to`, while `Record` is the one kind that carries its own `link_doctype`.
+
+	A dropped section leaves its children behind, and `_promote_orphans` lifts them to the top
+	level on the way out — the same treatment as an app removing a section.
+	"""
+	if not rows:
+		return rows
+
+	from .doctypes import get_readable_doctypes
+
+	buckets = _permission_rules()
+	readable = None
+
+	kept = []
+
+	for row in rows:
+		if buckets.get(row.get("item_type")) != READABLE_DOCTYPE:
+			kept.append(row)
+			continue
+
+		if readable is None:
+			# Read once, and only if a row actually asks. `get_readable_doctypes` is one
+			# role-based pass measured at 25 ms against 3,594 ms for per-doctype checks, but a
+			# bench where nothing extends anything should not pay even that.
+			readable = get_readable_doctypes()
+
+		doctype = row.get("link_to") if row.get("item_type") == "DocType" else row.get("link_doctype")
+		if doctype in readable:
+			kept.append(row)
+
+	return kept
+
+
+def _permission_rules() -> dict[str, str]:
+	"""`{type: permission_rule}` — the rule each kind declares for itself (#42231)."""
+	return dict(frappe.get_all("Navigation Item Type", fields=["name", "permission_rule"], as_list=True))
 
 
 def _layer_role(record) -> str:

--- a/frappe/shell/navigation.py
+++ b/frappe/shell/navigation.py
@@ -17,9 +17,12 @@
 # and `resolve_sidebar` are both unwhitelisted with one caller each.
 
 import json
+from urllib.parse import quote
 
 import frappe
 from frappe.desk.layers import resolve_layers
+
+from .extensions import extend
 
 # What a stored row carries. Read as columns rather than as a document, because `Sidebar`'s
 # document is desk v1's: the class subclasses `DeskViews` and the record holds v1's `items`
@@ -40,6 +43,12 @@ ITEM_FIELDS = (
 	"hidden",
 	"added",
 	"overrides",
+	# Read for the extension merge, not for the browser. `anchors` is consumed there and
+	# `switches_app` becomes a `url` on the way out — but both are in this list rather than
+	# read separately, because `overrides` may name any field a layer has an opinion about,
+	# and a site turning a contributed item's app-switching off is exactly such an opinion.
+	"anchors",
+	"switches_app",
 )
 
 # What reaches the browser. `hidden`, `added` and `overrides` are how a layer was *stored*;
@@ -63,6 +72,10 @@ WIRE_FIELDS = (
 # reason: one spelling of "not a person's own layer" has to reach the unique index.
 SITE_LAYER = ""
 
+# `Rail.NO_HOST`, and the same empty string for the same reason: an app's own rail extends
+# nobody, and one spelling of that has to reach the unique index — and this filter.
+NO_HOST = ""
+
 
 def resolve_navigation(app: str) -> dict:
 	"""The whole navigation payload for one prefix, as the session user sees it.
@@ -82,7 +95,11 @@ def resolve_navigation(app: str) -> dict:
 
 
 def _resolve_rail(app: str) -> list[dict]:
-	"""One app's rail: its own layer, then the site's, then this user's.
+	"""One app's rail: its own layer plus what other apps add to it, then the site's, then this user's.
+
+	Extension happens to the *base*, before the site and user layers are laid over it. That is
+	what makes a person's arrangement of a host rail one row rather than one row per extending
+	app: they are shown one list and they arrange one list (#42364).
 
 	When the app ships no `Rail` record the base is *derived* from the address table, and it goes
 	through the same merge as any other base rather than short-circuiting past it. That is not a
@@ -93,8 +110,14 @@ def _resolve_rail(app: str) -> list[dict]:
 	"""
 	layers = _rail_layers(app)
 	base = layers.pop("standard", None)
+	# A derived base's keys are doctype names nobody authored, so an anchor may not name one
+	# (#42364). The flag is computed here rather than inside the merge because this is the only
+	# line that knows which of the two bases it is holding.
+	shipped = base is not None
 	if base is None:
 		base = _derive_rail(app)
+
+	base = extend(base, _rail_contributions(app), anchorable=shipped)
 
 	return _merge(base, [layers.get("site", []), layers.get("user", [])])
 
@@ -274,7 +297,81 @@ def on_the_wire(item: dict) -> dict:
 	if wire.get("payload"):
 		wire["payload"] = _parse_payload(item)
 
+	if item.get("switches_app"):
+		wire["url"] = _switching_url(item) or wire.get("url")
+
 	return {field: value for field, value in wire.items() if value}
+
+
+def _switching_url(item: dict) -> str | None:
+	"""The absolute URL of a contributed item that leaves the host, or None if it has none.
+
+	The server builds it because the browser cannot. `routeFor` resolves through the router the
+	document is standing in, so every URL it can produce is inside the current prefix — which is
+	the whole reason a contributed item stays in the host by default and needs no code to do it.
+	Crossing is the exception, and it is a full document load either way (#42102).
+
+	The destination is the **contributing** app's prefix, which is what `app` on a merged item
+	says. A host's own row can never reach here: nothing sets `app` on one, because nothing about
+	it is foreign.
+
+	An item whose destination has no address under that prefix falls back to the ordinary
+	in-prefix link and logs — a working link in the wrong app beats no link at all. A `Module`
+	under a non-modular prefix is the case: there is no module route to land on (#42211).
+
+	A `Link` row is the one kind that is silently left alone. It already carries an absolute URL
+	that goes wherever its author pointed it, so switching apps says nothing about it, and
+	logging would report a mistake nobody made.
+	"""
+	from .doctypes import get_address_table, slug
+	from .registry import declared_prefix, is_modular, shell_base
+
+	app = item.get("app")
+	if not app:
+		return None
+
+	base = shell_base(declared_prefix(app))
+	modular = is_modular(app)
+	item_type = item.get("item_type")
+
+	if item_type == "Module":
+		return f"{base}/{slug(item['link_to'])}" if modular and item.get("link_to") else _no_address(item)
+
+	if item_type == "DocType":
+		doctype, record = item.get("link_to"), None
+	elif item_type == "Record":
+		doctype, record = item.get("link_doctype"), item.get("link_to")
+	elif item_type == "Link":
+		return None
+	else:
+		return _no_address(item)
+
+	address = get_address_table()["doctypes"].get(doctype)
+	if not address:
+		return _no_address(item)
+
+	doctype_slug, module_slug = address
+	if modular and not module_slug:
+		return _no_address(item)
+
+	segments = [base, module_slug, doctype_slug] if modular else [base, doctype_slug]
+	if record:
+		# The one request-shaped value in the path. Everything else is a slug the framework
+		# computed; a record name is user data and can hold a slash.
+		segments.append(quote(record, safe=""))
+
+	return "/".join(segments)
+
+
+def _no_address(item: dict) -> None:
+	frappe.log_error(
+		title="Navigation item cannot switch apps",
+		message=(
+			f"{item.get('item_type')} item {item.get('key')!r} contributed by {item.get('app')!r} "
+			"has no address under that app's prefix; it stays in the host prefix."
+		),
+	)
+	return None
 
 
 def _parse_payload(item: dict) -> dict:
@@ -312,7 +409,11 @@ def _rail_layers(app: str) -> dict[str, list[dict]]:
 	"""
 	records = frappe.get_all(
 		"Rail",
-		filters={"app": app, "user": ("in", (SITE_LAYER, frappe.session.user))},
+		filters={
+			"app": app,
+			"extends": NO_HOST,
+			"user": ("in", (SITE_LAYER, frappe.session.user)),
+		},
 		fields=["name", "standard", "user"],
 	)
 
@@ -322,11 +423,39 @@ def _rail_layers(app: str) -> dict[str, list[dict]]:
 	for record in records:
 		layers[_layer_role(record)] = rows.get(record.name, [])
 
-	# `mount_on` is read by nothing here, deliberately. #42364 took the question up and answered
-	# it against the column: a scalar cannot say what an app extending two hosts needs, so `Rail`
-	# gains `extends` and `mount_on` comes off. That is #42398's build, and it merges into this
-	# derived-and-shipped rail rather than replacing it.
+	# `extends` is blank in the filter above, so this returns the app's own three layers and never
+	# a record it ships for somebody else's rail. Those share this app's name and would otherwise
+	# arrive here as a second standard layer, which the merge has no way to tell from the first.
 	return layers
+
+
+def _rail_contributions(host: str) -> list[tuple[str, list[dict]]]:
+	"""What other apps add to this app's rail, in installation order.
+
+	Installation order, not name order, because it is the order the site actually did things in
+	and the only one an administrator can change. It decides the appended tail, and it decides
+	nothing else: anchors resolve against the finished list, so an anchor naming another
+	extender's item works whichever went on first (#42364).
+
+	Active apps only — `get_active_apps` rather than the installed list, for the reason boot uses
+	it: a **disabled** app must not keep serving anything, and an app still in `installed_apps`
+	but gone from the bench would raise on the next hook read. An app off that list contributes
+	nothing rather than contributing at the end.
+
+	Standard rows only, which the schema already guarantees: `extends` is blanked on any row that
+	is not app content, so a site or a person cannot file one app's items onto another's rail.
+	"""
+	records = frappe.get_all("Rail", filters={"extends": host, "standard": 1}, fields=["name", "app"])
+	if not records:
+		return []
+
+	order = frappe.get_active_apps(_ensure_on_bench=True)
+	records = sorted(
+		(record for record in records if record.app in order), key=lambda record: order.index(record.app)
+	)
+	rows = _rows_by_parent("Rail", "items", [record.name for record in records])
+
+	return [(record.app, rows.get(record.name, [])) for record in records]
 
 
 def _layer_role(record) -> str:

--- a/frappe/shell/navigation.py
+++ b/frappe/shell/navigation.py
@@ -453,9 +453,11 @@ def _rail_contributions(host: str) -> list[tuple[str, list[dict]]]:
 	if not records:
 		return []
 
-	order = frappe.get_active_apps(_ensure_on_bench=True)
+	# One pass over the app list, not a scan per record: both the membership test and the sort
+	# key would otherwise walk it, and this runs inside boot's blocking pre-mount fetch.
+	position = {app: index for index, app in enumerate(frappe.get_active_apps(_ensure_on_bench=True))}
 	records = sorted(
-		(record for record in records if record.app in order), key=lambda record: order.index(record.app)
+		(record for record in records if record.app in position), key=lambda record: position[record.app]
 	)
 	rows = _rows_by_parent("Rail", "items", [record.name for record in records])
 

--- a/frappe/tests/test_rail_extension.py
+++ b/frappe/tests/test_rail_extension.py
@@ -1,0 +1,247 @@
+# Copyright (c) 2026, Frappe Technologies and Contributors
+# License: MIT. See LICENSE
+
+"""The extension merge: `frappe/shell/extensions.py`.
+
+Pure list operations, so these are unit tests with no site behind them. That is the point of
+the module being separable at all — the ordering rules below are where #42364's design lives,
+and they are worth reading and exercising without a rail, a layer or a user in the way. What
+the merge does inside the resolver is `test_shell_navigation.py`'s.
+
+`erpnext` is the host and `telephony` the extender throughout. Neither has to be installed:
+nothing here resolves an app name, and the one place that does — dropping a disabled app's
+contribution — is a query in `navigation.py`.
+"""
+
+import json
+
+from frappe.shell.extensions import extend
+from frappe.tests import UnitTestCase
+
+HOST = "erpnext"
+APP = "telephony"
+OTHER = "payments"
+
+
+def item(key: str, **kwargs) -> dict:
+	return {"key": key, "item_type": "DocType", "link_doctype": "DocType", **kwargs}
+
+
+def anchored(key: str, *anchors: dict, **kwargs) -> dict:
+	return item(key, anchors=json.dumps(list(anchors)), **kwargs)
+
+
+def keys(items: list[dict]) -> list[str]:
+	return [entry["key"] for entry in items]
+
+
+class TestKeyNamespacing(UnitTestCase):
+	def test_a_contributed_key_is_namespaced_and_the_hosts_are_not(self):
+		"""The key is what every user edit is filed against (#42229), so a host key that changed
+		when a second app was installed would silently detach the site's arrangement. Namespacing
+		the newcomer is the only direction that leaves existing identities alone."""
+		merged = extend([item("leads")], [(APP, [item("leads")])], anchorable=True)
+
+		self.assertEqual(keys(merged), ["leads", "telephony:leads"])
+
+	def test_two_apps_may_ship_the_same_key(self):
+		"""`validate_item_keys` checks one record, so it never could have caught this. The merge
+		is where it has to hold, and it holds by construction rather than by a check."""
+		merged = extend([], [(APP, [item("calls")]), (OTHER, [item("calls")])], anchorable=True)
+
+		self.assertEqual(keys(merged), ["telephony:calls", "payments:calls"])
+
+	def test_a_contributed_subtree_keeps_its_own_shape(self):
+		"""`parent_key` names a sibling in the app's own list, so it is namespaced with the key
+		and the subtree travels as a unit. Nesting into the *host* is an anchor's job — reading
+		one column as sometimes-mine-sometimes-theirs would break an app's own hierarchy the day
+		a host happened to ship a row with the same key."""
+		merged = extend([], [(APP, [item("calls"), item("missed", parent_key="calls")])], anchorable=True)
+
+		self.assertEqual(merged[1]["parent_key"], "telephony:calls")
+
+	def test_a_keyless_row_is_skipped(self):
+		"""It would namespace to a bare `telephony:` that every other keyless row also produced."""
+		merged = extend([], [(APP, [{"item_type": "DocType"}, item("calls")])], anchorable=True)
+
+		self.assertEqual(keys(merged), ["telephony:calls"])
+
+
+class TestAnchors(UnitTestCase):
+	def base(self) -> list[dict]:
+		return [item("customers"), item("orders"), item("settings")]
+
+	def test_after_puts_the_row_next_to_the_key_it_names(self):
+		merged = extend(self.base(), [(APP, [anchored("calls", {"after": "customers"})])], anchorable=True)
+
+		self.assertEqual(keys(merged), ["customers", "telephony:calls", "orders", "settings"])
+
+	def test_before_puts_it_on_the_other_side(self):
+		merged = extend(self.base(), [(APP, [anchored("calls", {"before": "orders"})])], anchorable=True)
+
+		self.assertEqual(keys(merged), ["customers", "telephony:calls", "orders", "settings"])
+
+	def test_the_first_anchor_that_resolves_wins(self):
+		"""Which is how an app says "beside Invoices, or failing that beside Orders" without
+		knowing which version of the host is installed."""
+		merged = extend(
+			self.base(),
+			[(APP, [anchored("calls", {"after": "invoices"}, {"after": "orders"})])],
+			anchorable=True,
+		)
+
+		self.assertEqual(keys(merged), ["customers", "orders", "telephony:calls", "settings"])
+
+	def test_an_item_that_resolves_nothing_is_appended_and_never_dropped(self):
+		"""An app writes anchors against a host it does not ship and cannot pin, so a missing
+		anchor is the expected case. Landing in the wrong place is cosmetic; vanishing is a bug
+		report filed against the wrong app."""
+		merged = extend(self.base(), [(APP, [anchored("calls", {"after": "invoices"})])], anchorable=True)
+
+		self.assertEqual(keys(merged)[-1], "telephony:calls")
+
+	def test_an_anchor_naming_both_sides_names_neither(self):
+		"""Two positions is no position. Resolving it by precedence would turn a typo into a
+		silent placement nobody wrote."""
+		merged = extend(
+			self.base(),
+			[(APP, [anchored("calls", {"after": "customers", "before": "orders"})])],
+			anchorable=True,
+		)
+
+		self.assertEqual(keys(merged)[-1], "telephony:calls")
+
+	def test_an_unreadable_anchor_list_is_no_anchors(self):
+		"""The rows are authored by an app against a host it cannot see, so the reader of any
+		complaint would be the wrong person. The item still appears, where an app with no
+		anchors would have put it."""
+		merged = extend(self.base(), [(APP, [item("calls", anchors="{not json")])], anchorable=True)
+
+		self.assertEqual(keys(merged)[-1], "telephony:calls")
+
+	def test_a_derived_base_offers_no_anchor_targets(self):
+		"""A derived rail's keys are doctype names nobody authored, and one of them is a side
+		effect of what the reader happens to be allowed to see. An anchor cannot name one."""
+		merged = extend(self.base(), [(APP, [anchored("calls", {"after": "customers"})])], anchorable=False)
+
+		self.assertEqual(keys(merged)[-1], "telephony:calls")
+
+	def test_an_anchor_may_name_the_apps_own_row_without_writing_its_own_name(self):
+		"""Written-first is what makes the common case — aiming at the host — resolve to the
+		host. The own-namespace fallback is only reached when the host has no such key, so it
+		can never shadow one."""
+		merged = extend(
+			self.base(),
+			[(APP, [item("calls"), anchored("missed", {"after": "calls"})])],
+			anchorable=True,
+		)
+
+		self.assertEqual(keys(merged)[-2:], ["telephony:calls", "telephony:missed"])
+
+	def test_a_host_key_wins_over_the_apps_own(self):
+		merged = extend(
+			[item("calls")],
+			[(APP, [item("calls"), anchored("missed", {"after": "calls"})])],
+			anchorable=True,
+		)
+
+		self.assertEqual(keys(merged), ["calls", "telephony:missed", "telephony:calls"])
+
+
+class TestNesting(UnitTestCase):
+	def test_a_parent_key_anchor_nests_the_row_under_a_host_row(self):
+		merged = extend(
+			[item("sales"), item("customers", parent_key="sales"), item("settings")],
+			[(APP, [anchored("calls", {"parent_key": "sales"})])],
+			anchorable=True,
+		)
+
+		self.assertEqual(merged[2]["key"], "telephony:calls")
+		self.assertEqual(merged[2]["parent_key"], "sales")
+
+	def test_sitting_beside_a_row_means_sitting_at_its_depth(self):
+		"""Beside means beside. A sibling that landed at a different depth would be somewhere
+		else entirely."""
+		merged = extend(
+			[item("sales"), item("customers", parent_key="sales")],
+			[(APP, [anchored("calls", {"after": "customers"})])],
+			anchorable=True,
+		)
+
+		self.assertEqual(merged[2]["parent_key"], "sales")
+
+	def test_an_explicit_parent_wins_over_the_one_beside_implies(self):
+		merged = extend(
+			[item("sales"), item("customers", parent_key="sales"), item("support")],
+			[(APP, [anchored("calls", {"after": "customers", "parent_key": "support"})])],
+			anchorable=True,
+		)
+
+		self.assertEqual(merged[2]["parent_key"], "support")
+
+	def test_an_anchor_is_read_on_a_root_and_ignored_on_a_child(self):
+		"""Where a contributed subtree sits is its root's business. An anchor on a child would
+		tear the subtree apart to satisfy a row that never had a say in where it went."""
+		merged = extend(
+			[item("sales"), item("settings")],
+			[
+				(
+					APP,
+					[
+						item("calls"),
+						anchored("missed", {"after": "sales"}, parent_key="calls"),
+					],
+				)
+			],
+			anchorable=True,
+		)
+
+		self.assertEqual(keys(merged), ["sales", "settings", "telephony:calls", "telephony:missed"])
+		self.assertEqual(merged[3]["parent_key"], "telephony:calls")
+
+
+class TestTwoPasses(UnitTestCase):
+	"""Placing and anchoring in one pass would make an anchor that names another extender's item
+	resolve or not depending on which app was installed first — a property of a bench rather than
+	of either app. So every row is placed first, and only then does anything look for a key.
+	"""
+
+	def test_an_anchor_may_name_another_extenders_item_whichever_went_on_first(self):
+		calls = [(APP, [item("calls")])]
+		invoices = [(OTHER, [anchored("invoices", {"after": "telephony:calls"})])]
+
+		for order in (calls + invoices, invoices + calls):
+			merged = extend([item("customers")], order, anchorable=True)
+			self.assertEqual(
+				keys(merged)[-2:], ["telephony:calls", "payments:invoices"], msg=str(keys(merged))
+			)
+
+	def test_two_apps_naming_each_other_fall_back_rather_than_pick_a_winner(self):
+		merged = extend(
+			[item("customers")],
+			[
+				(APP, [anchored("calls", {"after": "payments:invoices"})]),
+				(OTHER, [anchored("invoices", {"after": "telephony:calls"})]),
+			],
+			anchorable=True,
+		)
+
+		self.assertEqual(len(merged), 3)
+		self.assertIn("telephony:calls", keys(merged))
+		self.assertIn("payments:invoices", keys(merged))
+
+
+class TestTheBaseIsLeftAlone(UnitTestCase):
+	def test_nothing_is_contributed_and_the_base_comes_back(self):
+		base = [item("customers")]
+		merged = extend(base, [], anchorable=True)
+
+		self.assertEqual(keys(merged), ["customers"])
+		self.assertIsNot(merged[0], base[0], "the base rows are copied, not handed out")
+
+	def test_a_contributed_row_records_which_app_contributed_it(self):
+		"""Which is the one thing `switches_app` needs and the only thing that can supply it: a
+		merged item is otherwise indistinguishable from a host row, deliberately."""
+		merged = extend([], [(APP, [item("calls")])], anchorable=True)
+
+		self.assertEqual(merged[0]["app"], APP)

--- a/frappe/tests/test_rail_extension.py
+++ b/frappe/tests/test_rail_extension.py
@@ -239,6 +239,20 @@ class TestTheBaseIsLeftAlone(UnitTestCase):
 		self.assertEqual(keys(merged), ["customers"])
 		self.assertIsNot(merged[0], base[0], "the base rows are copied, not handed out")
 
+	def test_two_rows_that_look_alike_are_told_apart_by_identity(self):
+		"""`list.remove` takes the first row that compares equal, so moving one row by value
+		would move whichever matched first. Nothing produces two equal rows today — keys are
+		unique by construction — and that is exactly the kind of invariant that stops being true
+		later, silently, in a list a person is looking at."""
+		merged = extend(
+			[item("customers")],
+			[(APP, [item("calls"), anchored("calls", {"after": "customers"})])],
+			anchorable=True,
+		)
+
+		self.assertEqual(len(merged), 3)
+		self.assertEqual(keys(merged).count("telephony:calls"), 2)
+
 	def test_a_contributed_row_records_which_app_contributed_it(self):
 		"""Which is the one thing `switches_app` needs and the only thing that can supply it: a
 		merged item is otherwise indistinguishable from a host row, deliberately."""

--- a/frappe/tests/test_shell_navigation.py
+++ b/frappe/tests/test_shell_navigation.py
@@ -71,8 +71,17 @@ def doctype_item(key: str, doctype: str, **kwargs) -> dict:
 	return item(key, link_doctype="DocType", link_to=doctype, **kwargs)
 
 
-def make_rail(items: list[dict], *, standard: int = 0, user: str | None = None):
-	doc = frappe.get_doc(doctype="Rail", app=APP, standard=standard, user=user or "", items=items)
+def make_rail(
+	items: list[dict], *, standard: int = 0, user: str | None = None, app: str = APP, extends: str = ""
+):
+	doc = frappe.get_doc(
+		doctype="Rail",
+		app=app,
+		extends=extends,
+		standard=standard,
+		user=user or "",
+		items=items,
+	)
 	with shipping():
 		return doc.insert(ignore_permissions=True)
 
@@ -419,3 +428,209 @@ class TestNavigationInBoot(NavigationTestCase):
 		from frappe.shell.boot import get_boot
 
 		self.assertLess(len(json.dumps(get_boot("/apps/desk"), default=str)), 40_000)
+
+
+# Extension — one app's rows on another app's rail
+#
+# No app on any bench ships a v2 rail, let alone one extending somebody else's, so there is
+# nothing here to convert and these fixtures are the only consumer the mechanism has (#42398).
+# The extending apps are named but never installed, which the resolver has to be told: it drops
+# a contribution from an app that is not active, so `active` below is what makes one count.
+
+EXTENDER = "telephony"
+OTHER_EXTENDER = "payments"
+
+
+@contextlib.contextmanager
+def active(*apps: str):
+	"""Present these apps to the resolver as installed and enabled, in this order.
+
+	`get_active_apps` is what decides whether a contribution counts and where in the appended
+	tail it lands, and it is the only thing in the merge that asks about an app at all.
+	"""
+	with patch("frappe.get_active_apps", return_value=[APP, *apps]):
+		yield
+
+
+def make_extension(items: list[dict], *, app: str = EXTENDER, host: str = APP):
+	return make_rail(items, standard=1, app=app, extends=host)
+
+
+def anchored(key: str, doctype: str, *anchors: dict, **kwargs) -> dict:
+	return doctype_item(key, doctype, anchors=json.dumps(list(anchors)), **kwargs)
+
+
+class TestExtendedRail(NavigationTestCase):
+	def test_a_contributed_item_reaches_the_hosts_rail(self):
+		make_rail([doctype_item("user", "User")], standard=1)
+		make_extension([doctype_item("calls", "Role")])
+
+		with active(EXTENDER):
+			rail = resolve_navigation(APP)["rail"]
+
+		self.assertEqual(keys(rail), ["user", "telephony:calls"])
+
+	def test_an_apps_own_rail_is_not_its_extension_of_somebody_elses(self):
+		"""Both records carry `app = frappe`, so the layer read has to name `extends` as well.
+		Without it the extension arrives as a second standard layer and the merge has no way to
+		tell it from the first."""
+		make_rail([doctype_item("user", "User")], standard=1)
+		make_rail([doctype_item("elsewhere", "Role")], standard=1, extends="erpnext")
+
+		with active(EXTENDER):
+			self.assertEqual(keys(resolve_navigation(APP)["rail"]), ["user"])
+
+	def test_an_app_that_is_not_active_contributes_nothing(self):
+		"""A disabled app must not keep serving anything, which is the rule boot already applies
+		to the app list and the prefix registry."""
+		make_rail([doctype_item("user", "User")], standard=1)
+		make_extension([doctype_item("calls", "Role")])
+
+		with active():
+			self.assertEqual(keys(resolve_navigation(APP)["rail"]), ["user"])
+
+	def test_extension_merges_into_a_derived_rail(self):
+		"""No app ships a `Rail` record, so this is the path every extension takes today. The
+		derived base offers no anchor targets, so the contribution appends."""
+		make_extension([anchored("calls", "Role", {"after": "User"})])
+
+		with active(EXTENDER):
+			rail = resolve_navigation(APP)["rail"]
+
+		self.assertIn("User", keys(rail))
+		self.assertEqual(keys(rail)[-1], "telephony:calls")
+
+	def test_a_person_arranges_one_list_and_not_one_per_app(self):
+		"""`extends` is standard-rows-only, so a person's arrangement of a host rail is one row
+		covering every item on it — including the ones another app put there."""
+		make_rail([doctype_item("user", "User"), doctype_item("role", "Role")], standard=1)
+		make_extension([doctype_item("calls", "Role")])
+		make_rail([item("telephony:calls"), item("user"), item("role")], user=frappe.session.user)
+
+		with active(EXTENDER):
+			self.assertEqual(keys(resolve_navigation(APP)["rail"]), ["telephony:calls", "user", "role"])
+
+	def test_a_person_may_hide_a_contributed_item(self):
+		make_rail([doctype_item("user", "User")], standard=1)
+		make_extension([doctype_item("calls", "Role")])
+		make_rail([item("telephony:calls", hidden=1)], user=frappe.session.user)
+
+		with active(EXTENDER):
+			self.assertEqual(keys(resolve_navigation(APP)["rail"]), ["user"])
+
+	def test_a_contribution_is_positioned_and_not_only_appended(self):
+		make_rail([doctype_item("user", "User"), doctype_item("role", "Role")], standard=1)
+		make_extension([anchored("calls", "Role", {"after": "user"})])
+
+		with active(EXTENDER):
+			self.assertEqual(keys(resolve_navigation(APP)["rail"]), ["user", "telephony:calls", "role"])
+
+	def test_two_apps_contribute_in_installation_order(self):
+		make_rail([doctype_item("user", "User")], standard=1)
+		make_extension([doctype_item("calls", "Role")])
+		make_extension([doctype_item("invoices", "Role")], app=OTHER_EXTENDER)
+
+		with active(OTHER_EXTENDER, EXTENDER):
+			self.assertEqual(
+				keys(resolve_navigation(APP)["rail"]),
+				["user", "payments:invoices", "telephony:calls"],
+			)
+
+	def test_the_stored_columns_never_reach_the_browser(self):
+		"""`anchors` is spent at merge and `switches_app` becomes a `url`. Both are read into the
+		merge because `overrides` may name any field a layer has an opinion about, and neither is
+		anything the client renders — navigation is 88% of a payload with a 40 KB ceiling."""
+		make_rail([doctype_item("user", "User")], standard=1)
+		make_extension([anchored("calls", "Role", {"after": "user"})])
+
+		with active(EXTENDER):
+			entry = resolve_navigation(APP)["rail"][1]
+
+		self.assertNotIn("anchors", entry)
+		self.assertNotIn("switches_app", entry)
+		self.assertNotIn("app", entry)
+
+
+class TestSwitchingApps(NavigationTestCase):
+	"""Following a contributed item keeps you in the host unless its app says otherwise.
+
+	That default needs no code — a contributed row is an ordinary prefix-relative link, because
+	addresses are bench-wide. Leaving is the exception, and only the server can build it: the
+	client resolves routes through the router this document holds, which cannot reach another
+	prefix at all (`routeFor.ts` says so in as many words).
+	"""
+
+	@contextlib.contextmanager
+	def prefixed(self, prefix: str = "telephony", modular: bool = False):
+		with (
+			patch("frappe.shell.registry.declared_prefix", return_value=prefix),
+			patch("frappe.shell.registry.is_modular", return_value=modular),
+		):
+			yield
+
+	def test_an_item_that_does_not_switch_carries_no_url(self):
+		make_rail([doctype_item("user", "User")], standard=1)
+		make_extension([doctype_item("calls", "Role")])
+
+		with active(EXTENDER):
+			entry = resolve_navigation(APP)["rail"][1]
+
+		self.assertNotIn("url", entry)
+
+	def test_a_switching_item_carries_the_finished_absolute_url(self):
+		make_rail([doctype_item("user", "User")], standard=1)
+		make_extension([doctype_item("calls", "Role", switches_app=1)])
+
+		with active(EXTENDER), self.prefixed():
+			entry = resolve_navigation(APP)["rail"][1]
+
+		self.assertEqual(entry["url"], "/apps/telephony/role")
+
+	def test_a_modular_prefix_puts_the_module_in_the_address(self):
+		"""The shape is the destination app's, not the host's — which is the whole reason the
+		server builds this and the client cannot."""
+		make_rail([doctype_item("user", "User")], standard=1)
+		make_extension([doctype_item("calls", "Role", switches_app=1)])
+
+		with active(EXTENDER), self.prefixed(modular=True):
+			entry = resolve_navigation(APP)["rail"][1]
+
+		self.assertEqual(entry["url"], "/apps/telephony/core/role")
+
+	def test_a_record_item_carries_the_record(self):
+		make_rail([doctype_item("user", "User")], standard=1)
+		make_extension(
+			[
+				item(
+					"admin",
+					item_type="Record",
+					link_doctype="User",
+					link_to="Administrator",
+					switches_app=1,
+				)
+			]
+		)
+
+		with active(EXTENDER), self.prefixed():
+			entry = resolve_navigation(APP)["rail"][1]
+
+		self.assertEqual(entry["url"], "/apps/telephony/user/Administrator")
+
+	def test_a_kind_with_no_cross_app_address_falls_back_to_the_host(self):
+		"""A working link in the wrong app beats no link at all, and `Link` already carries an
+		absolute URL of its own, so switching says nothing about it."""
+		make_rail([doctype_item("user", "User")], standard=1)
+		make_extension([item("docs", item_type="Link", url="https://frappe.io", switches_app=1)])
+
+		with active(EXTENDER), self.prefixed():
+			entry = resolve_navigation(APP)["rail"][1]
+
+		self.assertEqual(entry["url"], "https://frappe.io")
+
+	def test_a_host_row_never_switches(self):
+		"""Nothing sets `app` on one, because nothing about it is foreign — so the column is
+		inert on the rows it cannot mean anything for, rather than guarded against them."""
+		make_rail([doctype_item("user", "User", switches_app=1)], standard=1)
+
+		with active(), self.prefixed():
+			self.assertNotIn("url", resolve_navigation(APP)["rail"][0])

--- a/frappe/tests/test_shell_navigation.py
+++ b/frappe/tests/test_shell_navigation.py
@@ -536,6 +536,29 @@ class TestExtendedRail(NavigationTestCase):
 				["user", "payments:invoices", "telephony:calls"],
 			)
 
+	def test_a_contributed_item_is_filtered_by_doctype_read(self):
+		"""#42364 rule 6: doctype read is the only filter on a contribution — and the host is the
+		one party that cannot refuse one, which is why this does not wait for #42233."""
+		make_rail([doctype_item("user", "User")], standard=1)
+		make_extension([doctype_item("calls", "Role"), doctype_item("todos", "ToDo")])
+
+		with active(EXTENDER), set_user("Guest"):
+			rail = resolve_navigation(APP)["rail"]
+
+		self.assertNotIn("telephony:calls", keys(rail))
+
+	def test_the_target_apps_own_door_does_not_run(self):
+		"""`app_permission` gates entering a prefix, and following a contributed item does not
+		leave the host. Running it here would let an app you may not enter withhold items it put
+		on a rail you may."""
+		make_rail([doctype_item("user", "User")], standard=1)
+		make_extension([doctype_item("calls", "Role")])
+
+		with active(EXTENDER), patch("frappe.shell.permissions.has_app_permission") as door:
+			resolve_navigation(APP)
+
+		door.assert_not_called()
+
 	def test_the_stored_columns_never_reach_the_browser(self):
 		"""`anchors` is spent at merge and `switches_app` becomes a `url`. Both are read into the
 		merge because `overrides` may name any field a layer has an opinion about, and neither is

--- a/frontend/src/boot.ts
+++ b/frontend/src/boot.ts
@@ -22,6 +22,13 @@ export type NavigationItem = {
 	parent_key?: string;
 	link_doctype?: string;
 	link_to?: string;
+	/**
+	 * An absolute href, for the two rows that are not a route in this prefix: a `Link`
+	 * item, which points off the desk entirely, and a contributed item marked
+	 * `switches_app`, whose URL the server finishes because the router this document
+	 * holds cannot build one into another prefix (#42364). Either way, following it is
+	 * a full document load, so a row carrying one is an `<a>` and not a `RouterLink`.
+	 */
 	url?: string;
 	payload?: Record<string, unknown>;
 	label?: string;

--- a/frontend/src/shell/AppRail.vue
+++ b/frontend/src/shell/AppRail.vue
@@ -20,6 +20,11 @@
   An app that ships no rail rows still gets a rail: its own doctypes, permission-
   filtered, exactly the list this showed before. So the rail's appearance changes when
   an app ships rows and not when this lands (#42356).
+
+  Some of these rows may belong to another app entirely — one that ships a `Rail`
+  record naming this app in `extends`. Nothing here can tell, and nothing here should:
+  the server merged them into the base before the layers went on, so they arrive as
+  ordinary items in one ordered list (#42364).
 -->
 <template>
 	<nav class="flex w-52 shrink-0 flex-col gap-1 border-r border-outline-gray-2 p-2">
@@ -31,16 +36,18 @@
 		</RouterLink>
 
 		<div class="mt-2 overflow-y-auto">
-			<RouterLink
+			<component
 				v-for="item in doctypeItems"
 				:key="item.key"
-				:to="routeFor(item.link_to!)"
+				:is="item.url ? 'a' : RouterLink"
+				:to="item.url ? undefined : routeFor(item.link_to!)"
+				:href="item.url"
 				class="block truncate rounded px-2 py-1 text-sm text-ink-gray-7 hover:bg-surface-gray-2"
 			>
 				<!-- An item nobody labelled falls back to its destination, which is what a
 						 derived rail row is: an address and no authored presentation. -->
 				{{ item.label ?? item.link_to }}
-			</RouterLink>
+			</component>
 		</div>
 
 		<a
@@ -67,6 +74,13 @@ const boot = inject<Boot>("boot")!;
 // the branch is derived, and derivation produces `DocType` items and nothing else.
 // Renderers, and a rail that draws sections and opens sidebars, are the walking
 // skeleton's (#42233).
+//
+// A row carrying a `url` is rendered as a plain `<a>` above. That is a contributed item
+// whose app said `switches_app`, and leaving a prefix is a full document load — a
+// `RouterLink` would resolve it against this document's router, which cannot reach
+// another prefix at all. A contributed item that does NOT switch is an ordinary
+// `RouterLink` like any other, and needs nothing here: addresses are bench-wide, so a
+// foreign doctype opens under the host's prefix (#42364).
 const doctypeItems = computed(() =>
 	(boot.navigation?.rail ?? []).filter((item) => item.item_type === "DocType" && item.link_to)
 );


### PR DESCRIPTION
Builds [Extend another app's rail: extends, anchors and key namespacing](https://github.com/frappe/frappe/issues/42398), which is the build half of [Does mount_on resolve, and how do two apps' base layers order?](https://github.com/frappe/frappe/issues/42364). Part of [Desk v2 — the rail and the sidebar](https://github.com/frappe/frappe/issues/42226).

## What this does

One app can now add items to another app's rail while keeping its own, and `mount_on` comes off.

**`extends` on `Rail`.** A layer names the app whose rail it joins, and the unique index widens from `(app, user, standard)` to `(app, extends, user, standard)`. `mount_on` was desk v1's arrangement — a companion app surrendered its own rail and its apps-screen tile to live inside a host — and one column could only ever name one host, where Payments and Telephony each extend ERPNext *or* CRM *or* Helpdesk. The old index also meant `telephony` already owned `(telephony, "", 1)`, so a second record collided with its first: extending was unstorable, not merely unresolvable.

**Anchors.** A contributed row carries an ordered list of attempts, each naming a host key to sit `after` or `before` and optionally a `parent_key` to nest under. The first whose every named key resolves wins; none resolving appends at the top level and never drops, because an app writes its anchors against a host it does not ship and cannot pin.

**Two passes.** Every row is placed first, and only then does anything look for a key — so an anchor naming another extender's item resolves whichever app was installed first, which is a property of a bench rather than of either app. A cycle falls through to the next anchor and then to the append.

**Namespacing at merge.** A contributed key becomes `<app>:<key>` and host keys are untouched. The key is what every user edit is filed against, so an identity that changed when a second app was installed would silently detach a person's arrangement; host-wins-and-drop has the same fault from the other side.

**`switches_app` on `Navigation Item`.** Following a contributed item keeps you in the host and needs no code — addresses are bench-wide, so a foreign doctype opens under the host's prefix. Leaving is opt-in per item, and the server sends the finished absolute URL because `routeFor` resolves through the router this document holds and cannot cross a prefix. A column rather than a corner of `payload`, so `overrides` can name it.

Extension merges into the *base*, before the site and user layers go on, so a person arranging a host rail writes one row covering every item on it. It merges into a derived rail too, which is the path every app takes today since none ships a `Rail` record — and a derived base offers no anchor targets, its keys being doctype names nobody authored.

## Found by building

A shipped rail's name is its address while the doctype autonames by `hash`, so a second record at one address was read as a hash collision by `db_insert`, retried five times against an `autoname` that kept returning the same string, and then re-raised the driver's own `IntegrityError` naming a column and no cause. It now says so in `validate`. The unique index is still the guarantee.

## Checked on a site

`bench migrate` dropped `unique_layer_address` and created the four-column `unique_rail_address`, confirmed against `SHOW INDEX FROM tabRail`. A seeded host-and-extender pair resolves through `resolve_navigation`: with the extender inactive the rail is the host's two rows; active, it is `users, telephony:calls, roles, telephony:logs` with `calls` anchored after `users`; the switching row carries `/apps/telephony/note`; and the contributed row reaches the browser with four fields and neither `anchors` nor `switches_app` nor `app`.

Tests: 43 new — 22 unit in a new `test_rail_extension`, 17 in the resolver suite and 4 on `Rail`, taking those three suites to 91 — and 328 green in the four neighbouring suites — `test_shell`, `test_module_sidebar_boot`, `test_dock_preferences` and `test_sidebar`. 249 frontend vitest tests green, and `bench build --app frappe` builds the shell.

Desk v1 is untouched: `Dock` keeps `mount_on` and its complete mounting engine, and the 121 `test_dock_preferences` tests are green unchanged.

>no-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

