### PR TITLE
test: give the IMAP sync rule test account a unique email id

### DIFF
--- a/frappe/email/doctype/email_account/test_email_account.py
+++ b/frappe/email/doctype/email_account/test_email_account.py
@@ -473,8 +473,8 @@ class TestEmailAccount(IntegrationTestCase):
 	def test_email_sync_rule_ignores_reindexed_uids(self):
 		email_account = frappe.get_doc(
 			doctype="Email Account",
-			email_account_name="Test IMAP Account",
-			email_id="test@example.com",
+			email_account_name="Test IMAP Sync Account",
+			email_id="test_imap_sync@example.com",
 			use_imap=1,
 			email_sync_option="ALL",
 			initial_sync_count=100,


### PR DESCRIPTION
The account created in `test_email_sync_rule_ignores_reindexed_uids` reused `test@example.com`, which `_Test Email Account 1` already owns in test_records. It passes here only because the constraint on develop is the composite `unique_email_account_type` on `(email_id, enable_incoming, enable_outgoing)` and the two records differ on those flags.

v15 still has `email_id` unique on its own, so the backport of #42092 failed with `Duplicate entry 'test@example.com' for key 'email_id'`; that is fixed on the backport branch. This keeps develop identical to it so the next backport touching this test doesn't drift.