### PR TITLE
fix: quote boolean literals so they work as conditions too

### DIFF
--- a/frappe/query_builder/terms.py
+++ b/frappe/query_builder/terms.py
@@ -64,8 +64,8 @@ class ParameterizedValueWrapper(ValueWrapper):
 			elif isinstance(self.value, datetime):
 				self.value = frappe.db.format_datetime(self.value)
 			elif isinstance(self.value, bool):
-				# quoted, so it works both as a value (Check fields are smallint) and as a
-				# condition (`... OR '0'`) -- postgres rejects a bare 1/0 in the second case
+				# emit '1'/'0': fits both `SET check_field = '1'` (smallint) and
+				# `WHERE ... OR '0'` (a condition), where postgres rejects a bare 1
 				self.value = str(int(self.value))
 
 			sql = self.get_value_sql(

--- a/frappe/query_builder/terms.py
+++ b/frappe/query_builder/terms.py
@@ -64,7 +64,9 @@ class ParameterizedValueWrapper(ValueWrapper):
 			elif isinstance(self.value, datetime):
 				self.value = frappe.db.format_datetime(self.value)
 			elif isinstance(self.value, bool):
-				self.value = int(self.value)
+				# quoted, so it works both as a value (Check fields are smallint) and as a
+				# condition (`... OR '0'`) -- postgres rejects a bare 1/0 in the second case
+				self.value = str(int(self.value))
 
 			sql = self.get_value_sql(
 				quote_char=quote_char,

--- a/frappe/tests/test_query_builder.py
+++ b/frappe/tests/test_query_builder.py
@@ -3,11 +3,12 @@ from collections.abc import Callable
 from datetime import time
 
 from pypika.functions import Cast
+from pypika.terms import ValueWrapper
 
 import frappe
 from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.database.operator_map import func_in
-from frappe.query_builder import Case, ValueWrapper
+from frappe.query_builder import Case
 from frappe.query_builder.builder import Function
 from frappe.query_builder.custom import ConstantColumn
 from frappe.query_builder.functions import (
@@ -643,12 +644,16 @@ class TestParameterization(IntegrationTestCase):
 		query, _ = frappe.qb.update(DocType).set(DocType.is_submittable, False).walk()
 		self.assertIn("='0'", query)
 
-		# a bool used as a condition, as apps do: `(a < b) | ValueWrapper(flag)`
+		# a bool as a condition, not as a value: it must stay a quoted literal, since
+		# postgres accepts neither a bare 1 nor `true` as an operand of OR
 		user = frappe.qb.DocType("User")
-		query, _ = (
-			frappe.qb.from_(user).select(user.name).where((user.enabled == 1) | ValueWrapper(False)).walk()
-		)
-		self.assertIn("'0'", query)
+		condition = frappe.qb.from_(user).select(user.name).where((user.enabled == 1) | ValueWrapper(False))
+
+		query, _ = condition.walk()
+		self.assertIn("OR '0'", query)
+		self.assertNotIn("OR 0", query)
+		self.assertNotIn("OR false", query)
+		condition.run()  # and the database accepts it
 
 	def test_where_conditions_functions(self):
 		DocType = frappe.qb.DocType("DocType")

--- a/frappe/tests/test_query_builder.py
+++ b/frappe/tests/test_query_builder.py
@@ -7,7 +7,7 @@ from pypika.functions import Cast
 import frappe
 from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.database.operator_map import func_in
-from frappe.query_builder import Case
+from frappe.query_builder import Case, ValueWrapper
 from frappe.query_builder.builder import Function
 from frappe.query_builder.custom import ConstantColumn
 from frappe.query_builder.functions import (
@@ -632,16 +632,23 @@ class TestParameterization(IntegrationTestCase):
 		self.assertEqual(params["param1"], "some_value")
 
 	def test_bool_conditions(self):
-		# bools go out as 1/0: postgres does not cast `true` to smallint (Check fields)
+		# bools go out as '1'/'0': quoted, so they work as a value and as a condition
 		DocType = frappe.qb.DocType("DocType")
 		query, params = frappe.qb.update(DocType).set(DocType.is_submittable, True).walk()
 
-		self.assertIn("=1", query)
+		self.assertIn("='1'", query)
 		self.assertNotIn("true", query)
 		self.assertEqual(params, {})
 
 		query, _ = frappe.qb.update(DocType).set(DocType.is_submittable, False).walk()
-		self.assertIn("=0", query)
+		self.assertIn("='0'", query)
+
+		# a bool used as a condition, as apps do: `(a < b) | ValueWrapper(flag)`
+		user = frappe.qb.DocType("User")
+		query, _ = (
+			frappe.qb.from_(user).select(user.name).where((user.enabled == 1) | ValueWrapper(False)).walk()
+		)
+		self.assertIn("'0'", query)
 
 	def test_where_conditions_functions(self):
 		DocType = frappe.qb.DocType("DocType")


### PR DESCRIPTION
#42129 renders a Python `bool` as `1`/`0`. That is right when the value goes **into** a Check field, but wrong when the bool **is** a condition.

```sql
-- value: a Check field is smallint on postgres, so it needs a number
SET `is_submittable` = 1                       -- ok

-- condition: this needs a boolean
WHERE `produced_qty` < `qty` OR 0
-- postgres: argument of OR must be type boolean, not type integer
```

Quoting it covers both, because postgres takes the type from the surrounding context:

```sql
SET `is_submittable` = '1'                     -- ok
WHERE `produced_qty` < `qty` OR '0'            -- ok
```

Checked on postgres and mariadb: values into `smallint` / `varchar` / `boolean` columns, and conditions with `OR`, `AND`, `NOT`, `CASE WHEN` and a bare `WHERE`. On mariadb the stored value is unchanged and `EXPLAIN` still uses the index for `= '1'`.

This is the regression frappe/erpnext#58666 works around. With this change apps can keep passing plain bools.
