### PR TITLE
feat: save a navigation arrangement as anchors, not positions

### DIFF
--- a/frappe/desk/doctype/navigation_item/navigation_item.json
+++ b/frappe/desk/doctype/navigation_item/navigation_item.json
@@ -57,13 +57,12 @@
    "fieldtype": "Column Break"
   },
   {
-   "description": "What kind of thing this row opens. A Link to the code-owned type registry rather than a Select, because a Select's options live in one DocType JSON owned by one app, so a second app could only extend it with a Property Setter. Link rows are additive across apps with no shared field to fight over.",
+   "description": "What kind of thing this row opens. A Link to the code-owned type registry rather than a Select, because a Select's options live in one DocType JSON owned by one app, so a second app could only extend it with a Property Setter. Link rows are additive across apps with no shared field to fight over. Required on a row that IS an item — one an app ships, or one a layer added — and blank on a delta, which is an opinion about an item the layer below it holds and says nothing about what that item opens.",
    "fieldname": "item_type",
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Type",
-   "options": "Navigation Item Type",
-   "reqd": 1
+   "options": "Navigation Item Type"
   },
   {
    "fieldname": "destination_section",
@@ -171,13 +170,13 @@
   },
   {
    "collapsible": 1,
-   "description": "Only meaningful on a row one app contributes to another app's rail — a `Rail` layer with `extends` set. An app's own rows are already where their author put them, and a site or user layer says where a row goes by the order it lists it in.",
+   "description": "Only meaningful on a row one app contributes to another app's rail — a `Rail` layer with `extends` set. An app's own rows are already where their author put them. A site or user layer says where a row goes with an anchor too, but stores it on the row it is moving rather than here, because that row is a delta over somebody else's item.",
    "fieldname": "contribution_section",
    "fieldtype": "Section Break",
    "label": "Contribution"
   },
   {
-   "description": "Where this row wants to land in the host's list, as an ordered JSON list of attempts. Each attempt is an object naming at most one of `after` and `before`, a sibling to sit next to, and optionally `parent_key`, a row to nest under; every key it names has to be in the merged list for the attempt to resolve. The first that resolves wins and the rest are ignored, which is how an app says \"beside Customers, or failing that beside Contacts, or failing that anywhere\" without knowing which version of the host is installed. None resolving means the row is appended at the top level and never dropped, because a contributed item that lands in the wrong place is a cosmetic problem and one that vanishes is a bug report. Keys are written as the host wrote them, unprefixed; the merge namespaces contributed keys but never the anchors that name them.",
+   "description": "Where this row wants to land in the host's list, as an ordered JSON list of attempts. Each attempt is an object naming at most one of `after` and `before`, a sibling to sit next to, and optionally `parent_key`, a row to nest under; every key it names has to be in the merged list for the attempt to resolve. The first that resolves wins and the rest are ignored, which is how an app says \"beside Customers, or failing that beside Contacts, or failing that anywhere\" without knowing which version of the host is installed. None resolving means the row is appended at the top level and never dropped, because a contributed item that lands in the wrong place is a cosmetic problem and one that vanishes is a bug report. Keys are written as the host wrote them, unprefixed; the merge namespaces contributed keys but never the anchors that name them. A layer row uses the same list for the same reason one phase later: a person's move is stored as what it landed beside, not as a position, so an item an app ships afterwards lands where the app put it instead of after everything that person has arranged. There the fallback is the row's own shipped position rather than the end, because unlike a contributed row it has one.",
    "fieldname": "anchors",
    "fieldtype": "Code",
    "label": "Anchors",

--- a/frappe/desk/doctype/navigation_item/navigation_item.py
+++ b/frappe/desk/doctype/navigation_item/navigation_item.py
@@ -44,11 +44,33 @@ class NavigationItem(Document):
 		url: DF.Data | None
 	# end: auto-generated types
 
-	pass
+	def validate(self):
+		self.validate_type_on_an_item()
+
+	def validate_type_on_an_item(self):
+		"""A row that *is* an item names its type; a delta does not have one to name.
+
+		`item_type` is not `reqd` on the field, because two different kinds of row live in this
+		table. An **added** row brings an item nothing below it holds, and a row an app ships is
+		an item by definition -- both open something, so both must say what. A **delta** states an
+		opinion about an item a lower layer already holds, and what that item opens is not its
+		business: a person renaming a row would otherwise have to restate a type they have no view
+		on, and the copy would go stale the day the app changed it.
+
+		The shipped case is checked by the container instead, in `validate_item_keys`, because a
+		row cannot see whether its parent is standard without loading it.
+		"""
+		if self.added and not self.item_type:
+			frappe.throw(
+				_("Row {0} adds an item but does not say what kind. An added row is the item.").format(
+					self.idx
+				),
+				title=_("Missing Type"),
+			)
 
 
 def validate_item_keys(items):
-	"""Refuse a shipped list whose rows are not addressable, one by one.
+	"""Refuse a shipped list whose rows are not addressable or not typed, one by one.
 
 	A `key` is what every site and user edit is filed against, so a missing or duplicated one
 	is not a cosmetic slip: the deltas naming it go inert and the site quietly loses its
@@ -62,6 +84,14 @@ def validate_item_keys(items):
 	seen = set()
 
 	for item in items:
+		if not item.item_type:
+			# Checked here rather than on the field, which cannot be `reqd` because a delta row
+			# in a site or user layer has no type to give -- see `validate_type_on_an_item`.
+			frappe.throw(
+				_("Row {0} does not say what kind of item it is.").format(item.idx),
+				title=_("Missing Type"),
+			)
+
 		if not item.key:
 			frappe.throw(
 				_("Row {0} ({1}) has no key. Every item an app ships needs one, frozen for good.").format(

--- a/frappe/desk/layers.py
+++ b/frappe/desk/layers.py
@@ -23,8 +23,22 @@ Three things differ between the two, and each is a parameter:
 
 None of those is the merge itself, so the merge lives here and they are passed in as `key`,
 `apply_row` and `keep_unnamed`.
+
+Desk v2 arranges by a fourth rule, `anchored`. Its writer saves a person's move as an *anchor* --
+next to this row -- rather than as a position, so a layer names only what moved and everything
+else stays where the layer below it put it. The two rules cannot both be right for one surface:
+v1's positions the whole list from the rows a layer names, and desk v2's moves the named rows
+within a list it otherwise leaves alone. It is a parameter defaulted off, so v1's two callers are
+unchanged.
+
+Placement is at the bottom of this file rather than beside the merge, because the layer merge is
+not its only caller: `frappe/shell/extensions.py` places one app's rows into another app's rail by
+the same anchors, before any layer applies. Those are different phases of one resolution and they
+share exactly this -- given a list and some rows that want to sit next to something in it, produce
+one list.
 """
 
+import json
 from collections.abc import Callable
 from typing import Any
 
@@ -45,6 +59,7 @@ def resolve_layers(
 	key: Key,
 	apply_row: ApplyRow,
 	keep_unnamed: bool = True,
+	anchored: bool = False,
 ) -> tuple[list[dict], dict[str, bool]]:
 	"""Fold each layer into the one below it. Later layers win, for order and for hiding.
 
@@ -69,6 +84,10 @@ def resolve_layers(
 	`keep_unnamed` says what happens to an entry the layer never mentioned: kept after the ones it
 	did name (the sidebar), or dropped (the dock). See `apply_layer`.
 
+	`anchored` reads each row's `anchors` and moves only the rows that carry one, leaving the rest
+	of the list alone. It supersedes `keep_unnamed`, which has nothing left to decide once an
+	unnamed entry simply stays where it is.
+
 	The map is seeded from the base, so the base hides on the same terms as the layers above it:
 	an app may ship an entry off by default, and one row above naming that entry with hiding off
 	brings it back. The base used to be the one layer whose hiding was discarded, and seeding it
@@ -83,7 +102,13 @@ def resolve_layers(
 
 	for rows in layers:
 		resolved = apply_layer(
-			resolved, rows, hidden, key=key, apply_row=apply_row, keep_unnamed=keep_unnamed
+			resolved,
+			rows,
+			hidden,
+			key=key,
+			apply_row=apply_row,
+			keep_unnamed=keep_unnamed,
+			anchored=anchored,
 		)
 
 	return resolved, hidden
@@ -97,6 +122,7 @@ def apply_layer(
 	key: Key,
 	apply_row: ApplyRow,
 	keep_unnamed: bool = True,
+	anchored: bool = False,
 ) -> list[dict]:
 	"""Apply one layer's arrangement to `items`. Mutates `hidden`, which spans the layers.
 
@@ -113,6 +139,7 @@ def apply_layer(
 	base_keys = set(by_key)
 	arranged: list[str] = []
 	named: set[str] = set()
+	attempts: dict[str, list[dict]] = {}
 
 	for row in rows:
 		row_key = key(row)
@@ -132,8 +159,18 @@ def apply_layer(
 		arranged.append(row_key)
 		named.add(row_key)
 
+		if anchored:
+			# Read off the row rather than the entry. An anchor says where this *layer* wants the
+			# item, so it is the layer's own statement and not part of the item -- `apply_row`
+			# carries it into the entry only if the layer also declared it an override, which is
+			# a site turning a contributed row's anchor off and a different thing entirely.
+			attempts[row_key] = anchor_attempts(row.get("anchors"))
+
 	if not named:
 		return items
+
+	if anchored:
+		return anchor_layer(items, by_key, base_keys, arranged, attempts, key=key)
 
 	arranged_items = [by_key[row_key] for row_key in arranged]
 	# Entries the layer never named. The sidebar keeps them after the ones it did name, so an app
@@ -163,3 +200,230 @@ def apply_layer(
 		return unnamed + arranged_items
 
 	return arranged_items + unnamed
+
+
+def anchor_layer(
+	items: list[dict],
+	by_key: dict[str, dict],
+	base_keys: set[str],
+	arranged: list[str],
+	attempts: dict[str, list[dict]],
+	*,
+	key: Key,
+) -> list[dict]:
+	"""One layer applied by anchors: the list below, updated in place, then the moves.
+
+	The list keeps the order it arrived in. That is the whole difference from `apply_layer`'s
+	other half, and it is what makes a newly-shipped item land at its shipped position rather
+	than after everything a person has arranged: nothing but an anchored row moves, so an item
+	nobody moved is exactly where the layer below it put it.
+
+	A row the layer *added* has no place in that list to keep, so it is appended, in the order
+	the layer wrote its rows. Its anchors then move it like any other, and an added row whose
+	anchor does not resolve stays at the end -- the one case where the fallback is not a shipped
+	position, because it has none.
+	"""
+	merged = [by_key[key(item)] for item in items]
+	merged += [by_key[row_key] for row_key in arranged if row_key not in base_keys]
+
+	placed = [(by_key[row_key], attempts[row_key]) for row_key in arranged if attempts.get(row_key)]
+	if not placed:
+		return merged
+
+	# An overlay row was written against the very list it is being applied to, so a name it wrote
+	# is a key or it is nothing.
+	present = {key(item) for item in merged}
+	return place_by_anchors(
+		merged, placed, key=key, target_key=lambda _item, name: name if name in present else None
+	)
+
+
+# Placement
+#
+# An anchor is `{"after": key}`, `{"before": key}` or `{"parent_key": key}`, and a row carries an
+# ordered list of them: the first that resolves wins, and a row none of whose anchors resolve is
+# left where it already is. Two callers, two phases, one rule.
+#
+# What differs between them is only how a written name becomes a key in the list, so that is the
+# parameter. An overlay row names a key as it stands, because it was written against the very list
+# it is being applied to. A contributed row was written against a host its app cannot see, so its
+# names resolve to the host first and to the app's own namespaced rows second (#42364).
+
+
+Attempt = dict
+# `(item, written name) -> the key in the list it names, or a falsy value if there is none.`
+TargetKey = Callable[[Row, str], Any]
+
+
+def anchor_attempts(raw: Any) -> list[Attempt]:
+	"""A row's stored anchors, as an ordered list of well-formed attempts.
+
+	A malformed list is no anchors rather than an error. On a contributed row the reader of any
+	complaint would be the wrong person, since an app writes anchors against a host it cannot see;
+	on an overlay row the writer is an endpoint, so a malformed one is a bug that shows up as an
+	item that did not move rather than as a save that failed. Either way the row still appears.
+
+	An attempt naming both `after` and `before` names two positions and so names none. It is
+	dropped rather than resolved by precedence, because picking one would make a typo into a
+	silent placement nobody wrote.
+	"""
+	try:
+		anchors = json.loads(raw or "[]") if isinstance(raw, str) else (raw or [])
+	except (TypeError, ValueError):
+		return []
+
+	if not isinstance(anchors, list):
+		return []
+
+	attempts = []
+
+	for anchor in anchors:
+		if not isinstance(anchor, dict):
+			continue
+
+		after, before, parent = anchor.get("after"), anchor.get("before"), anchor.get("parent_key")
+		if after and before:
+			continue
+		if not (after or before or parent):
+			continue
+
+		attempts.append({"after": after, "before": before, "parent_key": parent})
+
+	return attempts
+
+
+def place_by_anchors(
+	items: list[dict],
+	placed: list[tuple[dict, list[Attempt]]],
+	*,
+	key: Key,
+	target_key: TargetKey,
+) -> list[dict]:
+	"""Move each row in `placed` to the first position it asks for that resolves.
+
+	`placed` pairs a row that is already in `items` with its ordered attempts. It is a pair rather
+	than a read off the row because the two callers store anchors in different places: an
+	extension reads them off the contributed row, and a layer reads them off the layer row rather
+	than off the entry it resolved to.
+
+	`anchored` is the cycle guard and the whole of it: it records what each moved row was moved
+	next to, so an anchor whose target chain leads back to the row being placed is refused and the
+	next anchor is tried. Two rows naming each other is the case, and neither an exception nor an
+	arbitrary winner would be right -- falling through to the next anchor, and then to leaving the
+	row alone, is the same answer this gives every other unresolvable one.
+	"""
+	anchored: dict[str, str] = {}
+
+	for item, attempts in placed:
+		attempt = _first_resolving(item, attempts, key=key, target_key=target_key, anchored=anchored)
+		if attempt is None:
+			continue
+
+		_place(items, item, attempt, key=key)
+		anchored[key(item)] = attempt["target"]
+
+	return items
+
+
+def _first_resolving(
+	item: dict, attempts: list[Attempt], *, key: Key, target_key: TargetKey, anchored: dict[str, str]
+) -> dict | None:
+	"""The first of this row's anchors whose every named key is present and not circular."""
+	for attempt in attempts:
+		resolved = _resolve(item, attempt, key=key, target_key=target_key, anchored=anchored)
+		if resolved:
+			return resolved
+
+	return None
+
+
+def _resolve(
+	item: dict, attempt: Attempt, *, key: Key, target_key: TargetKey, anchored: dict[str, str]
+) -> dict | None:
+	"""One attempt against the finished list, or None if any key it names is not there."""
+	resolved = {"after": None, "before": None, "parent_key": None, "target": None}
+
+	for field in ("after", "before", "parent_key"):
+		name = attempt.get(field)
+		if not name:
+			continue
+
+		target = target_key(item, name)
+		if not target:
+			return None
+
+		if _leads_back(target, key(item), anchored):
+			return None
+
+		resolved[field] = target
+
+	resolved["target"] = resolved["after"] or resolved["before"] or resolved["parent_key"]
+	return resolved
+
+
+def _leads_back(target: str, key: str, anchored: dict[str, str]) -> bool:
+	"""Whether following what each row was anchored to gets back to `key`."""
+	seen = set()
+
+	while target and target not in seen:
+		if target == key:
+			return True
+		seen.add(target)
+		target = anchored.get(target)
+
+	return False
+
+
+def _place(items: list[dict], item: dict, anchor: dict, *, key: Key):
+	"""Move `item` to where the anchor says, and give it the parent that implies.
+
+	`after` and `before` put a row beside another, so it takes that row's parent: beside means
+	beside, and a sibling that landed at a different depth would be somewhere else entirely. An
+	explicit `parent_key` wins over that, for the writer that means *under this section, next to
+	that row*.
+
+	A `parent_key` with no `after` or `before` lands the row after the last child that parent
+	already has, or immediately after the parent when it has none -- the position appending to
+	that section would give, which is what it asked for.
+	"""
+	beside = anchor["after"] or anchor["before"]
+	if _index_of(items, beside or anchor["parent_key"], key=key) is None:
+		# Unreachable as long as an anchor only ever resolves against a key that is in the list,
+		# which is what `target_key` promises. Checked anyway because one caller is boot: an
+		# exception here would blank the shell over a misplaced navigation row.
+		return
+
+	items.pop(_position_of(items, item))
+
+	if beside:
+		at = _index_of(items, beside, key=key)
+		parent = anchor["parent_key"]
+		if parent is None:
+			parent = items[at].get("parent_key")
+		item["parent_key"] = parent
+		items.insert(at + 1 if anchor["after"] else at, item)
+		return
+
+	item["parent_key"] = anchor["parent_key"]
+	items.insert(_last_child(items, anchor["parent_key"], key=key) + 1, item)
+
+
+def _index_of(items: list[dict], name: str, *, key: Key) -> int | None:
+	return next((index for index, entry in enumerate(items) if key(entry) == name), None)
+
+
+def _position_of(items: list[dict], item: dict) -> int:
+	"""Where this exact row is. By identity, not by equality: `list.remove` takes the first row
+	that compares equal, which is the right one only for as long as no two rows can match."""
+	return next(index for index, entry in enumerate(items) if entry is item)
+
+
+def _last_child(items: list[dict], parent: str, *, key: Key) -> int:
+	"""The index of `parent`'s last child, or of `parent` itself when it has none."""
+	at = _index_of(items, parent, key=key)
+
+	for index, entry in enumerate(items):
+		if entry.get("parent_key") == parent:
+			at = index
+
+	return at

--- a/frappe/desk/layers.py
+++ b/frappe/desk/layers.py
@@ -375,7 +375,13 @@ def _leads_back(target: str, key: str, anchored: dict[str, str]) -> bool:
 
 
 def _place(items: list[dict], item: dict, anchor: dict, *, key: Key):
-	"""Move `item` to where the anchor says, and give it the parent that implies.
+	"""Move `item` and everything under it to where the anchor says.
+
+	The row travels with its **subtree**. The list is flat and the tree is `parent_key`, so
+	moving a section on its own leaves its children sitting where they were: the tree is still
+	right, since a reader groups by `parent_key`, but the flat order no longer has children
+	following their parent -- and that invariant is what every reader of this list assumes,
+	including the editor that will read it straight back and draw it in order.
 
 	`after` and `before` put a row beside another, so it takes that row's parent: beside means
 	beside, and a sibling that landed at a different depth would be somewhere else entirely. An
@@ -387,25 +393,72 @@ def _place(items: list[dict], item: dict, anchor: dict, *, key: Key):
 	that section would give, which is what it asked for.
 	"""
 	beside = anchor["after"] or anchor["before"]
-	if _index_of(items, beside or anchor["parent_key"], key=key) is None:
+	target = beside or anchor["parent_key"]
+	if _index_of(items, target, key=key) is None:
 		# Unreachable as long as an anchor only ever resolves against a key that is in the list,
 		# which is what `target_key` promises. Checked anyway because one caller is boot: an
 		# exception here would blank the shell over a misplaced navigation row.
 		return
 
-	items.pop(_position_of(items, item))
+	block = _subtree(items, item, key=key)
 
-	if beside:
-		at = _index_of(items, beside, key=key)
-		parent = anchor["parent_key"]
-		if parent is None:
-			parent = items[at].get("parent_key")
-		item["parent_key"] = parent
-		items.insert(at + 1 if anchor["after"] else at, item)
+	# An anchor naming a row inside the subtree being moved has nowhere to land, because the
+	# target travels with it. Refused rather than resolved, which is what the cycle guard does
+	# with the same shape of request one level up.
+	if any(entry is not item and key(entry) == target for entry in block):
 		return
 
-	item["parent_key"] = anchor["parent_key"]
-	items.insert(_last_child(items, anchor["parent_key"], key=key) + 1, item)
+	for entry in block:
+		items.pop(_position_of(items, entry))
+
+	if beside:
+		parent = anchor["parent_key"]
+		if parent is None:
+			parent = items[_index_of(items, beside, key=key)].get("parent_key")
+		item["parent_key"] = parent
+		# `after` clears the target's own subtree, for the same reason the moving row brings its
+		# own: landing between a row and its children is not a position anybody can mean.
+		at = _end_of(items, beside, key=key) + 1 if anchor["after"] else _index_of(items, beside, key=key)
+	else:
+		item["parent_key"] = anchor["parent_key"]
+		# Appending to a section is landing after everything already in it.
+		at = _end_of(items, anchor["parent_key"], key=key) + 1
+
+	items[at:at] = block
+
+
+def _subtree(items: list[dict], item: dict, *, key: Key) -> list[dict]:
+	"""`item` and every row beneath it, in the order they already sit in."""
+	inside = _beneath(items, key(item), key=key)
+
+	return [entry for entry in items if key(entry) in inside]
+
+
+def _end_of(items: list[dict], root: str, *, key: Key) -> int:
+	"""The index of the last row in `root`'s subtree, or of `root` itself when it has none."""
+	inside = _beneath(items, root, key=key)
+
+	return max(index for index, entry in enumerate(items) if key(entry) in inside)
+
+
+def _beneath(items: list[dict], root: str, *, key: Key) -> set[str]:
+	"""`root` and every key under it.
+
+	Grown to a fixpoint rather than in one pass, so it does not depend on a parent preceding its
+	children -- which is the very invariant this exists to keep, and so is not one to assume
+	while keeping it.
+	"""
+	inside = {root}
+
+	while True:
+		found = {
+			key(entry) for entry in items if entry.get("parent_key") in inside and key(entry) not in inside
+		}
+		if not found:
+			break
+		inside |= found
+
+	return inside
 
 
 def _index_of(items: list[dict], name: str, *, key: Key) -> int | None:
@@ -416,14 +469,3 @@ def _position_of(items: list[dict], item: dict) -> int:
 	"""Where this exact row is. By identity, not by equality: `list.remove` takes the first row
 	that compares equal, which is the right one only for as long as no two rows can match."""
 	return next(index for index, entry in enumerate(items) if entry is item)
-
-
-def _last_child(items: list[dict], parent: str, *, key: Key) -> int:
-	"""The index of `parent`'s last child, or of `parent` itself when it has none."""
-	at = _index_of(items, parent, key=key)
-
-	for index, entry in enumerate(items):
-		if entry.get("parent_key") == parent:
-			at = index
-
-	return at

--- a/frappe/shell/arrangement.py
+++ b/frappe/shell/arrangement.py
@@ -92,25 +92,35 @@ def save_arrangement(container: str, address: str, items: str | list, scope: str
 	below = target.resolve(upto=BELOW[scope], keep_hidden=True)
 	desired = _as_items(items)
 
-	# An empty *reduction* is ordinary and means the layer goes: dragging an item away and back
-	# leaves nothing to store, and storing nothing is how that ends in the same state as a reset.
-	# An empty *submission* is not ordinary, because the client is always showing the list below
-	# it -- so a body that names none of it would arrive here as "nothing differs" and quietly do
-	# a reset's work. The two are different requests and one may not become the other by accident.
+	rows = reduce_arrangement(below, desired)
+
+	# Deleting is spelled the same way here as saving nothing, and that is deliberate: an empty
+	# reduction drops the layer, which is what keeps "drag it away and back" and "reset" from
+	# ending in two states that only look alike. It also means the one place a save can turn into
+	# a reset is this one, so it is the only place that has to be sure.
 	#
-	# The test is against the list below rather than against the body alone, because the body is
-	# filtered twice: `_as_items` drops what is not a row, and the reduction drops keys the list
-	# no longer holds. A stale editor sends rows that are shaped perfectly well and name items the
-	# app has since removed, and those survive the first filter to die at the second.
-	if below and _names_none_of(below, desired):
+	# It is sure when the submission **accounted for the whole list below**. The client is always
+	# showing that list, so a save that names every row of it and still reduces to nothing has
+	# genuinely said "this matches" -- while one that names only part of it has said nothing about
+	# the rest, and reading that as "delete everything" is a statement it did not make. Three
+	# separate ways of arriving at an empty reduction fall under this: a body where every row was
+	# malformed, one whose keys the list no longer holds, and one that keeps a single unchanged
+	# row and drops the others.
+	#
+	# The completeness test is only on this path on purpose. A save that *does* write rows is
+	# allowed to be incomplete, because rows nobody mentioned keeping the position the layer below
+	# gave them is the whole design -- and `reduce_arrangement` already drops an unknown key
+	# rather than refusing the save it came in, for the same reason. Missing rows only change the
+	# outcome catastrophically when the answer is delete.
+	if below and not rows and not _accounts_for(below, desired):
 		frappe.throw(
 			_(
-				"An arrangement has to name at least one item {0} still has. To go back to how it arrived, reset it."
+				"This arrangement does not cover everything {0} is showing, so it cannot be saved as one. Reload it, or reset it to go back to how it arrived."
 			).format(frappe.bold(target.app)),
 			title=_("Not an Arrangement"),
 		)
 
-	_write(target, reduce_arrangement(below, desired))
+	_write(target, rows)
 
 	return resolve_navigation(target.app)
 
@@ -287,15 +297,15 @@ def _is_name(value) -> bool:
 	return isinstance(value, str) and bool(value)
 
 
-def _names_none_of(below: list[dict], desired: list[dict]) -> bool:
-	"""Whether a submission names no row of the list it claims to be an arrangement of.
+def _accounts_for(below: list[dict], desired: list[dict]) -> bool:
+	"""Whether a submission names every row of the list it claims to be an arrangement of.
 
-	Only membership is asked about, not difference: a full list that happens to differ in
-	nothing names every row of it, and that save is the ordinary one whose layer goes.
+	Membership only, never difference: a full list that happens to differ in nothing names every
+	row of it, and that is the ordinary save whose layer goes.
 	"""
-	keys = {item["key"] for item in below if item.get("key")}
+	named = {item["key"] for item in desired}
 
-	return not any(item["key"] in keys for item in desired)
+	return all(item["key"] in named for item in below if item.get("key"))
 
 
 # The reduction

--- a/frappe/shell/arrangement.py
+++ b/frappe/shell/arrangement.py
@@ -95,13 +95,17 @@ def save_arrangement(container: str, address: str, items: str | list, scope: str
 	# An empty *reduction* is ordinary and means the layer goes: dragging an item away and back
 	# leaves nothing to store, and storing nothing is how that ends in the same state as a reset.
 	# An empty *submission* is not ordinary, because the client is always showing the list below
-	# it -- so a body whose every row was malformed would arrive here as "nothing differs" and
-	# quietly do a reset's work. The two are different requests and one may not become the other
-	# by accident.
-	if below and not desired:
+	# it -- so a body that names none of it would arrive here as "nothing differs" and quietly do
+	# a reset's work. The two are different requests and one may not become the other by accident.
+	#
+	# The test is against the list below rather than against the body alone, because the body is
+	# filtered twice: `_as_items` drops what is not a row, and the reduction drops keys the list
+	# no longer holds. A stale editor sends rows that are shaped perfectly well and name items the
+	# app has since removed, and those survive the first filter to die at the second.
+	if below and _names_none_of(below, desired):
 		frappe.throw(
 			_(
-				"An arrangement has to name at least one item. To go back to how {0} arrived, reset it."
+				"An arrangement has to name at least one item {0} still has. To go back to how it arrived, reset it."
 			).format(frappe.bold(target.app)),
 			title=_("Not an Arrangement"),
 		)
@@ -281,6 +285,17 @@ def _named(item) -> dict | None:
 
 def _is_name(value) -> bool:
 	return isinstance(value, str) and bool(value)
+
+
+def _names_none_of(below: list[dict], desired: list[dict]) -> bool:
+	"""Whether a submission names no row of the list it claims to be an arrangement of.
+
+	Only membership is asked about, not difference: a full list that happens to differ in
+	nothing names every row of it, and that save is the ordinary one whose layer goes.
+	"""
+	keys = {item["key"] for item in below if item.get("key")}
+
+	return not any(item["key"] in keys for item in desired)
 
 
 # The reduction

--- a/frappe/shell/arrangement.py
+++ b/frappe/shell/arrangement.py
@@ -242,13 +242,22 @@ def _as_items(items: str | list) -> list[dict]:
 
 
 def _named(item) -> dict | None:
-	"""One row of the client's list, or None if it does not name an item."""
+	"""One row of the client's list, or None if it does not name an item.
+
+	A `parent_key` that is *blank* is the top level and is the ordinary case. A `parent_key` that
+	is present but is not a name drops the whole row, rather than being read as blank: reading it
+	as blank would say the row belongs at the top level, which is a placement nobody asked for
+	and one the reduction would faithfully write down. Dropping the row says nothing about it
+	instead, so it stays exactly where the layer below put it.
+	"""
 	if not isinstance(item, dict) or not _is_name(item.get("key")):
 		return None
 
 	parent = item.get("parent_key")
+	if parent and not _is_name(parent):
+		return None
 
-	return {**item, "parent_key": parent if _is_name(parent) else None}
+	return {**item, "parent_key": parent or None}
 
 
 def _is_name(value) -> bool:

--- a/frappe/shell/arrangement.py
+++ b/frappe/shell/arrangement.py
@@ -138,6 +138,14 @@ def _target(container: str, address: str, scope: str) -> Target:
 	session user and can be nothing else, so "write somebody else's arrangement" is not a request
 	that can be made and does not need refusing.
 	"""
+	# Explicitly, not on the annotations alone. `validate_argument_types` only applies inside a
+	# request or a test, and Frappe accepts complex values throughout — so a parameter expected
+	# to be a string can arrive as a filter list, and `address` is read straight into a
+	# `get_value` filter below. `{"name": ["!=", ""]}` is a whole different query from
+	# `{"name": "..."}`, and the difference is invisible at the call site.
+	if not all(isinstance(argument, str) for argument in (container, address, scope)):
+		frappe.throw(_("A container, an address and a scope are each one name."))
+
 	if container not in CONTAINERS:
 		frappe.throw(_("{0} is not a navigation container.").format(container))
 

--- a/frappe/shell/arrangement.py
+++ b/frappe/shell/arrangement.py
@@ -1,0 +1,434 @@
+# ARRANGEMENT — the three endpoints a person's navigation edits go through.
+#
+# #42363 settled the rules; this is them. Desk v2's client has never persisted any user state,
+# so these are its first write that is not a document save, and the shape they take is the one
+# thing everything else on this surface has to agree with.
+#
+# The one idea underneath: **a move is an anchor, not a position.** A person who drags Contacts
+# above Deals has said "Contacts goes before Deals", not "Contacts is item 3" — and those two
+# stop meaning the same thing the moment the app ships a ninth item. So a saved layer names the
+# rows that moved and says what each moved next to, and everything nobody touched keeps the
+# position the layer below it gave it. It is the same anchor an app writes to insert its rows
+# into another app's rail (#42364), one phase later and against a list the writer *can* see.
+#
+# What crosses the wire is not that, though. The client sends **the whole ordered arrangement it
+# is showing**, which is desk v1's shape, and the server reduces it here. That division is
+# deliberate: a client that sent anchors would be computing identity and difference against a
+# base it holds a stale copy of, which is the mistake v1 made in the other direction — its
+# sidebar manager recomputes the server's item key in JS and gets it wrong two ways
+# (`sidebar_manager.js:294-298`).
+#
+# Three endpoints, against desk v1's twelve. V1 spends four on overlay writes, five on resets and
+# three on layer reads, and the multiplication is one word — `dock` or `sidebar`, `user` or
+# `site` — baked into each name. Here that word is an argument. Two of v1's resets are not
+# ported at all: `reset_dock_for_everyone` and `reset_to_standard` each delete the site layer
+# *and every user's* from one call, and a blast radius that large belongs to a considered
+# administrative action rather than to a button on a rail.
+
+import json
+from collections.abc import Callable
+from functools import partial
+from typing import NamedTuple
+
+import frappe
+from frappe import _
+
+from .navigation import SITE_LAYER, resolve_navigation, resolve_rail, resolve_sidebar
+from .permissions import has_app_permission
+
+# The two containers, and what each needs to find or write a layer. `field` is the table the
+# rows live in: `Sidebar` holds desk v1's `items` beside desk v2's `navigation_items`, so naming
+# the parentfield is what keeps a v2 write from landing in v1's sidebar.
+CONTAINERS = ("Rail", "Sidebar")
+ITEMS_FIELD = {"Rail": "items", "Sidebar": "navigation_items"}
+
+# A scope, and the scope whose resolved list a save at that scope is relative to. A person's
+# anchors are written against what they were shown, which is the site's arrangement; the site's
+# are written against what the apps ship.
+SCOPES = ("user", "site")
+BELOW = {"user": "site", "site": "base"}
+
+# What a delta row may have an opinion about. Presentation only: an arrangement changes how an
+# item reads and where it sits, never what it opens, because a row that could repoint its own
+# destination would let a person's layer turn an item into a different item under the same key —
+# and the key is what every other layer's edits are filed against (#42229).
+#
+# `parent_key` is not here on purpose. Reparenting travels as an anchor, since `after` and
+# `before` already carry the parent of the row they name: beside means beside, and a column that
+# said one thing while the anchor said another would need a precedence rule nobody would
+# remember.
+OVERRIDABLE = ("label", "icon", "collapsible", "keep_closed")
+
+
+@frappe.whitelist()
+def get_arrangement(container: str, address: str, scope: str = "user") -> list[dict]:
+	"""The list to arrange: resolved up to and including `scope`, hidden rows kept.
+
+	Hidden rows are the reason this is not just `boot.navigation`. Boot drops them, because the
+	browser cannot render a row it must not show — but an editor that dropped them would be an
+	editor in which hiding is a one-way door, and the whole point of a hide is that the person
+	who made it can take it back.
+	"""
+	return _target(container, address, scope).resolve(upto=scope, keep_hidden=True)
+
+
+@frappe.whitelist()
+def save_arrangement(container: str, address: str, items: str | list, scope: str = "user") -> dict:
+	"""Store one layer's arrangement and hand back the whole prefix's navigation.
+
+	`items` is the entire ordered list the client is showing, hidden rows included. What gets
+	stored is the difference between that and the list one scope below: the rows that moved, the
+	rows whose label or icon was changed, and the rows whose hidden flag differs. A row with
+	nothing to say is not written, so dragging an item away and back leaves no trace.
+
+	The return is `{rail, sidebars}` for the whole prefix rather than the one list that changed,
+	and the client swaps it into `boot.navigation` wholesale. That is v1's pattern and it is
+	affordable for the reason #42362 measured: the framework's own prefix resolves in 8-25 ms
+	warm at 20,618 B. It is also the only answer that stays correct — hiding a rail item of type
+	`Sidebar` changes which sidebars are reachable, so a response scoped to the list that was
+	written would be a half-truth the client had no way to notice.
+	"""
+	target = _target(container, address, scope)
+	below = target.resolve(upto=BELOW[scope], keep_hidden=True)
+
+	_write(target, reduce_arrangement(below, _as_items(items)))
+
+	return resolve_navigation(target.app)
+
+
+@frappe.whitelist()
+def reset_arrangement(container: str, address: str, scope: str = "user") -> dict:
+	"""Delete one layer and hand back what the prefix resolves to without it.
+
+	One layer, named by the same three arguments a save takes. Resetting your own rail cannot
+	reach the site's, and resetting the site's cannot reach anybody's.
+	"""
+	target = _target(container, address, scope)
+
+	_write(target, [])
+
+	return resolve_navigation(target.app)
+
+
+# Addressing and the gate
+
+
+class Target(NamedTuple):
+	"""One addressed layer: whose app it is, how to resolve it, and where it is stored.
+
+	The three travel together because each of the endpoints needs all three, and because
+	resolving a sidebar address costs a query — one that would otherwise be paid twice on a save,
+	once to gate the request and once to find the record to write.
+	"""
+
+	app: str
+	resolve: Callable[..., list[dict]]
+	layer: dict
+
+
+def _target(container: str, address: str, scope: str) -> Target:
+	"""Check the arguments and the caller, and describe the layer they name.
+
+	The gate is `has_app_permission` on the addressed app, plus `System Manager` for the site
+	scope (#42354). Unlike the reads this gate is the boundary rather than a choice of error
+	page: no doctype permission stands behind arranging the rail of an app you may not enter, so
+	there is nothing further along to refuse a request this one lets through.
+
+	There is deliberately no `user` argument anywhere in this module. The user scope is the
+	session user and can be nothing else, so "write somebody else's arrangement" is not a request
+	that can be made and does not need refusing.
+	"""
+	if container not in CONTAINERS:
+		frappe.throw(_("{0} is not a navigation container.").format(container))
+
+	if scope not in SCOPES:
+		frappe.throw(_("{0} is not an arrangement scope.").format(scope))
+
+	# `standard: 0` is in the stored address because an app's own layer and the site's
+	# arrangement of it are two records at one address, and resetting the site's must never reach
+	# the app's.
+	stored = {"user": frappe.session.user if scope == "user" else SITE_LAYER, "standard": 0}
+
+	if container == "Rail":
+		app = address
+		resolve = partial(resolve_rail, app)
+		stored |= {"app": app, "extends": ""}
+	else:
+		app, link_doctype, link_to = _sidebar_address(address)
+		resolve = partial(resolve_sidebar, link_doctype, link_to)
+		stored |= {"app": app, "link_doctype": link_doctype, "link_to": link_to}
+
+	# Before the gate, because `has_app_permission` falls back to "is a System User" for an app
+	# that declares no `app_permission` hook -- and an app that is not on the bench declares
+	# nothing, so an unknown name would pass a check it was never actually subject to.
+	if app not in frappe.get_active_apps():
+		frappe.throw(_("{0} is not an app on this site.").format(app))
+
+	if not has_app_permission(app):
+		frappe.throw(_("You are not permitted to arrange {0}.").format(app), frappe.PermissionError)
+
+	if scope == "site" and not _is_site_administrator():
+		frappe.throw(
+			_("Only a System Manager may change what everyone on this site sees."),
+			frappe.PermissionError,
+		)
+
+	return Target(app, resolve, {"doctype": container, **stored})
+
+
+def _sidebar_address(address: str) -> tuple[str, str, str]:
+	"""The app and the `(link_doctype, link_to)` pair behind a scrubbed sidebar address.
+
+	The client holds the scrubbed address and nothing else — it is the key `boot.navigation`
+	uses and the string a rail item of type `Sidebar` carries in `link_to` — and unscrubbing is
+	not a function: `module_def_accounts_receivable` could be two different modules. So the pair
+	is read back from the standard record, whose name #42355 made the scrubbed address for
+	exactly this kind of reason.
+
+	Reading it from the *standard* record also settles which app is being arranged, and makes an
+	address no app ships unarrangeable — which is #42229's rule about deltas over nothing being
+	inert, applied one step earlier so a person gets a refusal rather than a row that resolves to
+	nothing.
+	"""
+	record = frappe.db.get_value(
+		"Sidebar", {"name": address, "standard": 1}, ["app", "link_doctype", "link_to"], as_dict=True
+	)
+
+	if not record or not record.link_doctype:
+		frappe.throw(_("{0} is not a sidebar this site ships.").format(address))
+
+	return record.app, record.link_doctype, record.link_to
+
+
+def _is_site_administrator() -> bool:
+	return frappe.session.user == "Administrator" or "System Manager" in frappe.get_roles()
+
+
+def _as_items(items: str | list) -> list[dict]:
+	"""The client's list, however the request encoded it.
+
+	`frappe.whitelist` hands a JSON body through as a list and a form post as a string, and both
+	reach this endpoint — the client sends JSON, and a test or a `bench execute` passes the list
+	itself.
+	"""
+	if isinstance(items, str):
+		items = json.loads(items)
+
+	if not isinstance(items, list):
+		frappe.throw(_("An arrangement is a list of items."))
+
+	return [item for item in items if isinstance(item, dict) and item.get("key")]
+
+
+# The reduction
+
+
+def reduce_arrangement(base: list[dict], desired: list[dict]) -> list[dict]:
+	"""The whole ordered list a client is showing, as the smallest layer that produces it.
+
+	Every row written here says something the list below does not already say. That is what
+	makes an app's later change reach a person who has arranged their rail: a layer that recorded
+	every position would pin the whole list, and the ninth item an app ships would have nowhere
+	to land.
+
+	A key the base does not hold is **dropped**, not written and not refused. The case is
+	ordinary rather than exceptional — an app removed an item while somebody had the editor
+	open — and the two alternatives are both worse than dropping it: refusing loses the rest of a
+	save over a row the person never touched, and writing it would author an item into a layer
+	from values a browser supplied, under a key an app may later ship for something else.
+	Authoring new items into a layer is nobody's yet; the editor cannot make one, and every
+	arrangement it sends is of rows that came from the server.
+
+	Dropping those rows **first** is also what bounds the work. `anchors_for` compares two
+	orders with a longest-common-subsequence table, which is quadratic in the length of a
+	parent's list — fine for the 194 rows a real prefix resolves to, and not fine for a request
+	body that repeats one key ten thousand times. After this filter the list is at most the
+	base's length whatever the client sent, so the cost is a property of the site's navigation
+	rather than of the request.
+	"""
+	below = {item["key"]: item for item in base if item.get("key")}
+	desired = _known(desired, below)
+	anchors = anchors_for(base, desired)
+
+	return [row for item in desired if (row := _delta(item, below[item["key"]], anchors.get(item["key"])))]
+
+
+def _known(desired: list[dict], below: dict[str, dict]) -> list[dict]:
+	"""The client's list, keeping only rows the layer below holds, and each key only once.
+
+	A key sent twice keeps its **first** position, which is the answer `apply_layer` already
+	gives when a stored layer names one entry twice: the alternative is rendering it twice.
+	"""
+	seen = set()
+	kept = []
+
+	for item in desired:
+		key = item["key"]
+		if key in below and key not in seen:
+			seen.add(key)
+			kept.append(item)
+
+	return kept
+
+
+def _delta(item: dict, below: dict, anchors: list[dict] | None) -> dict | None:
+	"""One row, or None when this item is exactly what the layer below already resolves to."""
+	overrides = [field for field in OVERRIDABLE if _differs(item.get(field), below.get(field))]
+	hidden = int(bool(item.get("hidden")))
+
+	if not overrides and not anchors and hidden == int(bool(below.get("hidden"))):
+		return None
+
+	row = {"doctype": "Navigation Item", "key": item["key"], "hidden": hidden}
+
+	if overrides:
+		# The fieldnames are stored beside the values on purpose. An explicit list is what lets a
+		# person blank a label the app shipped, which "whatever is non-blank" cannot express, and
+		# it is what makes "did a human choose this" answerable at render time (#42229).
+		row["overrides"] = json.dumps(overrides)
+		row.update({field: _scalar(item.get(field)) for field in overrides})
+
+	if anchors:
+		row["anchors"] = json.dumps(anchors)
+
+	return row
+
+
+def _scalar(value):
+	"""One overridden value, as something a `Data` or `Check` column can hold.
+
+	The rows come off a request body, so a field can arrive as a list or an object where a
+	string was expected. Every overridable field is a scalar, so anything that is not one is
+	read as blank rather than handed to the database to interpret — this is the same reasoning
+	as the type annotations on the endpoints, applied one level down, where the annotation
+	cannot reach.
+	"""
+	return value if isinstance(value, str | int | float | bool) or value is None else None
+
+
+def _differs(sent, resolved) -> bool:
+	"""Whether the client changed a field, treating a blank and a missing one as the same thing.
+
+	The resolved list omits blank fields rather than sending `null`, so a field the person never
+	touched comes back as absent where it went out as absent — but a field they *cleared* comes
+	back as `""`. Those two have to be one value here, or clearing an already-blank label would
+	write a row saying nothing.
+	"""
+	return (_scalar(sent) or None) != (resolved or None)
+
+
+def anchors_for(base: list[dict], desired: list[dict]) -> dict[str, list[dict]]:
+	"""One anchor for each row that has to move, and nothing for the rows that do not.
+
+	Several sets of anchors describe the same list, so this picks one rule and it is written
+	here. **Order is compared per parent**, because the payload is a flat list the client renders
+	as a tree, and where a section's children sit relative to another section's is not something
+	anybody can see or intend. Within one parent, the rows to move are the ones outside the
+	longest common subsequence of the two orders — the largest set that can stay put — and each
+	one is anchored **after the row that precedes it in the list the person is looking at**.
+
+	Anchors are resolved in the order the layer's rows are written, which is the order of
+	`desired`, and that is what makes anchoring backwards safe: by the time a row is placed, the
+	row it names is already where it is going to be. The exception is a row that moved to the
+	front of its group, which has no predecessor. It anchors *before* the first following row
+	that is **not** itself moving, for the same reason — naming a row that has yet to move would
+	place it against a position that is about to change.
+
+	A row alone under a parent, with nothing on either side to name, anchors to the parent
+	itself. At the top level there is no such fallback and none is needed: a list of one is in
+	order whatever anybody says.
+	"""
+	base_groups = _siblings(base)
+	anchors: dict[str, list[dict]] = {}
+
+	for parent, keys in _siblings(desired).items():
+		staying = _longest_common(base_groups.get(parent, []), keys)
+		moving = [key for key in keys if key not in staying]
+
+		for key in moving:
+			index = keys.index(key)
+
+			if index:
+				anchors[key] = [{"after": keys[index - 1]}]
+				continue
+
+			ahead = next((other for other in keys[1:] if other in staying), None)
+			if ahead:
+				anchors[key] = [{"before": ahead}]
+			elif parent:
+				anchors[key] = [{"parent_key": parent}]
+
+	return anchors
+
+
+def _siblings(items: list[dict]) -> dict[str | None, list[str]]:
+	"""The keys under each parent, in order. `None` is the top level."""
+	groups: dict[str | None, list[str]] = {}
+
+	for item in items:
+		if item.get("key"):
+			groups.setdefault(item.get("parent_key") or None, []).append(item["key"])
+
+	return groups
+
+
+def _longest_common(before: list[str], after: list[str]) -> set[str]:
+	"""The largest set of keys that can keep their relative order, so the fewest rows move.
+
+	An ordinary longest-common-subsequence table. Both lists are one parent's children, which is
+	a handful of rows on any real navigation and cannot be otherwise: this runs on a save, not in
+	boot, and the quadratic cost is measured against a person having dragged something.
+	"""
+	rows, columns = len(before), len(after)
+	lengths = [[0] * (columns + 1) for _ in range(rows + 1)]
+
+	for i in range(rows - 1, -1, -1):
+		for j in range(columns - 1, -1, -1):
+			if before[i] == after[j]:
+				lengths[i][j] = lengths[i + 1][j + 1] + 1
+			else:
+				lengths[i][j] = max(lengths[i + 1][j], lengths[i][j + 1])
+
+	common: set[str] = set()
+	i = j = 0
+
+	while i < rows and j < columns:
+		if before[i] == after[j]:
+			common.add(before[i])
+			i, j = i + 1, j + 1
+		elif lengths[i + 1][j] >= lengths[i][j + 1]:
+			i += 1
+		else:
+			j += 1
+
+	return common
+
+
+# The stored layer
+
+
+def _write(target: Target, rows: list[dict]):
+	"""Put these rows in this layer, and delete the layer when there are none.
+
+	An empty layer and no layer resolve identically -- `apply_layer` returns the list unchanged
+	for a layer that named nothing -- so keeping one would be a row that means nothing, and
+	deleting it is what makes "arrange it back the way it was" and "reset" end in the same state
+	rather than in two states that only look alike.
+
+	`ignore_permissions`, because the gate is the endpoint's. Both containers' `has_permission`
+	hooks give a `Desk User` read and no write at all, which is what stops one person reading
+	another's layer through the API; a person arranging their own rail needs no write permission
+	on a table they can never write directly.
+	"""
+	doctype = target.layer["doctype"]
+	address = {field: value for field, value in target.layer.items() if field != "doctype"}
+	existing = frappe.db.get_value(doctype, address)
+
+	if not rows:
+		if existing:
+			frappe.delete_doc(doctype, existing, ignore_permissions=True, delete_permanently=True)
+		return
+
+	doc = frappe.get_doc(doctype, existing) if existing else frappe.get_doc(dict(target.layer))
+	doc.set(ITEMS_FIELD[doctype], rows)
+	doc.save(ignore_permissions=True)

--- a/frappe/shell/arrangement.py
+++ b/frappe/shell/arrangement.py
@@ -249,12 +249,16 @@ def _named(item) -> dict | None:
 	as blank would say the row belongs at the top level, which is a placement nobody asked for
 	and one the reduction would faithfully write down. Dropping the row says nothing about it
 	instead, so it stays exactly where the layer below put it.
+
+	Blank means `None` or `""` and nothing else. A truthiness test would let the *falsy*
+	non-names through -- `0`, `false`, `[]`, `{}` -- and then read each of them as the top level,
+	which is the very reparenting this exists to refuse.
 	"""
 	if not isinstance(item, dict) or not _is_name(item.get("key")):
 		return None
 
 	parent = item.get("parent_key")
-	if parent and not _is_name(parent):
+	if parent is not None and parent != "" and not _is_name(parent):
 		return None
 
 	return {**item, "parent_key": parent or None}

--- a/frappe/shell/arrangement.py
+++ b/frappe/shell/arrangement.py
@@ -210,12 +210,19 @@ def _as_items(items: str | list) -> list[dict]:
 	`frappe.whitelist` hands a JSON body through as a list and a form post as a string, and both
 	reach this endpoint — the client sends JSON, and a test or a `bench execute` passes the list
 	itself.
+
+	A string that will not parse is refused with the same message as a body that is not a list,
+	rather than raising the decoder's own error: both mean the caller sent something this is not,
+	and a `JSONDecodeError` off a whitelisted method is a 500 where the caller needs a sentence.
 	"""
 	if isinstance(items, str):
-		items = json.loads(items)
+		try:
+			items = json.loads(items)
+		except ValueError:
+			items = None
 
 	if not isinstance(items, list):
-		frappe.throw(_("An arrangement is a list of items."))
+		frappe.throw(_("An arrangement is a list of items."), title=_("Not an Arrangement"))
 
 	return [item for item in items if isinstance(item, dict) and item.get("key")]
 

--- a/frappe/shell/arrangement.py
+++ b/frappe/shell/arrangement.py
@@ -90,8 +90,23 @@ def save_arrangement(container: str, address: str, items: str | list, scope: str
 	"""
 	target = _target(container, address, scope)
 	below = target.resolve(upto=BELOW[scope], keep_hidden=True)
+	desired = _as_items(items)
 
-	_write(target, reduce_arrangement(below, _as_items(items)))
+	# An empty *reduction* is ordinary and means the layer goes: dragging an item away and back
+	# leaves nothing to store, and storing nothing is how that ends in the same state as a reset.
+	# An empty *submission* is not ordinary, because the client is always showing the list below
+	# it -- so a body whose every row was malformed would arrive here as "nothing differs" and
+	# quietly do a reset's work. The two are different requests and one may not become the other
+	# by accident.
+	if below and not desired:
+		frappe.throw(
+			_(
+				"An arrangement has to name at least one item. To go back to how {0} arrived, reset it."
+			).format(frappe.bold(target.app)),
+			title=_("Not an Arrangement"),
+		)
+
+	_write(target, reduce_arrangement(below, desired))
 
 	return resolve_navigation(target.app)
 

--- a/frappe/shell/arrangement.py
+++ b/frappe/shell/arrangement.py
@@ -222,6 +222,12 @@ def _as_items(items: str | list) -> list[dict]:
 	A string that will not parse is refused with the same message as a body that is not a list,
 	rather than raising the decoder's own error: both mean the caller sent something this is not,
 	and a `JSONDecodeError` off a whitelisted method is a 500 where the caller needs a sentence.
+
+	What comes back is rows whose `key` and `parent_key` are names, because both are read as
+	dictionary keys from here on. A list is not hashable, so one arriving in either column would
+	end a whitelisted save in an uncaught `TypeError` rather than in an answer. The row is
+	dropped rather than the request refused, for the reason `reduce_arrangement` drops an
+	unknown key: the rest of the arrangement is still what the person meant.
 	"""
 	if isinstance(items, str):
 		try:
@@ -232,7 +238,21 @@ def _as_items(items: str | list) -> list[dict]:
 	if not isinstance(items, list):
 		frappe.throw(_("An arrangement is a list of items."), title=_("Not an Arrangement"))
 
-	return [item for item in items if isinstance(item, dict) and item.get("key")]
+	return [row for item in items if (row := _named(item))]
+
+
+def _named(item) -> dict | None:
+	"""One row of the client's list, or None if it does not name an item."""
+	if not isinstance(item, dict) or not _is_name(item.get("key")):
+		return None
+
+	parent = item.get("parent_key")
+
+	return {**item, "parent_key": parent if _is_name(parent) else None}
+
+
+def _is_name(value) -> bool:
+	return isinstance(value, str) and bool(value)
 
 
 # The reduction

--- a/frappe/shell/extensions.py
+++ b/frappe/shell/extensions.py
@@ -24,8 +24,14 @@
 #    against a host it does not ship and cannot pin, so a missing anchor is the expected
 #    case rather than a broken one. Landing in the wrong place is cosmetic; vanishing is a
 #    bug report against the wrong app.
+#
+# The placement itself is not here. It is `frappe.desk.layers`, beside the layer merge, because
+# the overlay endpoints move a person's rows by the same anchors one phase later (#42363) -- and
+# `layers.py` is where a list operation with no database under it already lives. What stays here
+# is the one thing that differs: how a written name becomes a key, which for a contributed row
+# means the host first and this app's own rows second.
 
-import json
+from frappe.desk.layers import anchor_attempts, place_by_anchors
 
 # `<app>:<key>`. A colon because it cannot occur in an app name, which is a Python module
 # name, and because it reads as a qualifier rather than as part of a slug — `telephony:leads`
@@ -107,179 +113,36 @@ def _anchor(merged: list[dict], placed: list[dict], targets: set[str]) -> list[d
 	"""Move each contributed root to the first position it asks for that resolves.
 
 	Roots only. A row with a `parent_key` of its own is inside a contributed subtree, and
-	where that subtree sits is its root's business — an anchor on a child would tear the
+	where that subtree sits is its root's business -- an anchor on a child would tear the
 	subtree apart to satisfy a row that never had a say in the first place.
-
-	`anchored` is the cycle guard and the whole of it: it records what each moved row was
-	moved next to, so an anchor whose target chain leads back to the row being placed is
-	refused and the next anchor is tried. Two apps naming each other is the case, and neither
-	an exception nor an arbitrary winner would be right — falling through to the next anchor,
-	and then to the append, is the same answer the design gives every other unresolvable one.
 	"""
-	anchored: dict[str, str] = {}
+	roots = [(item, anchor_attempts(item.get("anchors"))) for item in placed if not item.get("parent_key")]
+	roots = [(item, attempts) for item, attempts in roots if attempts]
+	if not roots:
+		return merged
 
-	for item in placed:
-		if item.get("parent_key"):
-			continue
-
-		attempt = _first_resolving(item, targets, anchored)
-		if attempt is None:
-			continue
-
-		_place(merged, item, attempt)
-		anchored[item["key"]] = attempt["target"]
-
-	return merged
+	return place_by_anchors(merged, roots, key=_key, target_key=_written_then_own(targets))
 
 
-def _first_resolving(item: dict, targets: set[str], anchored: dict[str, str]) -> dict | None:
-	"""The first of this row's anchors whose every named key is present and not circular."""
-	for anchor in _attempts(item):
-		resolved = _resolve(item, anchor, targets, anchored)
-		if resolved:
-			return resolved
-
-	return None
+def _key(item: dict) -> str | None:
+	return item.get("key")
 
 
-def _attempts(item: dict) -> list[dict]:
-	"""This row's anchors, as an ordered list of well-formed attempts.
+def _written_then_own(targets: set[str]):
+	"""Resolve a name as written first and as this app's own second.
 
-	A malformed list is no anchors rather than an error. The rows are authored by an app
-	against a host it cannot see, so the reader of any complaint would be the wrong person;
-	the row still appears, at the end, which is what an app with no anchors gets anyway.
-
-	An attempt naming both `after` and `before` names two positions and so names none. It is
-	dropped rather than resolved by precedence, because picking one would make a typo into a
-	silent placement nobody wrote.
+	Written-first is what makes an anchor aimed at a host resolve to the host, which is the
+	case an app is nearly always writing; the own-namespace fallback is what lets an app
+	anchor to a row it shipped itself without having to write its own name into its own
+	file. It can never shadow a host key, because it is only reached when the host has no
+	such key.
 	"""
-	try:
-		anchors = json.loads(item.get("anchors") or "[]")
-	except (TypeError, ValueError):
-		return []
 
-	if not isinstance(anchors, list):
-		return []
+	def target_key(item: dict, name: str) -> str | None:
+		if name in targets:
+			return name
 
-	attempts = []
+		own = namespaced(item["app"], name)
+		return own if own in targets else None
 
-	for anchor in anchors:
-		if not isinstance(anchor, dict):
-			continue
-
-		after, before, parent = anchor.get("after"), anchor.get("before"), anchor.get("parent_key")
-		if after and before:
-			continue
-		if not (after or before or parent):
-			continue
-
-		attempts.append({"after": after, "before": before, "parent_key": parent})
-
-	return attempts
-
-
-def _resolve(item: dict, anchor: dict, targets: set[str], anchored: dict[str, str]) -> dict | None:
-	"""One attempt against the finished list, or None if any key it names is not there.
-
-	A key is read as written first and as this app's own second. Written-first is what makes
-	an anchor aimed at a host resolve to the host, which is the case an app is nearly always
-	writing; the own-namespace fallback is what lets an app anchor to a row it shipped itself
-	without having to write its own name into its own file. It can never shadow a host key,
-	because it is only reached when the host has no such key.
-	"""
-	app = item["app"]
-	resolved = {"after": None, "before": None, "parent_key": None, "target": None}
-
-	for field in ("after", "before", "parent_key"):
-		name = anchor.get(field)
-		if not name:
-			continue
-
-		key = _target_key(app, name, targets)
-		if key is None:
-			return None
-
-		if _leads_back(key, item["key"], anchored):
-			return None
-
-		resolved[field] = key
-
-	resolved["target"] = resolved["after"] or resolved["before"] or resolved["parent_key"]
-	return resolved
-
-
-def _target_key(app: str, name: str, targets: set[str]) -> str | None:
-	if name in targets:
-		return name
-
-	own = namespaced(app, name)
-	return own if own in targets else None
-
-
-def _leads_back(target: str, key: str, anchored: dict[str, str]) -> bool:
-	"""Whether following what each row was anchored to gets back to `key`."""
-	seen = set()
-
-	while target and target not in seen:
-		if target == key:
-			return True
-		seen.add(target)
-		target = anchored.get(target)
-
-	return False
-
-
-def _place(merged: list[dict], item: dict, anchor: dict):
-	"""Move `item` to where the anchor says, and give it the parent that implies.
-
-	`after` and `before` put a row beside another, so it takes that row's parent: beside
-	means beside, and a sibling that landed at a different depth would be somewhere else
-	entirely. An explicit `parent_key` wins over that, for the app that means *under this
-	section, next to that row*.
-
-	A `parent_key` with no `after` or `before` lands the row after the last child that parent
-	already has, or immediately after the parent when it has none — the position an app would
-	get by appending to that section, which is what it asked for.
-	"""
-	beside = anchor["after"] or anchor["before"]
-	target = _index_of(merged, beside or anchor["parent_key"])
-	if target is None:
-		# Unreachable as long as an anchor only ever resolves against a key that is in the list,
-		# which is what `targets` is. Checked anyway because the caller is boot: an exception here
-		# would blank the shell over a misplaced navigation row.
-		return
-
-	merged.pop(_position_of(merged, item))
-
-	if beside:
-		at = _index_of(merged, beside)
-		parent = anchor["parent_key"]
-		if parent is None:
-			parent = merged[at].get("parent_key")
-		item["parent_key"] = parent
-		merged.insert(at + 1 if anchor["after"] else at, item)
-		return
-
-	item["parent_key"] = anchor["parent_key"]
-	merged.insert(_last_child(merged, anchor["parent_key"]) + 1, item)
-
-
-def _index_of(merged: list[dict], key: str) -> int | None:
-	return next((index for index, entry in enumerate(merged) if entry.get("key") == key), None)
-
-
-def _position_of(merged: list[dict], item: dict) -> int:
-	"""Where this exact row is. By identity, not by equality: `list.remove` takes the first row
-	that compares equal, which is the right one only for as long as no two rows can match."""
-	return next(index for index, entry in enumerate(merged) if entry is item)
-
-
-def _last_child(merged: list[dict], parent: str) -> int:
-	"""The index of `parent`'s last child, or of `parent` itself when it has none."""
-	at = _index_of(merged, parent)
-
-	for index, entry in enumerate(merged):
-		if entry.get("parent_key") == parent:
-			at = index
-
-	return at
+	return target_key

--- a/frappe/shell/navigation.py
+++ b/frappe/shell/navigation.py
@@ -95,11 +95,16 @@ def resolve_navigation(app: str) -> dict:
 	item of type `Sidebar` already carries in `link_to`, so the browser still does one dictionary
 	lookup on a value it is holding.
 	"""
-	return {"rail": _resolve_rail(app), "sidebars": _resolve_sidebars(app)}
+	return {"rail": resolve_rail(app), "sidebars": _resolve_sidebars(app)}
 
 
-def _resolve_rail(app: str) -> list[dict]:
+def resolve_rail(app: str, *, upto: str = "user", keep_hidden: bool = False) -> list[dict]:
 	"""One app's rail: its own layer plus what other apps add to it, then the site's, then this user's.
+
+	`upto` stops the stack short, and `keep_hidden` leaves the hidden rows in. Both are the
+	arrangement editor's (#42363): it reads at the scope it writes, hidden rows and all, because
+	otherwise nothing a person hid could ever be unhidden, and it reads one scope lower to find
+	the list a person's moves are anchored against.
 
 	Extension happens to the *base*, before the site and user layers are laid over it. That is
 	what makes a person's arrangement of a host rail one row rather than one row per extending
@@ -123,7 +128,7 @@ def _resolve_rail(app: str) -> list[dict]:
 
 	base = extend(base, _rail_contributions(app), anchorable=shipped)
 
-	return _merge(base, [layers.get("site", []), layers.get("user", [])])
+	return _merge(base, _upto(layers, upto), keep_hidden=keep_hidden)
 
 
 def _resolve_sidebars(app: str) -> dict[str, list[dict]]:
@@ -147,7 +152,7 @@ def _resolve_sidebars(app: str) -> dict[str, list[dict]]:
 	for address in addresses:
 		by_layer = layers.get(address, {})
 		base = by_layer.get("standard", [])
-		items = _merge(base, [by_layer.get("site", []), by_layer.get("user", [])])
+		items = _merge(base, _upto(by_layer, "user"))
 		if items:
 			# An address that resolves to nothing is absent rather than empty. The payload is read
 			# by key, so the two mean the same thing to the browser, and a linked rail item whose
@@ -157,7 +162,32 @@ def _resolve_sidebars(app: str) -> dict[str, list[dict]]:
 	return resolved
 
 
-def _merge(base: list[dict], layers: list[list[dict]]) -> list[dict]:
+def resolve_sidebar(
+	link_doctype: str, link_to: str, *, upto: str = "user", keep_hidden: bool = False
+) -> list[dict]:
+	"""One sidebar at one address, for a caller that wants that one and not the prefix.
+
+	Boot resolves every sidebar in the prefix in one pair of queries, because a modular app has
+	one per module and per-address reads would put two queries per module into the blocking
+	pre-mount path. The arrangement editor is the other kind of caller: it is holding one sidebar
+	and paying one request for it, so it reads that one.
+	"""
+	by_layer = _sidebar_layers([(link_doctype, link_to)]).get((link_doctype, link_to), {})
+
+	return _merge(by_layer.get("standard", []), _upto(by_layer, upto), keep_hidden=keep_hidden)
+
+
+# The layers a resolution stacks, in order, up to and including the scope asked for. The editor
+# reads at the scope it is writing, so a person is shown their own arrangement and edits it; the
+# save then re-reads one scope *below* to get the list its anchors are relative to.
+LAYERS_UPTO = {"base": (), "site": ("site",), "user": ("site", "user")}
+
+
+def _upto(layers: dict[str, list[dict]], upto: str) -> list[list[dict]]:
+	return [layers.get(role, []) for role in LAYERS_UPTO[upto]]
+
+
+def _merge(base: list[dict], layers: list[list[dict]], *, keep_hidden: bool = False) -> list[dict]:
 	"""Fold the layers into the base and return what the browser renders.
 
 	The merge itself is `frappe.desk.layers`, imported rather than copied. It is 165 lines that
@@ -165,35 +195,70 @@ def _merge(base: list[dict], layers: list[list[dict]]) -> list[dict]:
 	desk v2 passes its own `key` and `apply_row` exactly as the dock and the sidebar each pass
 	theirs.
 
-	Hidden items are dropped here. `resolve_layers` returns `(resolved, hidden)` as two values and
-	deliberately leaves the flag unapplied, because the surface decides: desk v1's dock keeps a
-	hidden entry so its manager can list it under Hidden. Desk v2's payload has no manager UI to
-	feed, so shipping a row the client cannot use would spend bytes against the budget boot
-	already manages. Nothing is foreclosed — when the overlay editor lands (#42363) it calls the
-	resolver with the flag kept, which the engine already takes as a parameter.
-	"""
-	resolved, hidden = resolve_layers(
-		base,
-		layers,
-		key=item_key,
-		apply_row=apply_item_row,
-		# An item no layer named survives, after the ones a layer did name. This is the sidebar's
-		# side of that flag rather than the dock's, so an item an app ships later still reaches a
-		# person who has already arranged their rail instead of waiting in a manager that does not
-		# exist yet.
-		#
-		# It is not the whole of #42229's sparse move-list, which asks that a newly-shipped item
-		# land at its *shipped position* rather than after the arranged rows. Today's engine has
-		# no third option between "keep, at the end" and "drop", and with no writer on the branch
-		# the two behave identically. #42363 owns what a drag saves, and that decides whether the
-		# engine needs the position or whether a saved layer names every row anyway.
-		keep_unnamed=True,
-	)
+	Hidden items are dropped here, and `keep_hidden` is the one caller that wants them: the
+	arrangement editor, which has to show a person what they hid in order to let them unhide it
+	(#42363). `resolve_layers` returns `(resolved, hidden)` as two values and deliberately leaves
+	the flag unapplied, because the surface decides — desk v1's dock keeps a hidden entry so its
+	manager can list it under Hidden, and boot drops it, since shipping a row the browser cannot
+	render would spend bytes against a budget boot already manages.
 
-	return [
-		on_the_wire(item)
-		for item in _promote_orphans([item for item in resolved if not hidden.get(item_key(item))])
-	]
+	The arrangement is **anchored**: a layer moves the rows it anchored and leaves the rest of the
+	list where the layer below it put it. That is what #42229's sparse move-list asked for and
+	what neither half of `keep_unnamed` could give — an item an app ships later lands at its
+	shipped position rather than after everything a person has arranged. #42363 settled the writer
+	that produces the anchors, so the flag now has nothing left to decide and is not passed.
+	"""
+	resolved, hidden = resolve_layers(base, layers, key=item_key, apply_row=apply_item_row, anchored=True)
+
+	items = resolved if keep_hidden else _drop_hidden(resolved, hidden)
+
+	return [_on_the_wire(item, hidden) for item in _promote_orphans(items)]
+
+
+def _drop_hidden(items: list[dict], hidden: dict[str, bool]) -> list[dict]:
+	"""Drop every hidden item, and everything under one.
+
+	A person hiding a section means the branch, not the header. That is the opposite of an app
+	*removing* a section, where `_promote_orphans` lifts the children to the top level so an app
+	never silently withdraws what was under one — and the two look identical by the time the list
+	is flat, which is why the subtree has to go before orphans are promoted rather than after
+	(#42363 decision 9).
+
+	Walked upward from each row rather than downward from each section, so the cost is one pass
+	over a chain per item and a section nested in a hidden section needs no second sweep. The
+	`seen` set is the cycle guard: `parent_key` is authored, and a row that is its own ancestor
+	would otherwise loop here rather than merely render oddly.
+	"""
+	parents = {item_key(item): item.get("parent_key") for item in items}
+	dropped: set[str] = set()
+
+	for key in parents:
+		chain, at, seen = [], key, set()
+
+		while at and at not in seen:
+			seen.add(at)
+			chain.append(at)
+			if hidden.get(at) or at in dropped:
+				dropped.update(chain)
+				break
+			at = parents.get(at)
+
+	return [item for item in items if item_key(item) not in dropped]
+
+
+def _on_the_wire(item: dict, hidden: dict[str, bool]) -> dict:
+	"""One resolved item, carrying its hidden flag only when the caller kept hidden rows.
+
+	`on_the_wire` drops every blank field, so an item that is not hidden says nothing about it
+	either way — which is right for boot, where the flag cannot be false and is never read, and
+	right for the editor, which asks whether the key is there.
+	"""
+	wire = on_the_wire(item)
+
+	if hidden.get(item_key(item)):
+		wire["hidden"] = 1
+
+	return wire
 
 
 def item_key(row) -> str | None:
@@ -270,12 +335,11 @@ def _promote_orphans(items: list[dict]) -> list[dict]:
 	with it, so an app removing a section never silently removes everything under it. It also
 	matches #42230's rule for a user who has reparented into a section the site later withdrew.
 
-	It runs after hidden items are dropped, so hiding a section currently promotes its children
-	rather than taking them with it. That is the rule above applied to a case nobody has decided:
-	an app *removing* a section should not remove what was under it, but a person *hiding* one
-	may well mean the whole branch. Nothing exercises it -- no app ships a section and nothing
-	writes a hide -- and #42363 owns the editor that would first produce one, so it is recorded
-	here rather than settled by whichever line happened to be written first.
+	It runs after `_drop_hidden`, which is what keeps the two cases apart. A person *hiding* a
+	section means the whole branch, so its children are already gone by the time this runs; an app
+	*removing* one does not, so its children arrive here and are lifted. The passes stopped being
+	independent when #42363 gave a person a way to hide anything at all: before that, a hidden
+	section and a removed one reached this line looking exactly alike.
 	"""
 	present = {item_key(item) for item in items}
 	return [

--- a/frappe/tests/test_navigation_arrangement.py
+++ b/frappe/tests/test_navigation_arrangement.py
@@ -123,8 +123,14 @@ class TestReduction(NavigationTestCase):
 		# And a parent that is not a name drops the row rather than being read as blank. Blank
 		# means the top level, which is a placement nobody asked for and one the reduction would
 		# faithfully write down; dropping the row says nothing about it, so it stays put.
-		self.assertEqual(_as_items([shown("a", parent_key={"x": 1})]), [])
-		self.assertEqual(_as_items([shown("a", parent_key="")])[0]["parent_key"], None)
+		# Blank means `None` or `""` and nothing else. A truthiness test would let the *falsy*
+		# non-names through and read each of them as the top level, which is the reparenting
+		# this exists to refuse.
+		for parent in ({"x": 1}, ["s"], 0, False, [], {}):
+			self.assertEqual(_as_items([shown("a", parent_key=parent)]), [], f"parent {parent!r}")
+
+		for blank in ("", None):
+			self.assertEqual(_as_items([shown("a", parent_key=blank)])[0]["parent_key"], None)
 
 	def test_a_malformed_parent_does_not_move_a_row_to_the_top_level(self):
 		make_rail(
@@ -135,7 +141,8 @@ class TestReduction(NavigationTestCase):
 			standard=1,
 		)
 
-		save_arrangement("Rail", APP, showing(shown("people"), shown("user", parent_key=["oops"])))
+		for parent in (["oops"], 0, []):
+			save_arrangement("Rail", APP, showing(shown("people"), shown("user", parent_key=parent)))
 
 		entry = next(e for e in resolve_navigation(APP)["rail"] if e["key"] == "user")
 		self.assertEqual(entry["parent_key"], "people")

--- a/frappe/tests/test_navigation_arrangement.py
+++ b/frappe/tests/test_navigation_arrangement.py
@@ -496,6 +496,33 @@ class TestReset(NavigationTestCase):
 
 		self.assertEqual(rail_keys(), ["role", "user"], "their arrangement survives")
 
+	def test_a_save_that_covers_only_part_of_the_list_does_not_do_a_resets_work(self):
+		"""The third way to an empty reduction, and the narrowest. One row survives and says
+		nothing, the rest were dropped -- so the save named something, but it said nothing about
+		most of the list. Reading that as "delete everything" is a statement it did not make."""
+		make_rail([doctype_item("user", "User"), doctype_item("role", "Role")], standard=1)
+		save_arrangement("Rail", APP, showing(shown("role"), shown("user")))
+
+		with self.assertRaises(frappe.ValidationError):
+			save_arrangement("Rail", APP, showing(shown("role"), {"key": ["!=", ""]}))
+
+		self.assertEqual(rail_keys(), ["role", "user"], "their arrangement survives")
+
+	def test_an_incomplete_save_that_has_something_to_say_is_still_kept(self):
+		"""The other side of the check above: completeness is asked about only when the answer
+		would be to delete. A save that writes rows is allowed to be incomplete, because rows
+		nobody mentioned keeping the position the layer below gave them is the design."""
+		make_rail(
+			[doctype_item("user", "User"), doctype_item("role", "Role"), doctype_item("page", "Page")],
+			standard=1,
+		)
+
+		save_arrangement("Rail", APP, showing(shown("page"), shown("user", label="Mine")))
+
+		# `role` was never mentioned, so it keeps the position the layer below gave it -- the
+		# front -- and the two rows that were mentioned land in the order they were sent.
+		self.assertEqual(rail_keys(), ["role", "page", "user"])
+
 	def test_arranging_it_back_still_leaves_no_row(self):
 		"""The case the check above must not catch: a full list that happens to differ in
 		nothing is not malformed, and the layer still goes."""

--- a/frappe/tests/test_navigation_arrangement.py
+++ b/frappe/tests/test_navigation_arrangement.py
@@ -445,6 +445,27 @@ class TestReset(NavigationTestCase):
 		self.assertEqual(rail_keys(), ["role", "user"])
 		self.assertTrue(frappe.db.exists("Rail", {"app": APP, "standard": 0, "user": ""}))
 
+	def test_a_malformed_save_does_not_do_a_resets_work(self):
+		"""Every row unusable reduces to nothing, and storing nothing is how a *reset* ends. The
+		client is always showing the list below it, so a submission that names nothing is
+		malformed rather than a statement that nothing differs."""
+		make_rail([doctype_item("user", "User"), doctype_item("role", "Role")], standard=1)
+		save_arrangement("Rail", APP, showing(shown("role"), shown("user")))
+
+		with self.assertRaises(frappe.ValidationError):
+			save_arrangement("Rail", APP, showing({"key": ["!=", ""]}, {"nokey": 1}))
+
+		self.assertEqual(rail_keys(), ["role", "user"], "their arrangement survives")
+
+	def test_arranging_it_back_still_leaves_no_row(self):
+		"""The case the check above must not catch: a full list that happens to differ in
+		nothing is not malformed, and the layer still goes."""
+		make_rail([doctype_item("user", "User"), doctype_item("role", "Role")], standard=1)
+		save_arrangement("Rail", APP, showing(shown("role"), shown("user")))
+		save_arrangement("Rail", APP, showing(shown("user"), shown("role")))
+
+		self.assertFalse(frappe.db.exists("Rail", {"app": APP, "standard": 0}))
+
 	def test_a_reset_of_a_layer_that_is_not_there_is_not_an_error(self):
 		make_rail([doctype_item("user", "User")], standard=1)
 

--- a/frappe/tests/test_navigation_arrangement.py
+++ b/frappe/tests/test_navigation_arrangement.py
@@ -390,6 +390,17 @@ class TestTheGate(NavigationTestCase):
 		with self.assertRaises(frappe.ValidationError):
 			get_arrangement("Rail", "no_such_app")
 
+	def test_a_body_that_is_not_an_arrangement_is_refused_with_a_sentence(self):
+		"""Not with the JSON decoder's own error, which off a whitelisted method is a 500 where
+		the caller needs to be told what it sent."""
+		make_rail([doctype_item("user", "User")], standard=1)
+
+		# A body that is neither a string nor a list never reaches here: the endpoint's type
+		# annotation refuses it first. These two are the cases that do.
+		for body in ("{not json", '{"key": "a"}'):
+			with self.assertRaises(frappe.ValidationError):
+				save_arrangement("Rail", APP, body)
+
 	def test_a_container_that_is_not_one_is_refused(self):
 		with self.assertRaises(frappe.ValidationError):
 			get_arrangement("Custom Sidebar", APP)

--- a/frappe/tests/test_navigation_arrangement.py
+++ b/frappe/tests/test_navigation_arrangement.py
@@ -14,7 +14,9 @@ site the way an install does. What is added here is the other side of that: a pe
 import json
 
 import frappe
+from frappe.exceptions import FrappeTypeError
 from frappe.shell.arrangement import (
+	_target,
 	anchors_for,
 	get_arrangement,
 	reduce_arrangement,
@@ -400,6 +402,20 @@ class TestTheGate(NavigationTestCase):
 		for body in ("{not json", '{"key": "a"}'):
 			with self.assertRaises(frappe.ValidationError):
 				save_arrangement("Rail", APP, body)
+
+	def test_an_argument_that_is_not_a_name_is_refused_at_the_boundary(self):
+		"""Explicitly, not on the annotations alone: they apply only inside a request or a test,
+		and Frappe accepts complex values throughout — so a filter list arriving where a name was
+		expected turns `{"name": address}` into a different query entirely."""
+		for address in (["!=", ""], {"name": "x"}):
+			# Inside a request or a test the annotation gets there first, which is the belt...
+			with self.assertRaises(FrappeTypeError):
+				get_arrangement("Sidebar", address)
+
+			# ...and this is the braces, for the contexts where annotations are not applied:
+			# a background job, `bench execute`, or any other caller off a request.
+			with self.assertRaises(frappe.ValidationError):
+				_target("Sidebar", address, "user")
 
 	def test_a_container_that_is_not_one_is_refused(self):
 		with self.assertRaises(frappe.ValidationError):

--- a/frappe/tests/test_navigation_arrangement.py
+++ b/frappe/tests/test_navigation_arrangement.py
@@ -457,6 +457,19 @@ class TestReset(NavigationTestCase):
 
 		self.assertEqual(rail_keys(), ["role", "user"], "their arrangement survives")
 
+	def test_a_save_of_rows_the_list_no_longer_holds_does_not_do_a_resets_work(self):
+		"""The same hazard one filter later. These rows are shaped perfectly well, so the check
+		on the submission lets them through -- but the app has since dropped every key they
+		name, so the reduction drops them all and the layer would go. A save that names nothing
+		*of this list* is as stale as one that names nothing at all."""
+		make_rail([doctype_item("user", "User"), doctype_item("role", "Role")], standard=1)
+		save_arrangement("Rail", APP, showing(shown("role"), shown("user")))
+
+		with self.assertRaises(frappe.ValidationError):
+			save_arrangement("Rail", APP, showing(shown("gone"), shown("also_gone")))
+
+		self.assertEqual(rail_keys(), ["role", "user"], "their arrangement survives")
+
 	def test_arranging_it_back_still_leaves_no_row(self):
 		"""The case the check above must not catch: a full list that happens to differ in
 		nothing is not malformed, and the layer still goes."""

--- a/frappe/tests/test_navigation_arrangement.py
+++ b/frappe/tests/test_navigation_arrangement.py
@@ -329,6 +329,32 @@ class TestHidingASection(NavigationTestCase):
 
 		self.assertEqual(rail_keys(), ["s2", "b", "s1", "a"])
 
+	def test_a_nested_subtree_moves_whole(self):
+		"""One level deeper than the pair above: the moved section holds a section of its own,
+		so carrying "the row's children" is not enough and it has to be the whole subtree."""
+		make_rail(
+			[
+				item("s1", item_type="Section"),
+				item("s1a", item_type="Section", parent_key="s1"),
+				doctype_item("deep", "User", parent_key="s1a"),
+				item("s2", item_type="Section"),
+				doctype_item("b", "Role", parent_key="s2"),
+			],
+			standard=1,
+		)
+
+		shown = showing(
+			{"key": "s2"},
+			{"key": "b", "parent_key": "s2"},
+			{"key": "s1"},
+			{"key": "s1a", "parent_key": "s1"},
+			{"key": "deep", "parent_key": "s1a"},
+		)
+		save_arrangement("Rail", APP, shown)
+
+		self.assertEqual(rail_keys(), ["s2", "b", "s1", "s1a", "deep"])
+		self.assertEqual(keys(get_arrangement("Rail", APP)), [row["key"] for row in shown])
+
 	def test_what_the_editor_saves_is_what_it_reads_back(self):
 		"""The property the one above protects, stated end to end: a save followed by a read
 		gives the same list, so the editor never redraws itself into an arrangement nobody

--- a/frappe/tests/test_navigation_arrangement.py
+++ b/frappe/tests/test_navigation_arrangement.py
@@ -1,0 +1,437 @@
+# Copyright (c) 2026, Frappe Technologies and Contributors
+# License: MIT. See LICENSE
+
+"""The overlay write endpoints: `frappe/shell/arrangement.py`.
+
+Desk v2's first user-state write. Every test here is about what a person's edit stores and what
+it resolves back to, so the layers belong to `frappe`, which is certainly installed wherever this
+runs, and the doctypes they point at are ones every site has.
+
+The helpers come from `test_shell_navigation`, which already knows how to place app content on a
+site the way an install does. What is added here is the other side of that: a person editing it.
+"""
+
+import json
+
+import frappe
+from frappe.shell.arrangement import (
+	anchors_for,
+	get_arrangement,
+	reduce_arrangement,
+	reset_arrangement,
+	save_arrangement,
+)
+from frappe.shell.navigation import resolve_navigation
+from frappe.tests.classes.context_managers import set_user
+from frappe.tests.test_shell_navigation import (
+	ADDRESS_KEY,
+	APP,
+	NavigationTestCase,
+	doctype_item,
+	item,
+	keys,
+	make_rail,
+	make_sidebar,
+	shipping,
+)
+
+OTHER = "test_arranger@example.com"
+
+
+def rail_keys() -> list[str]:
+	return keys(resolve_navigation(APP)["rail"])
+
+
+def showing(*items: dict) -> list[dict]:
+	"""What a client sends: the whole ordered list it is showing, hidden rows and all."""
+	return list(items)
+
+
+def shown(key: str, **kwargs) -> dict:
+	return {"key": key, **kwargs}
+
+
+def a_person(email: str = OTHER, role: str = "System Manager") -> str:
+	"""Somebody other than the session user, so "a colleague sees their own" has somebody to be.
+
+	`System Manager` by default because that is the site scope's gate. The test that is about
+	the gate asks for `Desk User` instead: `has_app_permission` defaults to "is a System User",
+	so a Desk User is somebody who may enter the prefix and arrange their own rail, and may not
+	arrange everyone's.
+	"""
+	if not frappe.db.exists("User", email):
+		frappe.get_doc(
+			doctype="User",
+			email=email,
+			first_name="Arranger",
+			user_type="System User",
+			roles=[{"role": role}],
+		).insert(ignore_permissions=True)
+
+	return email
+
+
+class TestReduction(NavigationTestCase):
+	"""The reduction on its own: a whole ordered list in, the smallest layer that produces it out."""
+
+	def test_an_unchanged_list_writes_nothing(self):
+		base = [shown("a"), shown("b"), shown("c")]
+
+		self.assertEqual(reduce_arrangement(base, base), [])
+
+	def test_only_the_rows_that_moved_are_written(self):
+		base = [shown("a"), shown("b"), shown("c")]
+		rows = reduce_arrangement(base, [shown("c"), shown("a"), shown("b")])
+
+		self.assertEqual([row["key"] for row in rows], ["c"])
+		self.assertEqual(json.loads(rows[0]["anchors"]), [{"before": "a"}])
+
+	def test_a_rename_is_a_field_level_override(self):
+		base = [shown("a", label="Accounts")]
+		rows = reduce_arrangement(base, [shown("a", label="Money")])
+
+		self.assertEqual(rows[0]["label"], "Money")
+		self.assertEqual(json.loads(rows[0]["overrides"]), ["label"])
+
+	def test_clearing_a_label_the_app_shipped_is_expressible(self):
+		"""The reason `overrides` is a list of fieldnames rather than "whatever is non-blank"."""
+		rows = reduce_arrangement([shown("a", label="Accounts")], [shown("a", label="")])
+
+		self.assertEqual(json.loads(rows[0]["overrides"]), ["label"])
+		self.assertEqual(rows[0]["label"], "")
+
+	def test_clearing_an_already_blank_field_says_nothing(self):
+		"""The resolved list omits a blank field rather than sending `null`, so a field nobody
+		touched comes back absent and a field somebody cleared comes back as `""`. Reading those
+		as two different values would write a row that says nothing."""
+		self.assertEqual(reduce_arrangement([shown("a")], [shown("a", label="")]), [])
+
+	def test_a_hide_is_written_and_an_unhide_is_written(self):
+		self.assertEqual(reduce_arrangement([shown("a")], [shown("a", hidden=1)])[0]["hidden"], 1)
+		self.assertEqual(reduce_arrangement([shown("a", hidden=1)], [shown("a")])[0]["hidden"], 0)
+
+	def test_a_key_the_base_does_not_hold_is_dropped(self):
+		"""An app removed an item while somebody had the editor open. Refusing would lose the
+		rest of a save over a row they never touched, and writing it would author an item into a
+		layer from values a browser supplied."""
+		rows = reduce_arrangement([shown("a")], [shown("gone"), shown("a")])
+
+		self.assertEqual([row["key"] for row in rows], [])
+
+	def test_order_is_compared_per_parent(self):
+		"""The payload is a flat list the client renders as a tree, so where one section's
+		children sit relative to another section's is not something anybody can see or intend."""
+		base = [shown("s1"), shown("a", parent_key="s1"), shown("s2"), shown("b", parent_key="s2")]
+		desired = [shown("s1"), shown("s2"), shown("b", parent_key="s2"), shown("a", parent_key="s1")]
+
+		self.assertEqual(reduce_arrangement(base, desired), [])
+
+	def test_a_row_moved_to_the_front_names_a_row_that_is_not_also_moving(self):
+		"""Anchors resolve in the order the rows are written, so naming a row that has yet to
+		move would place this one against a position that is about to change."""
+		base = [shown(key) for key in "abcde"]
+		anchors = anchors_for(base, [shown(key) for key in "deabc"])
+
+		# `d` has nothing before it, so it names the first row ahead of it that is staying put --
+		# not `e`, which is about to move out from under it.
+		self.assertEqual(anchors["d"], [{"before": "a"}])
+		self.assertEqual(anchors["e"], [{"after": "d"}])
+
+	def test_a_key_sent_twice_keeps_its_first_position(self):
+		"""And is only compared once. The order comparison is quadratic in a parent's list, so a
+		body that repeated one key ten thousand times would size the work by the request rather
+		than by the site's navigation."""
+		base = [shown("a"), shown("b")]
+		rows = reduce_arrangement(base, [shown("b")] * 5000 + [shown("a")])
+
+		# One row, not five thousand: the repeats are gone before anything compares orders, and
+		# what is left is the same single move `[b, a]` reduces to.
+		self.assertEqual(len(rows), 1)
+		self.assertEqual(rows, reduce_arrangement(base, [shown("b"), shown("a")]))
+
+	def test_an_override_that_is_not_a_scalar_is_read_as_blank(self):
+		"""The rows come off a request body, where the endpoint's type annotations do not
+		reach: a `label` can arrive as a list."""
+		self.assertEqual(reduce_arrangement([shown("a")], [shown("a", label=["x"])]), [])
+
+		row = reduce_arrangement([shown("a", label="Accounts")], [shown("a", label={"x": 1})])[0]
+		self.assertIsNone(row["label"])
+
+	def test_the_fewest_possible_rows_move(self):
+		"""One item dragged to the end is one row, not the whole list re-positioned."""
+		base = [shown(key) for key in "abcdef"]
+		desired = [shown(key) for key in "bcdefa"]
+
+		self.assertEqual([row["key"] for row in reduce_arrangement(base, desired)], ["a"])
+
+
+class TestSavingAnArrangement(NavigationTestCase):
+	def test_a_reorder_survives_a_re_resolve(self):
+		make_rail([doctype_item("user", "User"), doctype_item("role", "Role")], standard=1)
+
+		save_arrangement("Rail", APP, showing(shown("role"), shown("user")))
+
+		self.assertEqual(rail_keys(), ["role", "user"])
+
+	def test_the_save_hands_back_the_whole_prefix(self):
+		"""Not the one list that changed. Hiding a rail item of type `Sidebar` changes which
+		sidebars are reachable, so a scoped response would be a half-truth."""
+		make_rail([doctype_item("user", "User"), doctype_item("role", "Role")], standard=1)
+
+		navigation = save_arrangement("Rail", APP, showing(shown("role"), shown("user")))
+
+		self.assertEqual(keys(navigation["rail"]), ["role", "user"])
+		self.assertIn("sidebars", navigation)
+
+	def test_arranging_it_back_leaves_no_row(self):
+		"""An empty layer and no layer resolve identically, so keeping one would be a row that
+		means nothing -- and it is what makes "drag it back" and "reset" end in one state."""
+		make_rail([doctype_item("user", "User"), doctype_item("role", "Role")], standard=1)
+
+		save_arrangement("Rail", APP, showing(shown("role"), shown("user")))
+		save_arrangement("Rail", APP, showing(shown("user"), shown("role")))
+
+		self.assertFalse(frappe.db.exists("Rail", {"app": APP, "standard": 0}))
+
+	def test_a_rename_reaches_the_payload(self):
+		make_rail([doctype_item("user", "User", label="People")], standard=1)
+
+		save_arrangement("Rail", APP, showing(shown("user", label="My People")))
+
+		self.assertEqual(resolve_navigation(APP)["rail"][0]["label"], "My People")
+
+	def test_a_hidden_item_leaves_the_payload(self):
+		make_rail([doctype_item("user", "User"), doctype_item("role", "Role")], standard=1)
+
+		save_arrangement("Rail", APP, showing(shown("user", hidden=1), shown("role")))
+
+		self.assertEqual(rail_keys(), ["role"])
+
+	def test_a_newly_shipped_item_lands_where_the_app_put_it(self):
+		"""#42229's sparse move-list, which is the whole reason a move is an anchor. A layer
+		that recorded positions would pin the list, and the item an app ships next would have
+		nowhere to land but the end."""
+		make_rail([doctype_item("user", "User"), doctype_item("role", "Role")], standard=1)
+		save_arrangement("Rail", APP, showing(shown("role"), shown("user")))
+
+		with shipping():
+			rail = frappe.get_doc("Rail", APP)
+			rail.append("items", doctype_item("page", "Page"))
+			rail.save(ignore_permissions=True)
+
+		self.assertEqual(rail_keys(), ["role", "user", "page"])
+
+	def test_an_item_nobody_moved_is_not_moved(self):
+		make_rail(
+			[doctype_item("user", "User"), doctype_item("role", "Role"), doctype_item("page", "Page")],
+			standard=1,
+		)
+
+		save_arrangement("Rail", APP, showing(shown("user", label="People"), shown("role"), shown("page")))
+
+		self.assertEqual(rail_keys(), ["user", "role", "page"])
+
+
+class TestHidingASection(NavigationTestCase):
+	"""#42363 decision 9, which is the one thing this build changed rather than added."""
+
+	def section_rail(self):
+		make_rail(
+			[
+				item("people", item_type="Section", label="People"),
+				doctype_item("user", "User", parent_key="people"),
+				doctype_item("role", "Role"),
+			],
+			standard=1,
+		)
+
+	def test_hiding_a_section_takes_its_children_with_it(self):
+		self.section_rail()
+
+		save_arrangement(
+			"Rail",
+			APP,
+			showing(shown("people", hidden=1), shown("user", parent_key="people"), shown("role")),
+		)
+
+		self.assertEqual(rail_keys(), ["role"])
+
+	def test_an_app_removing_a_section_still_promotes_its_children(self):
+		"""The same flat list by the time it is resolved, and the opposite answer. A person
+		hiding a section means the branch; an app withdrawing one must not silently withdraw
+		everything under it."""
+		make_rail([doctype_item("user", "User", parent_key="people")], standard=1)
+
+		entry = resolve_navigation(APP)["rail"][0]
+		self.assertNotIn("parent_key", entry)
+
+	def test_a_section_nested_in_a_hidden_one_goes_too(self):
+		make_rail(
+			[
+				item("outer", item_type="Section"),
+				item("inner", item_type="Section", parent_key="outer"),
+				doctype_item("user", "User", parent_key="inner"),
+			],
+			standard=1,
+		)
+
+		save_arrangement(
+			"Rail",
+			APP,
+			showing(
+				shown("outer", hidden=1),
+				shown("inner", parent_key="outer"),
+				shown("user", parent_key="inner"),
+			),
+		)
+
+		self.assertEqual(rail_keys(), [])
+
+
+class TestScopes(NavigationTestCase):
+	def test_a_person_sees_their_own_arrangement_and_not_a_colleagues(self):
+		make_rail([doctype_item("user", "User"), doctype_item("role", "Role")], standard=1)
+		save_arrangement("Rail", APP, showing(shown("role"), shown("user")))
+
+		with set_user(a_person()):
+			self.assertEqual(rail_keys(), ["user", "role"])
+
+		self.assertEqual(rail_keys(), ["role", "user"])
+
+	def test_the_site_layer_reaches_everyone(self):
+		make_rail([doctype_item("user", "User"), doctype_item("role", "Role")], standard=1)
+		save_arrangement("Rail", APP, showing(shown("role"), shown("user")), scope="site")
+
+		with set_user(a_person()):
+			self.assertEqual(rail_keys(), ["role", "user"])
+
+	def test_a_persons_moves_are_anchored_against_what_the_site_arranged(self):
+		"""A save reads one scope below its own, so a person's anchors name the list they were
+		actually looking at rather than the one the app ships."""
+		make_rail([doctype_item("user", "User"), doctype_item("role", "Role")], standard=1)
+		save_arrangement("Rail", APP, showing(shown("role"), shown("user")), scope="site")
+		save_arrangement("Rail", APP, showing(shown("role"), shown("user")))
+
+		self.assertFalse(frappe.db.exists("Rail", {"app": APP, "standard": 0, "user": frappe.session.user}))
+
+	def test_a_person_can_unhide_what_the_site_hid(self):
+		make_rail([doctype_item("user", "User"), doctype_item("role", "Role")], standard=1)
+		save_arrangement("Rail", APP, showing(shown("user", hidden=1), shown("role")), scope="site")
+
+		self.assertEqual(rail_keys(), ["role"])
+		self.assertEqual(
+			keys(get_arrangement("Rail", APP)),
+			["user", "role"],
+			"the editor is shown what was hidden, or a hide would be a one-way door",
+		)
+
+		save_arrangement("Rail", APP, showing(shown("user"), shown("role")))
+		self.assertEqual(rail_keys(), ["user", "role"])
+
+	def test_the_user_scope_is_the_session_user_and_cannot_be_argued(self):
+		"""There is no `user` argument in this module, so "write somebody else's arrangement" is
+		not a request that can be made and does not need refusing."""
+		import inspect
+
+		self.assertNotIn("user", inspect.signature(save_arrangement).parameters)
+
+
+class TestReset(NavigationTestCase):
+	def test_a_reset_deletes_one_layer(self):
+		make_rail([doctype_item("user", "User"), doctype_item("role", "Role")], standard=1)
+		save_arrangement("Rail", APP, showing(shown("role"), shown("user")))
+
+		reset_arrangement("Rail", APP)
+
+		self.assertEqual(rail_keys(), ["user", "role"])
+
+	def test_resetting_your_own_cannot_reach_the_sites(self):
+		"""Desk v1's two blast-radius resets delete the site layer and every user's from one
+		call. Neither is ported."""
+		make_rail([doctype_item("user", "User"), doctype_item("role", "Role")], standard=1)
+		save_arrangement("Rail", APP, showing(shown("role"), shown("user")), scope="site")
+		save_arrangement("Rail", APP, showing(shown("user", label="Mine")))
+
+		reset_arrangement("Rail", APP)
+
+		self.assertEqual(rail_keys(), ["role", "user"])
+		self.assertTrue(frappe.db.exists("Rail", {"app": APP, "standard": 0, "user": ""}))
+
+	def test_a_reset_of_a_layer_that_is_not_there_is_not_an_error(self):
+		make_rail([doctype_item("user", "User")], standard=1)
+
+		self.assertEqual(keys(reset_arrangement("Rail", APP)["rail"]), ["user"])
+
+
+class TestTheGate(NavigationTestCase):
+	def test_arranging_an_app_you_may_not_enter_is_refused(self):
+		make_rail([doctype_item("user", "User")], standard=1)
+
+		with set_user("Guest"), self.assertRaises(frappe.PermissionError):
+			save_arrangement("Rail", APP, showing(shown("user")))
+
+	def test_the_site_scope_needs_a_system_manager(self):
+		"""Unlike the reads, this gate is the boundary rather than a choice of error page: no
+		doctype permission stands behind arranging the rail of an app you may not enter."""
+		make_rail([doctype_item("user", "User")], standard=1)
+		reader = a_person("test_desk_user@example.com", role="Desk User")
+
+		with set_user(reader):
+			# Their own is theirs to arrange...
+			save_arrangement("Rail", APP, showing(shown("user", label="Mine")))
+
+			# ...and everyone's is not.
+			with self.assertRaises(frappe.PermissionError):
+				save_arrangement("Rail", APP, showing(shown("user")), scope="site")
+
+	def test_an_app_that_is_not_on_this_bench_is_refused(self):
+		"""Checked before the gate, because `has_app_permission` falls back to "is a System
+		User" for an app that declares no hook -- and an app that is not here declares none."""
+		with self.assertRaises(frappe.ValidationError):
+			get_arrangement("Rail", "no_such_app")
+
+	def test_a_container_that_is_not_one_is_refused(self):
+		with self.assertRaises(frappe.ValidationError):
+			get_arrangement("Custom Sidebar", APP)
+
+	def test_a_scope_that_is_not_one_is_refused(self):
+		with self.assertRaises(frappe.ValidationError):
+			get_arrangement("Rail", APP, scope="role")
+
+
+class TestSidebarArrangement(NavigationTestCase):
+	def test_a_sidebar_is_arranged_by_its_scrubbed_address(self):
+		"""The client holds the scrubbed address and nothing else, and unscrubbing is not a
+		function -- so the pair is read back from the standard record, whose name is that
+		address by construction."""
+		make_sidebar([doctype_item("user", "User"), doctype_item("role", "Role")], standard=1)
+
+		save_arrangement("Sidebar", ADDRESS_KEY, showing(shown("role"), shown("user")))
+
+		self.assertEqual(keys(resolve_navigation(APP)["sidebars"][ADDRESS_KEY]), ["role", "user"])
+
+	def test_a_sidebar_layer_lands_in_the_v2_table(self):
+		"""One `Sidebar` document holds desk v1's `items` beside desk v2's `navigation_items`,
+		so a write that named the wrong parentfield would edit v1's sidebar."""
+		make_sidebar([doctype_item("user", "User"), doctype_item("role", "Role")], standard=1)
+
+		save_arrangement("Sidebar", ADDRESS_KEY, showing(shown("role"), shown("user")))
+
+		layer = frappe.get_doc("Sidebar", {"standard": 0, "user": frappe.session.user})
+		self.assertTrue(layer.navigation_items)
+		self.assertEqual(layer.items, [])
+
+	def test_an_address_no_app_ships_is_refused(self):
+		with self.assertRaises(frappe.ValidationError):
+			get_arrangement("Sidebar", "module_def_nobody_ships_this")
+
+	def test_a_sidebar_reset_leaves_the_rail_alone(self):
+		make_rail([doctype_item("user", "User"), doctype_item("role", "Role")], standard=1)
+		make_sidebar([doctype_item("user", "User"), doctype_item("role", "Role")], standard=1)
+		save_arrangement("Rail", APP, showing(shown("role"), shown("user")))
+		save_arrangement("Sidebar", ADDRESS_KEY, showing(shown("role"), shown("user")))
+
+		reset_arrangement("Sidebar", ADDRESS_KEY)
+
+		self.assertEqual(rail_keys(), ["role", "user"])
+		self.assertEqual(keys(resolve_navigation(APP)["sidebars"][ADDRESS_KEY]), ["user", "role"])

--- a/frappe/tests/test_navigation_arrangement.py
+++ b/frappe/tests/test_navigation_arrangement.py
@@ -302,6 +302,57 @@ class TestHidingASection(NavigationTestCase):
 		entry = resolve_navigation(APP)["rail"][0]
 		self.assertNotIn("parent_key", entry)
 
+	def test_moving_a_section_takes_its_children_in_the_list_too(self):
+		"""The list is flat and the tree is `parent_key`, so a section that moved on its own
+		would leave its children sitting where they were. The tree would still read correctly --
+		a reader groups by `parent_key` -- but the flat order would no longer have children
+		following their parent, and the editor reads this list straight back and draws it in
+		order. So a save would come back looking like a different arrangement.
+		"""
+		make_rail(
+			[
+				item("s1", item_type="Section"),
+				doctype_item("a", "User", parent_key="s1"),
+				item("s2", item_type="Section"),
+				doctype_item("b", "Role", parent_key="s2"),
+			],
+			standard=1,
+		)
+
+		shown = showing(
+			{"key": "s2"},
+			{"key": "b", "parent_key": "s2"},
+			{"key": "s1"},
+			{"key": "a", "parent_key": "s1"},
+		)
+		save_arrangement("Rail", APP, shown)
+
+		self.assertEqual(rail_keys(), ["s2", "b", "s1", "a"])
+
+	def test_what_the_editor_saves_is_what_it_reads_back(self):
+		"""The property the one above protects, stated end to end: a save followed by a read
+		gives the same list, so the editor never redraws itself into an arrangement nobody
+		made."""
+		make_rail(
+			[
+				item("s1", item_type="Section"),
+				doctype_item("a", "User", parent_key="s1"),
+				item("s2", item_type="Section"),
+				doctype_item("b", "Role", parent_key="s2"),
+			],
+			standard=1,
+		)
+
+		shown = showing(
+			{"key": "s2"},
+			{"key": "b", "parent_key": "s2"},
+			{"key": "s1"},
+			{"key": "a", "parent_key": "s1"},
+		)
+		save_arrangement("Rail", APP, shown)
+
+		self.assertEqual(keys(get_arrangement("Rail", APP)), [row["key"] for row in shown])
+
 	def test_a_section_nested_in_a_hidden_one_goes_too(self):
 		make_rail(
 			[

--- a/frappe/tests/test_navigation_arrangement.py
+++ b/frappe/tests/test_navigation_arrangement.py
@@ -16,6 +16,7 @@ import json
 import frappe
 from frappe.exceptions import FrappeTypeError
 from frappe.shell.arrangement import (
+	_as_items,
 	_target,
 	anchors_for,
 	get_arrangement,
@@ -111,6 +112,18 @@ class TestReduction(NavigationTestCase):
 	def test_a_hide_is_written_and_an_unhide_is_written(self):
 		self.assertEqual(reduce_arrangement([shown("a")], [shown("a", hidden=1)])[0]["hidden"], 1)
 		self.assertEqual(reduce_arrangement([shown("a", hidden=1)], [shown("a")])[0]["hidden"], 0)
+
+	def test_a_key_or_parent_that_is_not_a_name_is_dropped(self):
+		"""Both are read as dictionary keys from here on, and a list is not hashable — so one
+		arriving in either column would end a whitelisted save in an uncaught `TypeError`."""
+		base = [shown("a"), shown("b")]
+
+		self.assertEqual(reduce_arrangement(base, _as_items([{"key": ["!=", ""]}, shown("a")])), [])
+		self.assertEqual(
+			_as_items([shown("a", parent_key={"x": 1})])[0]["parent_key"],
+			None,
+			"a parent that is not a name is no parent, not a crash",
+		)
 
 	def test_a_key_the_base_does_not_hold_is_dropped(self):
 		"""An app removed an item while somebody had the editor open. Refusing would lose the

--- a/frappe/tests/test_navigation_arrangement.py
+++ b/frappe/tests/test_navigation_arrangement.py
@@ -119,11 +119,26 @@ class TestReduction(NavigationTestCase):
 		base = [shown("a"), shown("b")]
 
 		self.assertEqual(reduce_arrangement(base, _as_items([{"key": ["!=", ""]}, shown("a")])), [])
-		self.assertEqual(
-			_as_items([shown("a", parent_key={"x": 1})])[0]["parent_key"],
-			None,
-			"a parent that is not a name is no parent, not a crash",
+
+		# And a parent that is not a name drops the row rather than being read as blank. Blank
+		# means the top level, which is a placement nobody asked for and one the reduction would
+		# faithfully write down; dropping the row says nothing about it, so it stays put.
+		self.assertEqual(_as_items([shown("a", parent_key={"x": 1})]), [])
+		self.assertEqual(_as_items([shown("a", parent_key="")])[0]["parent_key"], None)
+
+	def test_a_malformed_parent_does_not_move_a_row_to_the_top_level(self):
+		make_rail(
+			[
+				item("people", item_type="Section", label="People"),
+				doctype_item("user", "User", parent_key="people"),
+			],
+			standard=1,
 		)
+
+		save_arrangement("Rail", APP, showing(shown("people"), shown("user", parent_key=["oops"])))
+
+		entry = next(e for e in resolve_navigation(APP)["rail"] if e["key"] == "user")
+		self.assertEqual(entry["parent_key"], "people")
 
 	def test_a_key_the_base_does_not_hold_is_dropped(self):
 		"""An app removed an item while somebody had the editor open. Refusing would lose the

--- a/frappe/tests/test_shell_navigation.py
+++ b/frappe/tests/test_shell_navigation.py
@@ -71,6 +71,15 @@ def doctype_item(key: str, doctype: str, **kwargs) -> dict:
 	return item(key, link_doctype="DocType", link_to=doctype, **kwargs)
 
 
+def moved(key: str, *anchors: dict, **kwargs) -> dict:
+	"""A layer row that moves the item it names, which is the only way a layer moves anything.
+
+	The order of a layer's rows says nothing: an arrangement is a set of anchors, not a list of
+	positions (#42363), so a layer that names two rows and anchors neither leaves both alone.
+	"""
+	return item(key, anchors=json.dumps(list(anchors)), **kwargs)
+
+
 def make_rail(
 	items: list[dict], *, standard: int = 0, user: str | None = None, app: str = APP, extends: str = ""
 ):
@@ -183,11 +192,29 @@ class TestShippedRail(NavigationTestCase):
 			[doctype_item("user", "User"), doctype_item("role", "Role")],
 			standard=1,
 		)
-		make_rail([item("role"), item("user")])
+		make_rail([moved("role", {"before": "user"})])
 		self.assertEqual(keys(resolve_navigation(APP)["rail"]), ["role", "user"])
 
-		make_rail([item("user"), item("role")], user=frappe.session.user)
+		make_rail([moved("user", {"before": "role"})], user=frappe.session.user)
 		self.assertEqual(keys(resolve_navigation(APP)["rail"]), ["user", "role"])
+
+	def test_a_layer_that_anchors_nothing_moves_nothing(self):
+		"""The rule the two above rest on, stated on its own.
+
+		Desk v1 read a layer's row order as the arrangement, so naming two rows in the other
+		order swapped them. A desk v2 layer names rows to say something *about* them -- a label,
+		a hide -- and says where only through an anchor, which is what lets an app ship a new
+		item into its own position rather than after everything a person has touched.
+		"""
+		make_rail([doctype_item("user", "User"), doctype_item("role", "Role")], standard=1)
+		make_rail(
+			[item("role", label="Roles", overrides=json.dumps(["label"])), item("user")],
+			user=frappe.session.user,
+		)
+
+		rail = resolve_navigation(APP)["rail"]
+		self.assertEqual(keys(rail), ["user", "role"])
+		self.assertEqual(rail[1]["label"], "Roles")
 
 	def test_a_hidden_item_never_reaches_the_payload(self):
 		"""`resolve_layers` returns the hidden map unapplied because the surface decides.
@@ -505,7 +532,7 @@ class TestExtendedRail(NavigationTestCase):
 		covering every item on it — including the ones another app put there."""
 		make_rail([doctype_item("user", "User"), doctype_item("role", "Role")], standard=1)
 		make_extension([doctype_item("calls", "Role")])
-		make_rail([item("telephony:calls"), item("user"), item("role")], user=frappe.session.user)
+		make_rail([moved("telephony:calls", {"before": "user"})], user=frappe.session.user)
 
 		with active(EXTENDER):
 			self.assertEqual(keys(resolve_navigation(APP)["rail"]), ["telephony:calls", "user", "role"])

--- a/frontend/src/arrangement.ts
+++ b/frontend/src/arrangement.ts
@@ -86,22 +86,16 @@ export function move(items: ArrangedItem[], key: string, by: 1 | -1): ArrangedIt
 	const item = items.find((entry) => entry.key === key);
 	if (!item) return items;
 
-	const siblings = items.filter(
-		(entry) => (entry.parent_key ?? null) === (item.parent_key ?? null)
-	);
-	const swapWith = siblings[siblings.indexOf(item) + by];
-	if (!swapWith) return items;
+	const order = siblings(items);
+	const group = order.get(parentOf(item)) ?? [];
+	const at = group.indexOf(key);
+	if (at + by < 0 || at + by >= group.length) return items;
 
-	// Swapped in the flat list by position, so a section's children travel with neither row —
-	// the tree is rebuilt from `parent_key` on every render, and only the order of these two
-	// keys among their siblings has changed.
-	const next = [...items];
-	const here = next.indexOf(item);
-	const there = next.indexOf(swapWith);
-	next[here] = swapWith;
-	next[there] = item;
+	const swapped = [...group];
+	[swapped[at], swapped[at + by]] = [swapped[at + by], swapped[at]];
+	order.set(parentOf(item), swapped);
 
-	return next;
+	return flatten(items, order);
 }
 
 /**
@@ -117,10 +111,68 @@ export function dropOn(items: ArrangedItem[], key: string, onto: string): Arrang
 	const target = items.find((entry) => entry.key === onto);
 
 	if (!item || !target || item === target) return items;
-	if ((item.parent_key ?? null) !== (target.parent_key ?? null)) return items;
+	if (parentOf(item) !== parentOf(target)) return items;
 
-	const next = items.filter((entry) => entry !== item);
-	next.splice(next.indexOf(target) + (items.indexOf(item) < items.indexOf(target) ? 1 : 0), 0, item);
+	const order = siblings(items);
+	const group = [...(order.get(parentOf(item)) ?? [])];
+	// Dragged downwards a row lands after the row it was dropped on, upwards before it — which
+	// is the same rule either way: it takes the place the target is standing in.
+	const downwards = group.indexOf(key) < group.indexOf(onto);
 
-	return next;
+	group.splice(group.indexOf(key), 1);
+	group.splice(group.indexOf(onto) + (downwards ? 1 : 0), 0, key);
+	order.set(parentOf(item), group);
+
+	return flatten(items, order);
+}
+
+function parentOf(item: ArrangedItem): string | null {
+	return item.parent_key ?? null;
+}
+
+/** The keys under each parent, in their current order. `null` is the top level. */
+function siblings(items: ArrangedItem[]): Map<string | null, string[]> {
+	const order = new Map<string | null, string[]>();
+
+	for (const item of items) {
+		const group = order.get(parentOf(item)) ?? [];
+		group.push(item.key);
+		order.set(parentOf(item), group);
+	}
+
+	return order;
+}
+
+/**
+ * Rebuild the flat list from the sibling order, depth first, so a section's children travel
+ * with it.
+ *
+ * The list is flat and the tree is `parent_key`, so moving a section by swapping two rows leaves
+ * its children where they were — the saved arrangement is still right, because the reduction
+ * compares each parent's children separately, but the editor would draw rows under a heading
+ * they do not belong to. Re-flattening makes what is on screen and what is in the list the same
+ * thing, which is the only version anybody can check by looking.
+ *
+ * A row whose parent is not in the list is appended rather than dropped. The server promotes
+ * orphans before sending, so this should not arise; losing a row to a rule about drawing it
+ * would be much worse than showing it at the end.
+ */
+function flatten(items: ArrangedItem[], order: Map<string | null, string[]>): ArrangedItem[] {
+	const byKey = new Map(items.map((item) => [item.key, item]));
+	const flat: ArrangedItem[] = [];
+	const seen = new Set<string>();
+
+	const walk = (parent: string | null) => {
+		for (const key of order.get(parent) ?? []) {
+			const item = byKey.get(key);
+			if (!item || seen.has(key)) continue;
+			seen.add(key);
+			flat.push(item);
+			walk(key);
+		}
+	};
+
+	walk(null);
+
+	return [...flat, ...items.filter((item) => !seen.has(item.key))];
 }

--- a/frontend/src/arrangement.ts
+++ b/frontend/src/arrangement.ts
@@ -1,0 +1,126 @@
+// ARRANGING — the client half of desk v2's first user-state write.
+//
+// The whole ordered list goes up; the reduction to what actually changed happens on the server
+// (#42363). That division is not an accident of where the code was easier to write. A client
+// that sent anchors would be computing identity and difference against a copy of the base it
+// may already be holding stale, which is the mistake desk v1 makes in the other direction: its
+// sidebar manager recomputes the server's item key in JS and gets it wrong two ways, leaving
+// `filters` out of a key the server includes and returning a raw `"type|label"` where the server
+// returns a hash. Desk v2's key is authored, arrives on the wire, and is never computed here.
+//
+// Nothing in this file is a store. A save returns the whole `{rail, sidebars}` for the prefix and
+// the caller swaps it into `boot.navigation` wholesale, so the arrangement a person is looking at
+// and the navigation the shell renders never drift into two copies that have to be reconciled.
+
+import { call } from "frappe-ui";
+import type { Navigation, NavigationItem } from "@/boot";
+
+/** Which of the two containers is being arranged. They are two presentations of one model. */
+export type Container = "Rail" | "Sidebar";
+
+/**
+ * Whose layer. `user` is always the session user — the endpoints take no user argument, so
+ * arranging somebody else's navigation is not a request this client could make even by mistake.
+ * `site` is what everyone sees and needs a System Manager.
+ */
+export type Scope = "user" | "site";
+
+/**
+ * A row as the editor holds it: what the payload carries, plus the hidden flag.
+ *
+ * `hidden` is absent from `boot.navigation` — boot drops hidden rows, because the browser cannot
+ * render a row it must not show. The editor asks for them back, since a hide nobody can see is a
+ * hide nobody can undo.
+ */
+export type ArrangedItem = NavigationItem & { hidden?: 1 };
+
+/** The address of one container: an app name for a rail, a scrubbed address for a sidebar. */
+export type Address = { container: Container; address: string };
+
+export async function fetchArrangement(
+	{ container, address }: Address,
+	scope: Scope = "user"
+): Promise<ArrangedItem[]> {
+	return await call("frappe.shell.arrangement.get_arrangement", {
+		container,
+		address,
+		scope,
+	});
+}
+
+export async function saveArrangement(
+	{ container, address }: Address,
+	items: ArrangedItem[],
+	scope: Scope = "user"
+): Promise<Navigation> {
+	return await call("frappe.shell.arrangement.save_arrangement", {
+		container,
+		address,
+		scope,
+		items,
+	});
+}
+
+export async function resetArrangement(
+	{ container, address }: Address,
+	scope: Scope = "user"
+): Promise<Navigation> {
+	return await call("frappe.shell.arrangement.reset_arrangement", {
+		container,
+		address,
+		scope,
+	});
+}
+
+/**
+ * Move one row one place among its own siblings, and give back a new list.
+ *
+ * Siblings, not neighbours in the flat list. The payload is flat and the rail draws it as a
+ * tree, so the row above a section's first child is the section itself — stepping onto it would
+ * read as "move out of this section", which is a different edit and not the one the arrow means.
+ *
+ * A row already at the end of its group does not move, and does not wrap. The list is short
+ * enough to see all of, so wrapping would look like a bug rather than a feature.
+ */
+export function move(items: ArrangedItem[], key: string, by: 1 | -1): ArrangedItem[] {
+	const item = items.find((entry) => entry.key === key);
+	if (!item) return items;
+
+	const siblings = items.filter(
+		(entry) => (entry.parent_key ?? null) === (item.parent_key ?? null)
+	);
+	const swapWith = siblings[siblings.indexOf(item) + by];
+	if (!swapWith) return items;
+
+	// Swapped in the flat list by position, so a section's children travel with neither row —
+	// the tree is rebuilt from `parent_key` on every render, and only the order of these two
+	// keys among their siblings has changed.
+	const next = [...items];
+	const here = next.indexOf(item);
+	const there = next.indexOf(swapWith);
+	next[here] = swapWith;
+	next[there] = item;
+
+	return next;
+}
+
+/**
+ * Move one row to where another sits, which is what a drag means.
+ *
+ * Only between siblings. Dropping onto a row under a different parent would mean two edits at
+ * once — a reparent and a reorder — and a drag that silently did the first is how somebody's
+ * whole section ends up somewhere they did not put it. A drop that is not a sibling's is
+ * refused by returning the list unchanged, which reads as the row springing back.
+ */
+export function dropOn(items: ArrangedItem[], key: string, onto: string): ArrangedItem[] {
+	const item = items.find((entry) => entry.key === key);
+	const target = items.find((entry) => entry.key === onto);
+
+	if (!item || !target || item === target) return items;
+	if ((item.parent_key ?? null) !== (target.parent_key ?? null)) return items;
+
+	const next = items.filter((entry) => entry !== item);
+	next.splice(next.indexOf(target) + (items.indexOf(item) < items.indexOf(target) ? 1 : 0), 0, item);
+
+	return next;
+}

--- a/frontend/src/shell/AppRail.vue
+++ b/frontend/src/shell/AppRail.vue
@@ -25,6 +25,11 @@
   record naming this app in `extends`. Nothing here can tell, and nothing here should:
   the server merged them into the base before the layers went on, so they arrive as
   ordinary items in one ordered list (#42364).
+
+  The list arrives as a PROP rather than off `boot`, which is what lets it change without a
+  reload: a save returns the whole `{rail, sidebars}` and the shell swaps it in, so the rail
+  re-renders from the same server-resolved list it always renders from and never restacks a
+  layer of its own (#42232).
 -->
 <template>
 	<nav class="flex w-52 shrink-0 flex-col gap-1 border-r border-outline-gray-2 p-2">
@@ -50,9 +55,18 @@
 			</component>
 		</div>
 
+		<button
+			v-if="arrangeable"
+			class="mt-auto rounded px-2 py-1 text-left text-xs text-ink-gray-5 hover:bg-surface-gray-2"
+			@click="emit('arrange')"
+		>
+			Arrange
+		</button>
+
 		<a
 			href="/apps"
-			class="mt-auto rounded px-2 py-1 text-xs text-ink-gray-5 hover:bg-surface-gray-2"
+			:class="arrangeable ? '' : 'mt-auto'"
+			class="rounded px-2 py-1 text-xs text-ink-gray-5 hover:bg-surface-gray-2"
 		>
 			All apps
 		</a>
@@ -62,8 +76,14 @@
 <script setup lang="ts">
 import { computed, inject } from "vue";
 import { RouterLink } from "vue-router";
-import type { Boot } from "@/boot";
+import type { Boot, NavigationItem } from "@/boot";
 import { routeFor } from "@/router/routeFor";
+
+// `arrangeable` is off on the index at `/apps`, which belongs to no app: there is no rail to
+// arrange there and no address to name one by, since `boot.app` is null and `boot.navigation`
+// is absent. The shell decides it, because the shell is what knows it is on the index.
+const props = defineProps<{ items: NavigationItem[]; arrangeable?: boolean }>();
+const emit = defineEmits<{ arrange: [] }>();
 
 const boot = inject<Boot>("boot")!;
 
@@ -82,6 +102,6 @@ const boot = inject<Boot>("boot")!;
 // `RouterLink` like any other, and needs nothing here: addresses are bench-wide, so a
 // foreign doctype opens under the host's prefix (#42364).
 const doctypeItems = computed(() =>
-	(boot.navigation?.rail ?? []).filter((item) => item.item_type === "DocType" && item.link_to)
+	props.items.filter((item) => item.item_type === "DocType" && item.link_to)
 );
 </script>

--- a/frontend/src/shell/AppShell.vue
+++ b/frontend/src/shell/AppShell.vue
@@ -5,17 +5,44 @@
   the same in every app; an app contributes only INSIDE a routed view. There is no
   contributeSidebarItem, no contributeCommand, no shell-level hook of any kind
   (#42072).
+
+  Navigation lives here, one level above the rail, because it is not the rail's. A save
+  returns the WHOLE `{rail, sidebars}` for the prefix and the client swaps it in wholesale
+  (#42363) — so hiding a rail item of type `Sidebar` changes which sidebars are reachable, and
+  the one place that knows about both is this one. `boot.navigation` is kept in step for anything
+  that reads boot directly; the reactive copy is what renders.
 -->
 <template>
 	<div class="flex h-screen w-screen bg-surface-white text-ink-gray-9">
-		<AppRail />
+		<AppRail :items="navigation.rail" :arrangeable="!!boot.app" @arrange="arranging = true" />
 		<main class="flex min-w-0 flex-1 flex-col">
 			<RouterView />
 		</main>
+		<ArrangementEditor
+			v-if="arranging && boot.app"
+			container="Rail"
+			:address="boot.app"
+			title="Arrange this rail"
+			@saved="replace"
+			@close="arranging = false"
+		/>
 	</div>
 </template>
 
 <script setup lang="ts">
+import { inject, ref } from "vue";
 import { RouterView } from "vue-router";
+import type { Boot, Navigation } from "@/boot";
 import AppRail from "./AppRail.vue";
+import ArrangementEditor from "./ArrangementEditor.vue";
+
+const boot = inject<Boot>("boot")!;
+
+const arranging = ref(false);
+const navigation = ref<Navigation>(boot.navigation ?? { rail: [], sidebars: {} });
+
+function replace(next: Navigation) {
+	navigation.value = next;
+	boot.navigation = next;
+}
 </script>

--- a/frontend/src/shell/ArrangementEditor.vue
+++ b/frontend/src/shell/ArrangementEditor.vue
@@ -1,0 +1,156 @@
+<!--
+  The arrangement editor: reorder, hide, rename, on either container.
+
+  ONE component for the rail and for a sidebar, because they are one model. It takes a container
+  and an address and nothing else about which surface it is editing — the moment it branched on
+  that, desk v2 would have desk v1's shape, where one base class and two subclasses spend about
+  1,800 lines saying the same thing twice.
+
+  It shows the list ONE SCOPE DEEP, hidden rows included, which is not what the rail shows. A
+  person cannot unhide what they cannot see, so an editor that rendered `boot.navigation` would
+  make hiding a one-way door.
+
+  A drag saves nothing on its own, and neither does an arrow or a rename. The write is the Save
+  button, and until then every edit is local — the same choice desk v1 made, and it is a choice
+  rather than a constraint: a save costs a request and a round trip that replaces the whole of
+  `boot.navigation`, which is not what anybody wants per keystroke.
+
+  There is no drag library. `sortablejs` and `vuedraggable` sit in the lockfile but are asked for
+  by neither `package.base.json` nor frappe-ui, so adopting one would be a new shared dependency
+  under #42069's singleton rule — a real cost, weighed here against about fifteen lines of the
+  platform's own drag events. The arrows are not a fallback for the drag; they are the half that
+  works from a keyboard.
+-->
+<template>
+	<div class="flex w-80 shrink-0 flex-col border-l border-outline-gray-2 bg-surface-white">
+		<header class="flex items-center justify-between border-b border-outline-gray-2 p-3">
+			<h2 class="text-base font-medium text-ink-gray-8">{{ title }}</h2>
+			<Button variant="ghost" label="Close" @click="emit('close')" />
+		</header>
+
+		<p v-if="failed" class="p-3 text-sm text-ink-red-4">
+			{{ failed }}
+		</p>
+
+		<ul v-else class="flex-1 overflow-y-auto p-2" data-testid="arrangement">
+			<li
+				v-for="item in items"
+				:key="item.key"
+				:data-key="item.key"
+				:class="[
+					'flex items-center gap-1 rounded px-1 py-1',
+					item.parent_key ? 'ml-4' : '',
+					item.hidden ? 'opacity-50' : '',
+				]"
+				draggable="true"
+				@dragstart="dragging = item.key"
+				@dragover.prevent
+				@drop.prevent="drop(item.key)"
+			>
+				<input
+					class="min-w-0 flex-1 rounded bg-transparent px-1 py-0.5 text-sm text-ink-gray-8 hover:bg-surface-gray-2 focus:bg-surface-gray-2"
+					:value="item.label ?? ''"
+					:placeholder="item.link_to ?? item.key"
+					:aria-label="`Name of ${item.key}`"
+					@input="rename(item.key, ($event.target as HTMLInputElement).value)"
+				/>
+				<Button
+					variant="ghost"
+					icon="chevron-up"
+					:aria-label="`Move ${item.key} up`"
+					@click="items = move(items, item.key, -1)"
+				/>
+				<Button
+					variant="ghost"
+					icon="chevron-down"
+					:aria-label="`Move ${item.key} down`"
+					@click="items = move(items, item.key, 1)"
+				/>
+				<Button
+					variant="ghost"
+					:icon="item.hidden ? 'eye-off' : 'eye'"
+					:aria-label="`${item.hidden ? 'Show' : 'Hide'} ${item.key}`"
+					@click="toggleHidden(item.key)"
+				/>
+			</li>
+		</ul>
+
+		<footer class="flex items-center gap-2 border-t border-outline-gray-2 p-3">
+			<Button variant="solid" label="Save" :loading="busy" @click="save" />
+			<Button label="Reset" :loading="busy" @click="reset" />
+		</footer>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
+import { Button } from "frappe-ui";
+import type { Navigation } from "@/boot";
+import {
+	type ArrangedItem,
+	type Container,
+	dropOn,
+	fetchArrangement,
+	move,
+	resetArrangement,
+	saveArrangement,
+} from "@/arrangement";
+
+const props = defineProps<{ container: Container; address: string; title: string }>();
+const emit = defineEmits<{ close: []; saved: [Navigation] }>();
+
+const items = ref<ArrangedItem[]>([]);
+const dragging = ref<string | null>(null);
+const busy = ref(false);
+// A message rather than a boolean. An editor that failed to load its list is indistinguishable
+// from one whose navigation is empty, and "you have nothing to arrange" is a false statement to
+// put over a request that never landed.
+const failed = ref<string | null>(null);
+
+onMounted(load);
+
+async function load() {
+	try {
+		items.value = await fetchArrangement(props);
+	} catch (error) {
+		failed.value = `Could not load this arrangement: ${(error as Error).message}`;
+	}
+}
+
+function rename(key: string, label: string) {
+	// The whole row is replaced rather than mutated, so `items` is a list of values and a stale
+	// reference cannot leak an edit into a list this has already sent.
+	items.value = items.value.map((item) => (item.key === key ? { ...item, label } : item));
+}
+
+function toggleHidden(key: string) {
+	items.value = items.value.map((item) =>
+		item.key === key ? { ...item, hidden: item.hidden ? undefined : (1 as const) } : item
+	);
+}
+
+function drop(onto: string) {
+	if (dragging.value) items.value = dropOn(items.value, dragging.value, onto);
+	dragging.value = null;
+}
+
+async function save() {
+	await write(() => saveArrangement(props, items.value));
+}
+
+async function reset() {
+	await write(() => resetArrangement(props));
+	await load();
+}
+
+async function write(request: () => Promise<Navigation>) {
+	busy.value = true;
+	try {
+		emit("saved", await request());
+	} catch (error) {
+		failed.value = `Could not save this arrangement: ${(error as Error).message}`;
+	} finally {
+		busy.value = false;
+	}
+}
+</script>

--- a/frontend/src/shell/tests/arrangement.test.ts
+++ b/frontend/src/shell/tests/arrangement.test.ts
@@ -75,6 +75,19 @@ describe("moving a row", () => {
     expect(keys(move(nested, "x", 1))).toEqual(["s", "x", "b"]);
   });
 
+  it("takes a section's children with it", () => {
+    // The list is flat and the tree is `parent_key`, so swapping two headers alone would leave
+    // each section's children sitting under the other one on screen.
+    const sections = [
+      item("s1"),
+      item("a", { parent_key: "s1" }),
+      item("s2"),
+      item("b", { parent_key: "s2" }),
+    ];
+
+    expect(keys(move(sections, "s1", 1))).toEqual(["s2", "b", "s1", "a"]);
+  });
+
   it("leaves a list it cannot find the row in alone", () => {
     expect(move(flat, "nope", 1)).toBe(flat);
   });
@@ -98,6 +111,17 @@ describe("dropping a row", () => {
 
   it("refuses a drop on itself", () => {
     expect(dropOn(flat, "a", "a")).toBe(flat);
+  });
+
+  it("carries a dragged section's children too", () => {
+    const sections = [
+      item("s1"),
+      item("a", { parent_key: "s1" }),
+      item("s2"),
+      item("b", { parent_key: "s2" }),
+    ];
+
+    expect(keys(dropOn(sections, "s2", "s1"))).toEqual(["s2", "b", "s1", "a"]);
   });
 });
 

--- a/frontend/src/shell/tests/arrangement.test.ts
+++ b/frontend/src/shell/tests/arrangement.test.ts
@@ -1,0 +1,272 @@
+// The arrangement editor and the list operations under it (#42363).
+//
+// Mounted with Vue's own `createApp` into happy-dom rather than through `@vue/test-utils`,
+// which this package does not have. The editor is small enough that the difference is a
+// `nextTick` and a `querySelector`, and a new devDependency for one component is a cost the
+// shell's singleton rules make everyone else pay too.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createApp, h, nextTick } from "vue";
+import { createMemoryHistory, createRouter } from "vue-router";
+
+// The real barrel drags the icon plugins in. `Button` is stubbed as the element it renders,
+// keeping `aria-label` and `@click`, which is all these tests reach for.
+vi.mock("frappe-ui", () => ({
+  call: vi.fn(),
+  // A render function, not a `template`: vitest resolves `vue` to the runtime-only build,
+  // which has no compiler, so a string template silently renders nothing at all.
+  Button: {
+    props: ["label", "icon", "variant", "loading"],
+    emits: ["click"],
+    setup: (props: { label?: string }, { emit }: { emit: (event: string) => void }) => () =>
+      h("button", { onClick: () => emit("click") }, props.label ?? ""),
+  },
+}));
+
+import { call as mockedCall } from "frappe-ui";
+import AppRail from "../AppRail.vue";
+import ArrangementEditor from "../ArrangementEditor.vue";
+import { dropOn, move, saveArrangement, type ArrangedItem } from "@/arrangement";
+
+const call = mockedCall as unknown as ReturnType<typeof vi.fn>;
+
+/** Let the mount's own `await` chain settle, then let Vue re-render off it. */
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await nextTick();
+}
+
+function item(key: string, extra: Partial<ArrangedItem> = {}): ArrangedItem {
+  return { key, item_type: "DocType", link_to: key, ...extra };
+}
+
+function keys(items: ArrangedItem[]): string[] {
+  return items.map((entry) => entry.key);
+}
+
+describe("moving a row", () => {
+  const flat = [item("a"), item("b"), item("c")];
+
+  it("swaps a row with the one after it", () => {
+    expect(keys(move(flat, "a", 1))).toEqual(["b", "a", "c"]);
+  });
+
+  it("swaps a row with the one before it", () => {
+    expect(keys(move(flat, "c", -1))).toEqual(["a", "c", "b"]);
+  });
+
+  it("does not wrap at either end", () => {
+    expect(keys(move(flat, "a", -1))).toEqual(["a", "b", "c"]);
+    expect(keys(move(flat, "c", 1))).toEqual(["a", "b", "c"]);
+  });
+
+  it("steps over a row under a different parent", () => {
+    // `x` is the last child of the section, so "down" for `b` is `c` -- not `x`, which is
+    // between them in the flat list but is not its sibling.
+    const nested = [item("a"), item("s"), item("x", { parent_key: "s" }), item("b"), item("c")];
+
+    expect(keys(move(nested, "b", 1))).toEqual(["a", "s", "x", "c", "b"]);
+  });
+
+  it("does not move a row out of its section", () => {
+    const nested = [item("s"), item("x", { parent_key: "s" }), item("b")];
+
+    expect(keys(move(nested, "x", -1))).toEqual(["s", "x", "b"]);
+    expect(keys(move(nested, "x", 1))).toEqual(["s", "x", "b"]);
+  });
+
+  it("leaves a list it cannot find the row in alone", () => {
+    expect(move(flat, "nope", 1)).toBe(flat);
+  });
+});
+
+describe("dropping a row", () => {
+  const flat = [item("a"), item("b"), item("c")];
+
+  it("puts a row where the one it was dropped on sits", () => {
+    expect(keys(dropOn(flat, "a", "c"))).toEqual(["b", "c", "a"]);
+    expect(keys(dropOn(flat, "c", "a"))).toEqual(["c", "a", "b"]);
+  });
+
+  it("refuses a drop onto a row under a different parent", () => {
+    // Two edits at once -- a reparent and a reorder -- and a drag that silently did the first
+    // is how a whole section ends up somewhere nobody put it.
+    const nested = [item("s"), item("x", { parent_key: "s" }), item("b")];
+
+    expect(dropOn(nested, "b", "x")).toBe(nested);
+  });
+
+  it("refuses a drop on itself", () => {
+    expect(dropOn(flat, "a", "a")).toBe(flat);
+  });
+});
+
+describe("the endpoint client", () => {
+  beforeEach(() => call.mockReset());
+
+  it("sends the whole ordered list and the address it belongs to", async () => {
+    call.mockResolvedValue({ rail: [], sidebars: {} });
+    const items = [item("b"), item("a")];
+
+    await saveArrangement({ container: "Sidebar", address: "module_def_core" }, items);
+
+    expect(call).toHaveBeenCalledWith("frappe.shell.arrangement.save_arrangement", {
+      container: "Sidebar",
+      address: "module_def_core",
+      scope: "user",
+      items,
+    });
+  });
+
+  it("defaults to a person's own layer, and never names a user", async () => {
+    call.mockResolvedValue({ rail: [], sidebars: {} });
+
+    await saveArrangement({ container: "Rail", address: "frappe" }, []);
+
+    const [, args] = call.mock.calls[0];
+    expect(args.scope).toBe("user");
+    expect(args).not.toHaveProperty("user");
+  });
+});
+
+async function editor(rows: ArrangedItem[]) {
+  call.mockReset();
+  call.mockResolvedValue(rows);
+
+  const host = document.createElement("div");
+  document.body.appendChild(host);
+  const saved: unknown[] = [];
+  const app = createApp({
+    render: () =>
+      h(ArrangementEditor, {
+        container: "Rail",
+        address: "frappe",
+        title: "Arrange this rail",
+        onSaved: (navigation: unknown) => saved.push(navigation),
+      }),
+  });
+  app.mount(host);
+  await flush();
+
+  return {
+    host,
+    saved,
+    rowKeys: () =>
+      [...host.querySelectorAll("[data-key]")].map((row) => row.getAttribute("data-key")),
+    click: async (label: string) => {
+      const target =
+        host.querySelector<HTMLElement>(`[aria-label="${label}"]`) ??
+        [...host.querySelectorAll("button")].find((button) => button.textContent === label);
+      target!.click();
+      await flush();
+    },
+    type: async (label: string, value: string) => {
+      const input = host.querySelector<HTMLInputElement>(`[aria-label="${label}"]`)!;
+      input.value = value;
+      input.dispatchEvent(new Event("input"));
+      await flush();
+    },
+    sent: () => call.mock.calls.at(-1)![1].items as ArrangedItem[],
+  };
+}
+
+describe("the editor", () => {
+  it("shows what a person hid, or a hide would be a one-way door", async () => {
+    const { rowKeys } = await editor([item("a"), item("b", { hidden: 1 })]);
+
+    expect(rowKeys()).toEqual(["a", "b"]);
+  });
+
+  it("saves the whole list it is showing, not the difference", async () => {
+    // The reduction is the server's. A client that sent anchors would be computing identity
+    // against a base it may be holding stale, which is desk v1's mistake in reverse.
+    const editing = await editor([item("a"), item("b")]);
+    call.mockResolvedValue({ rail: [], sidebars: {} });
+
+    await editing.click("Move a down");
+    await editing.click("Save");
+
+    expect(keys(editing.sent())).toEqual(["b", "a"]);
+  });
+
+  it("carries a rename as the row's label", async () => {
+    const editing = await editor([item("a", { label: "Accounts" })]);
+    call.mockResolvedValue({ rail: [], sidebars: {} });
+
+    await editing.type("Name of a", "Money");
+    await editing.click("Save");
+
+    expect(editing.sent()[0].label).toBe("Money");
+  });
+
+  it("toggles a hide both ways", async () => {
+    const editing = await editor([item("a")]);
+    call.mockResolvedValue({ rail: [], sidebars: {} });
+
+    await editing.click("Hide a");
+    await editing.click("Save");
+    expect(editing.sent()[0].hidden).toBe(1);
+
+    await editing.click("Show a");
+    await editing.click("Save");
+    expect(editing.sent()[0].hidden).toBeUndefined();
+  });
+
+  it("hands the whole prefix's navigation back to the shell", async () => {
+    const editing = await editor([item("a")]);
+    const navigation = { rail: [item("a")], sidebars: {} };
+    call.mockResolvedValue(navigation);
+
+    await editing.click("Hide a");
+    await editing.click("Save");
+
+    expect(editing.saved).toEqual([navigation]);
+  });
+
+  it("says a load failed rather than showing an empty list", async () => {
+    // An empty list is a real answer -- an app with nothing on its rail -- so a swallowed
+    // failure would render a confident, false "nothing to arrange".
+    call.mockReset();
+    call.mockRejectedValue(new Error("nope"));
+
+    const host = document.createElement("div");
+    createApp({
+      render: () =>
+        h(ArrangementEditor, { container: "Rail", address: "frappe", title: "Arrange" }),
+    }).mount(host);
+    await flush();
+
+    expect(host.textContent).toContain("Could not load this arrangement");
+    expect(host.querySelector("[data-testid='arrangement']")).toBeNull();
+  });
+});
+
+describe("the rail's way in", () => {
+  function rail(arrangeable: boolean) {
+    const host = document.createElement("div");
+    const app = createApp({
+      render: () => h(AppRail, { items: [], arrangeable }),
+    });
+    app.provide("boot", { app: arrangeable ? "frappe" : null });
+    // A real router, because the rail's home link is a real `RouterLink` and resolves through
+    // the injections a router provides. A memory history keeps it out of happy-dom's URL.
+    app.use(
+      createRouter({
+        history: createMemoryHistory(),
+        routes: [{ path: "/", name: "home", component: { render: () => null } }],
+      })
+    );
+    app.mount(host);
+    return host;
+  }
+
+  it("offers Arrange inside an app", () => {
+    expect(rail(true).textContent).toContain("Arrange");
+  });
+
+  it("does not offer it on the index, which belongs to no app", () => {
+    // `/apps` has no rail to arrange and no address to name one by: `boot.app` is null there
+    // and `boot.navigation` is absent, so the button would open an editor addressed at nothing.
+    expect(rail(false).textContent).not.toContain("Arrange");
+  });
+});


### PR DESCRIPTION
Builds [The overlay write endpoints: what a drag saves and what it returns](https://github.com/frappe/frappe/issues/42363), which settled every rule and built nothing. Ticket: [Build the overlay write endpoints and a minimal arrangement editor](https://github.com/frappe/frappe/issues/42403). Part of [Desk v2 — the rail and the sidebar](https://github.com/frappe/frappe/issues/42226).

Desk v2 had no way for anyone to save an arrangement. This is its first user-state write of any kind — before this the only non-GET call on the branch was document save.

## A move is an anchor, not a position

A person who drags Contacts above Deals has said "Contacts goes before Deals", not "Contacts is item 3", and the two stop meaning the same thing the moment the app ships a ninth item. So a saved layer names the rows that moved and says what each moved next to; everything nobody touched keeps the position the layer below gave it.

Measured on a real site: reordering the framework's own **194-item derived rail stores exactly one row with one anchor** (`[{"before": "API Request Log"}]`). A save round-trips in 18.4 ms and the navigation payload stays at 20,618 B, unchanged from what #42362 measured.

That is #42229's sparse move-list, which the engine could not express before. `layers.py` offered only keep-at-the-end or drop, so a layer that recorded positions would pin the whole list and the next item an app shipped would have nowhere to land.

## What is here

**`frappe/shell/arrangement.py`** — three whitelisted endpoints taking container, address and scope, against desk v1's twelve. V1 spends four calls on overlay writes, five on resets and three on layer reads, and the multiplication is one word (`dock` or `sidebar`, `user` or `site`) baked into each name; here that word is an argument. V1's two blast-radius resets, each deleting the site layer *and every user's* from one call, are not ported.

**The placement primitive moves into `frappe/desk/layers.py`.** #42398 already wrote it for extension — one app's rows anchoring into another app's rail — and this is the same operation one phase later, against a list the writer can see. So it lives beside the layer merge, and `frappe/shell/extensions.py` calls it. What stays in `extensions.py` is the one thing that differs: a contributed name resolves to the host first and to its own app second, where an overlay name is a key or it is nothing. `resolve_layers` gains a keyword-only `anchored`, defaulted off, so desk v1's two callers are unchanged.

**The reduction is the server's.** The client sends the whole ordered list it is showing — v1's shape — and the server reduces it to the rows outside the longest common subsequence of the two orders, compared **per parent**, plus field-level overrides. A client that sent anchors would be computing identity and difference against a base it may hold stale, which is the mistake v1 makes in the other direction: `sidebar_manager.js:294-298` recomputes the server's item key in JS, leaving `filters` out of a key the server includes and returning a raw `"type|label"` where the server returns a hash.

Several anchor sets describe the same list. The rule picked is written where the code is: each moved row anchors **after its predecessor in the list the person is looking at**, and a row moved to the front of its group anchors *before* the first following row that is not itself moving — naming one that has yet to move would place it against a position that is about to change. Verified as a round trip over 10,000 randomised base/desired pairs including reparenting: the reduction and the placement agree exactly, every time.

**`item_type` stops being `reqd`.** Two kinds of row live in this table. A row an app ships, or one a layer *added*, opens something and must say what. A **delta** states an opinion about an item a lower layer holds, and what that item opens is not its business — a person renaming a row would otherwise have to restate a type they have no view on, and the copy would go stale the day the app changed it. The requirement moves to where the row really is an item: the container's `validate_item_keys` for shipped rows, and the row's own `validate` for added ones.

**Hiding a section now takes its children with it**, while an app *removing* one still promotes them. Those two looked identical by the time the list was flat, because `_promote_orphans` ran after the hidden filter — and nothing could hide anything until this PR, so the case had never come up.

**The editor** is one component for both containers, because they are one model. It reads one scope deep with hidden rows kept, since a person cannot unhide what they cannot see. Reorder by drag or by arrow, hide, rename; Save writes, Reset deletes the layer. **No drag library**: `sortablejs` and `vuedraggable` sit in the lockfile but are asked for by neither `package.base.json` nor frappe-ui, so adopting one would be a new shared dependency under #42069's singleton rule — weighed here against about fifteen lines of the platform's own drag events. The arrows are not a fallback for the drag; they are the half that works from a keyboard.

## The gate

`has_app_permission` on the addressed app, plus `System Manager` for the site scope (#42354). Unlike the reads this is the boundary rather than a choice of error page: no doctype permission stands behind arranging the rail of an app you may not enter. There is **no `user` argument anywhere in the module**, so "write somebody else's arrangement" is not a request that can be made and does not need refusing.

## Four things `/quality-code-review` found

- **A repeated key was a denial of service.** The order comparison is quadratic in a parent's list, so a body repeating one key ten thousand times sized the work by the request rather than by the site's navigation. Unknown and duplicate keys are now dropped *before* anything quadratic runs, which bounds the list by the base whatever the client sent.
- **Override values were unvalidated below the annotation.** The endpoints' type annotations stop at the argument; a `label` inside the list could still arrive as an object. Anything that is not a scalar is now read as blank.
- **An app not on this bench passed the gate.** `has_app_permission` falls back to "is a System User" for an app that declares no `app_permission` hook, and an app that is not here declares none — so an unknown name passed a check it was never subject to. Checked against `get_active_apps` first.
- **The Arrange button appeared on `/apps`**, the index, which belongs to no app: `boot.app` is null and `boot.navigation` is absent there, so it would have opened an editor addressed at nothing.

## Two existing tests changed, on purpose

`test_the_site_layer_then_the_users` and `test_a_person_arranges_one_list_and_not_one_per_app` both asserted desk v1's rule, that a layer's row *order* is the arrangement. Under the anchored rule a layer names rows to say something about them and says *where* only through an anchor. Both are rewritten to anchor, and `test_a_layer_that_anchors_nothing_moves_nothing` now states the new rule on its own.

## Tests

**488 Python tests green across ten suites**, 39 of them new in `test_navigation_arrangement`, plus the whole of `test_dock_preferences` (121, desk v1's own overlay and mounting engine, untouched — charter point 10) and `test_sidebar` (98). **268 frontend tests**, 19 new.

Verified on a real site rather than only in the harness: `bench migrate`, then the editor list, a reorder, a hide and a reset driven end to end against the framework's 194-item rail.

>no-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
