### PR TITLE
feat: draw the sidebar a linked rail item opens

### DIFF
--- a/frontend/src/navigation/NavigationRow.vue
+++ b/frontend/src/navigation/NavigationRow.vue
@@ -1,5 +1,9 @@
 <!--
-  One row on the rail, and whatever hangs under it.
+  One row of navigation, and whatever hangs under it.
+
+  The rail and the sidebar panel are two presentations of one model (charter point 1), so
+  they draw their rows with one component. It was `shell/RailItem.vue` until the panel
+  arrived (#42421) and there was a second consumer to name it for.
 
   Recursive, because `parent_key` puts no limit on depth and a two-level component would
   silently swallow the third — the same class of quiet drop the tree builder's cycle guard
@@ -20,7 +24,8 @@
 			:to="destination.to"
 			:data-key="item.key"
 			:data-sidebar="destination.sidebar"
-			:class="ROW"
+			:aria-current="isCurrent ? 'page' : undefined"
+			:class="[ROW, isCurrent && CURRENT]"
 		>
 			{{ label }}
 		</RouterLink>
@@ -33,7 +38,8 @@
 			:href="destination.href"
 			:data-key="item.key"
 			:data-sidebar="destination.sidebar"
-			:class="ROW"
+			:aria-current="isCurrent ? 'page' : undefined"
+			:class="[ROW, isCurrent && CURRENT]"
 		>
 			{{ label }}
 		</a>
@@ -67,22 +73,24 @@
 		</component>
 
 		<ul v-if="node.children.length && open" class="ml-2 border-l border-outline-gray-2 pl-1">
-			<RailItem
+			<NavigationRow
 				v-for="child in node.children"
 				:key="child.item.key"
 				:node="child"
 				:context="context"
+				:current="current"
 			/>
 		</ul>
 
 		<!-- Expanded rows sit at this row's OWN level, not under it. "N more" is an overflow
 				 of the list it is in, so indenting what it reveals would say the module contains
 				 the overflow row, which is backwards. -->
-		<RailItem
+		<NavigationRow
 			v-for="child in expandedNodes"
 			:key="child.item.key"
 			:node="child"
 			:context="context"
+			:current="current"
 		/>
 	</li>
 </template>
@@ -96,12 +104,29 @@ import type { ItemContext } from "@/navigation/types";
 
 const ROW =
 	"flex w-full items-center truncate rounded px-2 py-1 text-left text-sm text-ink-gray-7 hover:bg-surface-gray-2";
+// A step past `hover:bg-surface-gray-2` rather than the same shade, or a reader could not
+// tell the row they are on from the row under the pointer.
+//
+// Marked on the row itself and not left to `router-link-active`: a linked rail item points at
+// the first row INSIDE its sidebar, so its own link is inactive from the second row on. The
+// explicit `aria-current` binding also SUPPRESSES the one `RouterLink` sets on an exactly
+// active link, which is what keeps the count at one row — the rail and the panel can hold the
+// same destination, and two independent highlights would light both.
+const CURRENT = "bg-surface-gray-3 font-medium text-ink-gray-9";
 const HEADING =
 	"w-full truncate px-2 pb-0.5 pt-3 text-left text-xs font-medium uppercase text-ink-gray-5";
 
-const props = defineProps<{ node: ItemNode; context: ItemContext }>();
+// `current` is the key of the one row the address is standing on, in THIS container
+// (`navigation/current.ts`). It is passed down rather than computed here because exactly one
+// row wins across the rail and the open panel together, and no row can know that alone.
+const props = defineProps<{
+	node: ItemNode;
+	context: ItemContext;
+	current?: string;
+}>();
 
 const item = computed(() => props.node.item);
+const isCurrent = computed(() => !!props.current && props.current === item.value.key);
 const rendering = computed(() => renderingOf(item.value, props.context));
 const label = computed(() => labelOf(item.value, props.context));
 

--- a/frontend/src/navigation/current.ts
+++ b/frontend/src/navigation/current.ts
@@ -1,0 +1,153 @@
+// Which row the address is on, and therefore which sidebar is open.
+//
+// Charter point 7: navigation follows the address, never the reverse. Nothing stores a
+// selection, so clicking a rail item and pasting its URL into a fresh tab have to end in
+// the same shell — which means the open panel is a FUNCTION OF THE PATH and of nothing
+// else. This module is that function.
+//
+// It is not `router-link-active`. Two reasons, and both are real rather than tidiness. A
+// rail item of type `Sidebar` resolves to the first destination INSIDE its sidebar
+// (`sidebar/frontend/item.js`), so standing on the third row of that sidebar leaves the
+// rail item's own link inactive while the panel it opens is exactly where you are; and
+// `router-link-active` is prefix-based per link, so a list and one of its saved views both
+// match `/sales-invoice/view/open` and two rows light up. One winner, chosen here, is the
+// only version of "the rail and the panel highlight whatever the current URL resolves to"
+// that a reader can act on.
+
+import type { NavigationItem } from "@/boot";
+import type { ItemContext, Rendering } from "./types";
+
+/** One route navigation can be standing on, and what being on it means. */
+export type Destination = { path: string; found: CurrentNavigation };
+
+/**
+ * One item context per container, because a context is composed once per LIST and there are
+ * two kinds of list here. `Module Contents` is what makes the difference real: it measures
+ * "what is left of this module" against `context.items`, so a row in a sidebar handed the
+ * rail's context would hide the doctypes the RAIL already shows and repeat the ones its own
+ * panel does.
+ */
+export type NavigationContexts = {
+	rail: ItemContext;
+	sidebars: Record<string, ItemContext>;
+};
+
+export type CurrentNavigation = {
+	/** The rail row to highlight: the destination itself, or the item that opens the panel. */
+	railKey?: string;
+	/** The scrubbed address of the sidebar to show, if the address is inside one (#42356). */
+	sidebar?: string;
+	/** The row inside that sidebar to highlight. */
+	rowKey?: string;
+};
+
+/**
+ * How specifically `itemPath` covers `currentPath` — its segment count, or -1 for no cover.
+ *
+ * Segment-wise rather than `startsWith`, which would read `/sales-orders` as sitting under
+ * `/sales-order`. A list covers its own records and its saved views, so `/sales-invoice`
+ * stays lit while you read `/sales-invoice/SI-001`; and where a list and a view both cover
+ * the address, the view is deeper and wins.
+ */
+export function coverage(currentPath: string, itemPath: string): number {
+	const current = currentPath.split("/").filter(Boolean);
+	const item = itemPath.split("/").filter(Boolean);
+
+	if (item.length > current.length) return -1;
+	for (let index = 0; index < item.length; index += 1) {
+		if (item[index] !== current[index]) return -1;
+	}
+
+	return item.length;
+}
+
+/**
+ * Every route in this prefix that navigation can be standing on, and what each one means.
+ *
+ * Separate from the match because the two change at different rates. Resolving a
+ * destination costs a `renderingOf` and a `router.resolve`, twice over — the registry
+ * resolves once to keep an unresolvable route out of `RouterLink` — and the framework's own
+ * prefix carries 194 rail items (#42362). Doing that per navigation would put hundreds of
+ * route resolutions in the way of every click. The payload changes only on a save, so this
+ * is computed against the payload and the match against the path.
+ *
+ * Everything with a route competes: the rail's own rows, and the rows of every sidebar the
+ * rail can open. A rail item that opens a sidebar competes THROUGH that sidebar's rows
+ * rather than through its own destination, because its own destination is one of those rows
+ * already (`sidebar/frontend/item.js`) and counting it twice would let the linked item beat
+ * the panel it opens — the panel would then open with nothing marked inside it.
+ *
+ * Order is the order the person is looking at: the rail top to bottom, and a linked item's
+ * panel where the item sits. That is what breaks a tie, and ties are ordinary rather than
+ * exotic — #42357 counted 101 rows in ERPNext linking outside their own module, so one
+ * address really does sit in two places.
+ */
+export function navigationDestinations(
+	rail: NavigationItem[],
+	sidebars: Record<string, NavigationItem[]>,
+	contexts: NavigationContexts
+): Destination[] {
+	const destinations: Destination[] = [];
+	const router = contexts.rail.router;
+
+	const add = (rendering: Rendering | null, found: CurrentNavigation) => {
+		// `href` rows leave the prefix and `group`/`expand` rows go nowhere, so neither can be
+		// where you are standing.
+		if (!rendering || !("to" in rendering)) return;
+
+		// Resolvable, because `renderingOf` already resolved it once (`registry.ts`).
+		destinations.push({ path: router.resolve(rendering.to).path, found });
+	};
+
+	for (const item of rail) {
+		const rendering = contexts.rail.renderingOf(item);
+		const sidebar = rendering && "sidebar" in rendering ? rendering.sidebar : undefined;
+
+		if (sidebar) {
+			// Its own rows, through their own context — the one the panel will draw them with,
+			// so what is a destination here is a destination there.
+			const inside = contexts.sidebars[sidebar] ?? contexts.rail;
+			for (const row of sidebars[sidebar] ?? []) {
+				add(inside.renderingOf(row), { railKey: item.key, sidebar, rowKey: row.key });
+			}
+			continue;
+		}
+
+		add(rendering, { railKey: item.key });
+	}
+
+	return destinations;
+}
+
+/**
+ * The rail row, the sidebar and the row inside it that `path` is standing on.
+ *
+ * Deepest coverage wins; where two cover the address equally, the first in the list does.
+ *
+ * An address no destination covers returns `{}`: no highlight, and no panel. There is no
+ * last panel to fall back to, because falling back is storing a selection.
+ */
+export function currentFrom(destinations: Destination[], path: string): CurrentNavigation {
+	let best: CurrentNavigation = {};
+	let depth = -1;
+
+	for (const destination of destinations) {
+		const covers = coverage(path, destination.path);
+		if (covers > depth) {
+			depth = covers;
+			best = destination.found;
+		}
+	}
+
+	return best;
+}
+
+/** Both halves, for a caller with no reason to hold the destinations. */
+export function currentNavigation(
+	rail: NavigationItem[],
+	sidebars: Record<string, NavigationItem[]>,
+	contexts: NavigationContexts,
+	path: string
+): CurrentNavigation {
+	return currentFrom(navigationDestinations(rail, sidebars, contexts), path);
+}

--- a/frontend/src/navigation/tests/current.test.ts
+++ b/frontend/src/navigation/tests/current.test.ts
@@ -1,0 +1,172 @@
+// Which row the address is standing on (#42421).
+import { describe, expect, it } from "vitest";
+import { createMemoryHistory, createRouter } from "vue-router";
+
+import { Addresses } from "@/addresses";
+import type { Boot, NavigationItem } from "@/boot";
+import { registerShell } from "@/router/routeFor";
+import { itemContext } from "@/navigation/context";
+import { coverage, currentNavigation } from "@/navigation/current";
+import { registerContributions } from "@/contributions/registry";
+
+const addresses = new Addresses({
+	doctypes: {
+		"CRM Deal": ["crm-deal", "fcrm"],
+		"Sales Invoice": ["sales-invoice", "accounts"],
+	},
+	modules: { fcrm: "FCRM", accounts: "Accounts" },
+});
+
+const boot = {
+	app: "crm",
+	shell_base: "/apps/crm",
+	prefixes: { crm: { app: "crm", modular: false } },
+} as unknown as Boot;
+
+const stub = { render: () => null };
+const router = createRouter({
+	history: createMemoryHistory(),
+	routes: [
+		{ path: "/", name: "home", component: stub },
+		{ path: "/:doctype", name: "list", component: stub },
+		{ path: "/:doctype/view/:viewName", name: "saved-view", component: stub },
+		{ path: "/:doctype/:name", name: "record", component: stub },
+	],
+});
+registerShell({ boot, addresses, router });
+
+await registerContributions(["frappe"]);
+
+function at(
+	rail: NavigationItem[],
+	sidebars: Record<string, NavigationItem[]>,
+	path: string
+) {
+	const compose = (items: NavigationItem[]) =>
+		itemContext(boot, addresses, router, items, sidebars);
+
+	return currentNavigation(
+		rail,
+		sidebars,
+		{
+			rail: compose(rail),
+			sidebars: Object.fromEntries(
+				Object.entries(sidebars).map(([address, rows]) => [address, compose(rows)])
+			),
+		},
+		path
+	);
+}
+
+const deal: NavigationItem = { key: "deal", item_type: "DocType", link_to: "CRM Deal" };
+const invoice: NavigationItem = {
+	key: "invoice",
+	item_type: "DocType",
+	link_to: "Sales Invoice",
+};
+
+describe("coverage", () => {
+	it("counts the segments a row covers", () => {
+		expect(coverage("/crm-deal/CRM-DEAL-01", "/crm-deal")).toBe(1);
+		expect(coverage("/crm-deal", "/crm-deal")).toBe(1);
+		expect(coverage("/crm-deal", "/")).toBe(0);
+	});
+
+	it("does not read one name as a prefix of another", () => {
+		// `startsWith` would put `/crm-deals` under `/crm-deal`, which is a different doctype.
+		expect(coverage("/crm-deals", "/crm-deal")).toBe(-1);
+	});
+
+	it("does not cover what is shallower than the row", () => {
+		expect(coverage("/crm-deal", "/crm-deal/CRM-DEAL-01")).toBe(-1);
+	});
+});
+
+describe("the rail alone", () => {
+	it("marks the row whose list you are on", () => {
+		expect(at([deal, invoice], {}, "/sales-invoice")).toEqual({ railKey: "invoice" });
+	});
+
+	it("keeps the list marked while you read one of its records", () => {
+		// A record has no row of its own and never will — a rail cannot list 553 doctypes'
+		// records — so the list it belongs to is the honest answer.
+		expect(at([deal, invoice], {}, "/crm-deal/CRM-DEAL-01")).toEqual({ railKey: "deal" });
+	});
+
+	it("prefers the deeper of two rows that both cover the address", () => {
+		// A pinned record sits under the list it belongs to, so both rows cover its address and
+		// `router-link-active` would light both. The deeper one is where you are.
+		const pinned: NavigationItem = {
+			key: "pinned",
+			item_type: "Record",
+			link_doctype: "CRM Deal",
+			link_to: "CRM-DEAL-01",
+		};
+		expect(at([deal, pinned], {}, "/crm-deal/CRM-DEAL-01")).toEqual({ railKey: "pinned" });
+		// And order does not rescue the shallower one: coverage is compared first.
+		expect(at([pinned, deal], {}, "/crm-deal/CRM-DEAL-01")).toEqual({ railKey: "pinned" });
+	});
+
+	it("never marks a row that leaves the prefix", () => {
+		const link: NavigationItem = {
+			key: "docs",
+			item_type: "Link",
+			url: "https://docs.frappe.io",
+		};
+		expect(at([link], {}, "/crm-deal")).toEqual({});
+	});
+
+	it("marks nothing when no row covers the address", () => {
+		// And so shows no panel. There is no last panel to fall back to, because falling back
+		// is storing a selection (charter point 7).
+		expect(at([deal], {}, "/sales-invoice")).toEqual({});
+	});
+});
+
+describe("a rail item that opens a sidebar", () => {
+	const rail: NavigationItem[] = [
+		{ key: "accounts", item_type: "Sidebar", link_to: "module_def_accounts" },
+		deal,
+	];
+	const sidebars = { module_def_accounts: [invoice, { ...deal, key: "in-accounts" }] };
+
+	it("is marked from any row inside its sidebar, not only the first", () => {
+		// Its own destination is the sidebar's FIRST row, so `router-link-active` would go out
+		// the moment you moved to the second one.
+		expect(at(rail, sidebars, "/sales-invoice")).toEqual({
+			railKey: "accounts",
+			sidebar: "module_def_accounts",
+			rowKey: "invoice",
+		});
+	});
+
+	it("competes through its sidebar's rows rather than through its own destination", () => {
+		// Counting both would let the linked item beat the panel it opens, on the one row they
+		// share, and the panel would open with nothing marked in it.
+		expect(at(rail, sidebars, "/sales-invoice").rowKey).toBe("invoice");
+	});
+
+	it("wins a tie against a later rail row on the same doctype", () => {
+		// Sidebars link outside their own module all the time — #42357 counted 101 rows doing
+		// it in ERPNext — so one address really can sit in two places. The tie-break is the
+		// order the person is looking at: the rail top to bottom, and a linked item's panel
+		// where the item sits. Accounts is above Deals here and contains it.
+		expect(at(rail, sidebars, "/crm-deal")).toEqual({
+			railKey: "accounts",
+			sidebar: "module_def_accounts",
+			rowKey: "in-accounts",
+		});
+	});
+
+	it("loses that tie when the plain row is above it", () => {
+		expect(at([deal, ...rail.slice(0, 1)], sidebars, "/crm-deal")).toEqual({
+			railKey: "deal",
+		});
+	});
+
+	it("is absent when its sidebar has no rows", () => {
+		// #42356 leaves a sidebar that resolved to nothing out of the payload, and the renderer
+		// then draws the rail item as an independent one — which here means not at all.
+		expect(at(rail, { module_def_accounts: [] }, "/sales-invoice")).toEqual({});
+	});
+});

--- a/frontend/src/navigation/useItemTree.ts
+++ b/frontend/src/navigation/useItemTree.ts
@@ -1,0 +1,35 @@
+// The tree a container draws, with the cycle report attached.
+//
+// A composable rather than a call to `buildTree`, because the reporting is what has to be
+// shared and it is the part with state in it. `buildTree` stays pure — it is recomputed on
+// every render of a reactive list, so a logger inside it would fire per frame — and the
+// "once per key" set has to live somewhere that outlives one computation.
+//
+// One set per instance, which is one set per container. A key identifies a row within ONE
+// container (`registry.ts` learned this the hard way, on the depth guard), so a rail and a
+// sidebar may each hold a row called `accounts` and a shared set would report the second as
+// a repeat of the first and say nothing.
+
+import { computed, type ComputedRef, type MaybeRefOrGetter, toValue } from "vue";
+import type { NavigationItem } from "@/boot";
+import { buildTree, type ItemNode } from "./tree";
+
+export function useItemTree(
+	items: MaybeRefOrGetter<NavigationItem[]>,
+	container: MaybeRefOrGetter<string>
+): ComputedRef<ItemNode[]> {
+	const reported = new Set<string>();
+
+	return computed(() =>
+		buildTree(toValue(items), (key) => {
+			// A list that is wrong stays wrong, so the line would repeat on every save without
+			// saying anything new.
+			if (reported.has(key)) return;
+			reported.add(key);
+			console.error(
+				`[frappe] navigation item '${key}' in ${toValue(container)} is its own ancestor; ` +
+					`it is drawn at the top level.`
+			);
+		})
+	);
+}

--- a/frontend/src/navigation/useItemTree.ts
+++ b/frontend/src/navigation/useItemTree.ts
@@ -14,6 +14,12 @@ import { computed, type ComputedRef, type MaybeRefOrGetter, toValue } from "vue"
 import type { NavigationItem } from "@/boot";
 import { buildTree, type ItemNode } from "./tree";
 
+/**
+ * The tree for one container's rows, rebuilt whenever they change.
+ *
+ * @param items The container's flat, ordered list — a ref or a getter.
+ * @param container What to call it in a cycle report: `the rail`, `the <address> sidebar`.
+ */
 export function useItemTree(
 	items: MaybeRefOrGetter<NavigationItem[]>,
 	container: MaybeRefOrGetter<string>

--- a/frontend/src/shell/AppRail.vue
+++ b/frontend/src/shell/AppRail.vue
@@ -26,6 +26,16 @@
   the server merged them into the base before the layers went on, so they arrive as
   ordinary items in one ordered list (#42364).
 
+  The renderers decide what every row does; this file never knows one kind from
+  another. It used to render `DocType` and drop the other seven, which was #42228's
+  skip-a-missing-renderer rule arrived at by accident: there were no renderers at all,
+  so there was nothing to miss. There are eight now, each shipped the way an app would
+  ship one — the type record plus `frontend/item.js` beside it — so the framework's own
+  kinds and a contributed ninth reach this list through the same door (DP2, #42420). One
+  of those kinds, `Sidebar`, is what makes a rail item LINKED; the panel it opens is the
+  shell's, not the rail's, because a rail that owned it would own a surface that outlives
+  any one of its rows (#42421).
+
   The list arrives as a PROP rather than off `boot`, which is what lets it change without a
   reload: a save returns the whole `{rail, sidebars}` and the shell swaps it in, so the rail
   re-renders from the same server-resolved list it always renders from and never restacks a
@@ -41,7 +51,13 @@
 		</RouterLink>
 
 		<ul class="mt-2 overflow-y-auto">
-			<RailItem v-for="node in tree" :key="node.item.key" :node="node" :context="context" />
+			<NavigationRow
+				v-for="node in tree"
+				:key="node.item.key"
+				:node="node"
+				:context="context"
+				:current="current"
+			/>
 		</ul>
 
 		<button
@@ -63,53 +79,34 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject } from "vue";
-import { RouterLink, useRouter } from "vue-router";
-import type { Addresses } from "@/addresses";
+import { inject } from "vue";
+import { RouterLink } from "vue-router";
 import type { Boot, NavigationItem } from "@/boot";
-import { itemContext } from "@/navigation/context";
-import { buildTree } from "@/navigation/tree";
-import RailItem from "./RailItem.vue";
+import NavigationRow from "@/navigation/NavigationRow.vue";
+import { useItemTree } from "@/navigation/useItemTree";
+import type { ItemContext } from "@/navigation/types";
 
 // `arrangeable` is off on the index at `/apps`, which belongs to no app: there is no rail to
 // arrange there and no address to name one by, since `boot.app` is null and `boot.navigation`
 // is absent. The shell decides it, because the shell is what knows it is on the index.
+//
+// `context` and `current` arrive as props rather than being computed here, and that moved with
+// the panel (#42421). The context is composed once per list and the panel draws the same rows
+// off the same one; and exactly one row is current across the rail and the panel together, so
+// neither surface can work it out alone.
 const props = defineProps<{
 	items: NavigationItem[];
-	sidebars?: Record<string, NavigationItem[]>;
+	context: ItemContext;
+	current?: string;
 	arrangeable?: boolean;
 }>();
 const emit = defineEmits<{ arrange: [] }>();
 
 const boot = inject<Boot>("boot")!;
-const addresses = inject<Addresses>("addresses")!;
-const router = useRouter();
-
-// The renderers decide what every row does; this file no longer knows one kind from
-// another. It used to render `DocType` and drop the other seven, which was #42228's
-// skip-a-missing-renderer rule arrived at by accident: there were no renderers at all, so
-// there was nothing to miss. There are eight now, each shipped the way an app would ship
-// one — the type record plus `frontend/item.js` beside it — so the framework's own kinds
-// and a contributed ninth reach this list through the same door (DP2, #42420).
-const context = computed(() =>
-	itemContext(boot, addresses, router, props.items, props.sidebars ?? {})
-);
 
 // `parent_key` is the whole of hierarchy (#42227), and the server sends the tree flat. A
-// cycle in it is broken here and reported: every row in one has a parent that is present,
-// so the server's orphan promotion passes it through, and rendering the tree would then
-// simply omit the rows — a silent drop of authored navigation.
-const reportedCycles = new Set<string>();
-const tree = computed(() =>
-	buildTree(props.items, (key) => {
-		// Once per key per page session. `buildTree` is pure and recomputes whenever the list
-		// changes, which is what a save does — and a rail that is wrong stays wrong, so the
-		// line would repeat on every save without saying anything new.
-		if (reportedCycles.has(key)) return;
-		reportedCycles.add(key);
-		console.error(
-			`[frappe] navigation item '${key}' is its own ancestor; it is drawn at the top level.`
-		);
-	})
-);
+// cycle in it is broken and reported by `useItemTree`: every row in one has a parent that is
+// present, so the server's orphan promotion passes it through, and rendering the tree would
+// then simply omit the rows — a silent drop of authored navigation.
+const tree = useItemTree(() => props.items, "the rail");
 </script>

--- a/frontend/src/shell/AppShell.vue
+++ b/frontend/src/shell/AppShell.vue
@@ -115,10 +115,11 @@ const destinations = computed(() =>
 // by a click. It is a walk over resolved paths, with no router in it.
 const current = computed(() => currentFrom(destinations.value, route.path));
 
-// The panel, or nothing. `current.sidebar` is only ever a key `renderingOf` read off a rail
-// item, so the rows are there — but a sidebar that resolved to nothing is absent from the
-// payload rather than empty (#42356), and the `?? []` would draw a headed, empty panel if that
-// ever changed. An empty panel is the one state #42357 ruled out, so it is checked here too.
+// The panel, or nothing. `current.sidebar` is only ever a key a rail item's renderer read out
+// of this same payload, so the rows are there — the row count is checked anyway because an
+// empty panel is the one state #42357 ruled out, and it is fenced twice before this: a sidebar
+// that resolved to nothing is absent from the payload rather than empty (#42356), and the
+// `Sidebar` renderer then draws no rail item to open it.
 const panel = computed(() => {
 	const address = current.value.sidebar;
 	const items = address ? navigation.value.sidebars[address] : undefined;

--- a/frontend/src/shell/AppShell.vue
+++ b/frontend/src/shell/AppShell.vue
@@ -9,47 +9,151 @@
   Both halves go to the rail, and that is why they are one prop pair rather than two
   components: a rail item of type `Sidebar` is what makes an item LINKED (#42227), and it
   resolves its own destination out of the sidebar it opens — so the rail cannot draw the
-  rail without holding the sidebars too. The panel that shows one is #42421's.
+  rail without holding the sidebars too. The panel that shows one is this file's, not the
+  rail's: which sidebar is open is a fact about the ADDRESS, and the address outlives any
+  row on the rail (#42421).
 
   Navigation lives here, one level above the rail, because it is not the rail's. A save
   returns the WHOLE `{rail, sidebars}` for the prefix and the client swaps it in wholesale
   (#42363) — so hiding a rail item of type `Sidebar` changes which sidebars are reachable, and
   the one place that knows about both is this one. `boot.navigation` is kept in step for anything
   that reads boot directly; the reactive copy is what renders.
+
+  The item context is composed here for the same reason. It is composed once per LIST, and
+  since the panel draws rows out of the same payload the rail does, two contexts would be two
+  answers to `renderingOf` for one row — and a `Sidebar` item resolves through the sidebars,
+  so the two would not even be equal.
 -->
 <template>
 	<div class="flex h-screen w-screen bg-surface-white text-ink-gray-9">
 		<AppRail
 			:items="navigation.rail"
-			:sidebars="navigation.sidebars"
+			:context="contexts.rail"
+			:current="current.railKey"
 			:arrangeable="!!boot.app"
-			@arrange="arranging = true"
+			@arrange="arrangeRail"
+		/>
+		<AppSidebar
+			v-if="panel"
+			:key="panel.address"
+			:address="panel.address"
+			:items="panel.items"
+			:context="panel.context"
+			:title="panel.title"
+			:current="current.rowKey"
+			arrangeable
+			@arrange="arrangeSidebar"
 		/>
 		<main class="flex min-w-0 flex-1 flex-col">
 			<RouterView />
 		</main>
 		<ArrangementEditor
-			v-if="arranging && boot.app"
-			container="Rail"
-			:address="boot.app"
-			title="Arrange this rail"
+			v-if="arranging"
+			:container="arranging.container"
+			:address="arranging.address"
+			:title="arranging.title"
 			@saved="replace"
-			@close="arranging = false"
+			@close="arranging = null"
 		/>
 	</div>
 </template>
 
 <script setup lang="ts">
-import { inject, ref } from "vue";
-import { RouterView } from "vue-router";
-import type { Boot, Navigation } from "@/boot";
+import { computed, inject, ref } from "vue";
+import { RouterView, useRoute, useRouter } from "vue-router";
+import type { Addresses } from "@/addresses";
+import type { Boot, Navigation, NavigationItem } from "@/boot";
+import type { Container } from "@/arrangement";
+import { itemContext } from "@/navigation/context";
+import {
+	currentFrom,
+	navigationDestinations,
+	type NavigationContexts,
+} from "@/navigation/current";
 import AppRail from "./AppRail.vue";
+import AppSidebar from "./AppSidebar.vue";
 import ArrangementEditor from "./ArrangementEditor.vue";
 
 const boot = inject<Boot>("boot")!;
+const addresses = inject<Addresses>("addresses")!;
+const router = useRouter();
+const route = useRoute();
 
-const arranging = ref(false);
+// Which container is being arranged, or nothing. One editor rather than one per surface: the
+// three endpoints take the container as an argument, so a second component would only be the
+// same dialog with a different string baked in (#42363).
+const arranging = ref<{ container: Container; address: string; title: string } | null>(null);
 const navigation = ref<Navigation>(boot.navigation ?? { rail: [], sidebars: {} });
+
+// One context per container. The rail and each sidebar are separate LISTS, and a context is
+// composed once per list rather than once per row — `Module Contents` is what makes that more
+// than bookkeeping, since it measures "what is left of this module" against `context.items`.
+// A sidebar row handed the rail's context would answer that question about the rail.
+const contexts = computed<NavigationContexts>(() => {
+	const compose = (items: NavigationItem[]) =>
+		itemContext(boot, addresses, router, items, navigation.value.sidebars);
+
+	return {
+		rail: compose(navigation.value.rail),
+		sidebars: Object.fromEntries(
+			Object.entries(navigation.value.sidebars).map(([address, rows]) => [
+				address,
+				compose(rows),
+			])
+		),
+	};
+});
+
+// Every route navigation can be standing on. Off the PAYLOAD, so it survives a navigation:
+// building it costs a route resolution per row and the framework's own prefix carries 194 of
+// them (#42362), which is not a bill to pay on every click.
+const destinations = computed(() =>
+	navigationDestinations(navigation.value.rail, navigation.value.sidebars, contexts.value)
+);
+
+// And this is recomputed on every navigation, which is the whole design: nothing here is set
+// by a click. It is a walk over resolved paths, with no router in it.
+const current = computed(() => currentFrom(destinations.value, route.path));
+
+// The panel, or nothing. `current.sidebar` is only ever a key `renderingOf` read off a rail
+// item, so the rows are there — but a sidebar that resolved to nothing is absent from the
+// payload rather than empty (#42356), and the `?? []` would draw a headed, empty panel if that
+// ever changed. An empty panel is the one state #42357 ruled out, so it is checked here too.
+const panel = computed(() => {
+	const address = current.value.sidebar;
+	const items = address ? navigation.value.sidebars[address] : undefined;
+	if (!address || !items?.length) return null;
+
+	const owner = navigation.value.rail.find((item) => item.key === current.value.railKey);
+
+	return {
+		address,
+		items,
+		context: contexts.value.sidebars[address],
+		// The AUTHORED label and nothing else. `labelOf`'s fallbacks are all wrong for a
+		// `Sidebar` item: its renderer offers none, and the last resort is `link_to`, which
+		// here is the scrubbed address — a heading reading `module_def_accounts` is worse than
+		// no heading, and the rail item above it is highlighted either way.
+		title: owner?.label,
+	};
+});
+
+function arrangeRail() {
+	arranging.value = {
+		container: "Rail",
+		address: boot.app!,
+		title: "Arrange this rail",
+	};
+}
+
+function arrangeSidebar() {
+	if (!panel.value) return;
+	arranging.value = {
+		container: "Sidebar",
+		address: panel.value.address,
+		title: "Arrange this sidebar",
+	};
+}
 
 function replace(next: Navigation) {
 	navigation.value = next;

--- a/frontend/src/shell/AppSidebar.vue
+++ b/frontend/src/shell/AppSidebar.vue
@@ -1,0 +1,78 @@
+<!--
+  The panel a linked rail item opens.
+
+  The other half of charter point 1: a rail item is independent or LINKED, and this is
+  what linked means on screen. It draws `Navigation Item` rows — the same rows, the same
+  renderers and the same component as the rail, because they are two presentations of one
+  model and never two models (#42227).
+
+  NOTHING OPENS IT BY CLICKING. The address does. A rail item of type `Sidebar` resolves to
+  the first destination inside its sidebar and carries the sidebar's scrubbed key alongside
+  (`sidebar/frontend/item.js`), so following one is ordinary navigation and the panel that
+  appears is the shell reading the new address back (charter point 7,
+  `navigation/current.ts`). There is no selection stored anywhere, which is why pasting a
+  URL into a fresh tab lands on the same shell as clicking to it.
+
+  The empty panel does not exist. A sidebar that resolved to nothing is ABSENT from
+  `boot.navigation.sidebars` rather than empty (#42356), its rail item then renders as an
+  independent one, and with no rail item naming it there is no address that can open it
+  (#42357). The `v-if` in the shell is the last of three fences, not the first.
+
+  The title is the rail item's AUTHORED label, and an unlabelled item leaves the panel with
+  no heading at all. The payload allows nothing else: `sidebars` is keyed by scrubbed address
+  and carries rows rather than a record, so there is no `Sidebar` title to read — and
+  `labelOf`'s fallbacks all end at `link_to`, which for this kind is the scrubbed address. A
+  heading reading `module_def_accounts` is worse than none, and the rail item above the panel
+  is highlighted either way.
+-->
+<template>
+	<aside class="flex w-56 shrink-0 flex-col gap-1 border-r border-outline-gray-2 p-2">
+		<p v-if="title" class="truncate px-2 py-1.5 text-sm font-medium text-ink-gray-8">
+			{{ title }}
+		</p>
+
+		<ul class="overflow-y-auto">
+			<NavigationRow
+				v-for="node in tree"
+				:key="node.item.key"
+				:node="node"
+				:context="context"
+				:current="current"
+			/>
+		</ul>
+
+		<button
+			v-if="arrangeable"
+			class="mt-auto rounded px-2 py-1 text-left text-xs text-ink-gray-5 hover:bg-surface-gray-2"
+			@click="emit('arrange')"
+		>
+			Arrange
+		</button>
+	</aside>
+</template>
+
+<script setup lang="ts">
+import type { NavigationItem } from "@/boot";
+import NavigationRow from "@/navigation/NavigationRow.vue";
+import { useItemTree } from "@/navigation/useItemTree";
+import type { ItemContext } from "@/navigation/types";
+
+// `address` is the scrubbed key, and it is a prop because it is also what the arrangement
+// endpoints take for a `Sidebar` — they read the `(link_doctype, link_to)` pair back off the
+// standard record, since unscrubbing is not a function (`arrangement.py`). So the panel is an
+// arrangeable container on the same terms as the rail, with the same three endpoints.
+const props = defineProps<{
+	address: string;
+	items: NavigationItem[];
+	context: ItemContext;
+	title?: string;
+	current?: string;
+	arrangeable?: boolean;
+}>();
+const emit = defineEmits<{ arrange: [] }>();
+
+const tree = useItemTree(
+	() => props.items,
+	() => `the ${props.address} sidebar`
+);
+</script>

--- a/frontend/src/shell/tests/arrangement.test.ts
+++ b/frontend/src/shell/tests/arrangement.test.ts
@@ -24,6 +24,7 @@ vi.mock("frappe-ui", () => ({
 
 import { call as mockedCall } from "frappe-ui";
 import AppRail from "../AppRail.vue";
+import type { ItemContext } from "@/navigation/types";
 import ArrangementEditor from "../ArrangementEditor.vue";
 import { dropOn, move, saveArrangement, type ArrangedItem } from "@/arrangement";
 
@@ -269,7 +270,9 @@ describe("the rail's way in", () => {
   function rail(arrangeable: boolean) {
     const host = document.createElement("div");
     const app = createApp({
-      render: () => h(AppRail, { items: [], arrangeable }),
+      // An empty rail draws no rows, so the context is never asked anything here.
+      render: () =>
+        h(AppRail, { items: [], context: {} as unknown as ItemContext, arrangeable }),
     });
     app.provide("boot", { app: arrangeable ? "frappe" : null });
     // A real router, because the rail's home link is a real `RouterLink` and resolves through

--- a/frontend/src/shell/tests/rail.test.ts
+++ b/frontend/src/shell/tests/rail.test.ts
@@ -12,6 +12,7 @@ import type { Boot, NavigationItem } from "@/boot";
 import { registerContributions } from "@/contributions/registry";
 import { generatedRoutes } from "@/router/generated";
 import { registerShell } from "@/router/routeFor";
+import { itemContext } from "@/navigation/context";
 import { resetNavigationReports } from "@/navigation/registry";
 import AppRail from "../AppRail.vue";
 
@@ -55,7 +56,15 @@ function mount(
 	});
 	registerShell({ boot, addresses, router });
 
-	const app = createApp({ render: () => h(AppRail, { items: items.value, sidebars }) });
+	// The shell composes the context now, because the panel draws out of the same one
+	// (#42421). The rail is mounted here alone, so this stands in for it.
+	const app = createApp({
+		render: () =>
+			h(AppRail, {
+				items: items.value,
+				context: itemContext(boot, addresses, router, items.value, sidebars),
+			}),
+	});
 	app.provide("boot", boot);
 	app.provide("addresses", addresses);
 	app.use(router);

--- a/frontend/src/shell/tests/sidebar.test.ts
+++ b/frontend/src/shell/tests/sidebar.test.ts
@@ -1,0 +1,321 @@
+// The panel a linked rail item opens (#42421).
+//
+// Mounted through `AppShell`, not through `AppSidebar`, and that is the point: which sidebar
+// is open is a fact about the address, so a test that handed the panel its own rows would be
+// testing a list renderer and calling it navigation.
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createApp, nextTick } from "vue";
+import { createMemoryHistory, createRouter, type Router } from "vue-router";
+
+import { Addresses } from "@/addresses";
+import type { Boot, NavigationItem } from "@/boot";
+import { registerContributions } from "@/contributions/registry";
+import { registerShell } from "@/router/routeFor";
+import { resetNavigationReports } from "@/navigation/registry";
+import AppShell from "../AppShell.vue";
+
+// `Module Contents` is the one kind that reads the list it is in, so it is the one that can
+// tell the panel's context from the rail's.
+const fetchContents = vi.hoisted(() => vi.fn());
+vi.mock("@/contents", () => ({ fetchContents }));
+
+const addresses = new Addresses({
+	doctypes: {
+		"CRM Deal": ["crm-deal", "fcrm"],
+		"CRM Lead": ["crm-lead", "fcrm"],
+		"Sales Invoice": ["sales-invoice", "accounts"],
+	},
+	modules: { fcrm: "FCRM", accounts: "Accounts" },
+});
+
+const stub = { render: () => null };
+
+async function flush() {
+	await Promise.resolve();
+	await nextTick();
+}
+
+/** The shell, mounted at `path` over one navigation payload. */
+async function shell(
+	rail: NavigationItem[],
+	sidebars: Record<string, NavigationItem[]>,
+	path: string
+): Promise<{ host: HTMLElement; router: Router }> {
+	const boot = {
+		app: "crm",
+		shell_base: "/apps/crm",
+		prefixes: { crm: { app: "crm", modular: false } },
+		navigation: { rail, sidebars },
+	} as unknown as Boot;
+
+	const router = createRouter({
+		history: createMemoryHistory(),
+		routes: [
+			{ path: "/", name: "home", component: stub },
+			{ path: "/:doctype", name: "list", component: stub },
+			{ path: "/:doctype/view/:viewName", name: "saved-view", component: stub },
+			{ path: "/:doctype/:name", name: "record", component: stub },
+		],
+	});
+	registerShell({ boot, addresses, router });
+
+	const host = document.createElement("div");
+	document.body.appendChild(host);
+
+	const app = createApp(AppShell);
+	app.provide("boot", boot);
+	app.provide("addresses", addresses);
+	app.use(router);
+
+	await router.push(path);
+	await router.isReady();
+	app.mount(host);
+	await flush();
+
+	return { host, router };
+}
+
+function panel(host: HTMLElement) {
+	return host.querySelector("aside");
+}
+
+function marked(scope: Element | null) {
+	return Array.from(scope?.querySelectorAll("[aria-current='page']") ?? []).map((node) =>
+		node.getAttribute("data-key")
+	);
+}
+
+const invoice: NavigationItem = {
+	key: "invoice",
+	item_type: "DocType",
+	link_to: "Sales Invoice",
+};
+const lead: NavigationItem = { key: "lead", item_type: "DocType", link_to: "CRM Lead" };
+const accounts: NavigationItem = {
+	key: "accounts",
+	item_type: "Sidebar",
+	link_to: "module_def_accounts",
+	label: "Accounts",
+};
+const sidebars = { module_def_accounts: [invoice, lead] };
+
+beforeAll(async () => {
+	await registerContributions(["frappe"]);
+});
+
+beforeEach(() => {
+	document.body.innerHTML = "";
+	resetNavigationReports();
+});
+
+describe("what opens the panel", () => {
+	it("opens it because of where you are, not because of a click", async () => {
+		const { host } = await shell([accounts], sidebars, "/crm-lead");
+
+		// Nothing was clicked. `/crm-lead` is a row inside the Accounts sidebar, and that is
+		// the whole of it — which is what makes a pasted URL land on the same shell.
+		expect(panel(host)?.textContent).toContain("Sales Invoice");
+		expect(panel(host)?.textContent).toContain("CRM Lead");
+	});
+
+	it("heads it with the rail item's own label", async () => {
+		// `sidebars` is keyed by scrubbed address and carries rows, not a record, so there is
+		// no other title available — and the rail item is the words a reader clicked anyway.
+		const { host } = await shell([accounts], sidebars, "/sales-invoice");
+		expect(panel(host)?.textContent).toContain("Accounts");
+	});
+
+	it("shows no panel where the address is not inside a sidebar", async () => {
+		const deal: NavigationItem = { key: "deal", item_type: "DocType", link_to: "CRM Deal" };
+		const { host } = await shell([deal, accounts], sidebars, "/crm-deal");
+		expect(panel(host)).toBeNull();
+	});
+
+	it("swaps the panel away when navigation leaves it", async () => {
+		// No selection is stored, so leaving the sidebar's rows closes it. There is no last
+		// panel to fall back to.
+		const deal: NavigationItem = { key: "deal", item_type: "DocType", link_to: "CRM Deal" };
+		const { host, router } = await shell([accounts, deal], sidebars, "/sales-invoice");
+		expect(panel(host)).not.toBeNull();
+
+		await router.push("/crm-deal");
+		await flush();
+		expect(panel(host)).toBeNull();
+	});
+});
+
+describe("the empty case", () => {
+	it("draws no panel and no rail item when the sidebar has no rows", async () => {
+		// #42357: a linked rail item whose sidebar has nothing in it renders as an independent
+		// one — and a `Sidebar` item's whole content IS the sidebar, so it is simply not drawn.
+		// There is no empty panel anywhere in this design.
+		const { host } = await shell([accounts], { module_def_accounts: [] }, "/sales-invoice");
+		expect(panel(host)).toBeNull();
+		expect(host.querySelector("[data-key='accounts']")).toBeNull();
+	});
+
+	it("draws no panel when the sidebar is absent from the payload altogether", async () => {
+		const { host } = await shell([accounts], {}, "/sales-invoice");
+		expect(panel(host)).toBeNull();
+	});
+});
+
+describe("what is marked current", () => {
+	it("marks the row you are on and the rail item that opens it", async () => {
+		const { host } = await shell([accounts], sidebars, "/crm-lead");
+
+		expect(marked(host.querySelector("nav"))).toEqual(["accounts"]);
+		expect(marked(panel(host))).toEqual(["lead"]);
+	});
+
+	it("keeps the rail item marked from the second row on", async () => {
+		// The rail item's own link points at the sidebar's FIRST row, so `router-link-active`
+		// would go out here and the reader would lose the only sign of where they are.
+		const { host } = await shell([accounts], sidebars, "/crm-lead");
+		const railItem = host.querySelector("nav [data-key='accounts']");
+		expect(railItem?.getAttribute("aria-current")).toBe("page");
+	});
+
+	it("marks exactly one row across the rail and the panel together", async () => {
+		// `lead` is on the rail and in the sidebar. Two independent highlights would light both.
+		const { host } = await shell([accounts, lead], sidebars, "/crm-lead");
+		expect(marked(host)).toEqual(["accounts", "lead"]);
+		expect(marked(panel(host))).toEqual(["lead"]);
+		// The rail's own `lead` points exactly here, so `RouterLink` would mark it by itself.
+		// Binding `aria-current` explicitly is what suppresses that and keeps the count at one.
+		expect(
+			host.querySelector("nav [data-key='lead']")?.getAttribute("aria-current")
+		).toBeNull();
+	});
+
+	it("keeps the list marked while a record of it is open", async () => {
+		const { host } = await shell([accounts], sidebars, "/crm-lead/CRM-LEAD-01");
+		expect(marked(panel(host))).toEqual(["lead"]);
+	});
+});
+
+describe("two containers, one key", () => {
+	it("does not confuse a rail row with a sidebar row of the same name", async () => {
+		// A key identifies a row within ONE container — the same thing `registry.ts`'s depth
+		// guard exists for. Here it is the highlight: the rail's `lead` must not light up
+		// because the panel's `lead` is current.
+		const { host } = await shell(
+			[accounts, { ...lead, link_to: "CRM Deal" }],
+			sidebars,
+			"/crm-lead"
+		);
+
+		expect(marked(host.querySelector("nav"))).toEqual(["accounts"]);
+		expect(marked(panel(host))).toEqual(["lead"]);
+	});
+});
+
+describe("the panel is a container, not a view of the rail", () => {
+	it("offers its own Arrange, addressed at the sidebar", async () => {
+		// The three arrangement endpoints take the container as an argument and read the
+		// `(link_doctype, link_to)` pair back off the scrubbed address (`arrangement.py`), so
+		// the panel arranges on exactly the terms the rail does (#42363).
+		const { host } = await shell([accounts], sidebars, "/sales-invoice");
+		expect(panel(host)?.textContent).toContain("Arrange");
+	});
+});
+
+describe("what the panel draws", () => {
+	const section: NavigationItem = { key: "billing", item_type: "Section", label: "Billing" };
+	const nested = { ...invoice, parent_key: "billing" };
+
+	it("draws sections and what nests under them", async () => {
+		const { host } = await shell([accounts], { module_def_accounts: [section, nested] }, "/sales-invoice");
+
+		const heading = panel(host)?.querySelector("[data-key='billing']");
+		expect(heading?.textContent?.trim()).toBe("Billing");
+		// The row is inside the section's list, not beside it. `parent_key` is the whole of
+		// hierarchy and the server sends the tree flat (#42227).
+		expect(heading?.parentElement?.querySelector("[data-key='invoice']")).not.toBeNull();
+	});
+
+	it("marks a nested row, and the rail item above it", async () => {
+		const { host } = await shell([accounts], { module_def_accounts: [section, nested] }, "/sales-invoice");
+
+		expect(marked(panel(host))).toEqual(["invoice"]);
+		expect(marked(host.querySelector("nav"))).toEqual(["accounts"]);
+	});
+
+	it("reports a cycle in each container it happens in", async () => {
+		// A key identifies a row within one container, so one shared "reported once" set would
+		// swallow the panel's report as a repeat of the rail's and leave a sidebar silently
+		// missing rows.
+		const errors: string[] = [];
+		const original = console.error;
+		console.error = (...args: unknown[]) => errors.push(String(args[0]));
+
+		const loop = (key: string, parent_key: string): NavigationItem => ({
+			key,
+			item_type: "DocType",
+			link_to: "CRM Lead",
+			parent_key,
+		});
+
+		try {
+			await shell(
+				[accounts, loop("a", "b"), loop("b", "a")],
+				{ module_def_accounts: [invoice, loop("a", "b"), loop("b", "a")] },
+				"/sales-invoice"
+			);
+		} finally {
+			console.error = original;
+		}
+
+		expect(errors.filter((line) => line.includes("in the rail")).length).toBe(2);
+		expect(errors.filter((line) => line.includes("module_def_accounts sidebar")).length).toBe(2);
+	});
+});
+
+describe("the panel's own context", () => {
+	it("measures what is left of a module against the sidebar, not against the rail", async () => {
+		// A context is composed once per LIST, and there are two lists here. `Module Contents`
+		// expands into "what this module holds that the list does not already show" — so a row
+		// handed the rail's context would hide the doctypes the RAIL shows and repeat its own.
+		fetchContents.mockResolvedValue([
+			{ doctype: "CRM Lead", slug: "crm-lead", module: "FCRM" },
+			{ doctype: "Sales Invoice", slug: "sales-invoice", module: "Accounts" },
+		]);
+
+		const { host } = await shell(
+			[accounts, invoice],
+			{
+				module_def_accounts: [
+					lead,
+					{ key: "rest", item_type: "Module Contents", link_to: "FCRM" },
+				],
+			},
+			"/crm-lead"
+		);
+
+		const more = panel(host)?.querySelector<HTMLElement>("[data-key='rest']");
+		more?.click();
+		await flush();
+		await flush();
+
+		// `CRM Lead` is already in this panel, so it is not repeated...
+		expect(panel(host)?.querySelectorAll("[data-key='rest:CRM Lead']").length).toBe(0);
+		// ...and `Sales Invoice`, which the RAIL shows and this panel does not, is offered.
+		expect(panel(host)?.querySelector("[data-key='rest:Sales Invoice']")).not.toBeNull();
+	});
+});
+
+describe("the panel's heading", () => {
+	it("is the rail item's authored label", async () => {
+		const { host } = await shell([accounts], sidebars, "/sales-invoice");
+		expect(panel(host)?.querySelector("p")?.textContent?.trim()).toBe("Accounts");
+	});
+
+	it("is absent rather than a scrubbed address when nobody labelled the item", async () => {
+		// `labelOf` would fall through to `link_to`, which for this kind is the key boot files
+		// the sidebar under. A heading reading `module_def_accounts` is worse than none.
+		const { host } = await shell([{ ...accounts, label: undefined }], sidebars, "/sales-invoice");
+
+		expect(panel(host)).not.toBeNull();
+		expect(panel(host)?.textContent).not.toContain("module_def_accounts");
+	});
+});


### PR DESCRIPTION
Builds [The sidebar panel: what opens it, what it renders, and the empty case](https://github.com/frappe/frappe/issues/42421), a child of [Desk v2 — the rail and the sidebar](https://github.com/frappe/frappe/issues/42226).

Charter point 1 says a rail item is either *independent* or *linked*. Until now "linked" had no surface at all: `frontend/src/shell/` held two components, `AppRail.vue` and `ArrangementEditor.vue`, and nothing rendered `boot.navigation.sidebars`.

## What opens it

Not a click. `navigation/current.ts` reads the panel back off the address, in two stages:

- **Once per payload**, every route navigation can be standing on is resolved: the rail's own rows, and the rows of every sidebar the rail can open. A rail item of type `Sidebar` competes *through* its sidebar's rows rather than through its own destination, since its own destination is one of those rows already.
- **Once per navigation**, the deepest cover of the current path wins. Segment-wise, so `/sales-orders` is not read as sitting under `/sales-order`, and a list stays marked while you read one of its records.

Split that way because building the table costs a route resolution per row and the framework's own prefix carries 194 of them. Measured over a 194-item rail: **0.76 ms to build, 0.038 ms to match** — so a click pays the second number, not the first.

The result is one winner across the rail and the panel together, which is what `router-link-active` cannot give: a linked rail item points at the first row *inside* its sidebar, so its own link goes inactive from the second row on; and a list and one of its saved views both prefix-match the same address, so two rows light up.

## The empty case

There isn't one. A sidebar that resolved to nothing is absent from the payload (#42356), its rail item then renders as independent (#42357) — and since a `Sidebar` item's whole content *is* the sidebar, that means it is not drawn, so no address can open a panel that would be empty.

## Also

- `shell/RailItem.vue` → `navigation/NavigationRow.vue`. Two presentations of one model, one component.
- The panel is an **arrangeable container on the same terms as the rail**. The three endpoints already take the container as an argument and read the `(link_doctype, link_to)` pair back off the scrubbed address (`arrangement.py`); only the rail had a surface for it.
- **One item context per container.** A context is composed once per *list*, and there are two kinds of list now. `Module Contents` measures "what is left of this module" against `context.items`, so a sidebar row handed the rail's context hid the doctypes the rail shows and repeated its own. Caught by `/quality-code-review`; there is a test that fails without the fix.

## Tests

359 frontend tests (from 328), 33 of them new across `navigation/tests/current.test.ts` and `shell/tests/sidebar.test.ts`, mounted through `AppShell` rather than through the panel — which sidebar is open is a fact about the address, so a test that handed the panel its own rows would be testing a list renderer.

`test_shell` (49), `test_shell_navigation` (51) and `test_navigation_arrangement` (51) all green on a real site; nothing server-side changed, and `test_a_v2_resolver_never_reads_v1s_rows` already covers the ticket's concern that desk v1's `items` must not reach the browser.

>no-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)