### PR TITLE
feat: filter desk v2 navigation on the bucket each item type declares

### DIFF
--- a/frappe/shell/arrangement.py
+++ b/frappe/shell/arrangement.py
@@ -186,13 +186,25 @@ def _target(container: str, address: str, scope: str) -> Target:
 	# the app's.
 	stored = {"user": frappe.session.user if scope == "user" else SITE_LAYER, "standard": 0}
 
+	# The one deliberate bypass of the permission filter (#42231 decision 12), and it is the
+	# **site** scope that earns it: a manager arranging the site's navigation is arranging it for
+	# everybody, so a list filtered down to what they personally may see would let them delete
+	# other people's items by saving a list those items were never on. It stays off at user
+	# scope, where the person is arranging their own list and showing them rows they may not see
+	# would be a leak with nothing to buy it.
+	#
+	# It is set once, here, so the read and the reduce base a save is computed against are always
+	# filtered the same way. A save whose `below` held rows the editor never showed would anchor
+	# moves against a list the client was not looking at.
+	check_permission = scope != "site"
+
 	if container == "Rail":
 		app = address
-		resolve = partial(resolve_rail, app)
+		resolve = partial(resolve_rail, app, check_permission=check_permission)
 		stored |= {"app": app, "extends": ""}
 	else:
 		app, link_doctype, link_to = _sidebar_address(address)
-		resolve = partial(resolve_sidebar, link_doctype, link_to)
+		resolve = partial(resolve_sidebar, link_doctype, link_to, check_permission=check_permission)
 		stored |= {"app": app, "link_doctype": link_doctype, "link_to": link_to}
 
 	# Before the gate, because `has_app_permission` falls back to "is a System User" for an app

--- a/frappe/shell/navigation.py
+++ b/frappe/shell/navigation.py
@@ -23,6 +23,7 @@ import frappe
 from frappe.desk.layers import resolve_layers
 
 from .extensions import extend
+from .navigation_filter import NavigationContext, filter_items
 
 # What a stored row carries. Read as columns rather than as a document, because `Sidebar`'s
 # document is desk v1's: the class subclasses `DeskViews` and the record holds v1's `items`
@@ -73,12 +74,12 @@ WIRE_FIELDS = (
 SITE_LAYER = ""
 
 # `Rail.NO_HOST`, and the same empty string for the same reason: an app's own rail extends
-# nobody, and one spelling of that has to reach the unique index — and this filter.
+# nobody, and one spelling of that has to reach the unique index — and the layer query below.
 NO_HOST = ""
 
-# #42231's bucket for a kind whose destination is a doctype, and the one bucket this module
-# applies. The other five are #42233's, along with every authored row that is not contributed.
-READABLE_DOCTYPE = "Readable DocType"
+# Permission filtering is `navigation_filter`, imported rather than written here. One rule
+# dispatched on the bucket each type declares, in place of the single `Readable DocType` pass
+# this module used to apply to contributed rows alone (#42231).
 
 
 def resolve_navigation(app: str) -> dict:
@@ -94,11 +95,27 @@ def resolve_navigation(app: str) -> dict:
 	scrubbed address is byte-identical to the standard row's name — which is the string a rail
 	item of type `Sidebar` already carries in `link_to`, so the browser still does one dictionary
 	lookup on a value it is holding.
+
+	The sidebars resolve **first**, and the rail is filtered against what survived them. A rail
+	item of type `Sidebar` is visible only while its sidebar still holds a row (#42231's
+	`Derived From Children`), so the order is forced rather than chosen. Both halves share one
+	`NavigationContext`, so the permitted-doctype pass, the module sets and the type table are
+	each read once for the whole payload.
 	"""
-	return {"rail": resolve_rail(app), "sidebars": _resolve_sidebars(app)}
+	context = NavigationContext(app)
+	sidebars = context.sidebars
+
+	return {"rail": resolve_rail(app, context=context), "sidebars": sidebars}
 
 
-def resolve_rail(app: str, *, upto: str = "user", keep_hidden: bool = False) -> list[dict]:
+def resolve_rail(
+	app: str,
+	*,
+	upto: str = "user",
+	keep_hidden: bool = False,
+	check_permission: bool = True,
+	context: NavigationContext | None = None,
+) -> list[dict]:
 	"""One app's rail: its own layer plus what other apps add to it, then the site's, then this user's.
 
 	`upto` stops the stack short, and `keep_hidden` leaves the hidden rows in. Both are the
@@ -116,6 +133,11 @@ def resolve_rail(app: str, *, upto: str = "user", keep_hidden: bool = False) -> 
 	walking skeleton (#42233) converts one. Short-circuiting would make the per-user overlay
 	(#42230) work on converted apps only, so whether a person may reorder their own rail would
 	depend on something they cannot see.
+
+	`check_permission=False` is the one deliberate bypass in the system, and the layer editor is
+	its only permitted caller (#42231 decision 12). A manager arranging the site's rail is
+	arranging it for everybody, so a rail filtered down to what *they* may see would let them
+	silently delete other people's items by saving a list those items were never on.
 	"""
 	layers = _rail_layers(app)
 	base = layers.pop("standard", None)
@@ -128,10 +150,15 @@ def resolve_rail(app: str, *, upto: str = "user", keep_hidden: bool = False) -> 
 
 	base = extend(base, _rail_contributions(app), anchorable=shipped)
 
-	return _merge(base, _upto(layers, upto), keep_hidden=keep_hidden)
+	return _merge(
+		base,
+		_upto(layers, upto),
+		keep_hidden=keep_hidden,
+		context=_context(app, context, check_permission),
+	)
 
 
-def _resolve_sidebars(app: str) -> dict[str, list[dict]]:
+def resolve_sidebars(app: str, context: NavigationContext | None = None) -> dict[str, list[dict]]:
 	"""Every sidebar this app ships, resolved and keyed by scrubbed address.
 
 	Empty until an app ships rows, and deliberately so: derivation produces a rail and nothing
@@ -146,24 +173,34 @@ def _resolve_sidebars(app: str) -> dict[str, list[dict]]:
 	if not addresses:
 		return {}
 
+	# Always filtered. The editor's bypass is the rail's and the single-sidebar read's; boot is
+	# the only caller that wants a whole prefix, and boot never bypasses.
+	context = context or NavigationContext(app)
 	layers = _sidebar_layers(addresses)
 	resolved = {}
 
 	for address in addresses:
 		by_layer = layers.get(address, {})
 		base = by_layer.get("standard", [])
-		items = _merge(base, _upto(by_layer, "user"))
+		items = _merge(base, _upto(by_layer, "user"), context=context)
 		if items:
 			# An address that resolves to nothing is absent rather than empty. The payload is read
-			# by key, so the two mean the same thing to the browser, and a linked rail item whose
-			# sidebar has no rows renders as an independent one (#42357).
+			# by key, so the two mean the same thing to the browser — and to the rail, whose item
+			# for this address goes with it. #42421 found "renders as an independent one" (#42357)
+			# has no observable form: a `Sidebar` item's whole content is the sidebar, so with no
+			# rows it has no destination and is not drawn.
 			resolved[frappe.scrub(f"{address[0]} {address[1]}")] = items
 
 	return resolved
 
 
 def resolve_sidebar(
-	link_doctype: str, link_to: str, *, upto: str = "user", keep_hidden: bool = False
+	link_doctype: str,
+	link_to: str,
+	*,
+	upto: str = "user",
+	keep_hidden: bool = False,
+	check_permission: bool = True,
 ) -> list[dict]:
 	"""One sidebar at one address, for a caller that wants that one and not the prefix.
 
@@ -174,7 +211,14 @@ def resolve_sidebar(
 	"""
 	by_layer = _sidebar_layers([(link_doctype, link_to)]).get((link_doctype, link_to), {})
 
-	return _merge(by_layer.get("standard", []), _upto(by_layer, upto), keep_hidden=keep_hidden)
+	return _merge(
+		by_layer.get("standard", []),
+		_upto(by_layer, upto),
+		keep_hidden=keep_hidden,
+		# No app to build a context for, and none needed: a sidebar's own rows are filtered on
+		# their buckets alone, and the one rule that reaches across containers runs on the rail.
+		context=NavigationContext("") if check_permission else None,
+	)
 
 
 # The layers a resolution stacks, in order, up to and including the scope asked for. The editor
@@ -187,7 +231,25 @@ def _upto(layers: dict[str, list[dict]], upto: str) -> list[list[dict]]:
 	return [layers.get(role, []) for role in LAYERS_UPTO[upto]]
 
 
-def _merge(base: list[dict], layers: list[list[dict]], *, keep_hidden: bool = False) -> list[dict]:
+def _context(app: str, context: "NavigationContext | None", check_permission: bool):
+	"""The context a resolution filters against, or `None` for the editor's bypass.
+
+	One place decides it, so `check_permission=False` stays the single named exception it was
+	settled as rather than becoming a second code path through the merge.
+	"""
+	if not check_permission:
+		return None
+
+	return context or NavigationContext(app)
+
+
+def _merge(
+	base: list[dict],
+	layers: list[list[dict]],
+	*,
+	keep_hidden: bool = False,
+	context: "NavigationContext | None" = None,
+) -> list[dict]:
 	"""Fold the layers into the base and return what the browser renders.
 
 	The merge itself is `frappe.desk.layers`, imported rather than copied. It is 165 lines that
@@ -211,6 +273,12 @@ def _merge(base: list[dict], layers: list[list[dict]], *, keep_hidden: bool = Fa
 	resolved, hidden = resolve_layers(base, layers, key=item_key, apply_row=apply_item_row, anchored=True)
 
 	items = resolved if keep_hidden else _drop_hidden(resolved, hidden)
+
+	# Permission filtering goes here and nowhere else: after the arrangement has resolved, so a
+	# stored move means the same thing for two people, and after `_drop_hidden`, so a hidden
+	# subtree is never counted as a section's surviving children. `None` is the editor's bypass.
+	if context is not None:
+		items = filter_items(items, context)
 
 	return [_on_the_wire(item, hidden) for item in _promote_orphans(items)]
 
@@ -512,6 +580,13 @@ def _rail_contributions(host: str) -> list[tuple[str, list[dict]]]:
 
 	Standard rows only, which the schema already guarantees: `extends` is blanked on any row that
 	is not app content, so a site or a person cannot file one app's items onto another's rail.
+
+	Unfiltered. Contributed rows used to be the one thing this module filtered, on the narrow
+	`Readable DocType` rule and here, before the merge — the stopgap #42364 needed because the
+	host is the one party that cannot refuse a row another app files onto its rail. They now go
+	through the same pass as everything else, on whatever bucket their own type declares, which
+	is what "replace it rather than reconcile with it" asked for. A contributed `Page` item used
+	to ride in unchecked; it no longer does.
 	"""
 	records = frappe.get_all("Rail", filters={"extends": host, "standard": 1}, fields=["name", "app"])
 	if not records:
@@ -525,59 +600,7 @@ def _rail_contributions(host: str) -> list[tuple[str, list[dict]]]:
 	)
 	rows = _rows_by_parent("Rail", "items", [record.name for record in records])
 
-	return [(record.app, _readable(rows.get(record.name, []))) for record in records]
-
-
-def _readable(rows: list[dict]) -> list[dict]:
-	"""Drop a contributed row pointing at a doctype this person cannot read.
-
-	#42364's rule 6: doctype read is the only filter on a contribution, and the target app's
-	`app_permission` door does **not** run — that gate is about entering a prefix, and following
-	a foreign item does not leave the host.
-
-	It is here rather than waiting for #42233, which owns filtering authored rows generally,
-	because the host is the one party that cannot refuse: an app's own rows are its own problem,
-	while these arrive on somebody else's rail. The narrowness is the point — this is #42231's
-	`Readable DocType` bucket and only that one, read off the type table rather than hardcoded,
-	so #42233 replaces it with the full dispatch rather than finding a second rule to reconcile.
-
-	Which column names the doctype depends on the type: a `DocType` item's destination *is* the
-	doctype, in `link_to`, while `Record` is the one kind that carries its own `link_doctype`.
-
-	A dropped section leaves its children behind, and `_promote_orphans` lifts them to the top
-	level on the way out — the same treatment as an app removing a section.
-	"""
-	if not rows:
-		return rows
-
-	from .doctypes import get_readable_doctypes
-
-	buckets = _permission_rules()
-	readable = None
-
-	kept = []
-
-	for row in rows:
-		if buckets.get(row.get("item_type")) != READABLE_DOCTYPE:
-			kept.append(row)
-			continue
-
-		if readable is None:
-			# Read once, and only if a row actually asks. `get_readable_doctypes` is one
-			# role-based pass measured at 25 ms against 3,594 ms for per-doctype checks, but a
-			# bench where nothing extends anything should not pay even that.
-			readable = get_readable_doctypes()
-
-		doctype = row.get("link_to") if row.get("item_type") == "DocType" else row.get("link_doctype")
-		if doctype in readable:
-			kept.append(row)
-
-	return kept
-
-
-def _permission_rules() -> dict[str, str]:
-	"""`{type: permission_rule}` — the rule each kind declares for itself (#42231)."""
-	return dict(frappe.get_all("Navigation Item Type", fields=["name", "permission_rule"], as_list=True))
+	return [(record.app, rows.get(record.name, [])) for record in records]
 
 
 def _layer_role(record) -> str:

--- a/frappe/shell/navigation_filter.py
+++ b/frappe/shell/navigation_filter.py
@@ -1,0 +1,450 @@
+# NAVIGATION FILTERING — one rule, dispatched on the bucket each item type declares.
+#
+# #42231: filtering navigation is a courtesy and never a control. `frappe/utils/modules.py:48`
+# says it in the framework's own words — "Hiding a module hides the way to a document, never the
+# document itself" — so a rule here may skip an expensive case and be wrong in the safe
+# direction. What a document costs to open is decided at the document, by DocPerm.
+#
+# The single home is the whole point of the ticket. `is_item_allowed` (`desk/utils.py:70`)
+# returns False for a type it does not know and the dock's `is_reachable` (`dock.py:1043`)
+# returns True: one question, two answers, arrived at by nobody's decision and only because
+# there were two places to put it.
+#
+# It sits beside the resolver rather than beside the `Sidebar` model, which is where #42231
+# decision 10 put it. #42356 then moved resolution itself out of both containers' controllers,
+# for the reason that decision was reaching for — the rule spans two surfaces, so it belongs to
+# neither — and this filter's only caller is that resolver.
+#
+# No per-item permission call anywhere below. #42231 decision 7 measured 553 `has_permission`
+# calls at **3,594 ms** for an ordinary System User against **25 ms** for one role-based pass,
+# and this runs inside boot's blocking pre-mount fetch.
+
+from functools import cached_property
+
+import frappe
+from frappe.utils.modules import get_visible_modules
+
+# The six buckets, spelled as they are on `Navigation Item Type.permission_rule`.
+READABLE_DOCTYPE = "Readable DocType"
+MODULE_CONTENTS = "Module Contents"
+DERIVED_FROM_CHILDREN = "Derived From Children"
+PERMITTED_PAGE = "Permitted Page"
+ALWAYS_VISIBLE = "Always Visible"
+CUSTOM = "Custom"
+
+
+def filter_items(items: list[dict], context: "NavigationContext") -> list[dict]:
+	"""Drop every item this user may not see, then drop whatever is left holding nothing.
+
+	One pass for the buckets that decide an item on its own, then a fixpoint for the two that
+	decide it from what survived under it. The order is forced: a `Section` cannot know whether
+	it is empty until everything below it has been judged.
+
+	Runs on the **merged** list, after the layers have been folded in. #42231 decision 11 read
+	#42230's decisions 4 and 8 as opposite orderings and found they are not: a layer does two
+	things and they gate differently. *Arrangement* — order and parenting — resolves against the
+	full base, so one person's stored move means the same thing whatever they may see; then this
+	runs, over the arrangement's result, which is what stops an *addition* from bringing back an
+	item the person is not allowed to see.
+	"""
+	if not items:
+		return items
+
+	verdicts: dict[int, bool | None] = {}
+	custom: dict[str, list[int]] = {}
+	unknown: dict[str, int] = {}
+
+	for index, item in enumerate(items):
+		item_type = item.get("item_type")
+		bucket = context.rule(item_type)
+
+		if bucket == CUSTOM:
+			custom.setdefault(item_type, []).append(index)
+		elif bucket == DERIVED_FROM_CHILDREN:
+			# Left undecided on purpose. `None` is what the cascade below looks for.
+			verdicts[index] = None
+		elif bucket in (READABLE_DOCTYPE, MODULE_CONTENTS, PERMITTED_PAGE, ALWAYS_VISIBLE):
+			verdicts[index] = _decide(bucket, item, context)
+		else:
+			# No type row, or a row declaring a bucket this version does not implement.
+			verdicts[index] = False
+			unknown[item_type] = unknown.get(item_type, 0) + 1
+
+	for item_type, indexes in custom.items():
+		verdicts.update(_ask_the_type(item_type, indexes, items, context))
+
+	for item_type, count in unknown.items():
+		context.report_unfilterable(item_type, count)
+
+	return _cascade(items, verdicts, context)
+
+
+def _decide(bucket: str, item: dict, context: "NavigationContext") -> bool:
+	if bucket == ALWAYS_VISIBLE:
+		return True
+
+	if bucket == READABLE_DOCTYPE:
+		return context.may_read(_destination_doctype(item, context))
+
+	if bucket == MODULE_CONTENTS:
+		return context.module_is_offered(item.get("link_to"))
+
+	return context.page_is_permitted(item.get("link_to"))
+
+
+def _destination_doctype(item: dict, context: "NavigationContext") -> str | None:
+	"""Which column names the doctype, read off the type row rather than off a list of names.
+
+	A type whose `target_doctype` is `DocType` points *at* a doctype, so the doctype is its
+	`link_to`; every other type that reads this bucket points at a document and carries the
+	doctype separately in `link_doctype`. Both of the framework's cases fall out of that —
+	`DocType` and `Record` — and so does a contributed type that picks the bucket, which is what
+	#42228's two-files-and-no-framework-change property requires.
+	"""
+	if context.target(item.get("item_type")) == "DocType":
+		return item.get("link_to")
+
+	return item.get("link_doctype")
+
+
+def _ask_the_type(
+	item_type: str, indexes: list[int], items: list[dict], context: "NavigationContext"
+) -> dict[int, bool]:
+	"""The `Custom` bucket: hand the type's own `can_see` every item of its kind at once.
+
+	Batched, and that is the signature #42231 decision 9 settled rather than a detail of it. A
+	per-item `can_see(item, user)` is the shape that produced the 3,594 ms measurement, and it
+	invites an override to loop over `frappe.has_permission`; handing over the whole list plus
+	the context this pass has already computed makes the cheap implementation the obvious one.
+
+	A type that declares `Custom` and ships no `can_see` fails closed, like a type with no row
+	at all — the declaration is a promise of code, and the missing half is a bug in an app.
+	Anything the resolver raises is the same: a rail that silently shows everything because one
+	app's filter threw is the failure this bucket exists to make impossible.
+	"""
+	mine = [items[index] for index in indexes]
+	can_see = context.resolver(item_type)
+
+	if can_see is None:
+		context.report_unfilterable(item_type, len(mine), custom=True)
+		return dict.fromkeys(indexes, False)
+
+	try:
+		allowed = {entry.get("key") for entry in can_see(mine, context)}
+	except Exception:
+		frappe.log_error(title=f"Navigation item type {item_type} could not decide visibility")
+		return dict.fromkeys(indexes, False)
+
+	return {index: items[index].get("key") in allowed for index in indexes}
+
+
+def _cascade(items: list[dict], verdicts: dict[int, bool | None], context: "NavigationContext") -> list[dict]:
+	"""Drop a `Derived From Children` item holding nothing, and keep going until nothing moves.
+
+	To a fixpoint because emptiness propagates: a Section holding only an emptied Section is
+	itself empty, and one pass would leave the outer one standing (#42231 decision 6). `develop`
+	never checks a Section Break at all (`sidebar.py:1539`), so a section whose every row was
+	filtered away survives there as a heading over nothing — a door you cannot open, which is
+	exactly what a courtesy filter should not leave behind.
+
+	An item dropped by any *other* bucket leaves its children where they are; `_promote_orphans`
+	lifts them to the top level on the way out. That is deliberate and is the same treatment as
+	an app removing a section: a permission rule about a heading says nothing about the rows
+	under it.
+	"""
+	children: dict[str, list[int]] = {}
+	for index, item in enumerate(items):
+		parent = item.get("parent_key")
+		if parent:
+			children.setdefault(parent, []).append(index)
+
+	kept = {index for index in range(len(items)) if verdicts.get(index) is not False}
+
+	while True:
+		empty = {
+			index
+			for index in kept
+			if verdicts.get(index) is None and not _holds_something(index, items, children, kept, context)
+		}
+		if not empty:
+			break
+		kept -= empty
+
+	return [item for index, item in enumerate(items) if index in kept]
+
+
+def _holds_something(
+	index: int,
+	items: list[dict],
+	children: dict[str, list[int]],
+	kept: set[int],
+	context: "NavigationContext",
+) -> bool:
+	"""What is *under* a derived item, which is two different places depending on the type.
+
+	A `Section` holds its own child rows, found by `parent_key`. A type pointing at a `Sidebar`
+	holds that sidebar's rows, which are not on this list at all — so a rail item whose sidebar
+	filtered away to nothing goes with it. #42421 found that has no other observable form: a
+	`Sidebar` item's whole content is the sidebar, so with no rows it has no destination, and
+	"renders as independent" and "is not drawn" are the same picture.
+
+	`None` from `linked` means the sidebars are not resolved here and the question cannot be
+	asked, which keeps the item. Unknown is not empty.
+	"""
+	item = items[index]
+
+	if context.target(item.get("item_type")) == "Sidebar":
+		linked = context.linked
+		return linked is None or item.get("link_to") in linked
+
+	return any(child in kept for child in children.get(item.get("key"), []))
+
+
+class NavigationContext:
+	"""Every input the buckets read, computed at most once per resolution.
+
+	Per resolution, not per request, and `frappe.utils.caching.request_cache` is the obvious
+	home that would be wrong: nothing clears it on `frappe.set_user`, so a request that changes
+	user would answer the second one out of the first one's sets. These are per-user sets, and a
+	cache with no invalidation for the thing it varies on is worse than no cache.
+
+	It is also what the `Custom` bucket is handed, so an app's own `can_see` gets the sets this
+	pass has already paid for rather than computing its own.
+	"""
+
+	def __init__(self, app: str):
+		self.app = app
+		self.user = frappe.session.user
+		# #42231 decision 13: Administrator short-circuits every permission check, matching
+		# `permissions.py:109` — removing it would make navigation stricter than the permission
+		# system it is a courtesy over. It buys the consequence worth writing down: **Administrator
+		# is the worst possible account to test this filter with**, and every bug in these rules is
+		# invisible to the person most likely to be looking.
+		#
+		# It covers the permission buckets and nothing else. An empty section is a stray heading
+		# for Administrator too, and a type nobody can filter is a bug an administrator especially
+		# needs to see, so the cascade and the fail-closed path below run for everyone.
+		self.administrator = self.user == "Administrator"
+		self._sidebars: dict[str, list[dict]] | None = None
+		self._resolving = False
+		self._reported: set[str] = set()
+		# Looked up once per type, not once per container: a modular app resolves one sidebar per
+		# module, and `get_attr` re-checks the installed-app list on every call.
+		self._resolvers: dict[str, object] = {}
+
+	# The buckets' inputs
+
+	def may_read(self, doctype: str | None) -> bool:
+		return bool(doctype) and (self.administrator or doctype in self.readable_doctypes)
+
+	def module_is_offered(self, module: str | None) -> bool:
+		"""A module is offered when something in it is readable, unless this user blocked it.
+
+		The union of its contents is the only rule that needs no second thing for an
+		administrator to maintain, and desk v1 never had another one: a module became visible
+		there purely as a consequence of its workspaces surviving (`desktop.py:63-92`).
+
+		The block is a **veto and not a permission**, which is why it runs ahead of the
+		Administrator branch: it is this user's own `User.block_modules` row, so an administrator
+		who hid a module meant it. It gates module-derived items only — block Accounts and a
+		`DocType` item pointing at Sales Invoice stays, because cascading downward is what
+		`is_module_visible`'s docstring forbids. And it runs here, before any layer is added on
+		top, so no layer can resurface a blocked module (#42323).
+		"""
+		if not module or module in self.blocked_modules:
+			return False
+
+		return self.administrator or module in self.readable_modules
+
+	def page_is_permitted(self, page: str | None) -> bool:
+		return bool(page) and (self.administrator or page in self.permitted_pages)
+
+	@cached_property
+	def readable_doctypes(self) -> set[str]:
+		"""`get_doctypes_with_read() | get_shared_doctypes()`, once.
+
+		The shell's own set, not a second answer to the same question: `shell/doctypes.py:164`
+		already computes it for the derived rail and for an app's contents, and #42231 decision 10
+		exists because two functions answering "may this user read this doctype" is how the two
+		surfaces came to disagree in the first place.
+		"""
+		from .doctypes import get_readable_doctypes
+
+		return get_readable_doctypes()
+
+	@cached_property
+	def blocked_modules(self) -> set[str]:
+		"""Module names this user has hidden, as the complement of the framework's own answer.
+
+		`get_visible_modules` and not `User.get_blocked_modules()`, which `desktop.py:83` and
+		`desktop_icon.py:133` still read directly — a second module-visibility helper is the
+		divergence this ticket is closing on the item side, and it would be no better here. One
+		call for the whole list, since the batched helper exists precisely for that.
+
+		Over every `Module Def`, not over the modules in the address table. The address table only
+		names a module that owns at least one non-child doctype, so reading the universe off it
+		would make "this module has nothing addressable in it" and "this user blocked it" the same
+		answer — two different facts, and only one of them is a veto that outranks Administrator.
+		"""
+		modules = frappe.get_all("Module Def", pluck="name")
+
+		return set(modules) - set(get_visible_modules(modules))
+
+	@cached_property
+	def readable_modules(self) -> set[str]:
+		"""The modules holding at least one doctype this user may read.
+
+		A set operation over two things already in hand, which is what makes decision 5 nearly
+		free: the address table is cached on `metadata_version` and shared by every user, and the
+		readable set is the one pass above.
+		"""
+		from .doctypes import get_address_table
+
+		table = get_address_table()
+		names = table["modules"]
+
+		return {
+			names[module_slug]
+			for doctype, (_slug, module_slug) in table["doctypes"].items()
+			if module_slug in names and doctype in self.readable_doctypes
+		}
+
+	@cached_property
+	def permitted_pages(self) -> set[str]:
+		"""The `DeskViews` page set, read fresh rather than out of its six-hour per-user cache.
+
+		`get_allowed_pages(cache=True)` is what desk v1 reads, and #42231 decision 7 named that
+		cache a precedent not to extend: a stale set means a user keeps seeing an item for up to
+		six hours after losing the permission. Uncached it is one query, and only when a `Page`
+		item is actually on the list to ask about.
+		"""
+		from frappe.desk.desk_views import DeskViews
+
+		return set(DeskViews.get_allowed_pages())
+
+	# The type table
+
+	def rule(self, item_type: str | None) -> str | None:
+		return self._types.get(item_type, (None, None))[0]
+
+	def target(self, item_type: str | None) -> str | None:
+		return self._types.get(item_type, (None, None))[1]
+
+	def resolver(self, item_type: str):
+		"""The `can_see` an app contributed beside its renderer, or None.
+
+		One hook and not a second one: #42228 found that a kind is one contribution rather than a
+		scattering, so the override rides in the same `navigation_item_resolvers` entry as the
+		rest of the type's server code. (#42228 spelled the hook `sidebar_item_resolvers`, before
+		#42312 renamed the row family to `Navigation Item`.)
+
+		Two apps claiming one type name is a collision rather than an ordering: the type row
+		itself is owned by whichever app ships it, so a second app's resolver is filing code
+		against somebody else's kind. The later app wins, loudly — `override_doctype_class` taking
+		`[-1]` *silently* (`base_document.py:151`) is the precedent #42228 rejected, and the noise
+		is the whole difference.
+		"""
+		if item_type in self._resolvers:
+			return self._resolvers[item_type]
+
+		self._resolvers[item_type] = None
+		paths = frappe.get_hooks("navigation_item_resolvers", default={}).get(item_type) or []
+
+		if len(paths) > 1:
+			frappe.log_error(
+				title="Two apps contribute one navigation item type",
+				message=f"{item_type} is resolved by {paths}; the last one wins.",
+			)
+
+		for path in reversed(paths):
+			try:
+				self._resolvers[item_type] = frappe.get_attr(f"{path}.can_see")
+				return self._resolvers[item_type]
+			except Exception:
+				# A path an app got wrong is a bug in that app, and every way of getting it wrong
+				# lands here: a missing attribute, an unimportable module, and `get_attr`'s own
+				# throw for an app that is not installed. The type falls through to failing
+				# closed, which logs and names it.
+				frappe.log_error(title=f"Navigation item type {item_type} has an unusable resolver")
+
+		return None
+
+	@cached_property
+	def _types(self) -> dict[str, tuple[str, str]]:
+		"""`{type: (bucket, target_doctype)}` — what every kind declares about itself.
+
+		One query for both columns. The bucket lives on the type's own standard JSON record
+		because the server needs it before it runs anything, and because that keeps #42228's
+		property intact: a doctype-pointing kind picks a bucket in its JSON and writes no Python
+		at all (#42231 decision 9).
+		"""
+		return {
+			row.name: (row.permission_rule, row.target_doctype)
+			for row in frappe.get_all(
+				"Navigation Item Type", fields=["name", "permission_rule", "target_doctype"]
+			)
+		}
+
+	# What a derived item on the rail hangs off
+
+	@property
+	def sidebars(self) -> dict[str, list[dict]] | None:
+		"""This app's resolved sidebars, filtered, computed once and shared with the rail.
+
+		The rail is resolved *after* them and reads this, because a rail item pointing at a
+		sidebar derives from that sidebar's rows. Boot wants both anyway, so sharing costs
+		nothing there; the arrangement editor resolves a rail on its own and pays one pair of
+		queries to answer the same question honestly.
+
+		`None` while they are themselves being resolved. A sidebar row that points at a sidebar
+		would otherwise re-enter this and never come back, and "not resolved yet" is genuinely
+		not the same answer as "resolved to nothing".
+		"""
+		if not self.app:
+			# A caller holding one sidebar and no prefix. Unknown, not empty.
+			return None
+
+		if self._sidebars is None and not self._resolving:
+			from .navigation import resolve_sidebars
+
+			self._resolving = True
+			try:
+				self._sidebars = resolve_sidebars(self.app, self)
+			finally:
+				self._resolving = False
+
+		return self._sidebars
+
+	@property
+	def linked(self) -> set[str] | None:
+		sidebars = self.sidebars
+
+		return None if sidebars is None else set(sidebars)
+
+	# Failing closed, loudly
+
+	def report_unfilterable(self, item_type: str | None, count: int, *, custom: bool = False):
+		"""One log row per type per resolution, naming the kind and how many items it cost.
+
+		Deduped because `Error Log` writes are buffered and flushed at commit, so forty items of
+		one broken kind would land as forty near-identical rows nobody reads — which is how a
+		loud failure becomes a quiet one.
+
+		Failing closed is #42228's verdict on a missing *renderer* wearing its other hat: "no rule"
+		and "no renderer" behave identically, so an item that cannot be filtered is skipped and
+		logged. Not a security argument — under a courtesy filter an invisible item plus a log
+		entry surfaces the bug, while a silently visible one never does.
+		"""
+		if item_type in self._reported:
+			return
+
+		self._reported.add(item_type)
+		reason = (
+			"declares the Custom permission rule and contributes no `can_see`"
+			if custom
+			else "has no `Navigation Item Type` row, or declares a permission rule this version does not know"
+		)
+		frappe.log_error(
+			title="Navigation item type cannot be filtered",
+			message=f"{item_type!r} {reason}; {count} item(s) were skipped.",
+		)

--- a/frappe/tests/test_navigation_filter.py
+++ b/frappe/tests/test_navigation_filter.py
@@ -1,0 +1,583 @@
+# Copyright (c) 2026, Frappe Technologies and Contributors
+# License: MIT. See LICENSE
+
+"""The desk v2 navigation filter: `frappe/shell/navigation_filter.py`.
+
+**Every test here runs as somebody other than Administrator, and that is not a style choice.**
+#42231 decision 13 keeps Administrator's short-circuit, so Administrator passes every permission
+bucket before it is read — the shell measured them at 6 ms against an ordinary user's 3,594 ms
+largely because of that branch. A suite written as Administrator would pass against a filter that
+does nothing at all.
+
+The user is a `Desk User` with no other role. Measured on this bench, that reads 56 doctypes:
+`ToDo` yes, `Role` no — which is the pair almost every test below is built out of. `Role` is a
+core doctype whose permissions have only ever been System Manager's, so the pair is stable
+wherever this runs.
+"""
+
+import contextlib
+from unittest.mock import patch
+
+import frappe
+from frappe.shell.arrangement import get_arrangement, save_arrangement
+from frappe.shell.navigation import resolve_navigation, resolve_rail
+from frappe.tests.classes.context_managers import set_user
+from frappe.tests.test_shell_navigation import (
+	ADDRESS_KEY,
+	APP,
+	NavigationTestCase,
+	doctype_item,
+	item,
+	keys,
+	make_rail,
+	make_sidebar,
+	shipping,
+)
+
+READABLE = "ToDo"
+UNREADABLE = "Role"
+
+# A module holding something this user may read, and one holding nothing. `Desk` owns `ToDo`;
+# the empty one is minted per test rather than picked off the site, because which of a bench's
+# modules happen to be empty for a Desk User is a fact about the apps installed on it.
+FULL_MODULE = "Desk"
+EMPTY_MODULE = "Navigation Filter Test"
+
+# A page every desk session has, and one whose `Page.roles` has only ever been System
+# Manager's. Both are core frappe pages, so the pair travels.
+PERMITTED_PAGE = "desktop"
+FORBIDDEN_PAGE = "permission-manager"
+
+
+def a_desk_user(email: str = "navigation_filter@example.com") -> str:
+	if not frappe.db.exists("User", email):
+		frappe.get_doc(
+			doctype="User",
+			email=email,
+			first_name="Filtered",
+			user_type="System User",
+			roles=[{"role": "Desk User"}],
+		).insert(ignore_permissions=True)
+
+	return email
+
+
+def a_module(name: str = EMPTY_MODULE) -> str:
+	"""A module with no doctypes in it, so `Module Contents` has nothing to find."""
+	if not frappe.db.exists("Module Def", name):
+		frappe.get_doc(doctype="Module Def", module_name=name, app_name="frappe").insert(
+			ignore_permissions=True
+		)
+
+	return name
+
+
+def block(module: str, user: str):
+	"""Hide a module from one user the way `User.block_modules` does, and clear what caches it.
+
+	`tabBlock Module` holds **0 rows across 45 users** on both bench sites, so the veto cannot be
+	observed without seeding one — which is why it had never been exercised.
+	"""
+	doc = frappe.get_doc("User", user)
+	doc.append("block_modules", {"module": module})
+	doc.save(ignore_permissions=True)
+	frappe.clear_cache(user=user)
+
+
+def a_type(type_name: str, rule: str, **kwargs) -> str:
+	"""A `Navigation Item Type` row, for the cases the framework's own eight cannot produce."""
+	with shipping():
+		frappe.get_doc(
+			doctype="Navigation Item Type",
+			type_name=type_name,
+			module="Desk",
+			permission_rule=rule,
+			**kwargs,
+		).insert(ignore_permissions=True)
+
+	return type_name
+
+
+def vanish(type_name: str):
+	"""Take a type row away after its items were authored.
+
+	This is the only way to *reach* the unknown-kind path, and it is also the real one:
+	`item_type` is a Link, so nothing can author a row naming a type nobody shipped. An app that
+	contributed a kind and was then uninstalled leaves exactly this behind.
+	"""
+	frappe.db.delete("Navigation Item Type", {"name": type_name})
+
+
+def a_todo() -> str:
+	return frappe.get_doc(doctype="ToDo", description="Filtered").insert(ignore_permissions=True).name
+
+
+@contextlib.contextmanager
+def contributing(item_type: str, path: str = "frappe.tests.test_navigation_filter"):
+	"""Stand in for an app's `navigation_item_resolvers` entry, leaving every other hook alone."""
+	real = frappe.get_hooks
+
+	def hooks(hook=None, default="_KEEP_DEFAULT_LIST", app_name=None):
+		if hook == "navigation_item_resolvers":
+			return {item_type: [path]}
+		return real(hook, default, app_name)
+
+	with patch("frappe.get_hooks", hooks):
+		yield
+
+
+def can_see(items, context):
+	"""The `Custom` bucket's contributed half, as an app would ship it.
+
+	Batched by design: it is handed every item of its kind at once, plus the context whose sets
+	this pass has already paid for, and returns the ones it allows.
+	"""
+	seen.append(len(items))
+
+	return [entry for entry in items if entry.get("label") != "secret"]
+
+
+seen: list[int] = []
+
+
+def rail_keys(user: str) -> list[str]:
+	with set_user(user):
+		return keys(resolve_navigation(APP)["rail"])
+
+
+class FilterTestCase(NavigationTestCase):
+	def setUp(self):
+		super().setUp()
+		self.user = a_desk_user()
+		seen.clear()
+		# `block` writes a `Block Module` row and clears the user cache to make it visible. The
+		# savepoint rolls the row back; nothing rolls the cache back, so a stale `User` document
+		# would carry one test's block into the next one. Both users, because the veto test blocks
+		# a module on Administrator.
+		for user in (self.user, "Administrator"):
+			self.addCleanup(frappe.clear_cache, user=user)
+
+	def errors(self, title: str) -> int:
+		return frappe.db.count("Error Log", {"method": title})
+
+
+class TestReadableDocType(FilterTestCase):
+	"""The bucket every doctype-pointing kind declares, and the only one the branch had."""
+
+	def test_an_item_pointing_at_an_unreadable_doctype_is_dropped(self):
+		make_rail(
+			[doctype_item("mine", READABLE), doctype_item("theirs", UNREADABLE)],
+			standard=1,
+		)
+
+		self.assertEqual(rail_keys(self.user), ["mine"])
+
+	def test_a_record_item_is_checked_on_its_own_link_doctype(self):
+		"""`Record` is the one kind that carries the doctype separately, and the column it is read
+		from comes off the type row's `target_doctype` rather than off a list of type names.
+
+		Checked at doctype level and no further. #42231 decision 4 accepted the leak outright: a
+		per-row `has_permission(doctype, doc=name)` is exactly the shape the 3,594 ms measurement
+		punishes, so a Record item can show and then refuse on click."""
+		make_rail(
+			[
+				item("mine", item_type="Record", link_doctype=READABLE, link_to=a_todo()),
+				item("theirs", item_type="Record", link_doctype=UNREADABLE, link_to="System Manager"),
+			],
+			standard=1,
+		)
+
+		self.assertEqual(rail_keys(self.user), ["mine"])
+
+	def test_administrator_sees_what_the_bucket_would_have_dropped(self):
+		"""#42231 decision 13. Removing the short-circuit would make navigation stricter than the
+		permission system it is a courtesy over — and it is why every other test here changes
+		user first."""
+		make_rail([doctype_item("theirs", UNREADABLE)], standard=1)
+
+		self.assertEqual(keys(resolve_navigation(APP)["rail"]), ["theirs"])
+
+
+class TestModuleContents(FilterTestCase):
+	"""A module is offered when something in it is readable, and never when this user blocked it."""
+
+	def test_a_module_holding_something_readable_survives(self):
+		make_rail([item("desk", item_type="Module", link_to=FULL_MODULE)], standard=1)
+
+		self.assertEqual(rail_keys(self.user), ["desk"])
+
+	def test_a_module_holding_nothing_readable_is_dropped(self):
+		make_rail([item("empty", item_type="Module", link_to=a_module())], standard=1)
+
+		self.assertEqual(rail_keys(self.user), [])
+
+	def test_a_blocked_module_ships_nothing(self):
+		"""Not #42230's `hidden`, which travels with a flag so the person who set it can unset it.
+		A blocked module is not reversible by the reader, so it is absent rather than flagged."""
+		make_rail([item("desk", item_type="Module", link_to=FULL_MODULE)], standard=1)
+		block(FULL_MODULE, self.user)
+
+		self.assertEqual(rail_keys(self.user), [])
+
+	def test_no_layer_can_resurface_a_blocked_module(self):
+		"""The veto runs with permission filtering, over the merged list, so an addition is
+		subject to it. `develop`'s `test_curation_cannot_resurface_a_blocked_module` is the
+		behaviour this matches."""
+		make_rail([doctype_item("mine", READABLE)], standard=1)
+		make_rail(
+			[item("desk", item_type="Module", link_to=FULL_MODULE, added=1)],
+			user=self.user,
+		)
+		block(FULL_MODULE, self.user)
+
+		self.assertEqual(rail_keys(self.user), ["mine"])
+
+	def test_an_item_inside_a_blocked_module_is_not_touched(self):
+		"""The veto gates module-derived items only. Cascading downward is what
+		`is_module_visible`'s own docstring forbids: hiding a module hides the way to a document,
+		never the document."""
+		make_rail([doctype_item("todo", READABLE)], standard=1)
+		block(FULL_MODULE, self.user)
+
+		self.assertEqual(rail_keys(self.user), ["todo"])
+
+	def test_an_empty_module_and_a_blocked_one_are_not_the_same_answer(self):
+		"""Administrator short-circuits the contents rule and is still subject to the veto, so the
+		two facts have to be told apart. Reading the module universe off the address table
+		collapsed them: it only names a module owning at least one non-child doctype, so a module
+		with nothing in it looked exactly like a blocked one."""
+		make_rail([item("empty", item_type="Module", link_to=a_module())], standard=1)
+
+		self.assertEqual(keys(resolve_navigation(APP)["rail"]), ["empty"])
+
+	def test_the_block_is_a_veto_and_not_a_permission(self):
+		"""So it runs ahead of the Administrator branch rather than behind it. An administrator
+		who hid a module from themselves meant it; that is their own preference row, and nothing
+		else on the User form says otherwise."""
+		make_rail([item("desk", item_type="Module", link_to=FULL_MODULE)], standard=1)
+		block(FULL_MODULE, "Administrator")
+
+		self.assertEqual(keys(resolve_navigation(APP)["rail"]), [])
+
+
+class TestTheOtherBuckets(FilterTestCase):
+	def test_a_page_the_user_has_not_got_is_dropped(self):
+		make_rail(
+			[
+				item("desktop", item_type="Page", link_to=PERMITTED_PAGE),
+				item("nowhere", item_type="Page", link_to=FORBIDDEN_PAGE),
+			],
+			standard=1,
+		)
+
+		self.assertEqual(rail_keys(self.user), ["desktop"])
+
+	def test_a_link_is_never_filtered(self):
+		"""`Always Visible` is an explicit bucket rather than a fall-through, which is the whole
+		difference from the dock's ungated `URL` case."""
+		make_rail([item("out", item_type="Link", url="https://frappe.io")], standard=1)
+
+		self.assertEqual(rail_keys(self.user), ["out"])
+
+
+class TestTheCascade(FilterTestCase):
+	"""`Derived From Children`: an item is worth showing while something under it survives."""
+
+	def test_a_section_whose_children_all_went_goes_too(self):
+		make_rail(
+			[
+				item("group", item_type="Section", label="Admin"),
+				doctype_item("theirs", UNREADABLE, parent_key="group"),
+			],
+			standard=1,
+		)
+
+		self.assertEqual(rail_keys(self.user), [])
+
+	def test_a_section_keeping_one_child_stays(self):
+		make_rail(
+			[
+				item("group", item_type="Section", label="Mixed"),
+				doctype_item("theirs", UNREADABLE, parent_key="group"),
+				doctype_item("mine", READABLE, parent_key="group"),
+			],
+			standard=1,
+		)
+
+		self.assertEqual(rail_keys(self.user), ["group", "mine"])
+
+	def test_an_emptied_section_takes_the_section_holding_it(self):
+		"""To a fixpoint, not one pass. A section holding only an emptied section is itself
+		empty, and stopping after one sweep leaves the outer one standing over nothing."""
+		make_rail(
+			[
+				item("outer", item_type="Section", label="Outer"),
+				item("inner", item_type="Section", label="Inner", parent_key="outer"),
+				doctype_item("theirs", UNREADABLE, parent_key="inner"),
+			],
+			standard=1,
+		)
+
+		self.assertEqual(rail_keys(self.user), [])
+
+	def test_an_item_dropped_by_any_other_bucket_leaves_its_children(self):
+		"""A permission rule about a heading says nothing about the rows under it, so they are
+		promoted to the top level — the same treatment as an app removing a section."""
+		make_rail(
+			[
+				doctype_item("theirs", UNREADABLE),
+				doctype_item("mine", READABLE, parent_key="theirs"),
+			],
+			standard=1,
+		)
+
+		with set_user(self.user):
+			rail = resolve_navigation(APP)["rail"]
+
+		self.assertEqual(keys(rail), ["mine"])
+		self.assertNotIn("parent_key", rail[0])
+
+	def test_a_hidden_section_is_not_counted_as_a_surviving_child(self):
+		"""Filtering runs after `_drop_hidden`, so a section whose only child the person hid is
+		empty rather than full."""
+		make_rail(
+			[
+				item("group", item_type="Section", label="Mine"),
+				doctype_item("mine", READABLE, parent_key="group"),
+			],
+			standard=1,
+		)
+		make_rail([item("mine", hidden=1)], user=self.user)
+
+		self.assertEqual(rail_keys(self.user), [])
+
+
+class TestLinkedSidebars(FilterTestCase):
+	"""A rail item of type `Sidebar` derives from rows that are not on the rail at all."""
+
+	def test_a_rail_item_whose_sidebar_filtered_away_is_dropped(self):
+		"""#42421 found this has no other observable form: a `Sidebar` item's whole content is
+		the sidebar, so with no rows it has no destination, and "renders as independent" and "is
+		not drawn" are the same picture."""
+		make_sidebar([doctype_item("theirs", UNREADABLE)], standard=1)
+		make_rail(
+			[item("core", item_type="Sidebar", link_doctype="Sidebar", link_to=ADDRESS_KEY)],
+			standard=1,
+		)
+
+		with set_user(self.user):
+			payload = resolve_navigation(APP)
+
+		self.assertEqual(keys(payload["rail"]), [])
+		self.assertNotIn(ADDRESS_KEY, payload["sidebars"])
+
+	def test_a_rail_item_whose_sidebar_keeps_a_row_stays(self):
+		make_sidebar([doctype_item("mine", READABLE), doctype_item("theirs", UNREADABLE)], standard=1)
+		make_rail(
+			[item("core", item_type="Sidebar", link_doctype="Sidebar", link_to=ADDRESS_KEY)],
+			standard=1,
+		)
+
+		with set_user(self.user):
+			payload = resolve_navigation(APP)
+
+		self.assertEqual(keys(payload["rail"]), ["core"])
+		self.assertEqual(keys(payload["sidebars"][ADDRESS_KEY]), ["mine"])
+
+
+class TestFailingClosed(FilterTestCase):
+	"""An item nobody can filter is skipped and logged, which is #42228's verdict on a missing
+	renderer wearing its other hat: "no rule" and "no renderer" behave the same way."""
+
+	TITLE = "Navigation item type cannot be filtered"
+
+	def test_an_item_of_an_unknown_type_is_dropped_and_logged(self):
+		"""`is_item_allowed` returns False here and the dock's `is_reachable` returns True. The
+		divergence is resolved in the sidebar's favour."""
+		make_rail(
+			[
+				doctype_item("mine", READABLE),
+				item("mystery", item_type=a_type("Vanishing", "Always Visible")),
+			],
+			standard=1,
+		)
+		vanish("Vanishing")
+		before = self.errors(self.TITLE)
+
+		self.assertEqual(rail_keys(self.user), ["mine"])
+		self.assertEqual(self.errors(self.TITLE), before + 1)
+
+	def test_one_log_row_per_type_however_many_items(self):
+		"""`Error Log` writes are buffered and flushed at commit, so forty items of one broken
+		kind would land as forty near-identical rows nobody reads — which is how a loud failure
+		becomes a quiet one."""
+		gone = a_type("Vanishing", "Always Visible")
+		make_rail([item(f"mystery{index}", item_type=gone) for index in range(5)], standard=1)
+		vanish(gone)
+		before = self.errors(self.TITLE)
+
+		self.assertEqual(rail_keys(self.user), [])
+		self.assertEqual(self.errors(self.TITLE), before + 1)
+
+	def test_a_custom_type_shipping_no_resolver_fails_closed(self):
+		"""The declaration is a promise of code, so the missing half is a bug in an app rather
+		than a reason to show the item."""
+		a_type("Unresolved", "Custom")
+		make_rail([item("mine", item_type="Unresolved")], standard=1)
+		before = self.errors(self.TITLE)
+
+		self.assertEqual(rail_keys(self.user), [])
+		self.assertEqual(self.errors(self.TITLE), before + 1)
+
+	def test_administrator_is_not_exempt_from_this_one(self):
+		"""The short-circuit is over the *permission* buckets. A kind nobody can filter is a bug
+		an administrator especially needs to see, and an empty section is a stray heading for
+		them too."""
+		make_rail([item("mystery", item_type=a_type("Vanishing", "Always Visible"))], standard=1)
+		vanish("Vanishing")
+
+		self.assertEqual(keys(resolve_navigation(APP)["rail"]), [])
+
+
+class TestTheCustomBucket(FilterTestCase):
+	"""The one door out, and #42228's finding that a kind is one contribution rather than a
+	scattering: the override rides in the same hook entry as the rest of the type's server code."""
+
+	def test_the_type_decides_and_is_asked_once(self):
+		a_type("Contributed", "Custom")
+		make_rail(
+			[
+				item("keep", item_type="Contributed", label="fine"),
+				item("drop", item_type="Contributed", label="secret"),
+				item("keep_too", item_type="Contributed", label="fine"),
+			],
+			standard=1,
+		)
+
+		with contributing("Contributed"):
+			self.assertEqual(rail_keys(self.user), ["keep", "keep_too"])
+
+		# Batched, not per item. A per-item signature is the shape that produced the 3,594 ms
+		# measurement, and it invites an override to loop over `frappe.has_permission`.
+		self.assertEqual(seen, [3])
+
+	def test_a_resolver_that_raises_fails_closed(self):
+		"""A rail that silently showed everything because one app's filter threw is the failure
+		this bucket exists to make impossible."""
+
+		def boom(items, context):
+			raise ValueError("no")
+
+		a_type("Contributed", "Custom")
+		make_rail([item("mine", item_type="Contributed")], standard=1)
+
+		with contributing("Contributed"), patch(f"{__name__}.can_see", boom):
+			self.assertEqual(rail_keys(self.user), [])
+
+	def test_the_resolver_is_handed_the_sets_this_pass_already_paid_for(self):
+		captured = {}
+
+		def nosy(items, context):
+			captured["readable"] = context.readable_doctypes
+			captured["user"] = context.user
+			return items
+
+		a_type("Contributed", "Custom")
+		make_rail([item("mine", item_type="Contributed")], standard=1)
+
+		with contributing("Contributed"), patch(f"{__name__}.can_see", nosy):
+			self.assertEqual(rail_keys(self.user), ["mine"])
+
+		self.assertEqual(captured["user"], self.user)
+		self.assertIn(READABLE, captured["readable"])
+
+
+class TestContributedRows(FilterTestCase):
+	"""What replacing `_readable` actually changed.
+
+	Contributed rows were the one thing this resolver filtered, on `Readable DocType` alone and
+	before the merge — the stopgap #42364 needed because the host is the one party that cannot
+	refuse a row another app files onto its rail. They now go through the same pass as everything
+	else, on whatever bucket their own type declares.
+	"""
+
+	def test_a_contributed_doctype_item_is_still_dropped(self):
+		make_rail([doctype_item("mine", READABLE)], standard=1)
+		make_rail([doctype_item("theirs", UNREADABLE)], standard=1, extends=APP, app="crm")
+
+		self.assertEqual(rail_keys(self.user), ["mine"])
+
+	def test_a_contributed_page_item_is_now_checked_too(self):
+		"""Under the old narrow rule a contributed `Page` item rode in unchecked, because the
+		rule only knew one bucket."""
+		make_rail([doctype_item("mine", READABLE)], standard=1)
+		make_rail(
+			[item("nowhere", item_type="Page", link_to=FORBIDDEN_PAGE)],
+			standard=1,
+			extends=APP,
+			app="crm",
+		)
+
+		self.assertEqual(rail_keys(self.user), ["mine"])
+
+
+class TestWhereTheFilterSits(FilterTestCase):
+	"""#42231 decision 11: arrangement resolves before filtering, addition is filtered after."""
+
+	def test_a_layer_cannot_add_an_item_the_user_may_not_see(self):
+		make_rail([doctype_item("mine", READABLE)], standard=1)
+		make_rail([doctype_item("theirs", UNREADABLE, added=1)], user=self.user)
+
+		self.assertEqual(rail_keys(self.user), ["mine"])
+
+	def test_a_move_resolves_against_the_full_list_and_not_the_filtered_one(self):
+		"""#42230 decision 8's property, which is why the merge runs first. The move names an
+		item this user cannot see; it still lands where the person who wrote it meant, because
+		the anchor was resolved before anything was dropped."""
+		make_rail(
+			[doctype_item("a", READABLE), doctype_item("gone", UNREADABLE), doctype_item("b", READABLE)],
+			standard=1,
+		)
+		make_rail(
+			[item("b", anchors='[{"before": "gone"}]')],
+			user=self.user,
+		)
+
+		self.assertEqual(rail_keys(self.user), ["a", "b"])
+
+
+class TestTheEditorBypass(FilterTestCase):
+	"""The single named exception (#42231 decision 12), and the scope that earns it."""
+
+	def test_the_site_scope_shows_a_manager_rows_they_cannot_see(self):
+		"""A manager arranging the site's rail is arranging it for everybody. Filtered down to
+		what they personally may see, saving that list would silently delete other people's
+		items."""
+		make_rail([doctype_item("mine", READABLE), doctype_item("theirs", UNREADABLE)], standard=1)
+
+		self.assertEqual(keys(get_arrangement("Rail", APP, scope="site")), ["mine", "theirs"])
+
+	def test_the_user_scope_does_not(self):
+		"""Nothing is bought by it: a person arranging their own list has nobody else's items to
+		delete, so showing them rows they may not see would be a leak with no upside."""
+		make_rail([doctype_item("mine", READABLE), doctype_item("theirs", UNREADABLE)], standard=1)
+
+		with set_user(self.user):
+			self.assertEqual(keys(get_arrangement("Rail", APP)), ["mine"])
+
+	def test_a_save_reduces_against_the_same_list_it_showed(self):
+		"""The read and the reduce base are set from one place, so a person's moves anchor
+		against the list the client was actually looking at."""
+		make_rail([doctype_item("mine", READABLE), doctype_item("theirs", UNREADABLE)], standard=1)
+
+		with set_user(self.user):
+			showing = get_arrangement("Rail", APP)
+			payload = save_arrangement("Rail", APP, [dict(entry) for entry in showing])
+
+		self.assertEqual(keys(payload["rail"]), ["mine"])
+
+	def test_the_bypass_is_off_everywhere_else(self):
+		make_rail([doctype_item("theirs", UNREADABLE)], standard=1)
+
+		with set_user(self.user):
+			self.assertEqual(keys(resolve_rail(APP)), [])


### PR DESCRIPTION
Builds the single navigation filter that [What filters an item, and where](https://github.com/frappe/frappe/issues/42231) designed, for [Filter an authored rail](https://github.com/frappe/frappe/issues/42422).

## What was there

`_readable` (`frappe/shell/navigation.py`) applied exactly one bucket, `Readable DocType`, and only to rows another app **contributed** to a host's rail — the narrow thing the rail-extension work needed, because the host is the one party that cannot refuse a row filed onto it. Every other row was unfiltered. No leak existed yet only because every rail on the branch is derived and derivation reads `get_readable_doctypes()` already; the moment an app ships an authored `Rail` record that stops being true.

## What this does

**Six buckets, read off the type row.** Each `Navigation Item Type` declares its own `permission_rule`, so a doctype-pointing kind picks a value in its JSON and writes no Python at all:

| bucket | rule |
|---|---|
| `Readable DocType` | the destination doctype is in `get_doctypes_with_read() \| get_shared_doctypes()` |
| `Module Contents` | something in the module is readable, and the user has not blocked it |
| `Derived From Children` | something under it survived |
| `Permitted Page` | the page is in the `DeskViews` page set |
| `Always Visible` | never filtered |
| `Custom` | the type's own batched `can_see(items, ctx)`, from a `navigation_item_resolvers` hook entry |

Which column names the doctype comes off the type's `target_doctype` rather than a hardcoded list of type names, so `DocType` and `Record` fall out of one rule and so does a contributed kind that picks the bucket.

**The section cascade.** An emptied `Section` drops like an emptied `Sidebar`, to a fixpoint, so a section holding only an emptied section goes too. `develop` never permission-checks a Section Break, which leaves a heading over nothing — a door you cannot open. A rail item of type `Sidebar` derives from that sidebar's rows, which is why the sidebars now resolve before the rail.

**Unknown kinds fail closed and log once per type.** `is_item_allowed` returns `False` for a type it does not know and the dock's `is_reachable` returns `True`; that disagreement arrived by there being two places to put one rule, and it is resolved in the sidebar's favour. The log is deduped because `Error Log` writes are buffered and flushed at commit, so forty items of one broken kind would land as forty rows nobody reads.

**`User.block_modules` becomes a veto.** It gates module-derived items only — block Accounts and a `DocType` item pointing at Sales Invoice stays — and it runs before any layer merges, so no layer can resurface a blocked module. It is a preference rather than a permission, so it applies to Administrator too, who short-circuits every other bucket.

**Where the filter sits.** On the merged list, after `_drop_hidden` and before orphans are promoted. Arrangement resolves against the full base, so one person's stored move means the same thing whatever they may see; the filter then runs over its result, which is what stops an addition from bringing back an item the person is not allowed to see. The layer editor keeps the one named bypass, at **site** scope only: a manager arranging for everybody must not silently delete other people's items, while a person arranging their own list has nobody else's to delete.

## Cost

No per-item permission call anywhere. Inputs are computed once per resolution — one `get_readable_doctypes` pass, one `get_visible_modules` call, one read of the type table — and shared by the rail and every sidebar in the prefix. Measured on this bench, `resolve_navigation("frappe")` warm: **194 items, 20,618 B, 6.3-7.9 ms** as Administrator, unchanged from before this landed; the filter pass alone over those 194 items, for an ordinary Desk User and with a cold context each time, is **1.6-2.3 ms**.

Not `request_cache`, which would be the obvious home and is wrong: nothing clears it on `frappe.set_user`, and these are per-user sets.

## Tests

34 new (`frappe/tests/test_navigation_filter.py`), and **every one runs as somebody other than Administrator** — the short-circuit means a suite written as Administrator would pass against a filter that does nothing at all. 217 green across the six navigation and shell suites.

One defect the review caught and the tests now pin: reading the module universe off the address table made "this module has nothing addressable in it" and "this user blocked it" the same answer. They are two different facts, and only one of them outranks Administrator.

>no-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
