### PR TITLE
fix: apply the module veto to a sidebar addressed at that module

### DIFF
--- a/frappe/shell/arrangement.py
+++ b/frappe/shell/arrangement.py
@@ -34,6 +34,7 @@ import frappe
 from frappe import _
 
 from .navigation import SITE_LAYER, resolve_navigation, resolve_rail, resolve_sidebar
+from .navigation_filter import NavigationContext
 from .permissions import has_app_permission
 
 # The two containers, and what each needs to find or write a layer. `field` is the table the
@@ -206,6 +207,21 @@ def _target(container: str, address: str, scope: str) -> Target:
 		app, link_doctype, link_to = _sidebar_address(address)
 		resolve = partial(resolve_sidebar, link_doctype, link_to, check_permission=check_permission)
 		stored |= {"app": app, "link_doctype": link_doctype, "link_to": link_to}
+
+		# A sidebar this person's blocked module takes away resolves to nothing, and a save
+		# against nothing is a **delete**: the reduction drops every submitted row and `_write`
+		# reads an empty one as "drop the layer". So an editor still open when the block landed
+		# would quietly destroy an arrangement its owner cannot see to rebuild. Refused rather
+		# than special-cased in the reducer, because the honest answer to "arrange this" is that
+		# there is no longer a list to arrange. Site scope bypasses this with the rest of the
+		# filter, since the block is one person's and the site's list is everybody's.
+		if check_permission and not NavigationContext("").address_is_offered(link_doctype, link_to):
+			frappe.throw(
+				_("{0} is not available to you, so there is nothing here to arrange.").format(
+					frappe.bold(link_to)
+				),
+				title=_("Nothing to Arrange"),
+			)
 
 	# Before the gate, because `has_app_permission` falls back to "is a System User" for an app
 	# that declares no `app_permission` hook -- and an app that is not on the bench declares

--- a/frappe/shell/navigation.py
+++ b/frappe/shell/navigation.py
@@ -180,6 +180,12 @@ def resolve_sidebars(app: str, context: NavigationContext | None = None) -> dict
 	resolved = {}
 
 	for address in addresses:
+		# Before the rows and before the layers, because a blocked module ships nothing and no
+		# layer may put it back (#42323). The rows would each survive on their own: they are
+		# `DocType` items, and the block deliberately does not cascade down to them.
+		if not context.address_is_offered(*address):
+			continue
+
 		by_layer = layers.get(address, {})
 		base = by_layer.get("standard", [])
 		items = _merge(base, _upto(by_layer, "user"), context=context)
@@ -209,15 +215,20 @@ def resolve_sidebar(
 	pre-mount path. The arrangement editor is the other kind of caller: it is holding one sidebar
 	and paying one request for it, so it reads that one.
 	"""
+	# No app to build a context for, and none needed: a sidebar's own rows are filtered on their
+	# buckets alone, and the one rule that reaches across containers runs on the rail.
+	context = NavigationContext("") if check_permission else None
+
+	if context is not None and not context.address_is_offered(link_doctype, link_to):
+		return []
+
 	by_layer = _sidebar_layers([(link_doctype, link_to)]).get((link_doctype, link_to), {})
 
 	return _merge(
 		by_layer.get("standard", []),
 		_upto(by_layer, upto),
 		keep_hidden=keep_hidden,
-		# No app to build a context for, and none needed: a sidebar's own rows are filtered on
-		# their buckets alone, and the one rule that reaches across containers runs on the rail.
-		context=NavigationContext("") if check_permission else None,
+		context=context,
 	)
 
 

--- a/frappe/shell/navigation_filter.py
+++ b/frappe/shell/navigation_filter.py
@@ -259,6 +259,33 @@ class NavigationContext:
 	def page_is_permitted(self, page: str | None) -> bool:
 		return bool(page) and (self.administrator or page in self.permitted_pages)
 
+	def address_is_offered(self, link_doctype: str | None, link_to: str | None) -> bool:
+		"""Whether a whole sidebar's address survives this user's own vetoes.
+
+		A veto and never a permission, so this asks one question and not the two
+		`module_is_offered` asks. Whether a module holds anything readable is already decided
+		row by row, and a module sidebar may link outside its own module — 101 of ERPNext's
+		rows do — so requiring the module's *contents* here would empty a sidebar whose rows
+		are all fine. What is left over is the block, which nothing else can ask on this user's
+		behalf.
+
+		It exists because a module-primary rail reaches a module through a `Sidebar` item whose
+		rows are `DocType` items, and `block_modules` gates module-derived items only. So the
+		veto #42323 settled — a blocked module ships nothing, its page stays reachable — held
+		for a `Module` item and missed the case charter point 2 exists for. Blocking Accounts on
+		ERPNext's rail left all 73 rows and the rail item standing.
+
+		The address is where it lands rather than the rail item, and that is what keeps it one
+		rule: a desk v2 module sidebar is *addressed* at its `Module Def`, so the sidebar is the
+		thing the block can name. The rail item then goes on its own, through the
+		`Derived From Children` cascade it already runs under — no new bucket, no second path,
+		and a site or user layer over that sidebar goes with it for free.
+		"""
+		if link_doctype != "Module Def":
+			return True
+
+		return bool(link_to) and link_to not in self.blocked_modules
+
 	@cached_property
 	def readable_doctypes(self) -> set[str]:
 		"""`get_doctypes_with_read() | get_shared_doctypes()`, once.

--- a/frappe/shell/navigation_filter.py
+++ b/frappe/shell/navigation_filter.py
@@ -262,24 +262,15 @@ class NavigationContext:
 	def address_is_offered(self, link_doctype: str | None, link_to: str | None) -> bool:
 		"""Whether a whole sidebar's address survives this user's own vetoes.
 
-		A veto and never a permission, so this asks one question and not the two
-		`module_is_offered` asks. Whether a module holds anything readable is already decided
-		row by row, and a module sidebar may link outside its own module — 101 of ERPNext's
-		rows do — so requiring the module's *contents* here would empty a sidebar whose rows
-		are all fine. What is left over is the block, which nothing else can ask on this user's
-		behalf.
+		The block only, and not the two questions `module_is_offered` asks. A module sidebar may
+		link outside its own module — 101 of ERPNext's rows do — so asking about the module's
+		*contents* here would empty a sidebar whose rows are all fine.
 
-		It exists because a module-primary rail reaches a module through a `Sidebar` item whose
-		rows are `DocType` items, and `block_modules` gates module-derived items only. So the
-		veto #42323 settled — a blocked module ships nothing, its page stays reachable — held
-		for a `Module` item and missed the case charter point 2 exists for. Blocking Accounts on
-		ERPNext's rail left all 73 rows and the rail item standing.
-
-		The address is where it lands rather than the rail item, and that is what keeps it one
-		rule: a desk v2 module sidebar is *addressed* at its `Module Def`, so the sidebar is the
-		thing the block can name. The rail item then goes on its own, through the
-		`Derived From Children` cascade it already runs under — no new bucket, no second path,
-		and a site or user layer over that sidebar goes with it for free.
+		It lands on the address rather than on the rail item because that is what keeps it one
+		rule: a module sidebar is addressed at its `Module Def`, so the block has something to
+		name, and the rail item then goes on its own through the `Derived From Children` cascade
+		(#42423). Without it the veto misses every module-primary rail, since such a rail reaches
+		a module through a `Sidebar` item whose rows are `DocType` items.
 		"""
 		if link_doctype != "Module Def":
 			return True

--- a/frappe/tests/test_navigation_filter.py
+++ b/frappe/tests/test_navigation_filter.py
@@ -389,15 +389,10 @@ class TestLinkedSidebars(FilterTestCase):
 class TestTheModuleVetoOnASidebar(FilterTestCase):
 	"""`block_modules` reaching a sidebar through the module it is *addressed* at.
 
-	The tests above cover a `Module` item, which is how a doctype-primary app meets a module.
-	A module-primary app never authors one: it reaches a module through a `Sidebar` item, and
-	that sidebar holds `DocType` rows, which the veto deliberately does not touch. So blocking
-	Accounts on ERPNext's rail left all 73 rows and the rail item standing (#42423), and the
-	rule #42323 settled missed the case charter point 2 exists for.
-
-	`Module Def` is the whole test: a desk v2 module sidebar is addressed at its module, so the
-	block has something to name. The rail item then goes on its own through the
-	`Derived From Children` cascade, which is why nothing below asserts a second mechanism.
+	The tests above cover a `Module` item, which is how a doctype-primary app meets a module. A
+	module-primary app never authors one: it reaches a module through a `Sidebar` item holding
+	`DocType` rows, which the veto deliberately does not touch — so it used to miss that whole
+	shape of rail (#42423).
 	"""
 
 	DOCTYPE_ADDRESS = ("DocType", READABLE)
@@ -498,6 +493,36 @@ class TestTheModuleVetoOnASidebar(FilterTestCase):
 			rows = resolve_sidebar(*ADDRESS, check_permission=False)
 
 		self.assertEqual(keys(rows), ["mine"])
+
+	def test_arranging_a_blocked_module_s_sidebar_is_refused(self):
+		"""A save against a list that resolves to nothing is a **delete**: every submitted row
+		reduces away and an empty reduction drops the layer. So an editor still open when the
+		block landed would destroy an arrangement its owner can no longer see to rebuild."""
+		make_sidebar([doctype_item("mine", READABLE), doctype_item("also", "Note")], standard=1)
+
+		with set_user(self.user):
+			showing = [dict(entry) for entry in get_arrangement("Sidebar", ADDRESS_KEY)]
+			showing.insert(0, showing.pop())
+			save_arrangement("Sidebar", ADDRESS_KEY, showing)
+
+		block("Core", self.user)
+
+		with set_user(self.user):
+			with self.assertRaises(frappe.ValidationError):
+				save_arrangement("Sidebar", ADDRESS_KEY, showing)
+
+		self.assertTrue(
+			frappe.db.exists("Sidebar", {"link_to": "Core", "user": self.user, "standard": 0}),
+			"the arrangement is still there",
+		)
+
+	def test_the_site_scope_may_still_arrange_it(self):
+		"""The block is one person's and the site's list is everybody's, so site scope bypasses
+		this with the rest of the filter."""
+		make_sidebar([doctype_item("mine", READABLE)], standard=1)
+		block("Core", "Administrator")
+
+		self.assertEqual(keys(get_arrangement("Sidebar", ADDRESS_KEY, scope="site")), ["mine"])
 
 
 class TestFailingClosed(FilterTestCase):

--- a/frappe/tests/test_navigation_filter.py
+++ b/frappe/tests/test_navigation_filter.py
@@ -23,6 +23,7 @@ from frappe.shell.arrangement import get_arrangement, save_arrangement
 from frappe.shell.navigation import resolve_navigation, resolve_rail
 from frappe.tests.classes.context_managers import set_user
 from frappe.tests.test_shell_navigation import (
+	ADDRESS,
 	ADDRESS_KEY,
 	APP,
 	NavigationTestCase,
@@ -383,6 +384,120 @@ class TestLinkedSidebars(FilterTestCase):
 
 		self.assertEqual(keys(payload["rail"]), ["core"])
 		self.assertEqual(keys(payload["sidebars"][ADDRESS_KEY]), ["mine"])
+
+
+class TestTheModuleVetoOnASidebar(FilterTestCase):
+	"""`block_modules` reaching a sidebar through the module it is *addressed* at.
+
+	The tests above cover a `Module` item, which is how a doctype-primary app meets a module.
+	A module-primary app never authors one: it reaches a module through a `Sidebar` item, and
+	that sidebar holds `DocType` rows, which the veto deliberately does not touch. So blocking
+	Accounts on ERPNext's rail left all 73 rows and the rail item standing (#42423), and the
+	rule #42323 settled missed the case charter point 2 exists for.
+
+	`Module Def` is the whole test: a desk v2 module sidebar is addressed at its module, so the
+	block has something to name. The rail item then goes on its own through the
+	`Derived From Children` cascade, which is why nothing below asserts a second mechanism.
+	"""
+
+	DOCTYPE_ADDRESS = ("DocType", READABLE)
+	DOCTYPE_ADDRESS_KEY = "doctype_todo"
+
+	def module_sidebar_on_the_rail(self):
+		"""What a module-primary rail ships: a linked item over a sidebar of readable rows."""
+		make_sidebar([doctype_item("mine", READABLE)], standard=1)
+		make_rail(
+			[item("core", item_type="Sidebar", link_doctype="Sidebar", link_to=ADDRESS_KEY)],
+			standard=1,
+		)
+
+	def test_a_module_sidebar_goes_when_its_module_is_blocked(self):
+		self.module_sidebar_on_the_rail()
+		block("Core", self.user)
+
+		with set_user(self.user):
+			payload = resolve_navigation(APP)
+
+		self.assertNotIn(ADDRESS_KEY, payload["sidebars"])
+		self.assertEqual(keys(payload["rail"]), [], "the rail item goes with its sidebar")
+
+	def test_the_same_sidebar_survives_when_another_module_is_blocked(self):
+		"""The veto names one module, so it is worth showing that it names only that one."""
+		self.module_sidebar_on_the_rail()
+		block(FULL_MODULE, self.user)
+
+		with set_user(self.user):
+			payload = resolve_navigation(APP)
+
+		self.assertEqual(keys(payload["sidebars"][ADDRESS_KEY]), ["mine"])
+		self.assertEqual(keys(payload["rail"]), ["core"])
+
+	def test_a_row_inside_a_blocked_module_is_still_reachable_elsewhere(self):
+		"""Unchanged, and the reason this rule sits on the address rather than on the rows.
+		Hiding a module hides the way to a document, never the document."""
+		make_rail([doctype_item("todo", READABLE)], standard=1)
+		block("Core", self.user)
+
+		self.assertEqual(rail_keys(self.user), ["todo"])
+
+	def test_a_doctype_addressed_sidebar_is_not_subject_to_the_veto(self):
+		"""CRM's shape. A sidebar addressed at a doctype names no module, so no block reaches it
+		-- including the block on the module that doctype happens to belong to."""
+		make_sidebar(
+			[doctype_item("mine", READABLE)],
+			standard=1,
+			link_doctype=self.DOCTYPE_ADDRESS[0],
+			link_to=self.DOCTYPE_ADDRESS[1],
+		)
+		block("Core", self.user)
+
+		with set_user(self.user):
+			payload = resolve_navigation(APP)
+
+		self.assertEqual(keys(payload["sidebars"][self.DOCTYPE_ADDRESS_KEY]), ["mine"])
+
+	def test_no_layer_can_resurface_a_blocked_module_s_sidebar(self):
+		"""The address is judged before the layers are read, so a person's own additions to that
+		sidebar never get the chance to bring it back."""
+		self.module_sidebar_on_the_rail()
+		make_sidebar([doctype_item("added", READABLE, added=1)], user=self.user)
+		block("Core", self.user)
+
+		with set_user(self.user):
+			payload = resolve_navigation(APP)
+
+		self.assertNotIn(ADDRESS_KEY, payload["sidebars"])
+
+	def test_the_veto_outranks_administrator_here_too(self):
+		"""Same reason as the `Module` item: it is this account's own preference row."""
+		self.module_sidebar_on_the_rail()
+		block("Core", "Administrator")
+
+		self.assertNotIn(ADDRESS_KEY, resolve_navigation(APP)["sidebars"])
+
+	def test_one_sidebar_read_on_its_own_answers_the_same_way(self):
+		"""`resolve_sidebar` is the arrangement editor's read, and a rule that held only on the
+		boot path would let a person arrange a sidebar boot will never send them."""
+		from frappe.shell.navigation import resolve_sidebar
+
+		make_sidebar([doctype_item("mine", READABLE)], standard=1)
+		block("Core", self.user)
+
+		with set_user(self.user):
+			self.assertEqual(resolve_sidebar(*ADDRESS), [])
+
+	def test_the_editor_bypass_still_sees_it(self):
+		"""`check_permission=False` is the layer editor's, and a manager arranging the site's
+		sidebar must not silently delete rows out of a list their own block shortened."""
+		from frappe.shell.navigation import resolve_sidebar
+
+		make_sidebar([doctype_item("mine", READABLE)], standard=1)
+		block("Core", self.user)
+
+		with set_user(self.user):
+			rows = resolve_sidebar(*ADDRESS, check_permission=False)
+
+		self.assertEqual(keys(rows), ["mine"])
 
 
 class TestFailingClosed(FilterTestCase):


### PR DESCRIPTION
`block_modules` gates module-derived items, which covers a `Module` item and nothing else. A module-primary rail never authors one: it reaches a module through a `Sidebar` item whose rows are `DocType` items, and those survive the block on purpose.

So the rule settled on [Does block_modules retire into the per-user overlay?](https://github.com/frappe/frappe/issues/42323) — a blocked module ships nothing, its page stays reachable — held for the doctype-primary case and missed the one [charter point 2](https://github.com/frappe/frappe/issues/42226) exists for. Measured on ERPNext's rail: blocking `Accounts` left all 73 rows and the rail item standing.

## The fix

A desk v2 module sidebar is **addressed** at its `Module Def`, so the address is the thing the block can name. `NavigationContext.address_is_offered` asks that one question, and the rail item goes with its sidebar through the `Derived From Children` cascade it already ran under — no new bucket and no second code path.

- **A veto and never a permission**, so it asks one question and not the two `module_is_offered` asks. A module sidebar may link outside its own module (101 of ERPNext's rows do), so requiring the module's *contents* here would empty a sidebar whose rows are all fine.
- **Judged before the layers are read**, so nothing a person added to that sidebar can bring it back.
- **A doctype-addressed sidebar is untouched** — CRM's shape names no module, so no block reaches it.
- **The editor's `check_permission=False` bypass still sees it**, so a manager arranging the site's sidebar cannot silently delete rows out of a list their own block shortened.
- Costs nothing for an app with no module sidebars: the `link_doctype` test short-circuits before `blocked_modules` is touched.

## Tests

8 new tests in `frappe/tests/test_navigation_filter.py`, all as a `Desk User`. 42 in that module, and the 7 surrounding navigation suites stay green (317 tests). Found and driven by [ERPNext's module-primary rail](https://github.com/frappe/frappe/issues/42423).

>no-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)