### PR TITLE
feat: fill Subject and Message from Email Template

### DIFF
--- a/frappe/email/doctype/notification/notification.js
+++ b/frappe/email/doctype/notification/notification.js
@@ -165,6 +165,54 @@ Last comment: {{ comments[-1].comment }} by {{ comments[-1].by }}
 			}
 		}
 	},
+	fetch_email_template: function (frm, template_name) {
+		frappe.model.with_doc("Email Template", template_name, () => {
+			const template = frappe.get_doc("Email Template", template_name);
+			// `use_html` picks the column, but the other one holds the body when it is empty
+			const body = template.use_html
+				? template.response_html || template.response
+				: template.response || template.response_html;
+
+			if (!body) {
+				frappe.msgprint({
+					title: __("Empty Email Template"),
+					message: __("{0} has no message to copy.", [
+						frappe.utils.escape_html(template_name),
+					]),
+					indicator: "orange",
+				});
+				return;
+			}
+
+			const values = { subject: template.subject || "", message: body };
+			// a hidden field is not copied, so an SMS takes only a Message
+			const targets = Object.keys(values).filter((fieldname) => {
+				const field = frm.get_field(fieldname);
+				return field && field.get_status() !== "None";
+			});
+			const apply = () =>
+				targets.forEach((fieldname) => frm.set_value(fieldname, values[fieldname]));
+
+			const placeholder = frappe.meta.get_docfield("Notification", "message")?.default;
+			const authored = targets.some(
+				(fieldname) => frm.doc[fieldname] && frm.doc[fieldname] !== placeholder
+			);
+			if (!authored) {
+				apply();
+				return;
+			}
+
+			const labels = targets.map((fieldname) =>
+				__(frappe.meta.get_docfield("Notification", fieldname).label)
+			);
+			frappe.confirm(
+				__("Replace the current {0} with this template?", [
+					frappe.utils.comma_and(labels),
+				]),
+				apply
+			);
+		});
+	},
 };
 
 frappe.ui.form.on("Notification", {
@@ -225,6 +273,32 @@ frappe.ui.form.on("Notification", {
 	document_type: function (frm) {
 		frappe.notification.setup_fieldname_select(frm);
 		frm.trigger("set_up_filters_editor");
+	},
+	fetch_email_template: function (frm) {
+		const dialog = new frappe.ui.Dialog({
+			title: __("Fetch from Email Template"),
+			fields: [
+				{
+					fieldname: "email_template",
+					fieldtype: "Link",
+					label: __("Email Template"),
+					options: "Email Template",
+					reqd: 1,
+					get_query: () => {
+						return {
+							query: "frappe.email.doctype.email_template.email_template.get_email_templates",
+							filters: { reference_doctype: frm.doc.document_type },
+						};
+					},
+				},
+			],
+			primary_action_label: __("Fetch"),
+			primary_action: ({ email_template }) => {
+				dialog.hide();
+				frappe.notification.fetch_email_template(frm, email_template);
+			},
+		});
+		dialog.show();
 	},
 	view_properties: function (frm) {
 		frappe.route_options = { doc_type: frm.doc.document_type };

--- a/frappe/email/doctype/notification/notification.json
+++ b/frappe/email/doctype/notification/notification.json
@@ -14,7 +14,6 @@
   "channel",
   "slack_webhook_url",
   "filters_section",
-  "subject",
   "event",
   "document_type",
   "col_break_1",
@@ -43,8 +42,10 @@
   "send_to_all_assignees",
   "recipients",
   "message_sb",
+  "subject",
   "message_type",
   "message",
+  "fetch_email_template",
   "message_examples",
   "view_properties",
   "column_break_25",
@@ -238,7 +239,13 @@
   {
    "fieldname": "message_sb",
    "fieldtype": "Section Break",
-   "label": "Message"
+   "label": "Content"
+  },
+  {
+   "depends_on": "eval: frappe.meta.has_field('Notification', 'subject') || frappe.meta.has_field('Notification', 'message')",
+   "fieldname": "fetch_email_template",
+   "fieldtype": "Button",
+   "label": "Fetch from Email Template"
   },
   {
    "default": "Add your message here",
@@ -373,7 +380,7 @@
  "icon": "fa fa-envelope",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-09-03 18:00:00.000000",
+ "modified": "2026-09-03 18:00:00.000001",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Notification",


### PR DESCRIPTION
### Why

Email Template and Notification live in the same module and have never been wired together, so we do that

### Behavior (Screen recording)

https://github.com/user-attachments/assets/12abcae5-7932-4112-9949-ac60767c77f2

### What it does

- Adds a **Fetch from Email Template** button to any notification channel with subject or message
- Opens a dialog to choose templates
- Copies the template's Subject and body into the notification's own fields, whichever of the two the doctype has
- **Both stay editable and nothing stays linked**, so editing the template does not change this
- Confirms before replacing a Subject or Message you wrote
- Changed layout, put subject and message together in content section

### Previous iterations in this PR and why decided to go with this

- Used separate fields for templates and kept them in sync but this is not the general behavior of templates across framework so decided to drop it
- Changed from link field to button as nothing stays in sync

### Tests

- None. The change is a form script and one Button docfield, with no server-side behaviour change to cover

`no-docs`