### PR TITLE
fix(postgres): cast autoincrement names in joins

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -40,6 +40,12 @@ CORE_DOCTYPES = DOCTYPES_FOR_DOCTYPE | frozenset(
 )
 
 
+def _cast_autoincrement_name(field: Field, doctype: str) -> Term:
+	if frappe.db.db_type == "postgres" and frappe.get_meta(doctype).autoname == "autoincrement":
+		return functions.Cast(field, "varchar")
+	return field
+
+
 def _apply_date_field_filter_conversion(value, operator: str, doctype: str, field):
 	"""Apply datetime to date conversion for Date fieldtype filters.
 
@@ -1698,9 +1704,8 @@ class Engine:
 				# permissions are already checked by has_permission
 				return
 
-			self.query = self.query.inner_join(self.permission_table).on(
-				self.table.parent == self.permission_table.name
-			)
+			parent_name = _cast_autoincrement_name(self.permission_table.name, self.permission_doctype)
+			self.query = self.query.inner_join(self.permission_table).on(self.table.parent == parent_name)
 
 		if condition := self.get_permission_conditions(self.permission_doctype, self.permission_table):
 			self.query = self.query.where(condition)
@@ -2206,7 +2211,8 @@ class LinkTableField(DynamicTableField):
 		table = frappe.qb.DocType(self.doctype)
 		main_table = frappe.qb.DocType(self.parent_doctype)
 		if not query.is_joined(table):
-			clause = table.name == getattr(main_table, self.link_fieldname)
+			link_name = _cast_autoincrement_name(table.name, self.doctype)
+			clause = link_name == getattr(main_table, self.link_fieldname)
 
 			if engine and engine.apply_permissions:
 				if condition := engine.get_permission_conditions(self.doctype, table):

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -380,7 +380,10 @@ from {tables}
 
 		# left join link tables
 		for link in self.link_tables:
-			args.tables += f" {self.join} {link.table_name} {link.table_alias} on ({link.table_alias}.`name` = {self.tables[0]}.`{link.fieldname}`)"
+			link_name = f"{link.table_alias}.`name`"
+			if frappe.db.db_type == "postgres" and frappe.get_meta(link.doctype).autoname == "autoincrement":
+				link_name = f"cast({link_name} as varchar)"
+			args.tables += f" {self.join} {link.table_name} {link.table_alias} on ({link_name} = {self.tables[0]}.`{link.fieldname}`)"
 
 		if self.grouped_or_conditions:
 			self.conditions.append(f"({' or '.join(self.grouped_or_conditions)})")

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -49,6 +49,44 @@ def setup_patched_blog_post():
 	yield
 
 
+@contextmanager
+def setup_autoincrement_link_doctypes():
+	target_dt_name = "Test Auto Link Target"
+	source_dt_name = "Test Auto Link Source"
+
+	frappe.delete_doc_if_exists("DocType", source_dt_name, force=True)
+	frappe.delete_doc_if_exists("DocType", target_dt_name, force=True)
+
+	try:
+		new_doctype(
+			target_dt_name,
+			autoname="autoincrement",
+			fields=[{"label": "Target Title", "fieldname": "target_title", "fieldtype": "Data"}],
+		).insert(ignore_permissions=True)
+		new_doctype(
+			source_dt_name,
+			fields=[
+				{
+					"label": "Link Field",
+					"fieldname": "link_field",
+					"fieldtype": "Link",
+					"options": target_dt_name,
+				}
+			],
+		).insert(ignore_permissions=True)
+
+		target_doc = frappe.get_doc(doctype=target_dt_name, target_title="Target").insert(
+			ignore_permissions=True
+		)
+		source_doc = frappe.get_doc(doctype=source_dt_name, link_field=target_doc.name).insert(
+			ignore_permissions=True
+		)
+		yield target_dt_name, source_dt_name, target_doc, source_doc
+	finally:
+		frappe.delete_doc_if_exists("DocType", source_dt_name, force=True)
+		frappe.delete_doc_if_exists("DocType", target_dt_name, force=True)
+
+
 class TestDBQuery(IntegrationTestCase):
 	def setUp(self):
 		setup_for_tests()
@@ -466,6 +504,29 @@ class TestDBQuery(IntegrationTestCase):
 		)
 		self.assertEqual(result[0].allocated_user_email, "admin@example.com")
 		todo.delete()
+
+	def test_autoincrement_link_field_join(self):
+		with setup_autoincrement_link_doctypes() as (
+			_target_dt_name,
+			source_dt_name,
+			target_doc,
+			source_doc,
+		):
+			query = DatabaseQuery(source_dt_name).execute(
+				fields=["name", "link_field.target_title"],
+				filters={"name": source_doc.name},
+				run=False,
+			)
+			result = DatabaseQuery(source_dt_name).execute(
+				fields=["name", "link_field.target_title"],
+				filters={"name": source_doc.name},
+			)
+
+			self.assertEqual(result[0].target_title, target_doc.target_title)
+			if frappe.db.db_type == "postgres":
+				self.assertIn('CAST("TABTEST AUTO LINK TARGET_1"."NAME" AS VARCHAR)', query.upper())
+			else:
+				self.assertNotIn("CAST(", query.upper())
 
 	def test_build_match_conditions(self):
 		clear_user_permissions_for_doctype("Test Blog Post", "test2@example.com")

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -10,6 +10,7 @@ from frappe.tests.classes.context_managers import enable_safe_exec
 from frappe.tests.test_db_query import (
 	create_nested_doctype,
 	create_nested_doctype_records,
+	setup_autoincrement_link_doctypes,
 	setup_patched_blog_post,
 	setup_test_user,
 )
@@ -1471,6 +1472,26 @@ class TestQuery(IntegrationTestCase):
 		test_user_doc.remove_roles(test_role)
 		frappe.delete_doc("Role", test_role, force=True)
 
+	def test_autoincrement_link_field_join(self):
+		with setup_autoincrement_link_doctypes() as (
+			_target_dt_name,
+			source_dt_name,
+			target_doc,
+			source_doc,
+		):
+			query = frappe.qb.get_query(
+				source_dt_name,
+				fields=["name", "link_field.target_title"],
+				filters={"name": source_doc.name},
+			)
+			result = query.run(as_dict=True)
+
+			self.assertEqual(result[0].target_title, target_doc.target_title)
+			if frappe.db.db_type == "postgres":
+				self.assertIn('CAST("TABTEST AUTO LINK TARGET"."NAME" AS VARCHAR)', query.get_sql().upper())
+			else:
+				self.assertNotIn("CAST(", query.get_sql().upper())
+
 	def test_filter_direct_field_permission(self):
 		"""Test that filtering is only allowed on permitted direct fields."""
 		with setup_patched_blog_post(), setup_test_user(set_user=True) as user:
@@ -2455,6 +2476,55 @@ class TestQuery(IntegrationTestCase):
 		).run()
 		# Query should succeed and return results (tuple or list)
 		self.assertTrue(len(result) >= 0, "Query should succeed with proper permissions")
+
+	def test_autoincrement_parent_permission_join(self):
+		child_dt_name = "Test Auto Parent Child"
+		parent_dt_name = "Test Auto Parent"
+
+		frappe.delete_doc_if_exists("DocType", parent_dt_name, force=True)
+		frappe.delete_doc_if_exists("DocType", child_dt_name, force=True)
+		self.addCleanup(frappe.delete_doc_if_exists, "DocType", child_dt_name, force=True)
+		self.addCleanup(frappe.delete_doc_if_exists, "DocType", parent_dt_name, force=True)
+
+		new_doctype(
+			child_dt_name,
+			istable=1,
+			fields=[{"label": "Child Value", "fieldname": "child_value", "fieldtype": "Data"}],
+		).insert(ignore_permissions=True)
+		new_doctype(
+			parent_dt_name,
+			autoname="autoincrement",
+			fields=[
+				{
+					"label": "Child Table",
+					"fieldname": "child_table",
+					"fieldtype": "Table",
+					"options": child_dt_name,
+				}
+			],
+		).insert(ignore_permissions=True)
+		parent_doc = frappe.get_doc(
+			{
+				"doctype": parent_dt_name,
+				"child_table": [{"child_value": "Child"}],
+			}
+		).insert(ignore_permissions=True)
+
+		query = frappe.qb.get_query(
+			child_dt_name,
+			fields=["name", "child_value"],
+			filters={"parent": parent_doc.name},
+			parent_doctype=parent_dt_name,
+			ignore_permissions=False,
+			user="Administrator",
+		)
+		result = query.run(as_dict=True)
+
+		self.assertEqual(result[0].child_value, "Child")
+		if frappe.db.db_type == "postgres":
+			self.assertIn('CAST("TABTEST AUTO PARENT"."NAME" AS VARCHAR)', query.get_sql().upper())
+		else:
+			self.assertNotIn("CAST(", query.get_sql().upper())
 
 	def test_child_table_filters_orphaned_rows(self):
 		"""Test that child table queries filter out orphaned rows (rows without valid parent)."""


### PR DESCRIPTION
## Stack

1. This PR fixes autoincrement joins.
2. #42441 fixes non-text LIKE filters.
3. #42442 fixes managed database ownership.

Merge these PRs in order.

## What changed

- Cast autoincrement name columns to varchar in PostgreSQL Link joins.
- Apply the cast to child-table permission joins.
- Cover the current and legacy query paths.

## Why

Link and child parent fields use varchar. PostgreSQL rejects joins between these fields and bigint autoincrement names.

## Tests

- Added current query tests for Link and child permission joins.
- Added a legacy query test for Link joins.
- Ran all 67 legacy query tests on PostgreSQL.

Closes #39447
