### PR TITLE
fix(postgres): cast non-text fields for like filters

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -18,6 +18,7 @@ from frappe.database.utils import (
 	convert_to_value,
 	get_doctype_name,
 	get_doctype_sort_info,
+	is_non_text_field,
 )
 from frappe.model import CORE_DOCTYPES as PERMITTED_CORE_DOCTYPES
 from frappe.model import OPTIONAL_FIELDS, get_permitted_fields
@@ -768,10 +769,9 @@ class Engine:
 			target_doctype = filter_doctype
 
 			# Skip applying ifnull if field already has null-handling function
-			if isinstance(_field, functions.IfNull | functions.Coalesce):
-				return operator_fn(_field, _value)
-
-			if self._should_apply_ifnull(target_doctype, filter_field_name, _operator, _value):
+			if not isinstance(_field, functions.IfNull | functions.Coalesce) and self._should_apply_ifnull(
+				target_doctype, filter_field_name, _operator, _value
+			):
 				fallback_sql = self._get_ifnull_fallback(target_doctype, filter_field_name)
 				if fallback_sql == "''":
 					fallback_value = ""
@@ -790,6 +790,13 @@ class Engine:
 						return operator_fn(_field, _value)
 
 				_field = functions.IfNull(_field, ValueWrapper(fallback_value))
+
+			if (
+				self.is_postgres
+				and _operator.casefold() in ("like", "not like", "ilike")
+				and is_non_text_field(target_doctype, filter_field_name)
+			):
+				_field = functions.Cast(_field, "varchar")
 
 			return operator_fn(_field, _value)
 

--- a/frappe/database/utils.py
+++ b/frappe/database/utils.py
@@ -25,6 +25,7 @@ NestedSetHierarchy = (
 	"not descendants of",
 	"descendants of (inclusive)",
 )
+TEXT_SQL_TYPES = frozenset(("varchar", "text", "longtext", "smalltext"))
 # split when non-alphabetical character is found
 QUERY_TYPE_PATTERN = re.compile(r"\s*([A-Za-z]*)")
 
@@ -37,6 +38,36 @@ def convert_to_value(o: FilterValue):
 	elif isinstance(o, (KeysView, ValuesView)):
 		return tuple(convert_to_value(item) for item in o)
 	return o
+
+
+def is_non_text_field(doctype: str, fieldname: str, df=None) -> bool:
+	"""Return whether a DocField is stored in a non-text database column."""
+	if fieldname == "name":
+		try:
+			if frappe.get_meta(doctype).autoname == "autoincrement":
+				return True
+		except frappe.DoesNotExistError:
+			return False
+
+	if df is None:
+		try:
+			df = frappe.get_meta(doctype).get_field(fieldname)
+		except frappe.DoesNotExistError:
+			return False
+
+	if df is None:
+		from frappe.model.meta import get_default_df
+
+		df = get_default_df(fieldname)
+	if df is None:
+		return False
+
+	db_type = frappe.db.type_map.get(df.fieldtype)
+	if not db_type:
+		return False
+
+	db_type = db_type[0] if isinstance(db_type, tuple | list) else db_type
+	return str(db_type).lower() not in TEXT_SQL_TYPES
 
 
 def get_query_type(query: str) -> str:

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -20,7 +20,7 @@ import frappe.permissions
 import frappe.share
 from frappe import _
 from frappe.core.doctype.server_script.server_script_utils import get_server_script_map
-from frappe.database.utils import DefaultOrderBy, FallBackDateTimeStr, NestedSetHierarchy
+from frappe.database.utils import DefaultOrderBy, FallBackDateTimeStr, NestedSetHierarchy, is_non_text_field
 from frappe.model import OPTIONAL_FIELDS, get_permitted_fields
 from frappe.model.meta import get_table_columns
 from frappe.model.utils import is_virtual_doctype
@@ -979,6 +979,13 @@ from {tables}
 		meta = self.get_meta(f.doctype)
 		df = meta.get("fields", {"fieldname": f.fieldname})
 		df = df[0] if df else None
+		if (
+			frappe.db.db_type == "postgres"
+			and f.operator.lower() in ("like", "not like")
+			and is_non_text_field(f.doctype, f.fieldname, df)
+			and "cast(" not in column_name.lower()
+		):
+			column_name = f"cast({column_name} as varchar)"
 
 		# _assign and _liked_by store a JSON array of user ids, so `=`/`!=` never match a
 		# single member; treat them as `like`/`not like` against the serialized value.

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -585,6 +585,17 @@ class TestDBQuery(IntegrationTestCase):
 			{"name": "DocType"} in DatabaseQuery("DocType").execute(filters={"name": ["like", "J%"]})
 		)
 
+	def test_like_filter_on_non_text_field(self):
+		filters = {"docstatus": ["like", "0"]}
+		query = DatabaseQuery("DocType").execute(fields=["name"], filters=filters, run=False)
+		names = DatabaseQuery("DocType").execute(filters=filters, pluck="name")
+
+		self.assertIn("DocType", names)
+		if frappe.db.db_type == "postgres":
+			self.assertIn('CAST("TABDOCTYPE"."DOCSTATUS" AS VARCHAR) ILIKE', query.upper())
+		else:
+			self.assertNotIn("CAST(", query.upper())
+
 	def test_filters_4(self):
 		self.assertTrue(
 			{"name": "DocField"} in DatabaseQuery("DocType").execute(filters={"name": "DocField"})

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -94,6 +94,16 @@ class TestQuery(IntegrationTestCase):
 			query,
 		)
 
+	def test_like_filter_on_non_text_field(self):
+		query = frappe.qb.get_query("DocType", fields=["name"], filters={"docstatus": ["like", "0"]})
+		names = query.run(pluck=True)
+
+		self.assertIn("DocType", names)
+		if frappe.db.db_type == "postgres":
+			self.assertIn('CAST("DOCSTATUS" AS VARCHAR) ILIKE', query.get_sql().upper())
+		else:
+			self.assertNotIn("CAST(", query.get_sql().upper())
+
 	def test_string_fields(self):
 		self.assertEqual(
 			frappe.qb.get_query("User", fields="name, email", filters={"name": "Administrator"}).get_sql(),


### PR DESCRIPTION
## Stack

1. #42440 fixes autoincrement joins.
2. This PR fixes non-text LIKE filters.
3. #42442 fixes managed database ownership.

Merge these PRs in order. Review the second commit for this change.

## What changed

- Detect non-text columns from DocField metadata.
- Cast these columns to varchar before PostgreSQL pattern comparisons.
- Cover the current and legacy query paths.

## Why

PostgreSQL does not apply LIKE or ILIKE directly to numeric columns. MariaDB applies an implicit conversion.

## Tests

- Added a current query regression test for numeric LIKE filters.
- Added a legacy query regression test for numeric LIKE filters.
- Ran all 67 legacy query tests on PostgreSQL.

Closes #16722
