### PR TITLE
fix(postgres): support managed database ownership

### DIFF
--- a/frappe/database/postgres/setup_db.py
+++ b/frappe/database/postgres/setup_db.py
@@ -1,6 +1,8 @@
 import os
 import re
 
+from psycopg2 import sql
+
 import frappe
 from frappe.database.db_manager import DbManager
 from frappe.utils import cint
@@ -22,7 +24,12 @@ def setup_database():
 	if psql_version := root_conn.sql("SHOW server_version_num", as_dict=True):
 		semver_version_num = psql_version[0].get("server_version_num") or "140000"
 		if cint(semver_version_num) > 150000:
-			root_conn.sql(f'ALTER DATABASE "{frappe.conf.db_name}" OWNER TO "{frappe.conf.db_user}"')
+			_set_database_owner(
+				root_conn,
+				frappe.conf.db_name,
+				frappe.conf.db_user,
+				cint(semver_version_num),
+			)
 	root_conn.close()
 
 	# On Azure Managed PostgreSQL the public schema is owned by the azure_pg_admin role.
@@ -58,6 +65,30 @@ def setup_database():
 			db_conn.rollback()
 	finally:
 		db_conn.close()
+
+
+def _set_database_owner(root_conn, db_name: str, db_user: str, postgres_version: int) -> None:
+	role_privilege = "SET" if postgres_version >= 160000 else "MEMBER"
+	can_set_role = root_conn.sql(
+		"SELECT pg_has_role(current_user, %s, %s)",
+		(db_user, role_privilege),
+		pluck=True,
+	)
+	needs_membership = not can_set_role or not can_set_role[0]
+
+	if needs_membership:
+		root_conn.execute_query(sql.SQL("GRANT {} TO current_user").format(sql.Identifier(db_user)))
+
+	try:
+		root_conn.execute_query(
+			sql.SQL("ALTER DATABASE {} OWNER TO {}").format(
+				sql.Identifier(db_name),
+				sql.Identifier(db_user),
+			)
+		)
+	finally:
+		if needs_membership:
+			root_conn.execute_query(sql.SQL("REVOKE {} FROM current_user").format(sql.Identifier(db_user)))
 
 
 def bootstrap_database(verbose, source_sql=None):

--- a/frappe/tests/test_postgres_setup.py
+++ b/frappe/tests/test_postgres_setup.py
@@ -1,0 +1,87 @@
+from unittest.mock import MagicMock, call
+
+from psycopg2 import sql
+
+from frappe.database.postgres.setup_db import _set_database_owner
+from frappe.tests import UnitTestCase
+
+
+class TestPostgresSetup(UnitTestCase):
+	def test_database_owner_uses_temporary_membership(self):
+		root_conn = MagicMock()
+		root_conn.sql.return_value = [False]
+		db_name = 'site"database'
+		db_user = 'site"user'
+
+		_set_database_owner(root_conn, db_name, db_user, 160000)
+
+		self.assertEqual(
+			root_conn.method_calls,
+			[
+				call.sql(
+					"SELECT pg_has_role(current_user, %s, %s)",
+					(db_user, "SET"),
+					pluck=True,
+				),
+				call.execute_query(sql.SQL("GRANT {} TO current_user").format(sql.Identifier(db_user))),
+				call.execute_query(
+					sql.SQL("ALTER DATABASE {} OWNER TO {}").format(
+						sql.Identifier(db_name),
+						sql.Identifier(db_user),
+					)
+				),
+				call.execute_query(sql.SQL("REVOKE {} FROM current_user").format(sql.Identifier(db_user))),
+			],
+		)
+
+	def test_database_owner_keeps_existing_membership(self):
+		root_conn = MagicMock()
+		root_conn.sql.return_value = [True]
+
+		_set_database_owner(root_conn, "site_database", "site_user", 150001)
+
+		self.assertEqual(
+			root_conn.method_calls,
+			[
+				call.sql(
+					"SELECT pg_has_role(current_user, %s, %s)",
+					("site_user", "MEMBER"),
+					pluck=True,
+				),
+				call.execute_query(
+					sql.SQL("ALTER DATABASE {} OWNER TO {}").format(
+						sql.Identifier("site_database"),
+						sql.Identifier("site_user"),
+					)
+				),
+			],
+		)
+
+	def test_database_owner_revokes_membership_after_failure(self):
+		root_conn = MagicMock()
+		root_conn.sql.return_value = [False]
+		root_conn.execute_query.side_effect = (None, RuntimeError("ownership failed"), None)
+
+		with self.assertRaisesRegex(RuntimeError, "ownership failed"):
+			_set_database_owner(root_conn, "site_database", "site_user", 160000)
+
+		self.assertEqual(
+			root_conn.method_calls,
+			[
+				call.sql(
+					"SELECT pg_has_role(current_user, %s, %s)",
+					("site_user", "SET"),
+					pluck=True,
+				),
+				call.execute_query(sql.SQL("GRANT {} TO current_user").format(sql.Identifier("site_user"))),
+				call.execute_query(
+					sql.SQL("ALTER DATABASE {} OWNER TO {}").format(
+						sql.Identifier("site_database"),
+						sql.Identifier("site_user"),
+					)
+				),
+				call.execute_query(
+					sql.SQL("REVOKE {} FROM current_user").format(sql.Identifier("site_user"))
+				),
+			],
+		)


### PR DESCRIPTION
## Stack

1. #42440 fixes autoincrement joins.
2. #42441 fixes non-text LIKE filters.
3. This PR fixes managed database ownership.

Merge these PRs in order. Review the third commit for this change.

## What changed

- Check whether the root user can set the new site role.
- Grant the configured database user only when required.
- Revoke temporary access after success or failure.
- Keep any membership that existed before site creation.
- Compose database and role identifiers with the PostgreSQL driver.

## Why

Managed PostgreSQL root users can create roles without being able to set them. PostgreSQL then rejects the database ownership transfer.

The proposed branch fixes the default case where the database and user names match. This version also supports a separate configured database user and safely handles quoted identifiers.

## Tests

- Added three focused unit tests.
- Tested quote-containing identifiers in the composed statements.
- Tested the flow through Frappe on PostgreSQL 18.4 with a restricted root role.
- Verified separate database and user names.
- Verified ownership transfer and membership cleanup.
- Verified cleanup after an ownership error.

Co-authored with @Shinonn23.

Closes #38659