### PR TITLE
test(postgres): enable user permission defaults

### DIFF
--- a/frappe/tests/test_defaults.py
+++ b/frappe/tests/test_defaults.py
@@ -3,9 +3,7 @@
 import frappe
 from frappe.core.doctype.user_permission.test_user_permission import create_user
 from frappe.defaults import *
-from frappe.query_builder.utils import db_type_is
 from frappe.tests import IntegrationTestCase
-from frappe.tests.test_query_builder import run_only_if
 
 
 class TestDefaults(IntegrationTestCase):
@@ -70,28 +68,30 @@ class TestDefaults(IntegrationTestCase):
 		frappe.delete_doc("User Permission", perm_doc.name)
 		frappe.set_user(old_user)
 
-	@run_only_if(db_type_is.MARIADB)
 	def test_user_permission_defaults(self):
-		# Create user permission
-		create_user("user_default_test@example.com", "Website Manager")
-		frappe.set_user("user_default_test@example.com")
-		set_global_default("Country", "")
-		clear_user_default("Country")
+		user = "user_default_test@example.com"
+		create_user(user, "Website Manager")
 
-		perm_doc = frappe.get_doc(
-			doctype="User Permission", user=frappe.session.user, allow="Country", for_value="India"
-		).insert(ignore_permissions=True)
+		with self.set_user(user):
+			set_global_default("Country", "")
+			clear_user_default("Country")
 
-		frappe.db.set_value("User Permission", perm_doc.name, "is_default", 1)
-		set_global_default("Country", "United States")
-		self.assertEqual(get_user_default("Country"), "India")
+			perm_doc = frappe.get_doc(
+				doctype="User Permission", user=user, allow="Country", for_value="India"
+			).insert(ignore_permissions=True)
 
-		frappe.db.set_value("User Permission", perm_doc.name, "is_default", 0)
-		clear_user_default("Country")
-		self.assertEqual(get_user_default("Country"), None)
+			perm_doc.is_default = 1
+			perm_doc.save(ignore_permissions=True)
+			set_global_default("Country", "United States")
+			self.assertEqual(get_user_default("Country"), "India")
 
-		perm_doc = frappe.get_doc(
-			doctype="User Permission", user=frappe.session.user, allow="Country", for_value="United States"
-		).insert(ignore_permissions=True)
+			perm_doc.is_default = 0
+			perm_doc.save(ignore_permissions=True)
+			clear_user_default("Country")
+			self.assertEqual(get_user_default("Country"), None)
 
-		self.assertEqual(get_user_default("Country"), "United States")
+			frappe.get_doc(
+				doctype="User Permission", user=user, allow="Country", for_value="United States"
+			).insert(ignore_permissions=True)
+
+			self.assertEqual(get_user_default("Country"), "United States")


### PR DESCRIPTION
## Stack

1. #42440 fixes autoincrement joins.
2. #42441 fixes non-text LIKE filters.
3. #42442 fixes managed database ownership.
4. This PR enables the user permission defaults test.

Merge these PRs in order. Review the fourth commit for this change.

## What changed

- Run the user permission defaults test on every supported database.
- Save User Permission changes through the document API so cache invalidation runs.
- Restore the active test user with the shared context manager.
- Remove imports that supported the old MariaDB-only skip.

## Why

The test uses direct database updates for a cache-sensitive DocType. Those updates skip document events, so the result depends on whether the user permission cache is populated.

Normal User Permission saves clear that cache. The corrected test now passes on PostgreSQL without a production code change.

## Tests

- Ran the focused test on PostgreSQL.
- Ran all seven defaults tests on PostgreSQL.
- Ran the pre-commit checks for the changed file.

Part of #34660