### PR TITLE
fix(postgres): preserve valid distinct ordering

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -328,7 +328,7 @@ class DatabaseQuery:
 
 		if self.distinct:
 			args.fields = "distinct " + args.fields
-			if frappe.db.db_type == "postgres":
+			if frappe.db.db_type == "postgres" and not self._can_apply_distinct_order_by(args.order_by):
 				# PostgreSQL requires ORDER BY expressions to appear in SELECT list when using DISTINCT
 				args.order_by = ""
 
@@ -473,6 +473,41 @@ from {tables}
 			args.order_by = args.order_by.replace(order_field, f"`{order_column}`")
 
 		return args
+
+	def _can_apply_distinct_order_by(self, order_by: str) -> bool:
+		if not order_by:
+			return True
+
+		selected_fields = set()
+		for field in self.fields:
+			if field is None:
+				continue
+			field, *alias = re.split(r"\s+as\s+", field, maxsplit=1, flags=re.IGNORECASE)
+			field = self._normalize_field_reference(field)
+			if field == "*" or field.endswith(".*"):
+				return True
+			if "(" not in field:
+				selected_fields.add(field)
+				selected_fields.add(field.rsplit(".", 1)[-1])
+				if "." not in field:
+					selected_fields.add(f"tab{self.doctype}.{field}")
+			if alias:
+				selected_fields.add(self._normalize_field_reference(alias[0]))
+
+		order_by = re.sub(r"^\s*order\s+by\s+", "", order_by, flags=re.IGNORECASE)
+		for order_field in order_by.split(","):
+			order_field = re.sub(r"\s+(asc|desc)\s*$", "", order_field, flags=re.IGNORECASE)
+			order_field = self._normalize_field_reference(order_field)
+			if order_field.isdigit():
+				if not 0 < cint(order_field) <= len(self.fields):
+					return False
+			elif order_field not in selected_fields:
+				return False
+		return True
+
+	@staticmethod
+	def _normalize_field_reference(field: str) -> str:
+		return field.replace("`", "").replace('"', "").strip()
 
 	def parse_args(self):
 		"""Convert fields and filters from strings to list, dicts."""

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -1223,6 +1223,33 @@ class TestDBQuery(IntegrationTestCase):
 		)
 		self.assertTrue(len(doctypes[0]) == 2)  # same for pg as well since we order_by None
 
+	def test_distinct_keeps_valid_order_by(self):
+		for field, order_by in (
+			("user_type", "user_type asc"),
+			("user_type as type", "type asc"),
+			("user_type", "`tabUser`.`user_type` asc"),
+		):
+			with self.subTest(field=field, order_by=order_by):
+				query = DatabaseQuery("User").execute(
+					fields=[field], distinct=True, order_by=order_by, run=False
+				)
+				result = DatabaseQuery("User").execute(
+					fields=[field], distinct=True, order_by=order_by, as_list=True
+				)
+
+				self.assertIn("order by", query.lower())
+				self.assertEqual(list(result), sorted(result))
+
+	def test_distinct_drops_unselected_order_by_on_postgres(self):
+		query = DatabaseQuery("User").execute(
+			fields=["user_type"], distinct=True, order_by="creation desc", run=False
+		)
+
+		if frappe.db.db_type == "postgres":
+			self.assertNotIn("order by", query.lower())
+		else:
+			self.assertIn("order by", query.lower())
+
 	def test_field_comparison(self):
 		"""Test DatabaseQuery.execute to test field comparison"""
 		users_unedited = frappe.get_all(


### PR DESCRIPTION
## Stack

1. #42440 fixes autoincrement joins.
2. #42441 fixes non-text LIKE filters.
3. #42442 fixes managed database ownership.
4. #42443 enables the user permission defaults test.
5. #42444 enables recorder query optimization.
6. This PR preserves valid distinct ordering.

Merge these PRs in order. Review the sixth commit for this change.

## What changed

- Keep ORDER BY on PostgreSQL when every ordered field appears in the distinct result.
- Support selected aliases and qualified field names.
- Validate numeric result positions before keeping their ordering.
- Keep the existing fallback for ambiguous MariaDB-compatible ordering.

## Why

The legacy ORM removes every ORDER BY clause from PostgreSQL distinct queries. PostgreSQL accepts the clause when each ordered expression appears in the select list.

This caused valid queries to return in an unspecified order.

## Tests

- Added coverage for plain, aliased, and qualified selected fields.
- Added coverage for the unselected-field fallback.
- Ran all 69 legacy query tests on PostgreSQL.
- Verified the new cases through the MariaDB query path.
- Ran the pre-commit checks for both changed files.

Part of #34660
