### PR TITLE
fix(postgres): preserve query builder distinct ordering

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -343,8 +343,11 @@ class Engine:
 
 		if order_by:
 			if not (
-				self.is_postgres and is_select and distinct
-			):  # ignore in Postgres since order by fields need to appear in select distinct
+				self.is_postgres
+				and is_select
+				and distinct
+				and not self._can_apply_distinct_order_by(order_by)
+			):
 				self.apply_order_by(order_by)
 			else:
 				warnings.warn(
@@ -1349,6 +1352,44 @@ class Engine:
 				)
 			else:
 				self.query = self.query.orderby(order_field, order=order_direction)
+
+	def _can_apply_distinct_order_by(self, order_by: str) -> bool:
+		if not isinstance(order_by, str):
+			return True
+
+		selected_field_count = 0
+		selected_fields = set(self.field_aliases | self.function_aliases)
+		for field in self.fields:
+			if isinstance(field, ChildQuery):
+				continue
+			selected_field_count += 1
+			if isinstance(field, DynamicTableField):
+				term = field.field
+				if field.parent_fieldname:
+					selected_fields.add(f"{field.parent_fieldname}.{field.fieldname}")
+			else:
+				term = field
+
+			if isinstance(term, Star):
+				return True
+			if alias := getattr(field, "alias", None):
+				selected_fields.add(alias)
+			if isinstance(term, Field):
+				selected_fields.add(term.name)
+				if term.table is not None:
+					selected_fields.add(f"{term.table.get_table_name()}.{term.name}")
+
+		if order_by == DefaultOrderBy:
+			order_by = get_doctype_sort_info(self.doctype)[0]
+		for order_field in order_by.split(","):
+			order_field = re.sub(r"\s+(asc|desc)\s*$", "", order_field, flags=re.IGNORECASE)
+			order_field = order_field.replace("`", "").replace('"', "").strip()
+			if order_field.isdigit():
+				if not 0 < int(order_field) <= selected_field_count:
+					return False
+			elif order_field not in selected_fields:
+				return False
+		return True
 
 	def _apply_default_order_by(self):
 		"""Apply default ordering based on configured DocType metadata"""

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -2246,6 +2246,30 @@ class TestQuery(IntegrationTestCase):
 			self.assertIn(self.normalize_sql("ORDER BY `created_date`"), self.normalize_sql(sql))
 		self.assertIn(self.normalize_sql("`creation` `created_date`"), self.normalize_sql(sql))
 
+	def test_distinct_keeps_valid_order_by(self):
+		for field, order_by in (
+			("user_type", "user_type asc"),
+			("user_type as type", "type asc"),
+			("`tabUser`.`user_type`", "`tabUser`.`user_type` asc"),
+		):
+			with self.subTest(field=field, order_by=order_by):
+				query = frappe.qb.get_query("User", fields=[field], distinct=True, order_by=order_by)
+				result = query.run()
+
+				self.assertIn("order by", query.get_sql().lower())
+				self.assertEqual(list(result), sorted(result))
+
+	def test_distinct_drops_unselected_order_by_on_postgres(self):
+		if frappe.db.db_type == "postgres":
+			with self.assertWarnsRegex(UserWarning, "ORDER BY fields have been ignored"):
+				query = frappe.qb.get_query(
+					"User", fields=["user_type"], distinct=True, order_by="creation desc"
+				)
+			self.assertNotIn("order by", query.get_sql().lower())
+		else:
+			query = frappe.qb.get_query("User", fields=["user_type"], distinct=True, order_by="creation desc")
+			self.assertIn("order by", query.get_sql().lower())
+
 	def test_field_alias_permission_check(self):
 		query = frappe.qb.get_query(
 			"User",


### PR DESCRIPTION
## Stack

1. #42440 fixes autoincrement joins.
2. #42441 fixes non-text LIKE filters.
3. #42442 fixes managed database ownership.
4. #42443 enables the user permission defaults test.
5. #42444 enables recorder query optimization.
6. #42445 preserves legacy distinct ordering.
7. This PR preserves current query builder distinct ordering.

Merge these PRs in order. Review the seventh commit for this change.

## What changed

- Keep ORDER BY on PostgreSQL when every ordered field appears in the distinct result.
- Support selected aliases and qualified field names.
- Validate numeric result positions before keeping their ordering.
- Keep the existing warning for ambiguous ordering.

## Why

The current query builder removes every ORDER BY clause from PostgreSQL distinct queries. PostgreSQL accepts the clause when each ordered expression appears in the select list.

This caused valid queries to return in an unspecified order.

## Tests

- Added coverage for plain, aliased, and qualified selected fields.
- Added coverage for the unselected-field warning.
- Ran the focused PostgreSQL tests.
- Verified the new cases through the MariaDB query builder path.
- Ran the pre-commit checks for both changed files.

The full PostgreSQL query module reached an unrelated existing index test failure. The two changed tests pass independently.

Part of #34660
