### PR TITLE
fix(postgres): bind column metadata filters

### DIFF
--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -668,9 +668,8 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 		# Only plain btree indexes count: a partial, covering or non-btree index cannot be the
 		# framework-managed search index, so reporting it here would both suppress creating the
 		# real one and mark a hand-made index as framework-owned and droppable.
-		# pylint: disable=W1401
 		return self.sql(
-			f"""
+			"""
 			SELECT a.column_name AS name,
 			CASE LOWER(a.data_type)
 				WHEN 'character varying' THEN CONCAT('varchar(', a.character_maximum_length ,')')
@@ -695,15 +694,16 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 				JOIN pg_am am ON am.oid = ic.relam
 				JOIN pg_namespace n ON n.oid = tc.relnamespace
 				JOIN pg_attribute att ON att.attrelid = tc.oid AND att.attnum = i.indkey[0]
-				WHERE tc.relname = '{table_name}' AND n.nspname = '{self.db_schema}'
+				WHERE tc.relname = %(table_name)s AND n.nspname = %(schema)s
 					AND am.amname = 'btree'
 					AND i.indpred IS NULL
 					AND i.indnatts = i.indnkeyatts
 			) b ON b.column_name = a.column_name
-			WHERE a.table_name = '{table_name}'
-				AND a.table_schema = '{self.db_schema}'
+			WHERE a.table_name = %(table_name)s
+				AND a.table_schema = %(schema)s
 			GROUP BY a.column_name, a.data_type, a.column_default, a.character_maximum_length, a.is_nullable, a.numeric_precision, a.numeric_scale, a.datetime_precision;
 		""",
+			{"table_name": table_name, "schema": self.db_schema},
 			as_dict=1,
 		)
 

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -705,6 +705,12 @@ class TestDB(IntegrationTestCase):
 		self.assertIsInstance(note_docs, tuple)
 
 	@run_only_if(db_type_is.POSTGRES)
+	def test_table_columns_description_binds_table_name(self):
+		columns = frappe.db.get_table_columns_description("tabUser' OR TRUE --")
+
+		self.assertFalse(columns)
+
+	@run_only_if(db_type_is.POSTGRES)
 	def test_modify_query(self):
 		from frappe.database.postgres.database import modify_query
 


### PR DESCRIPTION
## Stack

1. #42440 fixes autoincrement joins.
2. #42441 fixes non-text LIKE filters.
3. #42442 fixes managed database ownership.
4. #42443 enables the user permission defaults test.
5. #42444 enables recorder query optimization.
6. #42445 preserves legacy distinct ordering.
7. #42446 preserves current query builder distinct ordering.
8. This PR binds PostgreSQL column metadata filters.

Merge these PRs in order. Review the eighth commit for this change.

## What changed

- Bind the table and schema filters in PostgreSQL column metadata queries.
- Remove direct interpolation from both catalog query scopes.
- Add a regression test with an SQL-like table name.

## Why

The column metadata query interpolates its table name into two SQL clauses. A crafted value can change the catalog query instead of selecting one table.

Bound values preserve the current metadata result and prevent the value from changing the SQL structure.

## Tests

- Ran the new injection regression test on PostgreSQL.
- Ran the existing schema-specific column metadata test on PostgreSQL.
- Ran the pre-commit checks for both changed files.

Part of #34660