### PR TITLE
fix(postgres): cast autoincrement names in joins

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -40,6 +40,12 @@ CORE_DOCTYPES = DOCTYPES_FOR_DOCTYPE | frozenset(
 )
 
 
+def _cast_autoincrement_name(field: Field, doctype: str) -> Term:
+	if frappe.db.db_type == "postgres" and frappe.get_meta(doctype).autoname == "autoincrement":
+		return functions.Cast(field, "varchar")
+	return field
+
+
 def _apply_date_field_filter_conversion(value, operator: str, doctype: str, field):
 	"""Apply datetime to date conversion for Date fieldtype filters.
 
@@ -1698,9 +1704,8 @@ class Engine:
 				# permissions are already checked by has_permission
 				return
 
-			self.query = self.query.inner_join(self.permission_table).on(
-				self.table.parent == self.permission_table.name
-			)
+			parent_name = _cast_autoincrement_name(self.permission_table.name, self.permission_doctype)
+			self.query = self.query.inner_join(self.permission_table).on(self.table.parent == parent_name)
 
 		if condition := self.get_permission_conditions(self.permission_doctype, self.permission_table):
 			self.query = self.query.where(condition)
@@ -2174,7 +2179,8 @@ class ChildTableField(DynamicTableField):
 	def apply_join(self, query: QueryBuilder, engine: "Engine" = None) -> QueryBuilder:
 		main_table = frappe.qb.DocType(self.parent_doctype)
 		if not query.is_joined(self.table):
-			join_conditions = (self.table.parent == main_table.name) & (
+			parent_name = _cast_autoincrement_name(main_table.name, self.parent_doctype)
+			join_conditions = (self.table.parent == parent_name) & (
 				self.table.parenttype == self.parent_doctype
 			)
 			if self.parent_fieldname:
@@ -2206,7 +2212,8 @@ class LinkTableField(DynamicTableField):
 		table = frappe.qb.DocType(self.doctype)
 		main_table = frappe.qb.DocType(self.parent_doctype)
 		if not query.is_joined(table):
-			clause = table.name == getattr(main_table, self.link_fieldname)
+			link_name = _cast_autoincrement_name(table.name, self.doctype)
+			clause = link_name == getattr(main_table, self.link_fieldname)
 
 			if engine and engine.apply_permissions:
 				if condition := engine.get_permission_conditions(self.doctype, table):
@@ -2238,7 +2245,7 @@ class ChildQuery:
 		filters = {
 			"parenttype": self.parent_doctype,
 			"parentfield": self.fieldname,
-			"parent": ["in", parent_names],
+			"parent": ["in", [str(name) for name in parent_names or ()]],
 		}
 		return frappe.qb.get_query(
 			self.doctype,

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -380,7 +380,8 @@ from {tables}
 
 		# left join link tables
 		for link in self.link_tables:
-			args.tables += f" {self.join} {link.table_name} {link.table_alias} on ({link.table_alias}.`name` = {self.tables[0]}.`{link.fieldname}`)"
+			link_name = cast_name(f"{link.table_alias}.`name`")
+			args.tables += f" {self.join} {link.table_name} {link.table_alias} on ({link_name} = {self.tables[0]}.`{link.fieldname}`)"
 
 		if self.grouped_or_conditions:
 			self.conditions.append(f"({' or '.join(self.grouped_or_conditions)})")

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -49,6 +49,80 @@ def setup_patched_blog_post():
 	yield
 
 
+@contextmanager
+def setup_autoincrement_link_doctypes():
+	target_dt_name = "Test Auto Link Target"
+	source_dt_name = "Test Auto Link Source"
+
+	frappe.delete_doc_if_exists("DocType", source_dt_name, force=True)
+	frappe.delete_doc_if_exists("DocType", target_dt_name, force=True)
+
+	try:
+		new_doctype(
+			target_dt_name,
+			autoname="autoincrement",
+			fields=[{"label": "Target Title", "fieldname": "target_title", "fieldtype": "Data"}],
+		).insert(ignore_permissions=True)
+		new_doctype(
+			source_dt_name,
+			fields=[
+				{
+					"label": "Link Field",
+					"fieldname": "link_field",
+					"fieldtype": "Link",
+					"options": target_dt_name,
+				}
+			],
+		).insert(ignore_permissions=True)
+
+		target_doc = frappe.get_doc(doctype=target_dt_name, target_title="Target").insert(
+			ignore_permissions=True
+		)
+		source_doc = frappe.get_doc(doctype=source_dt_name, link_field=target_doc.name).insert(
+			ignore_permissions=True
+		)
+		yield target_dt_name, source_dt_name, target_doc, source_doc
+	finally:
+		frappe.delete_doc_if_exists("DocType", source_dt_name, force=True)
+		frappe.delete_doc_if_exists("DocType", target_dt_name, force=True)
+
+
+@contextmanager
+def setup_autoincrement_parent_doctypes():
+	child_dt_name = "Test Auto Parent Child"
+	parent_dt_name = "Test Auto Parent"
+
+	frappe.delete_doc_if_exists("DocType", parent_dt_name, force=True)
+	frappe.delete_doc_if_exists("DocType", child_dt_name, force=True)
+
+	try:
+		new_doctype(
+			child_dt_name,
+			istable=1,
+			fields=[{"label": "Child Value", "fieldname": "child_value", "fieldtype": "Data"}],
+		).insert(ignore_permissions=True)
+		new_doctype(
+			parent_dt_name,
+			autoname="autoincrement",
+			fields=[
+				{
+					"label": "Child Table",
+					"fieldname": "child_table",
+					"fieldtype": "Table",
+					"options": child_dt_name,
+				}
+			],
+		).insert(ignore_permissions=True)
+
+		parent_doc = frappe.get_doc(doctype=parent_dt_name, child_table=[{"child_value": "Child"}]).insert(
+			ignore_permissions=True
+		)
+		yield parent_dt_name, child_dt_name, parent_doc
+	finally:
+		frappe.delete_doc_if_exists("DocType", parent_dt_name, force=True)
+		frappe.delete_doc_if_exists("DocType", child_dt_name, force=True)
+
+
 class TestDBQuery(IntegrationTestCase):
 	def setUp(self):
 		setup_for_tests()
@@ -466,6 +540,42 @@ class TestDBQuery(IntegrationTestCase):
 		)
 		self.assertEqual(result[0].allocated_user_email, "admin@example.com")
 		todo.delete()
+
+	def test_autoincrement_link_field_join(self):
+		with setup_autoincrement_link_doctypes() as (
+			_target_dt_name,
+			source_dt_name,
+			target_doc,
+			source_doc,
+		):
+			query = DatabaseQuery(source_dt_name).execute(
+				fields=["name", "link_field.target_title"],
+				filters={"name": source_doc.name},
+				run=False,
+			)
+			result = DatabaseQuery(source_dt_name).execute(
+				fields=["name", "link_field.target_title"],
+				filters={"name": source_doc.name},
+			)
+
+			self.assertEqual(result[0].target_title, target_doc.target_title)
+			if frappe.db.db_type == "postgres":
+				self.assertIn('CAST("TABTEST AUTO LINK TARGET_1"."NAME" AS VARCHAR)', query.upper())
+			else:
+				self.assertNotIn("CAST(", query.upper())
+
+	def test_autoincrement_child_table_join(self):
+		with setup_autoincrement_parent_doctypes() as (parent_dt_name, child_dt_name, parent_doc):
+			result = DatabaseQuery(parent_dt_name).execute(
+				fields=["name", f"`tab{child_dt_name}`.child_value"],
+				filters=[
+					[parent_dt_name, "name", "=", parent_doc.name],
+					[child_dt_name, "child_value", "=", "Child"],
+				],
+			)
+
+			self.assertEqual(len(result), 1)
+			self.assertEqual(result[0].child_value, "Child")
 
 	def test_build_match_conditions(self):
 		clear_user_permissions_for_doctype("Test Blog Post", "test2@example.com")

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -10,6 +10,8 @@ from frappe.tests.classes.context_managers import enable_safe_exec
 from frappe.tests.test_db_query import (
 	create_nested_doctype,
 	create_nested_doctype_records,
+	setup_autoincrement_link_doctypes,
+	setup_autoincrement_parent_doctypes,
 	setup_patched_blog_post,
 	setup_test_user,
 )
@@ -1471,6 +1473,53 @@ class TestQuery(IntegrationTestCase):
 		test_user_doc.remove_roles(test_role)
 		frappe.delete_doc("Role", test_role, force=True)
 
+	def test_autoincrement_link_field_join(self):
+		with setup_autoincrement_link_doctypes() as (
+			_target_dt_name,
+			source_dt_name,
+			target_doc,
+			source_doc,
+		):
+			query = frappe.qb.get_query(
+				source_dt_name,
+				fields=["name", "link_field.target_title"],
+				filters={"name": source_doc.name},
+			)
+			result = query.run(as_dict=True)
+
+			self.assertEqual(result[0].target_title, target_doc.target_title)
+			if frappe.db.db_type == "postgres":
+				self.assertIn('CAST("TABTEST AUTO LINK TARGET"."NAME" AS VARCHAR)', query.get_sql().upper())
+			else:
+				self.assertNotIn("CAST(", query.get_sql().upper())
+
+	def test_autoincrement_child_table_join(self):
+		with setup_autoincrement_parent_doctypes() as (parent_dt_name, _child_dt_name, parent_doc):
+			query = frappe.qb.get_query(
+				parent_dt_name,
+				fields=["name", "child_table.child_value"],
+				filters={"name": parent_doc.name, "child_table.child_value": "Child"},
+			)
+			result = query.run(as_dict=True)
+
+			self.assertEqual(len(result), 1)
+			self.assertEqual(result[0].child_value, "Child")
+			if frappe.db.db_type == "postgres":
+				self.assertIn('CAST("TABTEST AUTO PARENT"."NAME" AS VARCHAR)', query.get_sql().upper())
+			else:
+				self.assertNotIn("CAST(", query.get_sql().upper())
+
+	def test_autoincrement_child_query(self):
+		with setup_autoincrement_parent_doctypes() as (parent_dt_name, _child_dt_name, parent_doc):
+			result = frappe.qb.get_query(
+				parent_dt_name,
+				fields=["name", {"child_table": ["child_value"]}],
+				filters={"name": parent_doc.name},
+			).run(as_dict=True)
+
+			self.assertEqual(len(result), 1)
+			self.assertEqual(result[0].child_table[0].child_value, "Child")
+
 	def test_filter_direct_field_permission(self):
 		"""Test that filtering is only allowed on permitted direct fields."""
 		with setup_patched_blog_post(), setup_test_user(set_user=True) as user:
@@ -2455,6 +2504,24 @@ class TestQuery(IntegrationTestCase):
 		).run()
 		# Query should succeed and return results (tuple or list)
 		self.assertTrue(len(result) >= 0, "Query should succeed with proper permissions")
+
+	def test_autoincrement_parent_permission_join(self):
+		with setup_autoincrement_parent_doctypes() as (parent_dt_name, child_dt_name, parent_doc):
+			query = frappe.qb.get_query(
+				child_dt_name,
+				fields=["name", "child_value"],
+				filters={"parent": parent_doc.name},
+				parent_doctype=parent_dt_name,
+				ignore_permissions=False,
+				user="Administrator",
+			)
+			result = query.run(as_dict=True)
+
+			self.assertEqual(result[0].child_value, "Child")
+			if frappe.db.db_type == "postgres":
+				self.assertIn('CAST("TABTEST AUTO PARENT"."NAME" AS VARCHAR)', query.get_sql().upper())
+			else:
+				self.assertNotIn("CAST(", query.get_sql().upper())
 
 	def test_child_table_filters_orphaned_rows(self):
 		"""Test that child table queries filter out orphaned rows (rows without valid parent)."""


### PR DESCRIPTION
GitHub links this pull request in native stack #42456.

## What changed

- Cast autoincrement name columns to varchar in PostgreSQL Link, child table and parent permission joins.
- Compare child sub-query parent names as strings.
- Reuse the legacy `cast_name` helper for link joins in the legacy query path.

## Why

Link fields, child `parent` fields and permission joins compare varchar columns with bigint autoincrement names. PostgreSQL rejects these comparisons.

## Tests

- Added current query tests for Link, child table, child sub-query and parent permission joins.
- Added legacy query tests for Link and child table joins.
- Ran the full legacy and current query test modules on PostgreSQL.

Closes #39447
