### PR TITLE
fix(postgres): support managed database ownership

### DIFF
--- a/frappe/database/postgres/setup_db.py
+++ b/frappe/database/postgres/setup_db.py
@@ -1,6 +1,8 @@
 import os
 import re
 
+from psycopg2 import sql
+
 import frappe
 from frappe.database.db_manager import DbManager
 from frappe.utils import cint
@@ -22,7 +24,12 @@ def setup_database():
 	if psql_version := root_conn.sql("SHOW server_version_num", as_dict=True):
 		semver_version_num = psql_version[0].get("server_version_num") or "140000"
 		if cint(semver_version_num) > 150000:
-			root_conn.sql(f'ALTER DATABASE "{frappe.conf.db_name}" OWNER TO "{frappe.conf.db_user}"')
+			_set_database_owner(
+				root_conn,
+				frappe.conf.db_name,
+				frappe.conf.db_user,
+				cint(semver_version_num),
+			)
 	root_conn.close()
 
 	# On Azure Managed PostgreSQL the public schema is owned by the azure_pg_admin role.
@@ -58,6 +65,55 @@ def setup_database():
 			db_conn.rollback()
 	finally:
 		db_conn.close()
+
+
+def _set_database_owner(root_conn, db_name: str, db_user: str, postgres_version: int) -> None:
+	role_privilege = "SET" if postgres_version >= 160000 else "MEMBER"
+	can_set_role = root_conn.sql(
+		"SELECT pg_has_role(current_user, %s, %s)",
+		(db_user, role_privilege),
+		pluck=True,
+	)
+	needs_role_access = not can_set_role or not can_set_role[0]
+
+	if needs_role_access:
+		grant, restore = _get_temporary_role_statements(root_conn, db_user, postgres_version)
+		root_conn.execute_query(grant)
+
+	try:
+		root_conn.execute_query(
+			sql.SQL("ALTER DATABASE {} OWNER TO {}").format(
+				sql.Identifier(db_name),
+				sql.Identifier(db_user),
+			)
+		)
+	finally:
+		if needs_role_access:
+			root_conn.execute_query(restore)
+
+
+def _get_temporary_role_statements(
+	root_conn, db_user: str, postgres_version: int
+) -> tuple[sql.Composed, sql.Composed]:
+	grant = sql.SQL("GRANT {} TO current_user").format(sql.Identifier(db_user))
+	restore = sql.SQL("REVOKE {} FROM current_user").format(sql.Identifier(db_user))
+	if postgres_version < 160000:
+		return grant, restore
+
+	# A role can already hold a self-grant with INHERIT TRUE and SET FALSE.
+	# Only restore grants made by this user; grants from other users remain untouched.
+	existing_self_grant = root_conn.sql(
+		"""SELECT 1 FROM pg_auth_members membership
+		JOIN pg_roles member_role ON member_role.oid = membership.member
+		JOIN pg_roles target_role ON target_role.oid = membership.roleid
+		WHERE target_role.rolname = %s AND member_role.rolname = current_user
+			AND membership.grantor = membership.member""",
+		(db_user,),
+		pluck=True,
+	)
+	if existing_self_grant:
+		restore = grant + sql.SQL(" WITH SET FALSE")
+	return grant + sql.SQL(" WITH SET TRUE"), restore
 
 
 def bootstrap_database(verbose, source_sql=None):

--- a/frappe/tests/test_postgres_setup.py
+++ b/frappe/tests/test_postgres_setup.py
@@ -1,0 +1,83 @@
+from unittest.mock import MagicMock, call
+
+from psycopg2 import sql
+
+from frappe.database.postgres.setup_db import _set_database_owner
+from frappe.tests import UnitTestCase
+
+
+class TestPostgresSetup(UnitTestCase):
+	def test_database_owner_uses_temporary_membership(self):
+		for version in (150001, 160000):
+			with self.subTest(version=version):
+				root_conn = MagicMock()
+				root_conn.sql.side_effect = ([False], [])
+				db_name = 'site"database'
+				db_user = 'site"user'
+
+				_set_database_owner(root_conn, db_name, db_user, version)
+
+				grant = sql.SQL("GRANT {} TO current_user").format(sql.Identifier(db_user))
+				if version >= 160000:
+					grant += sql.SQL(" WITH SET TRUE")
+				self.assertEqual(
+					root_conn.execute_query.call_args_list,
+					[
+						call(grant),
+						call(
+							sql.SQL("ALTER DATABASE {} OWNER TO {}").format(
+								sql.Identifier(db_name), sql.Identifier(db_user)
+							)
+						),
+						call(sql.SQL("REVOKE {} FROM current_user").format(sql.Identifier(db_user))),
+					],
+				)
+
+	def test_database_owner_keeps_existing_membership(self):
+		for version, privilege in ((150001, "MEMBER"), (160000, "SET")):
+			with self.subTest(version=version):
+				root_conn = MagicMock()
+				root_conn.sql.return_value = [True]
+
+				_set_database_owner(root_conn, "site_database", "site_user", version)
+
+				root_conn.sql.assert_called_once_with(
+					"SELECT pg_has_role(current_user, %s, %s)", ("site_user", privilege), pluck=True
+				)
+				root_conn.execute_query.assert_called_once_with(
+					sql.SQL("ALTER DATABASE {} OWNER TO {}").format(
+						sql.Identifier("site_database"), sql.Identifier("site_user")
+					)
+				)
+
+	def test_database_owner_restores_membership_without_set(self):
+		for fail in (False, True):
+			with self.subTest(fail=fail):
+				root_conn = MagicMock()
+				root_conn.sql.side_effect = ([False], [1])
+				if fail:
+					root_conn.execute_query.side_effect = (None, RuntimeError("ownership failed"), None)
+					with self.assertRaisesRegex(RuntimeError, "ownership failed"):
+						_set_database_owner(root_conn, "site_database", "site_user", 160000)
+				else:
+					_set_database_owner(root_conn, "site_database", "site_user", 160000)
+
+				grant = sql.SQL("GRANT {} TO current_user").format(sql.Identifier("site_user"))
+				self.assertEqual(
+					root_conn.execute_query.call_args_list[0], call(grant + sql.SQL(" WITH SET TRUE"))
+				)
+				self.assertEqual(
+					root_conn.execute_query.call_args_list[-1], call(grant + sql.SQL(" WITH SET FALSE"))
+				)
+
+	def test_database_owner_revokes_membership_after_failure(self):
+		root_conn = MagicMock()
+		root_conn.sql.side_effect = ([False], [])
+		root_conn.execute_query.side_effect = (None, RuntimeError("ownership failed"), None)
+
+		with self.assertRaisesRegex(RuntimeError, "ownership failed"):
+			_set_database_owner(root_conn, "site_database", "site_user", 160000)
+
+		root_conn.execute_query.assert_called_with(
+			sql.SQL("REVOKE {} FROM current_user").format(sql.Identifier("site_user"))
+		)


### PR DESCRIPTION
GitHub links this pull request in native stack #42456.

## What changed

- Check whether the root user can set the new site role.
- Grant the configured database user only when required.
- Set the PostgreSQL 16+ SET option explicitly and restore any existing self-grant.
- Revoke temporary access after success or failure.
- Keep any membership that existed before site creation.
- Compose database and role identifiers with the PostgreSQL driver.

## Why

Managed PostgreSQL root users can create roles without being able to set them. PostgreSQL then rejects the database ownership transfer.

This supports separate database and user names and safely composes quoted identifiers. Existing membership options remain unchanged after ownership transfer.

## Tests

- Ran four focused unit tests, including existing membership with SET FALSE.
- Tested quote-containing identifiers in the composed statements.
- Tested the flow through Frappe on PostgreSQL 18.4 with a restricted root role.
- Verified separate database and user names.
- Verified ownership transfer and membership cleanup.
- Verified cleanup after an ownership error.
- Verified ownership transfer and grant restoration with both default and inherit-only self-grants on PostgreSQL 18.4.

Co-authored with @Shinonn23.

Closes #38659