### PR TITLE
fix(defaults): honor default user permissions

### DIFF
--- a/frappe/defaults.py
+++ b/frappe/defaults.py
@@ -27,10 +27,10 @@ def get_user_default(key, user=None):
 			d = d[0]
 		else:
 			d = user_defaults.get(frappe.scrub(key), None)
-			user_permission_default = get_user_permission_default(key, user_defaults)
-			if not d:
-				# If no default value is found, use the User Permission value
-				d = user_permission_default
+			value = (isinstance(d, list | tuple) and d[0]) or d
+			if not value or not_in_user_permission(key, value, user):
+				# the stored default is missing or not permitted for the user
+				d = get_user_permission_default(key, user_defaults, user)
 
 	value = (isinstance(d, list | tuple) and d[0]) or d
 	if not_in_user_permission(key, value, user):
@@ -39,8 +39,8 @@ def get_user_default(key, user=None):
 	return value
 
 
-def get_user_permission_default(key, defaults):
-	permissions = get_user_permissions()
+def get_user_permission_default(key, defaults, user=None):
+	permissions = get_user_permissions(user)
 	user_default = ""
 	if permissions.get(key):
 		# global default in user permission

--- a/frappe/tests/test_defaults.py
+++ b/frappe/tests/test_defaults.py
@@ -3,9 +3,7 @@
 import frappe
 from frappe.core.doctype.user_permission.test_user_permission import create_user
 from frappe.defaults import *
-from frappe.query_builder.utils import db_type_is
 from frappe.tests import IntegrationTestCase
-from frappe.tests.test_query_builder import run_only_if
 
 
 class TestDefaults(IntegrationTestCase):
@@ -70,28 +68,38 @@ class TestDefaults(IntegrationTestCase):
 		frappe.delete_doc("User Permission", perm_doc.name)
 		frappe.set_user(old_user)
 
-	@run_only_if(db_type_is.MARIADB)
 	def test_user_permission_defaults(self):
-		# Create user permission
-		create_user("user_default_test@example.com", "Website Manager")
-		frappe.set_user("user_default_test@example.com")
-		set_global_default("Country", "")
-		clear_user_default("Country")
+		user = "user_default_test@example.com"
+		create_user(user, "Website Manager")
 
-		perm_doc = frappe.get_doc(
-			doctype="User Permission", user=frappe.session.user, allow="Country", for_value="India"
-		).insert(ignore_permissions=True)
+		with self.set_user(user):
+			set_global_default("country", "United States")
+			set_global_default("Country", "")
+			clear_user_default("Country")
+			clear_user_default("country")
 
-		frappe.db.set_value("User Permission", perm_doc.name, "is_default", 1)
-		set_global_default("Country", "United States")
-		self.assertEqual(get_user_default("Country"), "India")
+			perm_doc = frappe.get_doc(
+				doctype="User Permission", user=user, allow="Country", for_value="India"
+			).insert(ignore_permissions=True)
 
-		frappe.db.set_value("User Permission", perm_doc.name, "is_default", 0)
-		clear_user_default("Country")
-		self.assertEqual(get_user_default("Country"), None)
+			perm_doc.is_default = 1
+			perm_doc.save(ignore_permissions=True)
+			set_global_default("Country", "United States")
+			self.assertEqual(get_user_default("Country"), "India")
 
-		perm_doc = frappe.get_doc(
-			doctype="User Permission", user=frappe.session.user, allow="Country", for_value="United States"
-		).insert(ignore_permissions=True)
+			perm_doc.is_default = 0
+			perm_doc.save(ignore_permissions=True)
+			clear_user_default("Country")
+			self.assertEqual(get_user_default("Country"), None)
 
-		self.assertEqual(get_user_default("Country"), "United States")
+			frappe.get_doc(
+				doctype="User Permission", user=user, allow="Country", for_value="United States"
+			).insert(ignore_permissions=True)
+
+			self.assertEqual(get_user_default("Country"), "United States")
+
+			# a permitted default chosen by the user beats the User Permission default
+			perm_doc.is_default = 1
+			perm_doc.save(ignore_permissions=True)
+			set_user_default("country", "United States")
+			self.assertEqual(get_user_default("Country"), "United States")


### PR DESCRIPTION
GitHub links this pull request in native stack #42456.

## What changed

- Fall back to a User Permission marked as default when the stored default is missing or not permitted for the user.
- Keep a permitted default chosen by the user ahead of the User Permission default.
- Load User Permissions for the user passed to `get_user_default`.
- Run the regression test on every supported database.
- Give the test deterministic system and global defaults.

## Why

A lowercase system default could replace a User Permission marked as default. Permission filtering then rejected the system value and returned `None`.

The old MariaDB-only test depended on the site country. This change tests the intended priority directly.

## Tests

- Ran all seven defaults tests on PostgreSQL.
- Ran Ruff import and lint checks for both changed files.

Part of #34660
