### PR TITLE
fix(postgres): enable recorder query optimization

### DIFF
--- a/frappe/core/doctype/recorder/recorder.py
+++ b/frappe/core/doctype/recorder/recorder.py
@@ -10,7 +10,7 @@ from frappe.custom.doctype.property_setter.property_setter import make_property_
 from frappe.model.document import Document
 from frappe.recorder import RECORDER_REQUEST_HASH
 from frappe.recorder import get as get_recorder_data
-from frappe.utils import cint, cstr, evaluate_filters, get_table_name
+from frappe.utils import cstr, evaluate_filters, get_table_name
 from frappe.utils.caching import redis_cache
 
 
@@ -239,24 +239,19 @@ def _optimize_query(query):
 
 
 def _fetch_table_stats(doctype: str, columns: list[str]) -> dict | None:
-	def sql_bool(val):
-		return cstr(val).lower() in ("yes", "1", "true")
-
 	if not frappe.db.table_exists(doctype):
 		return
 
-	table = get_table_name(doctype, wrap_in_backticks=True)
-
-	schema = []
-	for field in frappe.db.sql(f"describe {table}", as_dict=True):
-		schema.append(
-			{
-				"column": field["Field"],
-				"type": field["Type"],
-				"is_nullable": sql_bool(field["Null"]),
-				"default": field["Default"],
-			}
-		)
+	table_name = get_table_name(doctype)
+	schema = [
+		{
+			"column": field.name,
+			"type": field.type,
+			"is_nullable": not field.not_nullable,
+			"default": field.default,
+		}
+		for field in frappe.db.get_table_columns_description(table_name)
+	]
 
 	def update_cardinality(column, value):
 		for col in schema:
@@ -264,46 +259,91 @@ def _fetch_table_stats(doctype: str, columns: list[str]) -> dict | None:
 				col["cardinality"] = value
 				break
 
-	indexes = []
-	for idx in frappe.db.sql(f"show index from {table}", as_dict=True):
-		indexes.append(
-			{
-				"unique": not sql_bool(idx["Non_unique"]),
-				"cardinality": idx["Cardinality"],
-				"name": idx["Key_name"],
-				"sequence": idx["Seq_in_index"],
-				"nullable": sql_bool(idx["Null"]),
-				"column": idx["Column_name"],
-				"type": idx["Index_type"],
-			}
-		)
-		if idx["Seq_in_index"] == 1:
-			update_cardinality(idx["Column_name"], idx["Cardinality"])
-
-	total_rows = cint(
-		frappe.db.sql(
-			f"""select table_rows
-			   from  information_schema.tables
-			   where table_name = 'tab{doctype}'"""
-		)[0][0]
-	)
+	indexes = _fetch_table_indexes(table_name)
+	for index in indexes:
+		if index["sequence"] == 1 and index["cardinality"] is not None:
+			update_cardinality(index["column"], index["cardinality"])
 
 	# fetch accurate cardinality for columns by query. WARN: This can take A LOT of time.
 	for column in columns:
-		cardinality = _get_column_cardinality(table, column)
+		cardinality = _get_column_cardinality(table_name, column)
 		update_cardinality(column, cardinality)
 
 	return {
-		"table_name": table.strip("`"),
-		"total_rows": total_rows,
+		"table_name": table_name,
+		"total_rows": frappe.db.estimate_count(doctype),
 		"schema": schema,
 		"indexes": indexes,
 	}
 
 
+def _fetch_table_indexes(table_name: str) -> list[dict]:
+	if frappe.db.db_type == "postgres":
+		return _fetch_postgres_table_indexes(table_name)
+	return _fetch_mariadb_table_indexes(table_name)
+
+
+def _fetch_postgres_table_indexes(table_name: str) -> list[dict]:
+	return frappe.db.sql(
+		"""
+		SELECT
+			i.indisunique AS "unique",
+			NULL::bigint AS cardinality,
+			index_info.relname AS name,
+			indexed_column.ordinality AS sequence,
+			NOT column_info.attnotnull AS nullable,
+			column_info.attname AS column,
+			method.amname AS type
+		FROM pg_index i
+		JOIN pg_class table_info ON table_info.oid = i.indrelid
+		JOIN pg_class index_info ON index_info.oid = i.indexrelid
+		JOIN pg_namespace namespace ON namespace.oid = table_info.relnamespace
+		JOIN pg_am method ON method.oid = index_info.relam
+		JOIN LATERAL unnest(i.indkey) WITH ORDINALITY AS indexed_column(attnum, ordinality) ON TRUE
+		JOIN pg_attribute column_info
+			ON column_info.attrelid = table_info.oid AND column_info.attnum = indexed_column.attnum
+		WHERE table_info.relname = %(table_name)s
+			AND namespace.nspname = %(schema)s
+			AND indexed_column.ordinality <= i.indnkeyatts
+			AND i.indisvalid
+			AND i.indisready
+			AND i.indislive
+			AND i.indpred IS NULL
+			AND i.indexprs IS NULL
+			AND method.amname = 'btree'
+		ORDER BY index_info.relname, indexed_column.ordinality
+		""",
+		{"table_name": table_name, "schema": frappe.db.db_schema},
+		as_dict=True,
+	)
+
+
+def _fetch_mariadb_table_indexes(table_name: str) -> list[dict]:
+	return frappe.db.sql(
+		"""
+		SELECT
+			NOT non_unique AS `unique`,
+			cardinality,
+			index_name AS name,
+			seq_in_index AS sequence,
+			nullable = 'YES' AS nullable,
+			column_name AS `column`,
+			index_type AS type
+		FROM information_schema.statistics
+		WHERE table_schema = %(schema)s AND table_name = %(table_name)s
+		ORDER BY index_name, seq_in_index
+		""",
+		{"schema": frappe.db.cur_db_name, "table_name": table_name},
+		as_dict=True,
+	)
+
+
 @redis_cache
 def _get_column_cardinality(table, column):
-	return frappe.db.sql(f"select count(distinct {column}) from {table}")[0][0]
+	from frappe.query_builder.functions import Count
+
+	table = frappe.qb.Table(table)
+	return frappe.qb.from_(table).select(Count(table[column]).distinct()).run()[0][0]
 
 
 def get_doctype_name(table_name: str) -> str:

--- a/frappe/core/doctype/recorder/test_recorder.py
+++ b/frappe/core/doctype/recorder/test_recorder.py
@@ -6,11 +6,18 @@ from unittest.mock import patch
 
 import frappe
 import frappe.recorder
-from frappe.core.doctype.recorder.recorder import _optimize_query, serialize_request
+from frappe.core.doctype.doctype.test_doctype import new_doctype
+from frappe.core.doctype.recorder.recorder import (
+	_fetch_postgres_table_indexes,
+	_fetch_table_stats,
+	_get_column_cardinality,
+	_optimize_query,
+	serialize_request,
+)
 from frappe.query_builder.utils import db_type_is
 from frappe.recorder import get as get_recorder_data
 from frappe.tests import IntegrationTestCase
-from frappe.tests.test_query_builder import run_only_if
+from frappe.tests.test_query_builder import run_only_if, unimplemented_for
 from frappe.utils import set_request
 
 
@@ -203,17 +210,53 @@ class TestRecorder(IntegrationTestCase):
 
 
 class TestQueryOptimization(IntegrationTestCase):
-	@run_only_if(db_type_is.MARIADB)
+	@run_only_if(db_type_is.POSTGRES)
+	def test_expression_index_does_not_hide_column_candidate(self):
+		query = "select name from \"tabUser\" where email='xyz'"
+		self.assertEqual(_optimize_query(query).column, "email")
+		frappe.db.savepoint("recorder_expression_index")
+		try:
+			frappe.db.sql(
+				'CREATE INDEX "test_recorder_expression_index" ON "tabUser" (lower(first_name), email)'
+			)
+			indexes = _fetch_postgres_table_indexes("tabUser")
+			self.assertNotIn("test_recorder_expression_index", [index.name for index in indexes])
+			self.assertEqual(_optimize_query(query).column, "email")
+		finally:
+			frappe.db.rollback(save_point="recorder_expression_index")
+
+	@unimplemented_for(db_type_is.SQLITE)
+	def test_cardinality_quotes_reserved_column(self):
+		doctype = "Test Recorder Cardinality"
+		frappe.delete_doc_if_exists("DocType", doctype, force=True)
+		try:
+			new_doctype(doctype, fields=[{"fieldname": "user", "label": "User", "fieldtype": "Data"}]).insert(
+				ignore_permissions=True
+			)
+			for value in range(5):
+				frappe.get_doc(doctype=doctype, user=f"user_{value}").insert(ignore_permissions=True)
+			table = frappe.qb.DocType(doctype)
+			_get_column_cardinality.clear_cache()
+			stats = _fetch_table_stats(doctype, ["user"])
+			user_column = next(column for column in stats["schema"] if column["column"] == "user")
+			self.assertEqual(user_column["cardinality"], 5)
+			query = frappe.qb.from_(table).select(table.name).where(table.user == "user_0")
+			self.assertEqual(_optimize_query(query.get_sql()).column, "user")
+		finally:
+			frappe.delete_doc_if_exists("DocType", doctype, force=True)
+
+	@unimplemented_for(db_type_is.SQLITE)
 	def test_query_optimizer(self):
-		suggested_index = _optimize_query(
-			"""select name from
-			`tabUser` u
-			join `tabHas Role` r
-			on r.parent = u.name
-			where email='xyz'
-			and creation > '2023'
-			and bio like '%xyz%'
-			"""
-		)
-		self.assertEqual(suggested_index.table, "tabUser")
-		self.assertEqual(suggested_index.column, "email")
+		for quote in ('"', "`"):
+			with self.subTest(quote=quote):
+				suggested_index = _optimize_query(
+					f"""select name from
+					{quote}tabUser{quote} u
+					join {quote}tabHas Role{quote} r
+					on r.parent = u.name
+					where email='xyz'
+					and bio like '%xyz%'
+					"""
+				)
+				self.assertEqual(suggested_index.table, "tabUser")
+				self.assertEqual(suggested_index.column, "email")

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -729,12 +729,13 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 	def _estimate_count(self, table: str) -> int:
 		from frappe.utils.data import cint
 
-		# Scope to current schema to avoid cross-site estimates
+		# Scope to current schema to avoid cross-site estimates.
+		# reltuples is -1 until the table has been vacuumed or analyzed.
 		count = self.sql(
 			"select c.reltuples from pg_class c join pg_namespace n on n.oid = c.relnamespace where c.relname = %s and n.nspname = %s and c.relkind = 'r'",
 			(table, self.db_schema),
 		)
-		return cint(count[0][0]) if count else 0
+		return max(cint(count[0][0]), 0) if count else 0
 
 	@contextmanager
 	def unbuffered_cursor(self):

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -569,6 +569,11 @@ class TestDB(IntegrationTestCase):
 	def test_estimated_count(self):
 		self.assertGreater(frappe.db.estimate_count("DocField"), 100)
 
+	@run_only_if(db_type_is.POSTGRES)
+	def test_estimated_count_clamps_unanalyzed_table(self):
+		with patch.object(frappe.db, "sql", return_value=((-1.0,),)):
+			self.assertEqual(frappe.db._estimate_count("tabUser"), 0)
+
 	def test_datetime_serialization(self):
 		dt = now_datetime()
 		dt = dt.replace(microsecond=0)


### PR DESCRIPTION
GitHub links this pull request in native stack #42456.

## What changed

- Use the shared database APIs for column metadata and row estimates.
- Read PostgreSQL index metadata from its system catalogs.
- Read MariaDB index metadata with parameterized information schema filters.
- Ignore invalid, partial, expression, included, and non-btree PostgreSQL index entries.
- Quote column identifiers in cardinality queries, including reserved names such as user.
- Clamp negative PostgreSQL row estimates from tables that were never analyzed.
- Test PostgreSQL and MariaDB identifier quoting.
- Keep SQLite marked as unsupported.

## Why

The recorder optimizer uses MariaDB-only DESCRIBE, SHOW INDEX, and information schema queries. PostgreSQL fails before it can suggest an index.

The database-specific metadata queries preserve index column order. This stops the optimizer from suggesting indexes that already exist.

PostgreSQL reports `reltuples = -1` until a table is vacuumed or analyzed. A negative row count turns every index score negative, so the optimizer would suggest any candidate.

## Tests

- Ran all nine recorder tests on PostgreSQL.
- Verified expression indexes do not hide column candidates.
- Verified cardinality and index suggestions for a reserved column name.
- Verified both query quoting styles on PostgreSQL.
- Added a test for the clamped row estimate.
- The optimizer test drops the `creation > '2023'` predicate because PostgreSQL rejects `'2023'` as a timestamp literal.

Part of #34660
