### PR TITLE
fix(postgres): preserve valid distinct ordering

### DIFF
--- a/frappe/database/utils.py
+++ b/frappe/database/utils.py
@@ -28,6 +28,8 @@ NestedSetHierarchy = (
 TEXT_SQL_TYPES = frozenset(("varchar", "text", "longtext", "smalltext"))
 # split when non-alphabetical character is found
 QUERY_TYPE_PATTERN = re.compile(r"\s*([A-Za-z]*)")
+ORDER_BY_PREFIX_PATTERN = re.compile(r"^\s*order\s+by\s+", flags=re.IGNORECASE)
+ORDER_DIRECTION_PATTERN = re.compile(r"\s+(asc|desc)\s*$", flags=re.IGNORECASE)
 
 
 def convert_to_value(o: FilterValue):
@@ -99,6 +101,31 @@ def get_doctype_sort_info(doctype: str) -> tuple[str, str]:
 		return meta.sort_field or "creation", meta.sort_order or "DESC"
 	except frappe.DoesNotExistError:
 		return "creation", "DESC"
+
+
+def unquote_identifier(identifier: str) -> str:
+	return identifier.replace("`", "").replace('"', "").strip()
+
+
+def get_order_by_fields(order_by: str) -> list[str]:
+	"""Return the unquoted field references of an ORDER BY clause without directions."""
+	order_by = ORDER_BY_PREFIX_PATTERN.sub("", order_by)
+	fields = []
+	for order_field in order_by.split(","):
+		order_field = ORDER_DIRECTION_PATTERN.sub("", order_field)
+		fields.append(unquote_identifier(order_field))
+	return fields
+
+
+def is_order_by_in_select(order_by: str, selected_fields: set[str], selected_field_count: int) -> bool:
+	"""Return whether every ORDER BY field is a selected field, alias or valid result position."""
+	for order_field in get_order_by_fields(order_by):
+		if order_field.isdigit():
+			if not 0 < int(order_field) <= selected_field_count:
+				return False
+		elif order_field not in selected_fields:
+			return False
+	return True
 
 
 class LazyString:

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -20,7 +20,15 @@ import frappe.permissions
 import frappe.share
 from frappe import _
 from frappe.core.doctype.server_script.server_script_utils import get_server_script_map
-from frappe.database.utils import DefaultOrderBy, FallBackDateTimeStr, NestedSetHierarchy, is_non_text_field
+from frappe.database.utils import (
+	DefaultOrderBy,
+	FallBackDateTimeStr,
+	NestedSetHierarchy,
+	get_doctype_name,
+	is_non_text_field,
+	is_order_by_in_select,
+	unquote_identifier,
+)
 from frappe.model import OPTIONAL_FIELDS, get_permitted_fields
 from frappe.model.meta import get_table_columns
 from frappe.model.utils import is_virtual_doctype
@@ -328,7 +336,7 @@ class DatabaseQuery:
 
 		if self.distinct:
 			args.fields = "distinct " + args.fields
-			if frappe.db.db_type == "postgres":
+			if frappe.db.db_type == "postgres" and not self._can_apply_distinct_order_by(args.order_by):
 				# PostgreSQL requires ORDER BY expressions to appear in SELECT list when using DISTINCT
 				args.order_by = ""
 
@@ -471,6 +479,39 @@ from {tables}
 			args.order_by = args.order_by.replace(order_field, f"`{order_column}`")
 
 		return args
+
+	def _can_apply_distinct_order_by(self, order_by: str) -> bool:
+		if not order_by:
+			return True
+
+		selected_fields = set()
+		has_joins = len(self.tables) > 1 or bool(self.link_tables)
+		for field in self.fields:
+			if field is None:
+				continue
+			field, *alias = re.split(r"\s+as\s+", field, maxsplit=1, flags=re.IGNORECASE)
+			field = unquote_identifier(field)
+			if field == "*" or field.endswith(".*"):
+				selected_fields.update(self._get_star_columns(field))
+			elif "(" not in field:
+				selected_fields.add(field)
+				# An unqualified sort can use the output name, but an alias replaces that name.
+				if not alias or not has_joins:
+					selected_fields.add(field.rsplit(".", 1)[-1])
+				if "." not in field:
+					selected_fields.add(f"tab{self.doctype}.{field}")
+			if alias:
+				selected_fields.add(unquote_identifier(alias[0]))
+
+		return is_order_by_in_select(order_by, selected_fields, len(self.fields))
+
+	def _get_star_columns(self, field: str) -> set[str]:
+		doctype = self.doctype if field == "*" else get_doctype_name(field[:-2])
+		columns = set()
+		for column in get_table_columns(doctype):
+			columns.add(column)
+			columns.add(f"tab{doctype}.{column}")
+		return columns
 
 	def parse_args(self):
 		"""Convert fields and filters from strings to list, dicts."""

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -1272,6 +1272,59 @@ class TestDBQuery(IntegrationTestCase):
 		)
 		self.assertTrue(len(doctypes[0]) == 2)  # same for pg as well since we order_by None
 
+	def test_distinct_keeps_valid_order_by(self):
+		for field, order_by in (
+			("user_type", "user_type asc"),
+			("user_type as type", "type asc"),
+			("user_type", "`tabUser`.`user_type` asc"),
+		):
+			with self.subTest(field=field, order_by=order_by):
+				query = DatabaseQuery("User").execute(
+					fields=[field], distinct=True, order_by=order_by, run=False
+				)
+				result = DatabaseQuery("User").execute(
+					fields=[field], distinct=True, order_by=order_by, as_list=True
+				)
+
+				self.assertIn("order by", query.lower())
+				self.assertEqual(list(result), sorted(result))
+
+	def test_distinct_drops_unselected_order_by_on_postgres(self):
+		query = DatabaseQuery("User").execute(
+			fields=["user_type"], distinct=True, order_by="creation desc", run=False
+		)
+
+		if frappe.db.db_type == "postgres":
+			self.assertNotIn("order by", query.lower())
+		else:
+			self.assertIn("order by", query.lower())
+
+	def test_distinct_keeps_order_by_on_star_column(self):
+		query = DatabaseQuery("User").execute(
+			fields=["*"], distinct=True, order_by="user_type asc", run=False
+		)
+		result = DatabaseQuery("User").execute(fields=["*"], distinct=True, order_by="user_type asc")
+
+		self.assertIn("order by", query.lower())
+		self.assertEqual([row.user_type for row in result], sorted(row.user_type for row in result))
+
+	@run_only_if(db_type_is.POSTGRES)
+	def test_distinct_order_by_preserves_link_table_identity(self):
+		for order_by, keeps_order in (
+			("creation desc", False),
+			("`tabUser`.`creation` desc", False),
+			("language_creation asc", True),
+		):
+			with self.subTest(order_by=order_by):
+				query = DatabaseQuery("User").execute(
+					fields=["language.creation as language_creation"],
+					distinct=True,
+					order_by=order_by,
+					run=False,
+				)
+				self.assertEqual("order by" in query.lower(), keeps_order)
+				frappe.db.sql(query)
+
 	def test_field_comparison(self):
 		"""Test DatabaseQuery.execute to test field comparison"""
 		users_unedited = frappe.get_all(


### PR DESCRIPTION
GitHub links this pull request in native stack #42456.

## What changed

- Keep ORDER BY on PostgreSQL when every ordered field appears in the distinct result.
- Support selected aliases, qualified field names and star selections.
- Keep table identity when an aliased field comes from a joined table.
- Validate numeric result positions before keeping their ordering.
- Share the ORDER BY field parsing with the query builder through `frappe.database.utils`.
- Keep the existing fallback for ambiguous MariaDB-compatible ordering.

## Why

The legacy ORM removes every ORDER BY clause from PostgreSQL distinct queries. PostgreSQL accepts the clause when each ordered expression appears in the select list.

This caused valid queries to return in an unspecified order.

## Tests

- Added coverage for plain, aliased, qualified and star-selected fields.
- Added coverage for the unselected-field fallback and joined fields with matching column names.
- Ran the full legacy query test module on PostgreSQL.

Part of #34660
