### PR TITLE
fix(postgres): preserve query builder distinct ordering

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -18,7 +18,9 @@ from frappe.database.utils import (
 	convert_to_value,
 	get_doctype_name,
 	get_doctype_sort_info,
+	get_order_by_fields,
 	is_non_text_field,
+	is_order_by_in_select,
 )
 from frappe.model import CORE_DOCTYPES as PERMITTED_CORE_DOCTYPES
 from frappe.model import OPTIONAL_FIELDS, get_permitted_fields
@@ -343,8 +345,11 @@ class Engine:
 
 		if order_by:
 			if not (
-				self.is_postgres and is_select and distinct
-			):  # ignore in Postgres since order by fields need to appear in select distinct
+				self.is_postgres
+				and is_select
+				and distinct
+				and not self._can_apply_distinct_order_by(order_by)
+			):
 				self.apply_order_by(order_by)
 			else:
 				warnings.warn(
@@ -1293,6 +1298,10 @@ class Engine:
 	def _normalize_postgres_order_field(self, field):
 		"""In PostgreSQL order_by fields need to either be in group_by or be aggregated
 		when used with select and group_by"""
+		# DISTINCT ordering already refers to selected expressions. Wrapping them would
+		# create an unselected expression and PostgreSQL would reject the query.
+		if self.query._distinct or isinstance(field, int):
+			return field
 		current_sql = field.get_sql() if hasattr(field, "get_sql") else str(field)
 		if current_sql in self._grouped_queries:
 			return field
@@ -1350,6 +1359,45 @@ class Engine:
 			else:
 				self.query = self.query.orderby(order_field, order=order_direction)
 
+	def _can_apply_distinct_order_by(self, order_by: str) -> bool:
+		if not isinstance(order_by, str):
+			return True
+
+		selected_field_count = 0
+		selected_fields = set()
+		for field in self.fields:
+			if isinstance(field, ChildQuery):
+				continue
+			term = field.field if isinstance(field, DynamicTableField) else field
+			if isinstance(field, LinkTableField):
+				selected_fields.add(f"{field.link_fieldname}.{field.fieldname}")
+			elif isinstance(field, ChildTableField) and field.parent_fieldname:
+				selected_fields.add(f"{field.parent_fieldname}.{field.fieldname}")
+
+			if alias := getattr(field, "alias", None):
+				selected_fields.add(alias)
+			terms = self._get_star_fields(term) if isinstance(term, Star) else [term]
+			selected_field_count += len(terms)
+			for term in terms:
+				if not isinstance(term, Field):
+					continue
+				table = term.table if term.table is not None else self.table
+				if table == self.table:
+					selected_fields.add(term.name)
+				selected_fields.add(f"{table.get_table_name()}.{term.name}")
+
+		if order_by == DefaultOrderBy:
+			order_by = ", ".join(
+				f"{self.table.get_table_name()}.{field}"
+				for field in get_order_by_fields(get_doctype_sort_info(self.doctype)[0])
+			)
+		return is_order_by_in_select(order_by, selected_fields, selected_field_count)
+
+	def _get_star_fields(self, star: Star) -> list[Field]:
+		table = star.table if star.table is not None else self.table
+		columns = frappe.db.get_table_columns(get_doctype_name(table.get_table_name()))
+		return [table[column] for column in columns]
+
 	def _apply_default_order_by(self):
 		"""Apply default ordering based on configured DocType metadata"""
 		from pypika.enums import Order
@@ -1398,7 +1446,7 @@ class Engine:
 
 		return (match.group(1), match.group(3))
 
-	def _validate_and_parse_field_for_clause(self, field_name: str, clause_name: str) -> Field:
+	def _validate_and_parse_field_for_clause(self, field_name: str, clause_name: str) -> Field | int:
 		"""
 		Common helper to validate and parse field names for GROUP BY and ORDER BY clauses.
 
@@ -1410,8 +1458,7 @@ class Engine:
 			Parsed Field object ready for use in pypika query
 		"""
 		if field_name.isdigit():
-			# For numeric field references, return as-is (will be handled by caller)
-			return field_name
+			return int(field_name)
 
 		# Allow function aliases and field aliases - return as Field (no table prefix)
 		if field_name in self.function_aliases or field_name in self.field_aliases:
@@ -1479,7 +1526,7 @@ class Engine:
 
 		return parsed_fields
 
-	def _validate_order_by(self, order_by: str) -> list[tuple[Field | str, Order]]:
+	def _validate_order_by(self, order_by: str) -> list[tuple[Field | int, Order]]:
 		"""Validate the order_by string argument, apply joins for dynamic fields, and return parsed Field objects with directions."""
 		if not isinstance(order_by, str):
 			frappe.throw(_("Order By must be a string"), TypeError)

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -2274,6 +2274,116 @@ class TestQuery(IntegrationTestCase):
 			self.assertIn(self.normalize_sql("ORDER BY `created_date`"), self.normalize_sql(sql))
 		self.assertIn(self.normalize_sql("`creation` `created_date`"), self.normalize_sql(sql))
 
+	def test_distinct_keeps_valid_order_by(self):
+		for field, order_by in (
+			("user_type", "user_type asc"),
+			("user_type as type", "type asc"),
+			("`tabUser`.`user_type`", "`tabUser`.`user_type` asc"),
+		):
+			with self.subTest(field=field, order_by=order_by):
+				query = frappe.qb.get_query("User", fields=[field], distinct=True, order_by=order_by)
+				result = query.run()
+
+				self.assertIn("order by", query.get_sql().lower())
+				self.assertEqual(list(result), sorted(result))
+
+	def test_distinct_drops_unselected_order_by_on_postgres(self):
+		if frappe.db.db_type == "postgres":
+			with self.assertWarnsRegex(UserWarning, "ORDER BY fields have been ignored"):
+				query = frappe.qb.get_query(
+					"User", fields=["user_type"], distinct=True, order_by="creation desc"
+				)
+			self.assertNotIn("order by", query.get_sql().lower())
+		else:
+			query = frappe.qb.get_query("User", fields=["user_type"], distinct=True, order_by="creation desc")
+			self.assertIn("order by", query.get_sql().lower())
+
+	def test_distinct_keeps_order_by_on_star_column(self):
+		query = frappe.qb.get_query("User", fields=["*"], distinct=True, order_by="user_type asc")
+		result = query.run(as_dict=True)
+
+		self.assertIn("order by", query.get_sql().lower())
+		self.assertEqual([row.user_type for row in result], sorted(row.user_type for row in result))
+
+	def test_distinct_keeps_order_by_on_link_field(self):
+		query = frappe.qb.get_query(
+			"User",
+			fields=["name", "language.language_name"],
+			distinct=True,
+			order_by="language.language_name asc",
+		)
+		query.run()
+
+		self.assertIn("order by", query.get_sql().lower())
+
+	@run_only_if(db_type_is.POSTGRES)
+	def test_distinct_order_by_preserves_link_table_identity(self):
+		for order_by in ("creation desc", "`tabUser`.`creation` desc"):
+			with self.subTest(order_by=order_by):
+				with self.assertWarnsRegex(UserWarning, "ORDER BY fields have been ignored"):
+					query = frappe.qb.get_query(
+						"User",
+						fields=["language.creation as language_creation"],
+						distinct=True,
+						order_by=order_by,
+					)
+				self.assertNotIn("order by", query.get_sql().lower())
+				query.run()
+
+		for order_by in ("language_creation asc", "language.creation asc"):
+			with self.subTest(order_by=order_by):
+				query = frappe.qb.get_query(
+					"User",
+					fields=["language.creation as language_creation"],
+					distinct=True,
+					order_by=order_by,
+				)
+				self.assertIn("order by", query.get_sql().lower())
+				query.run()
+
+	def test_distinct_order_by_result_position(self):
+		for group_by in (None, "user_type, enabled"):
+			for position, direction in ((1, "asc"), (2, "desc")):
+				with self.subTest(group_by=group_by, position=position):
+					query = frappe.qb.get_query(
+						"User",
+						fields=["user_type", "enabled"],
+						distinct=True,
+						group_by=group_by,
+						order_by=f"{position} {direction}",
+					)
+					values = [row[position - 1] for row in query.run()]
+					self.assertEqual(values, sorted(values, reverse=direction == "desc"))
+
+	def test_distinct_order_by_star_result_position(self):
+		query = frappe.qb.get_query("User", fields=["*"], distinct=True, order_by="2 asc")
+		self.assertIn("ORDER BY 2 ASC", query.get_sql())
+		query.run()
+
+	def test_distinct_order_by_selected_grouped_field(self):
+		for field in ("creation", "enabled"):
+			with self.subTest(field=field):
+				query = frappe.qb.get_query(
+					"User",
+					fields=["name", field],
+					group_by="name",
+					distinct=True,
+					order_by=f"{field} asc",
+				)
+				values = [row[1] for row in query.run()]
+				self.assertEqual(values, sorted(values))
+
+	@run_only_if(db_type_is.POSTGRES)
+	def test_distinct_drops_invalid_result_position(self):
+		for position in (0, 2):
+			with self.subTest(position=position):
+				with self.assertWarnsRegex(UserWarning, "ORDER BY fields have been ignored"):
+					query = frappe.qb.get_query(
+						"User", fields=["user_type"], distinct=True, order_by=f"{position} asc"
+					)
+				self.assertNotIn("order by", query.get_sql().lower())
+				query.run()
+
 	def test_field_alias_permission_check(self):
 		query = frappe.qb.get_query(
 			"User",


### PR DESCRIPTION
GitHub links this pull request in native stack #42456.

## What changed

- Keep ORDER BY on PostgreSQL when every ordered field appears in the distinct result.
- Support selected aliases, qualified field names, star selections and Link table fields.
- Validate numeric result positions and emit them as numbers, including grouped queries and star selections.
- Distinguish fields on joined tables from fields on the main table.
- Preserve selected sort expressions in grouped distinct queries without adding another aggregate.
- Reuse the shared ORDER BY field parsing from `frappe.database.utils`.
- Keep the existing warning for ambiguous ordering.

## Why

The current query builder removes every ORDER BY clause from PostgreSQL distinct queries. PostgreSQL accepts the clause when each ordered expression appears in the select list.

This caused valid queries to return in an unspecified order.

## Tests

- Added coverage for plain, aliased, qualified, star and Link table fields.
- Added coverage for the unselected-field warning, joined fields, grouped queries, and valid and invalid numeric positions.
- Ran the full current query test module on PostgreSQL.

Part of #34660
