### PR TITLE
fix: add client_secret in blocklist of traceback_sanitizer

### DIFF
--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -355,6 +355,7 @@ def _get_traceback_sanitizer():
 		"token",
 		"key",
 		"pwd",
+		"client_secret",
 	]
 
 	placeholder = "********"


### PR DESCRIPTION
Add `client_secret` in blocklist of traceback_sanitizer so it's masked.
