### PR TITLE
fix(oauth): require client authentication on token introspection endpoint

### DIFF
--- a/frappe/integrations/oauth2.py
+++ b/frappe/integrations/oauth2.py
@@ -268,7 +268,12 @@ def authenticate_introspection_caller() -> str | None:
 	client_id = frappe.form_dict.get("client_id")
 	client_secret = frappe.form_dict.get("client_secret")
 
-	if not client_id or not client_secret:
+	if (
+		not isinstance(client_id, str)
+		or not isinstance(client_secret, str)
+		or not client_id
+		or not client_secret
+	):
 		return None
 
 	stored_secret = frappe.db.get_value("OAuth Client", client_id, "client_secret")

--- a/frappe/integrations/oauth2.py
+++ b/frappe/integrations/oauth2.py
@@ -1,4 +1,5 @@
 import datetime
+import hmac
 import json
 from typing import Literal, cast
 from urllib.parse import quote, urlencode, urlparse
@@ -255,8 +256,35 @@ def get_openid_configuration():
 	return response
 
 
+def authenticate_introspection_caller() -> str | None:
+	"""Verify the calling OAuth client's credentials per RFC 7662 §2.1 (Client Secret Post).
+
+	Note: HTTP Basic auth (Client Secret Basic) is not supported here - Frappe's own
+	request-level auth (validate_auth_via_api_keys) claims the Authorization: Basic
+	header globally for API key/secret pairs and 401s before this handler ever runs.
+
+	Returns the authenticated client_id, or None if the caller could not be authenticated.
+	"""
+	client_id = frappe.form_dict.get("client_id")
+	client_secret = frappe.form_dict.get("client_secret")
+
+	if not client_id or not client_secret:
+		return None
+
+	stored_secret = frappe.db.get_value("OAuth Client", client_id, "client_secret")
+	if not stored_secret or not hmac.compare_digest(stored_secret, client_secret):
+		return None
+
+	return client_id
+
+
 @frappe.whitelist(allow_guest=True, methods=["POST"])
 def introspect_token(token: str, token_type_hint: str | None = None):
+	authenticated_client_id = authenticate_introspection_caller()
+	if not authenticated_client_id:
+		frappe.local.response = frappe._dict({"active": False})
+		return
+
 	if token_type_hint not in ["access_token", "refresh_token"]:
 		token_type_hint = "access_token"
 	try:
@@ -269,6 +297,10 @@ def introspect_token(token: str, token_type_hint: str | None = None):
 			)
 
 		client = frappe.get_cached_doc("OAuth Client", bearer_token.client)
+
+		if client.client_id != authenticated_client_id:
+			frappe.local.response = frappe._dict({"active": False})
+			return
 
 		token_response = frappe._dict(
 			{

--- a/frappe/tests/test_oauth20.py
+++ b/frappe/tests/test_oauth20.py
@@ -284,6 +284,23 @@ class TestOAuth20(FrappeRequestTestCase):
 		self.assertEqual(response.status_code, 200)
 		self.assertEqual(response.json, {"active": False})
 
+	def test_introspect_token_rejects_non_string_credentials_from_json_body(self):
+		"""A JSON body preserves non-string types in form_dict (unlike form-encoded data);
+		a non-string client_secret must not reach hmac.compare_digest and crash the request."""
+		access_token, _token = self._make_bearer_token()
+		frappe.db.commit()  # nosemgrep
+
+		response = self.post(
+			"/api/method/frappe.integrations.oauth2.introspect_token",
+			headers={"content-type": "application/json"},
+			data=frappe.as_json(
+				{"token": access_token, "client_id": self.client_id, "client_secret": {"a": 1}}
+			),
+		)
+
+		self.assertEqual(response.status_code, 200)
+		self.assertEqual(response.json, {"active": False})
+
 	def test_invalid_login(self):
 		with suppress_stdout():
 			self.assertFalse(check_valid_openid_response(client=self))

--- a/frappe/tests/test_oauth20.py
+++ b/frappe/tests/test_oauth20.py
@@ -132,7 +132,7 @@ class TestOAuth20(FrappeRequestTestCase):
 	def test_openid_profile_post_body_token(self):
 		access_token, _token = self._make_bearer_token()
 		# The HTTP request runs in another thread and only sees committed fixtures.
-		frappe.db.commit()  # nosemgrep: frappe-semgrep-rules.rules.frappe-manual-commit
+		frappe.db.commit()  # nosemgrep
 
 		openid_response = self.post(
 			"/api/method/frappe.integrations.oauth2.openid_profile",
@@ -142,6 +142,147 @@ class TestOAuth20(FrappeRequestTestCase):
 
 		self.assertEqual(openid_response.status_code, 200)
 		self.assertEqual(openid_response.json.get("email"), "test@example.com")
+
+	def test_introspect_token_rejects_unauthenticated_caller(self):
+		access_token, _token = self._make_bearer_token()
+		frappe.db.commit()  # nosemgrep
+
+		response = self.post(
+			"/api/method/frappe.integrations.oauth2.introspect_token",
+			headers=self.form_header,
+			data={"token": access_token},
+		)
+
+		self.assertEqual(response.status_code, 200)
+		self.assertEqual(response.json, {"active": False})
+
+	def test_introspect_token_rejects_wrong_client_secret(self):
+		access_token, _token = self._make_bearer_token()
+		frappe.db.commit()  # nosemgrep
+
+		response = self.post(
+			"/api/method/frappe.integrations.oauth2.introspect_token",
+			headers=self.form_header,
+			data={"token": access_token, "client_id": self.client_id, "client_secret": "wrong-secret"},
+		)
+
+		self.assertEqual(response.status_code, 200)
+		self.assertEqual(response.json, {"active": False})
+
+	def test_introspect_token_rejects_mismatched_client(self):
+		"""A different, correctly-authenticated client must not introspect someone else's token."""
+		access_token, _token = self._make_bearer_token()
+
+		other_client = frappe.get_doc(
+			doctype="OAuth Client",
+			app_name="_Test Other OAuth Client",
+			client_secret="other_client_secret",
+			default_redirect_uri="http://localhost",
+			grant_type="Authorization Code",
+			redirect_uris="http://localhost",
+			response_type="Code",
+			scopes="all openid",
+			skip_authorization=1,
+		).insert()
+		frappe.db.commit()  # nosemgrep
+
+		try:
+			response = self.post(
+				"/api/method/frappe.integrations.oauth2.introspect_token",
+				headers=self.form_header,
+				data={
+					"token": access_token,
+					"client_id": other_client.client_id,
+					"client_secret": "other_client_secret",
+				},
+			)
+
+			self.assertEqual(response.status_code, 200)
+			self.assertEqual(response.json, {"active": False})
+		finally:
+			other_client.delete(force=True)
+			frappe.db.commit()  # nosemgrep
+
+	def test_introspect_token_succeeds_with_post_body_credentials(self):
+		access_token, _token = self._make_bearer_token()
+		frappe.db.commit()  # nosemgrep
+
+		response = self.post(
+			"/api/method/frappe.integrations.oauth2.introspect_token",
+			headers=self.form_header,
+			data={"token": access_token, "client_id": self.client_id, "client_secret": self.client_secret},
+		)
+
+		self.assertEqual(response.status_code, 200)
+		self.assertTrue(response.json.get("active"))
+		self.assertEqual(response.json.get("client_id"), self.client_id)
+		# scope includes "openid" (see setUp) - userinfo should be merged in
+		self.assertEqual(response.json.get("email"), "test@example.com")
+		self.assertTrue(response.json.get("sub"))
+
+	def test_introspect_token_owning_client_sees_revoked_token_status(self):
+		"""Auth gate must not block the legitimate owning client from checking its
+		own token's real status - only from seeing OTHER clients' tokens."""
+		access_token, token = self._make_bearer_token()
+		token.db_set("status", "Revoked")
+		frappe.db.commit()  # nosemgrep
+
+		response = self.post(
+			"/api/method/frappe.integrations.oauth2.introspect_token",
+			headers=self.form_header,
+			data={"token": access_token, "client_id": self.client_id, "client_secret": self.client_secret},
+		)
+
+		self.assertEqual(response.status_code, 200)
+		self.assertFalse(response.json.get("active"))
+		self.assertEqual(response.json.get("client_id"), self.client_id)
+
+	def test_introspect_refresh_token_hint_requires_client_auth(self):
+		refresh_token = frappe.generate_hash()
+		frappe.get_doc(
+			doctype="OAuth Bearer Token",
+			access_token=frappe.generate_hash(),
+			refresh_token=refresh_token,
+			client=self.client_id,
+			expires_in=3600,
+			scopes=self.scope,
+			status="Active",
+			user="test@example.com",
+		).insert(ignore_permissions=True)
+		frappe.db.commit()  # nosemgrep
+
+		unauthenticated = self.post(
+			"/api/method/frappe.integrations.oauth2.introspect_token",
+			headers=self.form_header,
+			data={"token": refresh_token, "token_type_hint": "refresh_token"},
+		)
+		self.assertEqual(unauthenticated.json, {"active": False})
+
+		authenticated = self.post(
+			"/api/method/frappe.integrations.oauth2.introspect_token",
+			headers=self.form_header,
+			data={
+				"token": refresh_token,
+				"token_type_hint": "refresh_token",
+				"client_id": self.client_id,
+				"client_secret": self.client_secret,
+			},
+		)
+		self.assertTrue(authenticated.json.get("active"))
+
+	def test_introspect_token_unknown_token_returns_inactive_for_authenticated_client(self):
+		response = self.post(
+			"/api/method/frappe.integrations.oauth2.introspect_token",
+			headers=self.form_header,
+			data={
+				"token": "this-token-does-not-exist",
+				"client_id": self.client_id,
+				"client_secret": self.client_secret,
+			},
+		)
+
+		self.assertEqual(response.status_code, 200)
+		self.assertEqual(response.json, {"active": False})
 
 	def test_invalid_login(self):
 		with suppress_stdout():


### PR DESCRIPTION
This PR adds a validation layer to require client authentication on token introspection endpoint.

closes Ticket 76748