### PR TITLE
fix(list view): keep the right column aligned across rows

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1123,8 +1123,8 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 					? this.max_number_of_avatars
 					: assign_to_length
 			);
-			has_assignto = true;
 		}
+		has_assignto = assign_to_count > 0;
 
 		return { has_assignto, assign_to_count };
 	}
@@ -1589,7 +1589,15 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	}
 
 	update_listview_classes(has_assignto, assign_to_count) {
+		// widest comment count on the page, in characters ("99+" is 3); sizes the count slot
+		const count_length = this.data.reduce(
+			(max, doc) => Math.max(max, Math.min(3, String(doc._comment_count || 0).length)),
+			1
+		);
+		this.$result.attr("data-comment-count-length", count_length);
+
 		// add class to result to indetify that it has assignto
+		this.$result.removeClass("assign-to-length-1 assign-to-length-2 assign-to-length-3");
 		if (has_assignto) {
 			this.$result.addClass(["has-assign-to", `assign-to-length-${assign_to_count}`]);
 			this.$result.removeClass("no-assign-to");
@@ -1658,13 +1666,13 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		if (this.list_view_settings && !this.list_view_settings.disable_comment_count) {
 			comment_count = `<span class="comment-count d-flex align-items-center">
 				${frappe.utils.icon("message-circle")}
-				${doc._comment_count > 99 ? "99+" : doc._comment_count || 0}
+				<span class="count">${doc._comment_count > 99 ? "99+" : doc._comment_count || 0}</span>
 			</span>`;
 		}
 
 		html += `
 			<div class="level-item list-row-activity hidden-xs">
-				<div class="hidden-md hidden-xs d-flex">
+				<div class="list-assignments-container hidden-md hidden-xs d-flex">
 					${assigned_to}
 				</div>
 				<span class="modified">${modified}</span>

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -160,30 +160,50 @@
 
 	.result.has-assign-to {
 		.list-row .level-right {
-			flex: 0 0 180px;
-			width: 180px;
+			flex: 0 0 auto;
+			min-width: 180px;
 		}
 
 		&.assign-to-length-1 {
 			.list-row .level-right {
-				flex: 0 0 165px;
-				width: 165px;
+				min-width: 165px;
 			}
 		}
 
 		&.assign-to-length-3 {
 			.list-row .level-right {
-				flex: 0 0 200px;
-				width: 200px;
+				min-width: 200px;
 			}
 		}
 	}
 
 	.result.no-assign-to {
 		.list-row .level-right {
-			flex: 0 0 130px;
-			width: 130px;
+			flex: 0 0 auto;
+			min-width: 130px;
 		}
+	}
+
+	// Fixed-width slots for avatars and comment counts so rows don't shift sideways.
+	.result.has-assign-to .list-assignments-container {
+		flex: none;
+		width: 56px;
+	}
+
+	.result.assign-to-length-1 .list-assignments-container {
+		width: 38px;
+	}
+
+	.result.assign-to-length-3 .list-assignments-container {
+		width: 74px;
+	}
+
+	.result[data-comment-count-length="2"] .comment-count .count {
+		min-width: 1.4em;
+	}
+
+	.result[data-comment-count-length="3"] .comment-count .count {
+		min-width: 2.1em;
 	}
 }
 
@@ -233,6 +253,7 @@
 	.list-row-activity {
 		justify-content: flex-end;
 		// min-width: 120px;
+		font-variant-numeric: tabular-nums;
 
 		& > span {
 			display: inline-block;
@@ -240,11 +261,17 @@
 
 		.modified {
 			margin-right: var(--margin-sm);
-			min-width: 1.5rem;
+			min-width: 2.7em; // fits the widest short timestamp, "11 M"
+			text-align: right;
 		}
 
 		.comment-count {
 			min-width: 35px;
+			gap: var(--margin-xs);
+
+			.count {
+				min-width: 0.7em;
+			}
 		}
 
 		.frappe-timestamp {
@@ -252,7 +279,10 @@
 			white-space: nowrap;
 		}
 
-		.list-assignments,
+		.list-assignments {
+			margin-right: var(--margin-sm);
+		}
+
 		.list-actions {
 			margin-right: var(--margin-md);
 		}


### PR DESCRIPTION

**Problem**: the timestamp, comment count and avatars on the right of each row have different widths per row (1 M vs 42 m, 0 vs 99+, one avatar vs three). Since the row packs from the right, a wider value pushed everything beside it, so columns didn't line up down the list.
<img width="1198" height="560" alt="image" src="https://github.com/user-attachments/assets/586841cf-0a2d-4093-a577-b558241a8334" />



**Fix**: each of those three now gets a fixed slot, sized once per page for the widest value on it. The .level-right widths become min-width floors so the reserved content isn't clipped.

Also fixes stale assign-to-length-N classes surviving re-render, and _assign = "[]" counting as assigned.
<img width="677" height="422" alt="image" src="https://github.com/user-attachments/assets/13bce9a8-7268-4fee-bb52-cc4212ce0894" />
