### PR TITLE
fix: draw a navigation item's authored icon

### DIFF
--- a/frontend/src/icons/Icon.vue
+++ b/frontend/src/icons/Icon.vue
@@ -1,0 +1,52 @@
+<!--
+  One icon, drawn from a name.
+
+  `fieldtype: Icon` stores an emoji glyph or a bare sprite symbol name, and its picker
+  writes both. A name the sprite does not hold draws nothing and logs once.
+-->
+<template>
+	<span v-if="emoji" :class="SLOT" aria-hidden="true">{{ name }}</span>
+
+	<svg
+		v-else-if="symbol"
+		:class="SLOT"
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		stroke-width="1.5"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		aria-hidden="true"
+	>
+		<use :href="`#${symbolId(name!)}`" />
+	</svg>
+
+	<span v-else-if="reserve" :class="SLOT" aria-hidden="true" />
+</template>
+
+<script setup lang="ts">
+import { computed, watchEffect } from "vue";
+import { hasSymbol, isEmoji, reportMissingIcon, spriteLoaded, symbolId } from "./sprite";
+
+// `shrink-0` because a row truncates its label and must never truncate the icon instead.
+const SLOT = "size-4 shrink-0 text-center leading-4";
+
+// Every shape is `aria-hidden`: the icon sits beside the label it illustrates, and naming
+// it would read the row twice.
+const props = defineProps<{
+	/** An emoji glyph, or a sprite symbol name. */
+	name?: string;
+	/** Hold the slot open when there is nothing to draw. */
+	reserve?: boolean;
+}>();
+
+const emoji = computed(() => !!props.name && isEmoji(props.name));
+// Reads `spriteLoaded` through `hasSymbol`, so this recomputes when the sprite lands.
+const symbol = computed(() => !!props.name && !emoji.value && hasSymbol(props.name));
+
+watchEffect(() => {
+	// Before the sprite lands every name is legitimately absent.
+	if (!props.name || emoji.value || symbol.value || !spriteLoaded.value) return;
+	reportMissingIcon(props.name);
+});
+</script>

--- a/frontend/src/icons/sprite.ts
+++ b/frontend/src/icons/sprite.ts
@@ -1,0 +1,89 @@
+// The shell's runtime icon source: the sprite desk v1 loads through `app_include_icons`.
+//
+// Both of frappe-ui's lucide paths are build-time and cannot draw a name that arrives
+// with boot, and `tailwind.config.js` gives nobody a safelist.
+
+import { ref } from "vue";
+
+const SPRITE_URL = "/assets/frappe/icons/lucide/icons.svg";
+// Not `lucide-sprite`: that id is frappe-ui's own sprite, whose symbol ids are bare, and
+// `recordPage/iconClasses.ts` reads it.
+const CONTAINER_ID = "frappe-icon-sprite";
+
+/** Flips once the sprite is in the document. */
+// A ref and not a plain flag: `<use>` picking up a symbol that arrives later is not
+// something every browser agrees on, so arrival has to be a reactive dependency.
+export const spriteLoaded = ref(false);
+
+let loading: Promise<void> | null = null;
+/** Every symbol name the sprite holds, indexed at load. */
+const names = new Set<string>();
+
+/** Fetches the sprite once per document; later callers join the first one's request. */
+export function loadSprite(): Promise<void> {
+	if (loading) return loading;
+
+	loading = fetch(SPRITE_URL, { credentials: "same-origin" })
+		.then((response) => {
+			if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+			return response.text();
+		})
+		.then((svg) => {
+			const element = container();
+			element.innerHTML = svg;
+			for (const symbol of element.querySelectorAll("symbol[id]")) names.add(symbol.id);
+			spriteLoaded.value = true;
+		})
+		.catch((error) => {
+			console.error(`[frappe] could not load the icon sprite from ${SPRITE_URL}`, error);
+		});
+
+	return loading;
+}
+
+/** Whether the sprite holds this symbol. False until the sprite lands. */
+export function hasSymbol(name: string): boolean {
+	// Reads the ref so a row drawn before the sprite landed recomputes when it does.
+	return spriteLoaded.value && names.has(symbolId(name));
+}
+
+/** The sprite's own spelling of a symbol id. */
+export function symbolId(name: string): string {
+	return `icon-${name}`;
+}
+
+/** Whether an `Icon` field's value is an emoji glyph rather than a symbol name. */
+// The same test as `frappe.utils.is_emoji`, since one picker writes for both.
+export function isEmoji(value: string): boolean {
+	return /^\p{Extended_Pictographic}(‍\p{Extended_Pictographic}|️|⃣)*$/u.test(value);
+}
+
+/** One line per name per page session, not one per row. */
+const reported = new Set<string>();
+
+/** Says a name resolved to nothing. */
+export function reportMissingIcon(name: string) {
+	if (reported.has(name)) return;
+	reported.add(name);
+	console.warn(`[frappe] no icon named '${name}' in the sprite; nothing is drawn.`);
+}
+
+/** Test-only: forget the sprite, so each test loads its own. */
+export function resetSprite() {
+	loading = null;
+	spriteLoaded.value = false;
+	names.clear();
+	reported.clear();
+	document.getElementById(CONTAINER_ID)?.remove();
+}
+
+function container(): HTMLElement {
+	const existing = document.getElementById(CONTAINER_ID);
+	if (existing) return existing;
+
+	const element = document.createElement("div");
+	element.id = CONTAINER_ID;
+	element.style.display = "none";
+	document.body.appendChild(element);
+	return element;
+}

--- a/frontend/src/icons/tests/icon.test.ts
+++ b/frontend/src/icons/tests/icon.test.ts
@@ -1,0 +1,122 @@
+// What an authored icon name draws, and what an unknown one does not.
+//
+// Mounted with Vue's own `createApp` into happy-dom: this package has no
+// `@vue/test-utils`, and a shared devDependency for one component is a cost every app pays.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createApp, h, nextTick } from "vue";
+
+import Icon from "../Icon.vue";
+import { loadSprite, resetSprite } from "../sprite";
+
+const SPRITE =
+	'<svg id="frappe-symbols" style="display:none">' +
+	'<symbol id="icon-users" viewBox="0 0 24 24"><circle cx="9" cy="7" r="4"/></symbol>' +
+	"</svg>";
+
+function stubFetch() {
+	vi.stubGlobal(
+		"fetch",
+		vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve(SPRITE) })
+	);
+}
+
+function mount(props: { name?: string; reserve?: boolean }) {
+	const host = document.createElement("div");
+	document.body.appendChild(host);
+	createApp({ render: () => h(Icon, props) }).mount(host);
+	return host;
+}
+
+beforeEach(() => {
+	document.body.innerHTML = "";
+	resetSprite();
+	stubFetch();
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+describe("a name in the sprite", () => {
+	it("draws the symbol", async () => {
+		await loadSprite();
+
+		const host = mount({ name: "users" });
+
+		expect(host.querySelector("use")?.getAttribute("href")).toBe("#icon-users");
+	});
+
+	it("is hidden from a screen reader", async () => {
+		// It sits beside the label it illustrates, so naming it reads the row twice.
+		await loadSprite();
+
+		const host = mount({ name: "users" });
+
+		expect(host.querySelector("svg")?.getAttribute("aria-hidden")).toBe("true");
+	});
+
+	it("appears when the sprite lands, without another render", async () => {
+		// `main.ts` fires the sprite without awaiting it, so a rail paints before it lands.
+		const host = mount({ name: "users" });
+		expect(host.querySelector("use")).toBeNull();
+
+		await loadSprite();
+		await nextTick();
+
+		expect(host.querySelector("use")?.getAttribute("href")).toBe("#icon-users");
+	});
+});
+
+describe("an emoji", () => {
+	it("is drawn as text, not looked up in the sprite", async () => {
+		// The other value `fieldtype: Icon` stores; the field sets `options: Emojis`.
+		await loadSprite();
+
+		const host = mount({ name: "🚀" });
+
+		expect(host.querySelector("svg")).toBeNull();
+		expect(host.textContent).toBe("🚀");
+	});
+});
+
+describe("a name the sprite does not hold", () => {
+	it("draws nothing and says so once", async () => {
+		// Not lucide's `circle-help` placeholder, which would sit in the rail unnoticed.
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		await loadSprite();
+
+		const host = mount({ name: "not-an-icon" });
+		mount({ name: "not-an-icon" });
+		await nextTick();
+
+		expect(host.querySelector("svg")).toBeNull();
+		expect(host.textContent).toBe("");
+		expect(warn).toHaveBeenCalledOnce();
+	});
+
+	it("says nothing while the sprite is still in flight", async () => {
+		// Before it lands every name is legitimately absent.
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		mount({ name: "users" });
+		await nextTick();
+
+		expect(warn).not.toHaveBeenCalled();
+	});
+});
+
+describe("the reserved slot", () => {
+	it("holds a row's indent open when there is nothing to draw", () => {
+		const host = mount({ reserve: true });
+
+		expect(host.querySelector("span")).not.toBeNull();
+	});
+
+	it("draws nothing at all without it", () => {
+		const host = mount({});
+
+		expect(host.querySelector("span")).toBeNull();
+		expect(host.querySelector("svg")).toBeNull();
+	});
+});

--- a/frontend/src/icons/tests/sprite.test.ts
+++ b/frontend/src/icons/tests/sprite.test.ts
@@ -1,0 +1,132 @@
+// The sprite loader: one fetch per document, and what a failed one costs.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+	hasSymbol,
+	isEmoji,
+	loadSprite,
+	reportMissingIcon,
+	resetSprite,
+	spriteLoaded,
+	symbolId,
+} from "../sprite";
+
+const SPRITE =
+	'<svg id="frappe-symbols" style="display:none">' +
+	'<symbol id="icon-users" viewBox="0 0 24 24"><circle cx="9" cy="7" r="4"/></symbol>' +
+	'<symbol id="icon-handshake" viewBox="0 0 24 24"><path d="M1 1"/></symbol>' +
+	"</svg>";
+
+function stubFetch(body = SPRITE, ok = true) {
+	const fetch = vi.fn().mockResolvedValue({
+		ok,
+		status: ok ? 200 : 404,
+		statusText: ok ? "OK" : "Not Found",
+		text: () => Promise.resolve(body),
+	});
+	vi.stubGlobal("fetch", fetch);
+	return fetch;
+}
+
+beforeEach(() => {
+	document.body.innerHTML = "";
+	resetSprite();
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+describe("loadSprite", () => {
+	it("fetches once however many callers ask", async () => {
+		// A sprite fetched per row would be 450 KB times the rail.
+		const fetch = stubFetch();
+
+		await Promise.all([loadSprite(), loadSprite(), loadSprite()]);
+
+		expect(fetch).toHaveBeenCalledTimes(1);
+		expect(fetch.mock.calls[0][0]).toBe("/assets/frappe/icons/lucide/icons.svg");
+	});
+
+	it("puts the symbols in the document and flips spriteLoaded", async () => {
+		stubFetch();
+		expect(spriteLoaded.value).toBe(false);
+
+		await loadSprite();
+
+		expect(spriteLoaded.value).toBe(true);
+		expect(document.getElementById("frappe-icon-sprite")).not.toBeNull();
+		expect(hasSymbol("users")).toBe(true);
+		expect(hasSymbol("not-an-icon")).toBe(false);
+	});
+
+	it("does not answer to `lucide-sprite`", async () => {
+		// That id belongs to frappe-ui's sprite, whose symbols carry bare ids, and
+		// `recordPage/iconClasses.ts` reads it.
+		stubFetch();
+
+		await loadSprite();
+
+		expect(document.getElementById("lucide-sprite")).toBeNull();
+	});
+
+	it("degrades when the sprite cannot be fetched", async () => {
+		// The rows keep their labels and their destinations.
+		const error = vi.spyOn(console, "error").mockImplementation(() => {});
+		stubFetch("", false);
+
+		await loadSprite();
+
+		expect(spriteLoaded.value).toBe(false);
+		expect(hasSymbol("users")).toBe(false);
+		expect(error).toHaveBeenCalledOnce();
+	});
+});
+
+describe("hasSymbol", () => {
+	it("is false before the sprite lands", () => {
+		expect(hasSymbol("users")).toBe(false);
+	});
+
+	it("does not find a symbol outside the sprite", async () => {
+		// `icon-users` is a bare word an app could put on an element of its own.
+		stubFetch();
+		await loadSprite();
+		const stray = document.createElement("div");
+		stray.id = "icon-stray";
+		document.body.appendChild(stray);
+
+		expect(hasSymbol("stray")).toBe(false);
+	});
+});
+
+describe("isEmoji", () => {
+	it("agrees with frappe.utils.is_emoji about what the Icon field stores", () => {
+		// Both values come out of one picker, so one has to read the other's writing.
+		expect(isEmoji("🚀")).toBe(true);
+		expect(isEmoji("⚠️")).toBe(true);
+		expect(isEmoji("users")).toBe(false);
+		expect(isEmoji("contact-round")).toBe(false);
+		expect(isEmoji("")).toBe(false);
+	});
+});
+
+describe("symbolId", () => {
+	it("uses the sprite's own spelling", () => {
+		expect(symbolId("users")).toBe("icon-users");
+	});
+});
+
+describe("reportMissingIcon", () => {
+	it("says a name once, not once per row", async () => {
+		// Every row of a sidebar can name the same missing icon.
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		reportMissingIcon("nope");
+		reportMissingIcon("nope");
+		reportMissingIcon("also-nope");
+
+		expect(warn).toHaveBeenCalledTimes(2);
+	});
+});

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -14,6 +14,7 @@ import { fetchAddresses, type Addresses } from "@/addresses";
 import { createShellRouter } from "@/router";
 import { registerShell } from "@/router/routeFor";
 import { loadTranslations } from "@/i18n";
+import { loadSprite } from "@/icons/sprite";
 import { registerContributions } from "@/contributions/registry";
 import AppShell from "@/shell/AppShell.vue";
 import Unauthorized from "@/shell/Unauthorized.vue";
@@ -38,6 +39,9 @@ async function start() {
 
 	// 2. Translations are fired, NOT awaited (#42070).
 	loadTranslations(boot.translations_version, boot.lang);
+
+	// 2a. The icon sprite, fired and not awaited for the same reason.
+	loadSprite();
 
 	// 2b. The address table, which IS awaited -- unlike translations, because the route
 	//     table cannot resolve a single URL without it and an untranslated first frame

--- a/frontend/src/navigation/NavigationRow.vue
+++ b/frontend/src/navigation/NavigationRow.vue
@@ -10,6 +10,9 @@
   exists to prevent. Nothing here decides what a row DOES: it asks the renderer, and draws
   one of the four shapes it can come back with (`navigation/types.ts`).
 
+  An icon is drawn on every shape that goes somewhere, and never on a heading; a heading
+  that carries one has it ignored.
+
   A row with no rendering and no children is not drawn at all. That is #42228's degrade for
   a kind with no renderer, widened to every reason an item cannot be placed here — a
   `Module` under a non-modular prefix, a `Page` whose slug this prefix does not serve. Its
@@ -27,7 +30,8 @@
 			:aria-current="isCurrent ? 'page' : undefined"
 			:class="[ROW, isCurrent && CURRENT]"
 		>
-			{{ label }}
+			<Icon :name="item.icon" :reserve="reserve" />
+			<span class="truncate">{{ label }}</span>
 		</RouterLink>
 
 		<!-- A destination outside it. Following this is a full document load, so it is an
@@ -41,7 +45,8 @@
 			:aria-current="isCurrent ? 'page' : undefined"
 			:class="[ROW, isCurrent && CURRENT]"
 		>
-			{{ label }}
+			<Icon :name="item.icon" :reserve="reserve" />
+			<span class="truncate">{{ label }}</span>
 		</a>
 
 		<!-- Rows that are not known until they are asked for. A BUTTON, not a link: it goes
@@ -54,7 +59,8 @@
 			:class="ROW"
 			@click="expand"
 		>
-			{{ label }}
+			<Icon :name="item.icon" :reserve="reserve" />
+			<span class="truncate">{{ label }}</span>
 		</button>
 
 		<!-- A heading. Collapsible ones are a button, because a heading a reader can close is
@@ -79,6 +85,7 @@
 				:node="child"
 				:context="context"
 				:current="current"
+				:reserve="reserve"
 			/>
 		</ul>
 
@@ -91,6 +98,7 @@
 			:node="child"
 			:context="context"
 			:current="current"
+			:reserve="reserve"
 		/>
 	</li>
 </template>
@@ -100,10 +108,11 @@ import { computed, ref, watch } from "vue";
 import { RouterLink } from "vue-router";
 import { buildTree, type ItemNode } from "@/navigation/tree";
 import { labelOf, renderingOf } from "@/navigation/registry";
+import Icon from "@/icons/Icon.vue";
 import type { ItemContext } from "@/navigation/types";
 
 const ROW =
-	"flex w-full items-center truncate rounded px-2 py-1 text-left text-sm text-ink-gray-7 hover:bg-surface-gray-2";
+	"flex w-full items-center gap-2 truncate rounded px-2 py-1 text-left text-sm text-ink-gray-7 hover:bg-surface-gray-2";
 // A step past `hover:bg-surface-gray-2` rather than the same shade, or a reader could not
 // tell the row they are on from the row under the pointer.
 //
@@ -119,10 +128,14 @@ const HEADING =
 // `current` is the key of the one row the address is standing on, in THIS container
 // (`navigation/current.ts`). It is passed down rather than computed here because exactly one
 // row wins across the rail and the open panel together, and no row can know that alone.
+//
+// `reserve` is decided once for a whole container and handed to every row in it, so a
+// container where only some rows carry an icon still reads as one list.
 const props = defineProps<{
 	node: ItemNode;
 	context: ItemContext;
 	current?: string;
+	reserve?: boolean;
 }>();
 
 const item = computed(() => props.node.item);

--- a/frontend/src/navigation/iconSlot.ts
+++ b/frontend/src/navigation/iconSlot.ts
@@ -1,0 +1,26 @@
+// Whether a container holds an icon slot open on the rows that have no icon.
+//
+// Decided once for a whole container, so a list where only some rows carry an icon still
+// reads as one list.
+
+import { computed, type ComputedRef, type MaybeRefOrGetter, toValue } from "vue";
+import type { NavigationItem } from "@/boot";
+import { renderingOf } from "./registry";
+import type { ItemContext } from "./types";
+
+/** True when any row that would draw an icon has one. */
+export function useIconSlot(
+	items: MaybeRefOrGetter<NavigationItem[]>,
+	context: MaybeRefOrGetter<ItemContext>
+): ComputedRef<boolean> {
+	return computed(() =>
+		toValue(items).some((item) => item.icon && drawsIcon(item, toValue(context)))
+	);
+}
+
+// Asked of the renderer rather than of `item_type`: a heading is whatever resolves to no
+// destination, which is `NavigationRow`'s own rule and not a list of kinds.
+function drawsIcon(item: NavigationItem, context: ItemContext): boolean {
+	const rendering = renderingOf(item, context);
+	return !!rendering && !("group" in rendering);
+}

--- a/frontend/src/shell/AppRail.vue
+++ b/frontend/src/shell/AppRail.vue
@@ -57,6 +57,7 @@
 				:node="node"
 				:context="context"
 				:current="current"
+				:reserve="reserve"
 			/>
 		</ul>
 
@@ -79,7 +80,7 @@
 </template>
 
 <script setup lang="ts">
-import { inject } from "vue";
+import { computed, inject } from "vue";
 import { RouterLink } from "vue-router";
 import type { Boot, NavigationItem } from "@/boot";
 import NavigationRow from "@/navigation/NavigationRow.vue";
@@ -109,4 +110,7 @@ const boot = inject<Boot>("boot")!;
 // present, so the server's orphan promotion passes it through, and rendering the tree would
 // then simply omit the rows — a silent drop of authored navigation.
 const tree = useItemTree(() => props.items, "the rail");
+
+// Whether an unadorned row holds its icon slot open, decided for the whole container.
+const reserve = computed(() => props.items.some((item) => item.icon));
 </script>

--- a/frontend/src/shell/AppRail.vue
+++ b/frontend/src/shell/AppRail.vue
@@ -80,11 +80,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject } from "vue";
+import { inject } from "vue";
 import { RouterLink } from "vue-router";
 import type { Boot, NavigationItem } from "@/boot";
 import NavigationRow from "@/navigation/NavigationRow.vue";
 import { useItemTree } from "@/navigation/useItemTree";
+import { useIconSlot } from "@/navigation/iconSlot";
 import type { ItemContext } from "@/navigation/types";
 
 // `arrangeable` is off on the index at `/apps`, which belongs to no app: there is no rail to
@@ -111,6 +112,8 @@ const boot = inject<Boot>("boot")!;
 // then simply omit the rows — a silent drop of authored navigation.
 const tree = useItemTree(() => props.items, "the rail");
 
-// Whether an unadorned row holds its icon slot open, decided for the whole container.
-const reserve = computed(() => props.items.some((item) => item.icon));
+const reserve = useIconSlot(
+	() => props.items,
+	() => props.context
+);
 </script>

--- a/frontend/src/shell/AppSidebar.vue
+++ b/frontend/src/shell/AppSidebar.vue
@@ -53,10 +53,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
 import type { NavigationItem } from "@/boot";
 import NavigationRow from "@/navigation/NavigationRow.vue";
 import { useItemTree } from "@/navigation/useItemTree";
+import { useIconSlot } from "@/navigation/iconSlot";
 import type { ItemContext } from "@/navigation/types";
 
 // `address` is the scrubbed key, and it is a prop because it is also what the arrangement
@@ -78,6 +78,8 @@ const tree = useItemTree(
 	() => `the ${props.address} sidebar`
 );
 
-// As on the rail: the icon slot is a property of the container, not of the row.
-const reserve = computed(() => props.items.some((item) => item.icon));
+const reserve = useIconSlot(
+	() => props.items,
+	() => props.context
+);
 </script>

--- a/frontend/src/shell/AppSidebar.vue
+++ b/frontend/src/shell/AppSidebar.vue
@@ -38,6 +38,7 @@
 				:node="node"
 				:context="context"
 				:current="current"
+				:reserve="reserve"
 			/>
 		</ul>
 
@@ -52,6 +53,7 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from "vue";
 import type { NavigationItem } from "@/boot";
 import NavigationRow from "@/navigation/NavigationRow.vue";
 import { useItemTree } from "@/navigation/useItemTree";
@@ -75,4 +77,7 @@ const tree = useItemTree(
 	() => props.items,
 	() => `the ${props.address} sidebar`
 );
+
+// As on the rail: the icon slot is a property of the container, not of the row.
+const reserve = computed(() => props.items.some((item) => item.icon));
 </script>

--- a/frontend/src/shell/ArrangementEditor.vue
+++ b/frontend/src/shell/ArrangementEditor.vue
@@ -54,21 +54,23 @@
 					:aria-label="`Name of ${item.key}`"
 					@input="rename(item.key, ($event.target as HTMLInputElement).value)"
 				/>
+				<!-- `lucide-` prefixed: frappe-ui's Button takes a CSS class, and a bare name
+						 draws nothing. Literal here, so Tailwind's JIT emits the class. -->
 				<Button
 					variant="ghost"
-					icon="chevron-up"
+					icon="lucide-chevron-up"
 					:aria-label="`Move ${item.key} up`"
 					@click="items = move(items, item.key, -1)"
 				/>
 				<Button
 					variant="ghost"
-					icon="chevron-down"
+					icon="lucide-chevron-down"
 					:aria-label="`Move ${item.key} down`"
 					@click="items = move(items, item.key, 1)"
 				/>
 				<Button
 					variant="ghost"
-					:icon="item.hidden ? 'eye-off' : 'eye'"
+					:icon="item.hidden ? 'lucide-eye-off' : 'lucide-eye'"
 					:aria-label="`${item.hidden ? 'Show' : 'Hide'} ${item.key}`"
 					@click="toggleHidden(item.key)"
 				/>

--- a/frontend/src/shell/tests/rail.test.ts
+++ b/frontend/src/shell/tests/rail.test.ts
@@ -14,6 +14,7 @@ import { generatedRoutes } from "@/router/generated";
 import { registerShell } from "@/router/routeFor";
 import { itemContext } from "@/navigation/context";
 import { resetNavigationReports } from "@/navigation/registry";
+import { loadSprite, resetSprite } from "@/icons/sprite";
 import AppRail from "../AppRail.vue";
 
 const addresses = new Addresses({
@@ -92,9 +93,25 @@ beforeAll(async () => {
 	await registerContributions(["frappe"]);
 });
 
+const SPRITE =
+	'<svg id="frappe-symbols" style="display:none">' +
+	'<symbol id="icon-users" viewBox="0 0 24 24"><circle cx="9" cy="7" r="4"/></symbol>' +
+	"</svg>";
+
+/** The sprite the rail's icons resolve against, loaded the way `main.ts` loads it. */
+function withSprite() {
+	vi.stubGlobal(
+		"fetch",
+		vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve(SPRITE) })
+	);
+	return loadSprite();
+}
+
 beforeEach(() => {
 	document.body.innerHTML = "";
 	resetNavigationReports();
+	resetSprite();
+	vi.unstubAllGlobals();
 	vi.restoreAllMocks();
 });
 
@@ -370,5 +387,57 @@ describe("a section's disclosure when the list changes under it", () => {
 
 		expect(row(host, "CRM Deal")).toBeNull();
 		expect(row(host, "CRM Lead")).not.toBeNull();
+	});
+});
+
+
+describe("an authored icon", () => {
+	// Every rail row CRM and ERPNext ship carries one; every sidebar row but four does not.
+	it("draws beside the label", async () => {
+		await withSprite();
+
+		const host = rail([{ ...doctype("CRM Deal"), icon: "users" }]);
+
+		expect(row(host, "CRM Deal")?.querySelector("use")?.getAttribute("href")).toBe(
+			"#icon-users"
+		);
+	});
+
+	it("leaves the label readable", async () => {
+		await withSprite();
+
+		const host = rail([{ ...doctype("CRM Deal"), icon: "users", label: "Deals" }]);
+
+		expect(row(host, "CRM Deal")?.textContent?.trim()).toBe("Deals");
+	});
+
+	it("is not drawn on a Section heading", async () => {
+		// A section that carries one has it ignored, never refused.
+		await withSprite();
+
+		const host = rail([
+			{ key: "sales", item_type: "Section", label: "Sales", icon: "users" },
+			doctype("CRM Deal", "sales"),
+		]);
+
+		expect(row(host, "sales")?.querySelector("use")).toBeNull();
+		expect(row(host, "sales")?.textContent?.trim()).toBe("Sales");
+	});
+
+	it("holds the slot open on the rows that have none", async () => {
+		// Decided for the whole container, so one unadorned row still reads as part of it.
+		await withSprite();
+
+		const host = rail([{ ...doctype("CRM Deal"), icon: "users" }, doctype("CRM Lead")]);
+
+		expect(row(host, "CRM Lead")?.querySelector("span[aria-hidden]")).not.toBeNull();
+	});
+
+	it("holds no slot open in a container where nothing has one", async () => {
+		await withSprite();
+
+		const host = rail([doctype("CRM Deal"), doctype("CRM Lead")]);
+
+		expect(row(host, "CRM Deal")?.querySelector("span[aria-hidden]")).toBeNull();
 	});
 });

--- a/frontend/src/shell/tests/rail.test.ts
+++ b/frontend/src/shell/tests/rail.test.ts
@@ -440,4 +440,17 @@ describe("an authored icon", () => {
 
 		expect(row(host, "CRM Deal")?.querySelector("span[aria-hidden]")).toBeNull();
 	});
+
+	it("holds none open for an icon only a heading carries", async () => {
+		// A heading draws no icon, so one on a section would indent every row under it
+		// for a slot nothing fills.
+		await withSprite();
+
+		const host = rail([
+			{ key: "sales", item_type: "Section", label: "Sales", icon: "users" },
+			doctype("CRM Deal", "sales"),
+		]);
+
+		expect(row(host, "CRM Deal")?.querySelector("span[aria-hidden]")).toBeNull();
+	});
 });

--- a/frontend/src/shell/tests/sidebar.test.ts
+++ b/frontend/src/shell/tests/sidebar.test.ts
@@ -12,6 +12,7 @@ import type { Boot, NavigationItem } from "@/boot";
 import { registerContributions } from "@/contributions/registry";
 import { registerShell } from "@/router/routeFor";
 import { resetNavigationReports } from "@/navigation/registry";
+import { loadSprite, resetSprite } from "@/icons/sprite";
 import AppShell from "../AppShell.vue";
 
 // `Module Contents` is the one kind that reads the list it is in, so it is the one that can
@@ -106,6 +107,8 @@ beforeAll(async () => {
 beforeEach(() => {
 	document.body.innerHTML = "";
 	resetNavigationReports();
+	resetSprite();
+	vi.unstubAllGlobals();
 });
 
 describe("what opens the panel", () => {
@@ -317,5 +320,53 @@ describe("the panel's heading", () => {
 
 		expect(panel(host)).not.toBeNull();
 		expect(panel(host)?.textContent).not.toContain("module_def_accounts");
+	});
+});
+
+
+describe("icons in the panel", () => {
+	// One model, two presentations, so the icon question is answered once for both. Only
+	// four sidebar rows on the bench carry one, all of them CRM's.
+	function withSprite() {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({
+				ok: true,
+				text: () =>
+					Promise.resolve(
+						'<svg id="frappe-symbols"><symbol id="icon-users"/></svg>'
+					),
+			})
+		);
+		return loadSprite();
+	}
+
+	it("draws one", async () => {
+		await withSprite();
+
+		const { host } = await shell(
+			[accounts],
+			{ module_def_accounts: [{ ...invoice, icon: "users" }, lead] },
+			"/sales-invoice"
+		);
+
+		expect(
+			panel(host)?.querySelector('[data-key="invoice"] use')?.getAttribute("href")
+		).toBe("#icon-users");
+	});
+
+	it("holds the slot open on the rest of that panel", async () => {
+		// The mixed container is CRM's case, where one jutting row would read as a mistake.
+		await withSprite();
+
+		const { host } = await shell(
+			[accounts],
+			{ module_def_accounts: [{ ...invoice, icon: "users" }, lead] },
+			"/sales-invoice"
+		);
+
+		expect(
+			panel(host)?.querySelector('[data-key="lead"] span[aria-hidden]')
+		).not.toBeNull();
 	});
 });


### PR DESCRIPTION
Closes the ticket [Nothing renders a navigation item's icon](https://github.com/frappe/frappe/issues/42433), off the map [Desk v2 — the rail and the sidebar](https://github.com/frappe/frappe/issues/42226).

## What was wrong

`Navigation Item.icon` is authored, stored, shipped and overridable, and nothing on the branch drew it. The column reaches the browser on every item through `WIRE_FIELDS` (`shell/navigation.py:67`) and it is one of the four keys the arrangement editor lists in `OVERRIDABLE` (`shell/arrangement.py:61`), so a person could change an icon that had never appeared.

It survived five merged PRs with every test green because no rail before CRM's authored an icon at all — every earlier rail was derived, and `_derive_rail` sets none.

## The spelling needed a reading, not a decision

The ticket suspected the fixtures and the field disagreed. They do not.

`fieldtype: Icon` has stored one of two things since long before desk v2 — **an emoji glyph, or the bare name of a symbol in the sprite** — and `frappe.utils.icon` (`public/js/frappe/utils/utils.js:1523`) has drawn both for as long, switching on `is_emoji`. The Icon control's picker writes both: the 1,640 lucide names in the sprite `app_include_icons` loads, plus a tab of emojis wherever the field's `options` is `Emojis`, which this field sets.

Every one of the 30 authored rows already uses a bare lucide name, and every one of those names is in that sprite:

| | rows | with an icon |
|---|---|---|
| rail (frappe + CRM + ERPNext) | 26 | 26 |
| sidebar | 333 | 4 |
| — of which `Section` headings | 46 | 0 |

**No fixture changes.**

## What was actually missing

The shell could not draw an icon from a name at all. frappe-ui's two lucide paths are both build-time — `~icons/lucide/<name>` is a virtual module resolved by name at build, and `lucide-<name>` is a JIT Tailwind utility whose CSS is emitted only for classes seen in source — and `frontend/tailwind.config.js` gives nobody a safelist, on the measurement that CRM's is 88% of its CSS gzip bytes. A name that arrives with boot can satisfy neither.

So `frontend/src/icons/` loads the sprite frappe already ships and desk v1 already loads, once per document, **fired and not awaited** beside translations in `main.ts`: an icon is decoration on a row whose label and destination are already correct, and 77 KB gzip of geometry does not belong on the blocking pre-mount path. `spriteLoaded` is a ref because `<use>` picking up a symbol that lands afterwards is not something every browser agrees on, and an icon that appears only at the next unrelated re-render is the same bug, intermittent.

An unknown name **draws nothing and logs once**, rather than lucide's `circle-help` placeholder: that placeholder is right where a developer typed the name and gets a build warning, and wrong here, where the name came off a row and it would sit in the rail until somebody noticed.

## What takes an icon

- Every row shape that goes somewhere — link, external anchor, and the `Module Contents` expander.
- **Not a `Section` heading.** A heading is 11px uppercase text introducing the rows under it, and an icon on it would out-weigh every row it introduces. None of the 46 shipped sections authors one; a section that does has it ignored, never refused.
- Independent and linked rail items are identical. Charter point 1 has one model and two presentations, and an icon is presentation of the row, not of what it opens.
- Whether an unadorned row holds its slot open is decided **once per container**, so the four CRM sidebars that carry exactly one icon each still read as a list rather than as a mistake.

## Also fixed

`ArrangementEditor.vue` passed bare names (`chevron-up`, `eye-off`) to frappe-ui's `Button`, which takes a `lucide-*` class and draws nothing for anything else, warning in dev. Same silence, in the shell's own chrome. Three call sites.

## Verified

Tests: **383 passing**, up from 359 — 24 new, across `icons/tests/`, `shell/tests/rail.test.ts` and `shell/tests/sidebar.test.ts`.

On `crm.localhost` after `bench build`: CRM's six rail icons and ERPNext's twenty render against a 1,640-symbol sprite; ERPNext's panels reserve nothing, because none of their 329 rows carries an icon; the console is clean.

>no-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
