### PR TITLE
fix: allow list values in JSON fields

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -587,7 +587,7 @@ class BaseDocument:
 					value = self.get_virtual_field_value(df)
 
 				fieldtype = df.fieldtype
-				if isinstance(value, list) and fieldtype not in table_fields:
+				if isinstance(value, list) and fieldtype not in table_fields and fieldtype != "JSON":
 					frappe.throw(_("Value for {0} cannot be a list").format(_(df.label, context=df.parent)))
 
 				if fieldtype == "Check":
@@ -596,7 +596,7 @@ class BaseDocument:
 				elif fieldtype == "Int" and not isinstance(value, int):
 					value = cint(value)
 
-				elif fieldtype == "JSON" and isinstance(value, dict):
+				elif fieldtype == "JSON" and isinstance(value, dict | list):
 					value = json.dumps(value, separators=(",", ":"))
 
 				elif fieldtype in float_like_fields and not isinstance(value, float):

--- a/frappe/tests/test_base_document.py
+++ b/frappe/tests/test_base_document.py
@@ -58,6 +58,24 @@ class TestBaseDocument(IntegrationTestCase):
 		# Text field: sanitized, onclick attribute stripped
 		self.assertNotIn("onclick", doc.description)
 
+	def test_json_field_accepts_list(self):
+		"""A JSON fieldtype holding a list is valid JSON and must serialize like a dict does."""
+		from frappe.core.doctype.doctype.test_doctype import new_doctype
+
+		if not frappe.db.exists("DocType", "Test JSON List"):
+			new_doctype(
+				"Test JSON List",
+				fields=[{"label": "Config", "fieldname": "config", "fieldtype": "JSON"}],
+			).insert()
+
+		doc = frappe.new_doc("Test JSON List")
+
+		doc.config = {"a": 1}
+		self.assertEqual(doc.get_valid_dict()["config"], '{"a":1}')
+
+		doc.config = [{"a": 1}, {"b": 2}]
+		self.assertEqual(doc.get_valid_dict()["config"], '[{"a":1},{"b":2}]')
+
 	def test_docstatus(self):
 		doc = BaseDocument({"docstatus": 0, "doctype": "ToDo"})
 		self.assertTrue(doc.docstatus.is_draft())


### PR DESCRIPTION
  `get_valid_dict` rejects any list value whose fieldtype is not a Table, and that check runs
  before the JSON branch. So a JSON field holding a list throws
  `ValidationError: Value for {0} cannot be a list`, even though a list is valid JSON and a dict
  in the same field serializes fine.

  The two paths were never reconciled: the list guard dates to 78262a2a04 (2016), the JSON
  fieldtype arrived in #16187 (2022), and the dict-serialization branch in 928bc46be3 (2023).

  This also breaks `bench migrate`, which is how it was reported: `remove_orphan_doctypes()`
  deletes an orphaned DocType, `delete_doc` serializes it to Deleted Document via `as_dict()`,
  and it hits `DocField.link_filters` — a JSON field whose natural value is a list.

  ### Change

  Exempt `JSON` from the list guard, and serialize lists in the JSON branch the same way dicts
  are already serialized. Both edits are needed: relaxing the guard alone would pass a raw Python
  list to the DB layer.

  `fieldtype != "JSON"` is used rather than `not in (*table_fields, "JSON")` to avoid allocating a
  tuple per field — `get_valid_dict` is a hot path with prior perf work on that exact line.

  This matches the convention already documented in `frappe/database/postgres/database.py`, where
  psycopg2's JSON auto-parsing is suppressed because frappe models JSON fields as strings and
  `json.loads` them on demand — the comment there cites this very check as the reason.

  ### Testing

  - Regression test added to `frappe/tests/test_base_document.py`, asserting both the dict and the
    list case so existing behaviour is pinned too. It fails with the fix reverted.
  - Verified round-trip insert → reload → re-save for dict, list, nested and empty-list values.
  - `bench migrate` completes, including the `remove_orphan_doctypes` phase.
  - Green: `test_db`, `test_document`, `test_base_document`, `test_trace`, `test_db_query`,
    `test_child_table`, `test_virtual_doctype`, `test_naming`.
  - Tested on MariaDB only.

  The change only relaxes a check, so no previously working path changes behaviour, and the value
  written is a plain JSON string in the same column — nothing older versions cannot read.

  closes #42462

`no-docs`