### PR TITLE
fix: remove notification_title and notification_description

### DIFF
--- a/frappe/email/doctype/notification/notification.json
+++ b/frappe/email/doctype/notification/notification.json
@@ -28,8 +28,6 @@
   "sender",
   "send_system_notification",
   "notification_type",
-  "notification_title",
-  "notification_message",
   "sender_email",
   "section_break_9",
   "condition_type",
@@ -95,14 +93,14 @@
    "read_only": 1
   },
   {
-   "depends_on": "eval: in_list(['Email', 'Slack'], doc.channel)",
+   "depends_on": "eval: in_list(['Email', 'Slack', 'System Notification'], doc.channel)",
    "description": "For a dynamic subject, use Jinja tags like this: <code>{{ doc.name }} Delivered</code>",
    "fieldname": "subject",
    "fieldtype": "Data",
    "ignore_xss_filter": 1,
    "in_list_view": 1,
    "label": "Subject",
-   "mandatory_depends_on": "eval: in_list(['Email', 'Slack'], doc.channel)"
+   "mandatory_depends_on": "eval: in_list(['Email', 'Slack', 'System Notification'], doc.channel)"
   },
   {
    "fieldname": "document_type",
@@ -238,7 +236,6 @@
    "options": "Notification Recipient"
   },
   {
-   "depends_on": "eval: doc.channel != 'System Notification'",
    "fieldname": "message_sb",
    "fieldtype": "Section Break",
    "label": "Message"
@@ -298,23 +295,6 @@
    "fieldtype": "Link",
    "label": "Notification Type",
    "options": "Notification Type"
-  },
-  {
-   "depends_on": "eval: doc.channel === 'System Notification' || doc.send_system_notification",
-   "description": "Supports Jinja.",
-   "fieldname": "notification_title",
-   "fieldtype": "Data",
-   "ignore_xss_filter": 1,
-   "label": "Notification Title",
-   "mandatory_depends_on": "eval: doc.channel === 'System Notification'"
-  },
-  {
-   "depends_on": "eval: doc.channel === 'System Notification' || doc.send_system_notification",
-   "description": "Supports Jinja. Email uses Message instead.",
-   "fieldname": "notification_message",
-   "fieldtype": "Small Text",
-   "ignore_xss_filter": 1,
-   "label": "Notification Message"
   },
   {
    "default": "0",
@@ -393,7 +373,7 @@
  "icon": "fa fa-envelope",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-09-03 12:00:00.000000",
+ "modified": "2026-09-03 18:00:00.000000",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Notification",

--- a/frappe/email/doctype/notification/notification.json
+++ b/frappe/email/doctype/notification/notification.json
@@ -301,7 +301,7 @@
   },
   {
    "depends_on": "eval: doc.channel === 'System Notification' || doc.send_system_notification",
-   "description": "Headline of the in-app notification. Falls back to Subject if left blank. Supports Jinja.",
+   "description": "Supports Jinja.",
    "fieldname": "notification_title",
    "fieldtype": "Data",
    "ignore_xss_filter": 1,
@@ -310,7 +310,7 @@
   },
   {
    "depends_on": "eval: doc.channel === 'System Notification' || doc.send_system_notification",
-   "description": "Optional body of the in-app notification. Supports Jinja.",
+   "description": "Supports Jinja. Email uses Message instead.",
    "fieldname": "notification_message",
    "fieldtype": "Small Text",
    "ignore_xss_filter": 1,
@@ -393,7 +393,7 @@
  "icon": "fa fa-envelope",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-04-22 15:37:19.355265",
+ "modified": "2026-09-03 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Notification",

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -68,8 +68,6 @@ class Notification(Document):
 		method: DF.Data | None
 		minutes_offset: DF.Int
 		module: DF.Link | None
-		notification_message: DF.SmallText | None
-		notification_title: DF.Data | None
 		notification_type: DF.Link | None
 		print_format: DF.Link | None
 		property_value: DF.Data | None
@@ -91,8 +89,7 @@ class Notification(Document):
 
 	def autoname(self):
 		if not self.name:
-			# Subject is optional for System Notification rules; fall back to the headline.
-			self.name = self.subject or self.notification_title
+			self.name = self.subject
 
 	# START: PreviewRenderer API
 
@@ -156,11 +153,6 @@ class Notification(Document):
 			validate_template(self.subject)
 
 		validate_template(self.message)
-
-		if self.notification_title:
-			validate_template(self.notification_title)
-		if self.notification_message:
-			validate_template(self.notification_message)
 
 		if self.event in ("Days Before", "Days After") and not self.date_changed:
 			frappe.throw(_("Please specify which date field must be checked"))
@@ -446,23 +438,15 @@ def get_context(context):
 
 	def create_system_notification(self, doc, context):
 		def _render(template):
-			# Templates (subject / notification_title / notification_message) come from the
-			# System Notification rule, authored by System Managers — the same trusted source as
-			# the other render_template calls in this controller.
+			# Subject and Message come from the rule, authored by System Managers — the same
+			# trusted source as the other render_template calls in this controller.
 			if not (template and "{" in template):
 				return template
 			return frappe.render_template(  # nosemgrep: frappe-semgrep-rules.rules.security.frappe-ssti
 				template, context
 			)
 
-		# Title falls back to the email Subject so existing rules keep their headline.
-		# Description, however, comes ONLY from the dedicated Notification Message — we do not
-		# fall back to the email Message, whose default placeholder ("Add your message here")
-		# would otherwise leak into the panel. This matches the older behaviour where the bell
-		# showed just the headline when there was no body.
 		subject = _render(self.subject)
-		title = _render(self.notification_title) or subject
-		description = _render(self.notification_message)
 
 		attachments = self.get_attachment(doc)
 
@@ -481,13 +465,8 @@ def get_context(context):
 			# even when the reference document belongs to a different app (or there is none).
 			# Falls through to NotificationLog.before_insert's document_type derivation when unset.
 			"app": frappe.db.get_value("Module Def", self.module, "app_name") if self.module else None,
-			"title": title,
+			"title": subject,
 			"subject": subject,
-			"description": description,
-			# Email body comes from the rule's Message field (its dedicated purpose), not the
-			# in-app Description: a non-skip notification_type can make the log email itself
-			# (NotificationLog.after_insert), and a blank Notification Message must not produce a
-			# body-less email. This restores the pre-split behaviour (email_content <- self.message).
 			"email_content": _render(self.message),
 			"from_user": doc.modified_by or doc.owner,
 			"attached_file": json.dumps(attachments) if attachments else None,

--- a/frappe/email/doctype/notification/test_notification.py
+++ b/frappe/email/doctype/notification/test_notification.py
@@ -269,7 +269,7 @@ class TestNotification(IntegrationTestCase):
 
 		notification = {
 			"name": "Test App From Module",
-			"notification_title": "Test App From Module",
+			"subject": "Test App From Module",
 			"document_type": "Event",
 			"module": "Core",  # owned by the frappe app
 			"event": "Minutes Before",
@@ -281,9 +281,9 @@ class TestNotification(IntegrationTestCase):
 		}
 
 		with get_test_notification(notification) as n:
-			frappe.db.delete("Notification Log", {"title": n.notification_title})
+			frappe.db.delete("Notification Log", {"title": n.subject})
 			trigger_notifications(None, "offset")
-			app = frappe.db.get_value("Notification Log", {"title": n.notification_title}, "app")
+			app = frappe.db.get_value("Notification Log", {"title": n.subject}, "app")
 			self.assertEqual(app, "frappe")
 
 	def test_minutes_negative_offset(self):

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -261,6 +261,7 @@ frappe.patches.v16_0.sync_installed_apps_to_site_config
 frappe.patches.v16_0.backfill_notification_log_title_description
 frappe.patches.v16_0.backfill_notification_email_type_preferences
 frappe.patches.v16_0.backfill_notification_log_app
+frappe.patches.v16_0.backfill_system_notification_rule_fields
 frappe.patches.v16_0.backfill_list_layout_route_signature
 execute:frappe.db.create_sequence_table()  # backfill SQLite sequence emulation table on existing sites
 frappe.desk.doctype.workspace.patches.set_standard_flag

--- a/frappe/patches/v16_0/backfill_system_notification_rule_fields.py
+++ b/frappe/patches/v16_0/backfill_system_notification_rule_fields.py
@@ -1,0 +1,21 @@
+import frappe
+
+
+def execute():
+	"""Backfill notification_title and notification_type on System Notification rules."""
+	frappe.reload_doctype("Notification")
+
+	notification = frappe.qb.DocType("Notification")
+
+	def _empty(col):
+		return col.isnull() | (col == "")
+
+	is_system_notification = notification.channel == "System Notification"
+
+	frappe.qb.update(notification).set(notification.notification_title, notification.subject).where(
+		is_system_notification & _empty(notification.notification_title) & ~_empty(notification.subject)
+	).run()
+
+	frappe.qb.update(notification).set(notification.notification_type, "Alert").where(
+		is_system_notification & _empty(notification.notification_type)
+	).run()

--- a/frappe/patches/v16_0/backfill_system_notification_rule_fields.py
+++ b/frappe/patches/v16_0/backfill_system_notification_rule_fields.py
@@ -2,7 +2,7 @@ import frappe
 
 
 def execute():
-	"""Backfill notification_title and notification_type on System Notification rules."""
+	"""Backfill subject and notification_type on System Notification rules."""
 	frappe.reload_doctype("Notification")
 
 	notification = frappe.qb.DocType("Notification")
@@ -12,9 +12,10 @@ def execute():
 
 	is_system_notification = notification.channel == "System Notification"
 
-	frappe.qb.update(notification).set(notification.notification_title, notification.subject).where(
-		is_system_notification & _empty(notification.notification_title) & ~_empty(notification.subject)
-	).run()
+	if frappe.db.has_column("Notification", "notification_title"):
+		frappe.qb.update(notification).set(notification.subject, notification.notification_title).where(
+			is_system_notification & _empty(notification.subject) & ~_empty(notification.notification_title)
+		).run()
 
 	frappe.qb.update(notification).set(notification.notification_type, "Alert").where(
 		is_system_notification & _empty(notification.notification_type)


### PR DESCRIPTION
Previously this was a backfill pr but now it is a straight up removal of a feature. 

Original intent of this was keeping message bodies separate if user checks send system notification in any "external" channel. For example email channel body is html and notification log's description would use html thus making it hard to render


This was met with scrutiny 😞 