### PR TITLE
fix(ui): show document ID in mobile form header

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -51,23 +51,11 @@ frappe.ui.form.Toolbar = class Toolbar {
 		} else if (this.frm.meta.title_field) {
 			let title_field = (this.frm.doc[this.frm.meta.title_field] || "").toString().trim();
 			title = strip_html(title_field || this.frm.docname);
-			if (
-				this.frm.doc.__islocal ||
-				title === this.frm.docname ||
-				this.frm.meta.autoname === "hash"
-			) {
-				this.page.set_title_sub("");
-			} else {
-				this.page.set_title_sub(this.frm.docname);
-				this.page.$sub_title_area.css("cursor", "copy");
-				this.page.$sub_title_area.on("click", (event) => {
-					event.stopImmediatePropagation();
-					frappe.utils.copy_to_clipboard(this.frm.docname);
-				});
-			}
 		} else {
 			title = this.frm.docname;
 		}
+
+		this.set_docname_subtitle(title);
 
 		title = __(title);
 		this.page.set_title(title);
@@ -80,6 +68,18 @@ frappe.ui.form.Toolbar = class Toolbar {
 		);
 
 		this.set_indicator();
+	}
+	set_docname_subtitle(title) {
+		if (this.frm.is_new() || title === this.frm.docname || this.frm.meta.autoname === "hash") {
+			this.page.set_title_sub("");
+			return;
+		}
+		this.page.set_title_sub(frappe.utils.escape_html(this.frm.docname));
+		this.page.$sub_title_area.css("cursor", "copy");
+		this.page.$sub_title_area.off("click.docname").on("click.docname", (event) => {
+			event.stopImmediatePropagation();
+			frappe.utils.copy_to_clipboard(this.frm.docname);
+		});
 	}
 	is_title_editable() {
 		let title_field = this.frm.meta.title_field;

--- a/frappe/public/js/frappe/ui/page.html
+++ b/frappe/public/js/frappe/ui/page.html
@@ -14,7 +14,10 @@
 					</span>
 				</button>
 				<div class="flex title-area ellipsis">
-					<ul class="nav d-sm-flex navbar-breadcrumbs ellipsis {{frappe.is_mobile() ? "mobile-no-divider" : ""}}  "></ul>
+					<div class="ellipsis title-area-text">
+						<ul class="nav d-sm-flex navbar-breadcrumbs ellipsis {{frappe.is_mobile() ? "mobile-no-divider" : ""}}  "></ul>
+						<div class="ellipsis sub-heading hide text-muted"></div>
+					</div>
 					<button class="btn btn-default more-button hide">
 						<svg class="icon icon-sm">
 							<use href="#icon-ellipsis">

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -149,7 +149,7 @@ frappe.ui.Page = class Page {
 	setup_page() {
 		this.$title_area = this.wrapper.find(".title-area");
 
-		this.$sub_title_area = this.wrapper.find("h6");
+		this.$sub_title_area = this.$title_area.find(".sub-heading");
 
 		if (this.title) this.set_title(this.title);
 

--- a/frappe/public/scss/desk/mobile.scss
+++ b/frappe/public/scss/desk/mobile.scss
@@ -36,10 +36,6 @@ body {
 			margin-top: var(--margin-sm);
 			margin-right: var(--margin-xs);
 		}
-
-		.page-head .sub-heading {
-			font-size: var(--text-xs);
-		}
 	}
 
 	// navbar & breadcrumbs
@@ -141,6 +137,22 @@ body {
 		.page-title {
 			.title-text {
 				@include get_textstyle("lg", "regular");
+			}
+
+			.sub-heading {
+				display: block;
+			}
+
+			// the title block is two lines tall here, so its siblings top-align
+			// against the first line instead of centering across both
+			&,
+			.title-area {
+				align-items: flex-start;
+			}
+
+			.sidebar-toggle-btn,
+			.page-indicator-pill {
+				margin-top: 2px;
 			}
 
 			.indicator {

--- a/frappe/public/scss/desk/page.scss
+++ b/frappe/public/scss/desk/page.scss
@@ -57,7 +57,9 @@
 		}
 
 		.sub-heading {
-			@include get_textstyle("sm", "regular");
+			@include get_textstyle("xs", "regular");
+			line-height: 1.15;
+			display: none;
 		}
 	}
 }


### PR DESCRIPTION
### Problem

On mobile, the form header shows only the document title. When a doctype has a `title_field`, the ID is nowhere on screen, because the form sidebar (where desktop shows it) is hidden on mobile. You cannot see or copy the ID of the record you are looking at.

The header already had CSS for a `.sub-heading` element, and `page.set_title_sub()` to fill it, but the element itself was never in `page.html`. `$sub_title_area` resolved to `wrapper.find("h6")`, which matches nothing, so the call has been a silent no-op. Worse, `wrapper` covers the whole page, so on any form that did render an `h6` in its body, the docname would have overwritten it.

### What this does

- Adds the `.sub-heading` element the CSS was already written for, wrapped with the breadcrumbs in `.title-area-text` so the title and the ID stack.
- Points `$sub_title_area` at that element instead of `h6`.
- Shows it only on mobile form routes. Desktop renders exactly as before.
- Escapes the docname before writing it, since `set_title_sub()` renders HTML and prompt-named documents can contain markup.

The ID is left out where it would only be noise: new documents, hash-named doctypes, and doctypes whose title is already the ID.

### Screenshots

Sales Invoice at a 390px viewport. Title is the customer name, so the ID had nowhere to go.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/Jatin3128/frappe/assets/mobile-form-header-docname/mobile-before.png" width="390"> | <img src="https://raw.githubusercontent.com/Jatin3128/frappe/assets/mobile-form-header-docname/mobile-after.png" width="390"> |

Hash-named doctype (Item Price). No random hash is added:

<img src="https://raw.githubusercontent.com/Jatin3128/frappe/assets/mobile-form-header-docname/mobile-hash-autoname.png" width="390">

Long ID at 360px. It truncates and never pushes the header actions:

<img src="https://raw.githubusercontent.com/Jatin3128/frappe/assets/mobile-form-header-docname/mobile-long-id.png" width="360">


### How to test

1. Open a document whose title differs from its ID (a Sales Invoice, say) at a 390px viewport or on a phone. The ID appears under the title.
2. Tap the ID. It copies to the clipboard.
3. Open a hash-named doctype such as Item Price. No ID line appears.
4. Open the same invoice on desktop. The header is unchanged.

### Notes

The header stays at its 48px `--page-head-height`, so the sticky offsets that derive from it (form tab bar, form sidebar) are unaffected. The duplicate `.sub-heading` font-size in `mobile.scss` is removed, since `page.scss` now sets the size in one place.

Internal ticket: 77660
