### PR TITLE
feat: keep the reader in the panel they are already in

### DIFF
--- a/frappe/desk/navigation_item_type/sidebar/frontend/item.js
+++ b/frappe/desk/navigation_item_type/sidebar/frontend/item.js
@@ -29,8 +29,24 @@ export default {
 			// A `group` has no destination and an `expand` is not one either — following an
 			// item must not fire a request. Both are skipped, so a sidebar whose first row is
 			// a section opens at the first thing under it, which is what a reader sees anyway.
-			if (rendering && ("to" in rendering || "href" in rendering))
-				return { ...rendering, sidebar: item.link_to };
+			if (!rendering || !("to" in rendering || "href" in rendering)) continue;
+
+			// The first row is usually in SEVERAL panels — 45 of ERPNext's 216 destinations are
+			// (#42464) — so its address alone cannot say which one this item opens, and the
+			// reader's open panel would otherwise win the tie and leave the rail highlighting
+			// where they came from. Naming the panel in the link is the fact the address was
+			// missing (#42432). It rides in the href rather than a click handler because these
+			// are plain `RouterLink`s: a handler would break middle-click and open-in-new-tab,
+			// and would not survive a paste. The shell consumes it and strips it on arrival.
+			if ("to" in rendering)
+				return {
+					...rendering,
+					to: { ...rendering.to, query: { ...rendering.to.query, panel: item.link_to } },
+					sidebar: item.link_to,
+				};
+
+			// An `href` leaves the prefix, so there is no panel of ours to name.
+			return { ...rendering, sidebar: item.link_to };
 		}
 
 		return null;

--- a/frappe/desk/navigation_item_type/sidebar/frontend/item.js
+++ b/frappe/desk/navigation_item_type/sidebar/frontend/item.js
@@ -31,13 +31,8 @@ export default {
 			// a section opens at the first thing under it, which is what a reader sees anyway.
 			if (!rendering || !("to" in rendering || "href" in rendering)) continue;
 
-			// The first row is usually in SEVERAL panels — 45 of ERPNext's 216 destinations are
-			// (#42464) — so its address alone cannot say which one this item opens, and the
-			// reader's open panel would otherwise win the tie and leave the rail highlighting
-			// where they came from. Naming the panel in the link is the fact the address was
-			// missing (#42432). It rides in the href rather than a click handler because these
-			// are plain `RouterLink`s: a handler would break middle-click and open-in-new-tab,
-			// and would not survive a paste. The shell consumes it and strips it on arrival.
+			// The first row usually sits in several panels, so the address alone cannot say
+			// which this item opens. In the href, not a handler: these are `RouterLink`s.
 			if ("to" in rendering)
 				return {
 					...rendering,

--- a/frappe/shell/navigation.py
+++ b/frappe/shell/navigation.py
@@ -722,3 +722,80 @@ def _derive_rail(app: str) -> list[dict]:
 		for doctype in sorted(owners)
 		if owners[doctype] == app and doctype in addressable and doctype in readable
 	]
+
+
+def report_overlaps(app: str) -> dict:
+	"""Which destinations this app's navigation offers from more than one panel (#42464).
+
+	Run it by hand — `bench execute frappe.shell.navigation.report_overlaps --kwargs
+	"{'app': 'erpnext'}"`. Deliberately **not** wired to install or migrate: one address in two
+	panels is usually correct rather than a mistake, so a warning there would fire 45 times on
+	ERPNext's current fixtures and teach authors to ignore it (#42432). Since #42464 the reader
+	keeps the panel they are in, so an overlap costs a cold-load choice, not a relocation.
+
+	Returns `{"shared": [...], "repeated": [...]}`: destinations offered by several panels with
+	the one a cold load takes, and destinations a single panel lists twice, where the first row
+	going down the panel wins the highlight.
+	"""
+	navigation = resolve_navigation(app)
+	sidebars = navigation["sidebars"]
+
+	# Cold-load order is the order the reader is looking at: the rail top to bottom. Panels not
+	# opened by any rail item sort last — they are unreachable, which #42357 already fences.
+	rail_order = {
+		item.get("link_to"): index
+		for index, item in enumerate(navigation["rail"])
+		if item.get("item_type") == "Sidebar" and item.get("link_to")
+	}
+
+	shared: dict[tuple, list[tuple[str, str]]] = {}
+	repeated = []
+
+	for address, rows in sorted(sidebars.items()):
+		seen: dict[tuple, str] = {}
+		for row in rows:
+			destination = _destination_of(row)
+			if not destination:
+				continue
+
+			if destination in seen:
+				repeated.append(
+					{
+						"panel": address,
+						"destination": " ".join(destination),
+						"kept": seen[destination],
+						"shadowed": row.get("key"),
+					}
+				)
+			else:
+				seen[destination] = row.get("key")
+				shared.setdefault(destination, []).append((address, row.get("key")))
+
+	return {
+		"shared": [
+			{
+				"destination": " ".join(destination),
+				"panels": [address for address, _ in places],
+				"cold_load": min(
+					(address for address, _ in places),
+					key=lambda address: rail_order.get(address, len(rail_order)),
+				),
+			}
+			for destination, places in sorted(shared.items())
+			if len(places) > 1
+		],
+		"repeated": repeated,
+	}
+
+
+def _destination_of(item: dict) -> tuple | None:
+	"""What an item points at, or None for a row that goes nowhere.
+
+	The `(link_doctype, link_to)` pair is the address in the model (#42227), so two rows pointing
+	at one destination compare equal here whatever kind or label they carry. `Link` rows leave
+	the prefix and `Section` rows go nowhere, so neither can be somewhere you are standing.
+	"""
+	if item.get("item_type") in ("Link", "Section") or not item.get("link_to"):
+		return None
+
+	return (item.get("link_doctype") or item.get("item_type"), item.get("link_to"))

--- a/frappe/shell/navigation.py
+++ b/frappe/shell/navigation.py
@@ -725,23 +725,14 @@ def _derive_rail(app: str) -> list[dict]:
 
 
 def report_overlaps(app: str) -> dict:
-	"""Which destinations this app's navigation offers from more than one panel (#42464).
+	"""Which destinations this app offers from more than one panel, as the session user sees it.
 
-	Run it by hand — `bench execute frappe.shell.navigation.report_overlaps --kwargs
-	"{'app': 'erpnext'}"`. Deliberately **not** wired to install or migrate: one address in two
-	panels is usually correct rather than a mistake, so a warning there would fire 45 times on
-	ERPNext's current fixtures and teach authors to ignore it (#42432). Since #42464 the reader
-	keeps the panel they are in, so an overlap costs a cold-load choice, not a relocation.
-
-	Returns `{"shared": [...], "repeated": [...]}`: destinations offered by several panels with
-	the one a cold load takes, and destinations a single panel lists twice, where the first row
-	going down the panel wins the highlight.
+	Run by hand, never on install or migrate: one address in two panels is usually correct.
 	"""
 	navigation = resolve_navigation(app)
 	sidebars = navigation["sidebars"]
 
-	# Cold-load order is the order the reader is looking at: the rail top to bottom. Panels not
-	# opened by any rail item sort last — they are unreachable, which #42357 already fences.
+	# Cold-load order is the rail top to bottom. A panel no rail item opens sorts last.
 	rail_order = {
 		item.get("link_to"): index
 		for index, item in enumerate(navigation["rail"])
@@ -791,9 +782,8 @@ def report_overlaps(app: str) -> dict:
 def _destination_of(item: dict) -> tuple | None:
 	"""What an item points at, or None for a row that goes nowhere.
 
-	The `(link_doctype, link_to)` pair is the address in the model (#42227), so two rows pointing
-	at one destination compare equal here whatever kind or label they carry. `Link` rows leave
-	the prefix and `Section` rows go nowhere, so neither can be somewhere you are standing.
+	The `(link_doctype, link_to)` pair is the address, so kind and label do not distinguish two
+	rows aimed at one place.
 	"""
 	if item.get("item_type") in ("Link", "Section") or not item.get("link_to"):
 		return None

--- a/frontend/src/navigation/current.ts
+++ b/frontend/src/navigation/current.ts
@@ -1,15 +1,7 @@
 // Which row the address is on, and therefore which sidebar is open.
 //
-// Charter point 7: navigation follows the address, never the reverse. This module is the
-// function from the address to the shell around it.
-//
-// That function takes one extra input, and #42432 narrowed the charter point to allow it:
-// where SEVERAL panels cover the address equally, the one the reader is already in wins.
-// One in five ERPNext destinations sits in more than one panel and `Item` sits in six, so
-// without it a reader is yanked out of the panel they are working in as the ordinary case.
-// The narrowing is bounded: the preference only ever picks among panels the address itself
-// already allows, never invents one and never beats a deeper cover — so a COLD load is
-// still a pure function of the path, and one URL still gives two colleagues one shell.
+// Charter point 7: navigation follows the address, never the reverse. Among panels covering
+// it EQUALLY the reader's open one wins, but a cold load is still the path alone.
 //
 // It is not `router-link-active`. Two reasons, and both are real rather than tidiness. A
 // rail item of type `Sidebar` resolves to the first destination INSIDE its sidebar
@@ -128,34 +120,14 @@ export function navigationDestinations(
 /**
  * The rail row, the sidebar and the row inside it that `path` is standing on.
  *
- * Deepest coverage always wins. Among covers of EQUAL depth, `prefer` decides: the earliest
- * of its sidebars to appear wins, and where it names none of them the first in list order
- * does, which is the rail read top to bottom.
- *
- * `prefer` is the reader's continuity, most wanted first — the panel open right now, then
- * whatever this tab last resolved for this address (#42464). It is a tie-break and only a
- * tie-break: a panel in it that does not cover the address, or covers it less deeply than
- * another, loses anyway. That is what keeps a cold load a function of the path.
- *
- * Where ONE panel lists a destination twice, the first row going down the panel wins the
- * highlight — the `>` below, since both rows are the same depth in the same panel. Recorded
- * as a decision rather than left as an accident (#42432): the reader is never relocated, so
- * the cost is a highlight one row from where they clicked, and the likely real case is a
- * pinned row above a categorised copy of itself, where reading order highlights the pinned
- * one. Lighting both stays out — this module exists because `router-link-active` lit two
- * rows at once, and two rows carrying `aria-current="page"` tell a screen reader there are
- * two current pages.
- *
- * An address no destination covers returns `{}`: no highlight, and no panel. The preference
- * cannot rescue it, because there is nothing for it to choose between.
+ * `prefer` holds the reader's panels, most wanted first, and breaks ties only: deeper
+ * coverage still wins, and an address nothing covers returns `{}`.
  */
 export function currentFrom(
 	destinations: Destination[],
 	path: string,
 	prefer: string[] = []
 ): CurrentNavigation {
-	// How wanted this panel is: its place in `prefer`, or one past the end for a panel nobody
-	// asked for. Lower is better, so an unpreferred cover never displaces a preferred one.
 	const rank = (found: CurrentNavigation) => {
 		const place = found.sidebar ? prefer.indexOf(found.sidebar) : -1;
 		return place === -1 ? prefer.length : place;
@@ -167,13 +139,13 @@ export function currentFrom(
 
 	for (const destination of destinations) {
 		const covers = coverage(path, destination.path);
-		// A row that does not cover the address is not a candidate at all, however wanted its
-		// panel is. Checked before the depth compare, since -1 ties the "nothing yet" depth.
+		// -1 ties the starting depth, so a row covering nothing must be dropped before the
+		// compare or a preferred panel wins on an address it does not hold.
 		if (covers < 0 || covers < depth) continue;
 
+		// Strictly more wanted, so list order still breaks a tie nothing prefers: the rail top
+		// to bottom, and the first of two rows one panel points at the same place.
 		const place = rank(destination.found);
-		// Strictly deeper always wins. At equal depth only a STRICTLY more wanted panel does,
-		// so first-in-list still breaks a tie nothing prefers.
 		if (covers > depth || place < wanted) {
 			depth = covers;
 			wanted = place;

--- a/frontend/src/navigation/current.ts
+++ b/frontend/src/navigation/current.ts
@@ -1,9 +1,15 @@
 // Which row the address is on, and therefore which sidebar is open.
 //
-// Charter point 7: navigation follows the address, never the reverse. Nothing stores a
-// selection, so clicking a rail item and pasting its URL into a fresh tab have to end in
-// the same shell — which means the open panel is a FUNCTION OF THE PATH and of nothing
-// else. This module is that function.
+// Charter point 7: navigation follows the address, never the reverse. This module is the
+// function from the address to the shell around it.
+//
+// That function takes one extra input, and #42432 narrowed the charter point to allow it:
+// where SEVERAL panels cover the address equally, the one the reader is already in wins.
+// One in five ERPNext destinations sits in more than one panel and `Item` sits in six, so
+// without it a reader is yanked out of the panel they are working in as the ordinary case.
+// The narrowing is bounded: the preference only ever picks among panels the address itself
+// already allows, never invents one and never beats a deeper cover — so a COLD load is
+// still a pure function of the path, and one URL still gives two colleagues one shell.
 //
 // It is not `router-link-active`. Two reasons, and both are real rather than tidiness. A
 // rail item of type `Sidebar` resolves to the first destination INSIDE its sidebar
@@ -122,19 +128,55 @@ export function navigationDestinations(
 /**
  * The rail row, the sidebar and the row inside it that `path` is standing on.
  *
- * Deepest coverage wins; where two cover the address equally, the first in the list does.
+ * Deepest coverage always wins. Among covers of EQUAL depth, `prefer` decides: the earliest
+ * of its sidebars to appear wins, and where it names none of them the first in list order
+ * does, which is the rail read top to bottom.
  *
- * An address no destination covers returns `{}`: no highlight, and no panel. There is no
- * last panel to fall back to, because falling back is storing a selection.
+ * `prefer` is the reader's continuity, most wanted first — the panel open right now, then
+ * whatever this tab last resolved for this address (#42464). It is a tie-break and only a
+ * tie-break: a panel in it that does not cover the address, or covers it less deeply than
+ * another, loses anyway. That is what keeps a cold load a function of the path.
+ *
+ * Where ONE panel lists a destination twice, the first row going down the panel wins the
+ * highlight — the `>` below, since both rows are the same depth in the same panel. Recorded
+ * as a decision rather than left as an accident (#42432): the reader is never relocated, so
+ * the cost is a highlight one row from where they clicked, and the likely real case is a
+ * pinned row above a categorised copy of itself, where reading order highlights the pinned
+ * one. Lighting both stays out — this module exists because `router-link-active` lit two
+ * rows at once, and two rows carrying `aria-current="page"` tell a screen reader there are
+ * two current pages.
+ *
+ * An address no destination covers returns `{}`: no highlight, and no panel. The preference
+ * cannot rescue it, because there is nothing for it to choose between.
  */
-export function currentFrom(destinations: Destination[], path: string): CurrentNavigation {
+export function currentFrom(
+	destinations: Destination[],
+	path: string,
+	prefer: string[] = []
+): CurrentNavigation {
+	// How wanted this panel is: its place in `prefer`, or one past the end for a panel nobody
+	// asked for. Lower is better, so an unpreferred cover never displaces a preferred one.
+	const rank = (found: CurrentNavigation) => {
+		const place = found.sidebar ? prefer.indexOf(found.sidebar) : -1;
+		return place === -1 ? prefer.length : place;
+	};
+
 	let best: CurrentNavigation = {};
 	let depth = -1;
+	let wanted = prefer.length;
 
 	for (const destination of destinations) {
 		const covers = coverage(path, destination.path);
-		if (covers > depth) {
+		// A row that does not cover the address is not a candidate at all, however wanted its
+		// panel is. Checked before the depth compare, since -1 ties the "nothing yet" depth.
+		if (covers < 0 || covers < depth) continue;
+
+		const place = rank(destination.found);
+		// Strictly deeper always wins. At equal depth only a STRICTLY more wanted panel does,
+		// so first-in-list still breaks a tie nothing prefers.
+		if (covers > depth || place < wanted) {
 			depth = covers;
+			wanted = place;
 			best = destination.found;
 		}
 	}
@@ -147,7 +189,8 @@ export function currentNavigation(
 	rail: NavigationItem[],
 	sidebars: Record<string, NavigationItem[]>,
 	contexts: NavigationContexts,
-	path: string
+	path: string,
+	prefer: string[] = []
 ): CurrentNavigation {
-	return currentFrom(navigationDestinations(rail, sidebars, contexts), path);
+	return currentFrom(navigationDestinations(rail, sidebars, contexts), path, prefer);
 }

--- a/frontend/src/navigation/panelMemory.ts
+++ b/frontend/src/navigation/panelMemory.ts
@@ -1,0 +1,67 @@
+// What panel this tab was last in, per address (#42464).
+//
+// The first thing the desk v2 shell stores. It narrows charter point 7 on purpose, and the
+// narrowing is exactly this wide: the record NEVER invents a panel and never beats a deeper
+// cover. It only ever picks among panels the address itself already allows, all of which are
+// equally correct answers to it (#42432). So a cold load in a fresh tab is still a pure
+// function of the address, and two colleagues opening one URL get one shell.
+//
+// `sessionStorage`, not `localStorage`, because the unit is the TAB. A reload and the back
+// button keep the panel, which is the whole point; a second tab on the same address starts
+// from the address again, which is what makes the cold load still mean something. Outliving
+// the tab would make the canonical panel unreachable without clearing site data.
+//
+// Keyed by path alone. The panel is a fact about which rows cover this address, and the query
+// is context rather than identity (#42102) — `?view=` and `?tab=` move you inside a list, not
+// into another panel, so hanging a separate record off each of them would only make the
+// panel flicker as you switch views.
+
+const KEY = "frappe:desk:panel";
+
+/**
+ * The whole record, or an empty one.
+ *
+ * Every read goes through here rather than caching, because `sessionStorage` is shared with
+ * anything else on the tab and this is a handful of short strings read once per navigation.
+ * Storage throws in more places than it looks — Safari's private mode has historically thrown
+ * on WRITE with a zero quota, and a sandboxed frame throws on ACCESS — so both sides swallow.
+ * A tab that cannot remember its panel falls back to resolving off the address, which is the
+ * behaviour that shipped before this and is never wrong, only less continuous.
+ */
+function read(): Record<string, string> {
+	try {
+		const raw = sessionStorage.getItem(KEY);
+		const parsed = raw ? JSON.parse(raw) : null;
+		// Anything but an object of strings is someone else's data or a half-written value.
+		return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+	} catch {
+		return {};
+	}
+}
+
+/** The panel this tab last resolved for `path`, if it remembers one. */
+export function recallPanel(path: string): string | undefined {
+	const remembered = read()[path];
+	return typeof remembered === "string" ? remembered : undefined;
+}
+
+/**
+ * Record `panel` as the answer for `path`.
+ *
+ * Called when the panel RESOLVES, not when a row is clicked. Rows are plain `RouterLink`s
+ * (`NavigationRow.vue`) and Vue Router's `RouterLink` cannot carry history state, so anything
+ * hung off the click would have cost the plain link and broken middle-click and
+ * open-in-new-tab. Resolution happens on every arrival however you got there — click, paste,
+ * reload, back — so this is the one hook that catches all of them.
+ */
+export function rememberPanel(path: string, panel: string): void {
+	const record = read();
+	if (record[path] === panel) return;
+
+	record[path] = panel;
+	try {
+		sessionStorage.setItem(KEY, JSON.stringify(record));
+	} catch {
+		// Full or forbidden. The panel still resolves; it just will not survive a reload.
+	}
+}

--- a/frontend/src/navigation/panelMemory.ts
+++ b/frontend/src/navigation/panelMemory.ts
@@ -18,6 +18,13 @@
 
 const KEY = "frappe:desk:panel";
 
+// How many addresses to keep, most recently resolved last. Every address that opens a panel is
+// recorded, and records get their own — reading 500 items writes 500 entries — so without a cap
+// this grows for as long as the tab lives and every navigation re-serialises all of it. The
+// oldest entry falls off, which costs that address its continuity and nothing else: it resolves
+// off the address again, the way it did before any of this.
+const KEEP = 100;
+
 /**
  * The whole record, or an empty one.
  *
@@ -58,7 +65,17 @@ export function rememberPanel(path: string, panel: string): void {
 	const record = read();
 	if (record[path] === panel) return;
 
+	// Re-inserted rather than assigned in place, so the freshest address is always last and the
+	// cap drops the least recently resolved one. Object key order is insertion order for string
+	// keys, which is what makes this work without a second structure to keep in step.
+	delete record[path];
 	record[path] = panel;
+
+	const addresses = Object.keys(record);
+	for (const stale of addresses.slice(0, Math.max(0, addresses.length - KEEP))) {
+		delete record[stale];
+	}
+
 	try {
 		sessionStorage.setItem(KEY, JSON.stringify(record));
 	} catch {

--- a/frontend/src/navigation/panelMemory.ts
+++ b/frontend/src/navigation/panelMemory.ts
@@ -1,47 +1,21 @@
-// What panel this tab was last in, per address (#42464).
-//
-// The first thing the desk v2 shell stores. It narrows charter point 7 on purpose, and the
-// narrowing is exactly this wide: the record NEVER invents a panel and never beats a deeper
-// cover. It only ever picks among panels the address itself already allows, all of which are
-// equally correct answers to it (#42432). So a cold load in a fresh tab is still a pure
-// function of the address, and two colleagues opening one URL get one shell.
-//
-// `sessionStorage`, not `localStorage`, because the unit is the TAB. A reload and the back
-// button keep the panel, which is the whole point; a second tab on the same address starts
-// from the address again, which is what makes the cold load still mean something. Outliving
-// the tab would make the canonical panel unreachable without clearing site data.
-//
-// Keyed by path alone. The panel is a fact about which rows cover this address, and the query
-// is context rather than identity (#42102) — `?view=` and `?tab=` move you inside a list, not
-// into another panel, so hanging a separate record off each of them would only make the
-// panel flicker as you switch views.
+// What panel this tab was last in, per address. `sessionStorage`, so the unit is the TAB: a
+// reload and back keep the panel, while a second tab resolves off the address again.
 
 const KEY = "frappe:desk:panel";
 
-// How many addresses to keep, most recently resolved last. Every address that opens a panel is
-// recorded, and records get their own — reading 500 items writes 500 entries — so without a cap
-// this grows for as long as the tab lives and every navigation re-serialises all of it. The
-// oldest entry falls off, which costs that address its continuity and nothing else: it resolves
-// off the address again, the way it did before any of this.
+// Every address that opens a panel is recorded and records get their own, so an uncapped
+// record grows for the life of the tab and every navigation re-serialises all of it.
 const KEEP = 100;
 
-/**
- * The whole record, or an empty one.
- *
- * Every read goes through here rather than caching, because `sessionStorage` is shared with
- * anything else on the tab and this is a handful of short strings read once per navigation.
- * Storage throws in more places than it looks — Safari's private mode has historically thrown
- * on WRITE with a zero quota, and a sandboxed frame throws on ACCESS — so both sides swallow.
- * A tab that cannot remember its panel falls back to resolving off the address, which is the
- * behaviour that shipped before this and is never wrong, only less continuous.
- */
+/** The whole record, or an empty one. */
 function read(): Record<string, string> {
 	try {
 		const raw = sessionStorage.getItem(KEY);
 		const parsed = raw ? JSON.parse(raw) : null;
-		// Anything but an object of strings is someone else's data or a half-written value.
 		return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
 	} catch {
+		// Storage throws on access in a sandboxed frame and at zero quota. A tab that cannot
+		// remember resolves off the address, which is never wrong, only less continuous.
 		return {};
 	}
 }
@@ -53,21 +27,17 @@ export function recallPanel(path: string): string | undefined {
 }
 
 /**
- * Record `panel` as the answer for `path`.
+ * Record `panel` as the answer for `path`, called when the panel resolves.
  *
- * Called when the panel RESOLVES, not when a row is clicked. Rows are plain `RouterLink`s
- * (`NavigationRow.vue`) and Vue Router's `RouterLink` cannot carry history state, so anything
- * hung off the click would have cost the plain link and broken middle-click and
- * open-in-new-tab. Resolution happens on every arrival however you got there — click, paste,
- * reload, back — so this is the one hook that catches all of them.
+ * Never off a click: rows are plain `RouterLink`s, which cannot carry history state, so a
+ * click handler would break middle-click and open-in-new-tab.
  */
 export function rememberPanel(path: string, panel: string): void {
 	const record = read();
 	if (record[path] === panel) return;
 
-	// Re-inserted rather than assigned in place, so the freshest address is always last and the
-	// cap drops the least recently resolved one. Object key order is insertion order for string
-	// keys, which is what makes this work without a second structure to keep in step.
+	// Re-insertion keeps key order least-recent first, so the cap below evicts the address
+	// that has gone longest without resolving.
 	delete record[path];
 	record[path] = panel;
 
@@ -79,6 +49,6 @@ export function rememberPanel(path: string, panel: string): void {
 	try {
 		sessionStorage.setItem(KEY, JSON.stringify(record));
 	} catch {
-		// Full or forbidden. The panel still resolves; it just will not survive a reload.
+		// Full or forbidden. The panel still resolves; it will not survive a reload.
 	}
 }

--- a/frontend/src/navigation/tests/current.test.ts
+++ b/frontend/src/navigation/tests/current.test.ts
@@ -173,12 +173,9 @@ describe("a rail item that opens a sidebar", () => {
 	});
 });
 
-// #42464, off the resolution in #42432. One in five ERPNext destinations sits in more than one
-// panel and `Item` sits in six, so being moved out of the panel you are working in is the
-// ordinary case rather than an edge.
+// One in five ERPNext destinations sits in more than one panel, and `Item` sits in six.
 describe("the panel the reader is already in", () => {
-	// Two panels that both list Sales Invoice, Buying above Stock — the shape ERPNext ships 45
-	// times over. Rail order alone always answers Buying.
+	// Two panels both listing Sales Invoice, Buying above Stock. Rail order answers Buying.
 	const rail: NavigationItem[] = [
 		{ key: "buying", item_type: "Sidebar", link_to: "module_def_buying" },
 		{ key: "stock", item_type: "Sidebar", link_to: "module_def_stock" },
@@ -205,8 +202,7 @@ describe("the panel the reader is already in", () => {
 	});
 
 	it("takes the earliest preference, so the open panel beats what the tab remembers", () => {
-		// The shell passes the panel open now ahead of the one recorded for this address, so
-		// walking into an address you once read elsewhere does not teleport you.
+		// So walking into an address you once read elsewhere does not teleport you.
 		expect(
 			at(rail, sidebars, "/sales-invoice", ["module_def_stock", "module_def_buying"])
 				.sidebar
@@ -214,9 +210,7 @@ describe("the panel the reader is already in", () => {
 	});
 
 	it("never beats a deeper cover", () => {
-		// The preference is a tie-break and only a tie-break. Standing on a record, the pinned
-		// row in Buying covers it more deeply than Stock's list, and being in Stock cannot
-		// change where you are.
+		// The pinned row in Buying covers the record more deeply than Stock's list.
 		const pinned: NavigationItem = {
 			key: "pinned",
 			item_type: "Record",
@@ -235,9 +229,8 @@ describe("the panel the reader is already in", () => {
 	});
 
 	it("ignores a preference no panel here answers to", () => {
-		// This is the whole of `?panel=` validation: a name that does not exist, does not hold
-		// this destination, or was filtered away by permissions is simply not among the covers,
-		// so it loses and the canonical panel answers. Silently, the way a stale `?view=` is.
+		// The whole of `?panel=` validation: an unknown name is not among the covers, so it
+		// loses and the canonical panel answers.
 		expect(at(rail, sidebars, "/sales-invoice", ["module_def_nowhere"]).sidebar).toBe(
 			"module_def_buying"
 		);
@@ -249,16 +242,14 @@ describe("the panel the reader is already in", () => {
 });
 
 describe("one panel listing a destination twice", () => {
-	// Neither app ships this yet — zero intra-panel duplicates across ERPNext's 318 rows — but
-	// both expect to add one, so #42432 recorded the rule rather than leaving it an accident.
+	// Neither app ships this yet, but both expect to add one.
 	const rail: NavigationItem[] = [
 		{ key: "stock", item_type: "Sidebar", link_to: "module_def_stock" },
 	];
 
 	it("highlights the first row going down the panel", () => {
-		// The likely real case is a pinned row above a categorised copy of itself, and reading
-		// order highlights the pinned one, which is what pinning it meant. The reader is not
-		// relocated either way — both rows are in the panel they are already in.
+		// The likely case is a pinned row above a categorised copy, where reading order
+		// highlights the pinned one.
 		const sidebars = {
 			module_def_stock: [
 				{ ...invoice, key: "pinned-invoice" },

--- a/frontend/src/navigation/tests/current.test.ts
+++ b/frontend/src/navigation/tests/current.test.ts
@@ -40,7 +40,8 @@ await registerContributions(["frappe"]);
 function at(
 	rail: NavigationItem[],
 	sidebars: Record<string, NavigationItem[]>,
-	path: string
+	path: string,
+	prefer: string[] = []
 ) {
 	const compose = (items: NavigationItem[]) =>
 		itemContext(boot, addresses, router, items, sidebars);
@@ -54,7 +55,8 @@ function at(
 				Object.entries(sidebars).map(([address, rows]) => [address, compose(rows)])
 			),
 		},
-		path
+		path,
+		prefer
 	);
 }
 
@@ -168,5 +170,101 @@ describe("a rail item that opens a sidebar", () => {
 		// #42356 leaves a sidebar that resolved to nothing out of the payload, and the renderer
 		// then draws the rail item as an independent one — which here means not at all.
 		expect(at(rail, { module_def_accounts: [] }, "/sales-invoice")).toEqual({});
+	});
+});
+
+// #42464, off the resolution in #42432. One in five ERPNext destinations sits in more than one
+// panel and `Item` sits in six, so being moved out of the panel you are working in is the
+// ordinary case rather than an edge.
+describe("the panel the reader is already in", () => {
+	// Two panels that both list Sales Invoice, Buying above Stock — the shape ERPNext ships 45
+	// times over. Rail order alone always answers Buying.
+	const rail: NavigationItem[] = [
+		{ key: "buying", item_type: "Sidebar", link_to: "module_def_buying" },
+		{ key: "stock", item_type: "Sidebar", link_to: "module_def_stock" },
+	];
+	const sidebars = {
+		module_def_buying: [invoice],
+		module_def_stock: [{ ...invoice, key: "invoice-in-stock" }],
+	};
+
+	it("takes the first in rail order on a cold load, with nothing to prefer", () => {
+		expect(at(rail, sidebars, "/sales-invoice")).toEqual({
+			railKey: "buying",
+			sidebar: "module_def_buying",
+			rowKey: "invoice",
+		});
+	});
+
+	it("keeps the reader in the panel they are already in", () => {
+		expect(at(rail, sidebars, "/sales-invoice", ["module_def_stock"])).toEqual({
+			railKey: "stock",
+			sidebar: "module_def_stock",
+			rowKey: "invoice-in-stock",
+		});
+	});
+
+	it("takes the earliest preference, so the open panel beats what the tab remembers", () => {
+		// The shell passes the panel open now ahead of the one recorded for this address, so
+		// walking into an address you once read elsewhere does not teleport you.
+		expect(
+			at(rail, sidebars, "/sales-invoice", ["module_def_stock", "module_def_buying"])
+				.sidebar
+		).toBe("module_def_stock");
+	});
+
+	it("never beats a deeper cover", () => {
+		// The preference is a tie-break and only a tie-break. Standing on a record, the pinned
+		// row in Buying covers it more deeply than Stock's list, and being in Stock cannot
+		// change where you are.
+		const pinned: NavigationItem = {
+			key: "pinned",
+			item_type: "Record",
+			link_doctype: "Sales Invoice",
+			link_to: "SI-001",
+		};
+		const deeper = { ...sidebars, module_def_buying: [invoice, pinned] };
+
+		expect(
+			at(rail, deeper, "/sales-invoice/SI-001", ["module_def_stock"])
+		).toEqual({
+			railKey: "buying",
+			sidebar: "module_def_buying",
+			rowKey: "pinned",
+		});
+	});
+
+	it("ignores a preference no panel here answers to", () => {
+		// This is the whole of `?panel=` validation: a name that does not exist, does not hold
+		// this destination, or was filtered away by permissions is simply not among the covers,
+		// so it loses and the canonical panel answers. Silently, the way a stale `?view=` is.
+		expect(at(rail, sidebars, "/sales-invoice", ["module_def_nowhere"]).sidebar).toBe(
+			"module_def_buying"
+		);
+	});
+
+	it("cannot conjure a panel for an address nothing covers", () => {
+		expect(at(rail, sidebars, "/crm-deal", ["module_def_stock"])).toEqual({});
+	});
+});
+
+describe("one panel listing a destination twice", () => {
+	// Neither app ships this yet — zero intra-panel duplicates across ERPNext's 318 rows — but
+	// both expect to add one, so #42432 recorded the rule rather than leaving it an accident.
+	const rail: NavigationItem[] = [
+		{ key: "stock", item_type: "Sidebar", link_to: "module_def_stock" },
+	];
+
+	it("highlights the first row going down the panel", () => {
+		// The likely real case is a pinned row above a categorised copy of itself, and reading
+		// order highlights the pinned one, which is what pinning it meant. The reader is not
+		// relocated either way — both rows are in the panel they are already in.
+		const sidebars = {
+			module_def_stock: [
+				{ ...invoice, key: "pinned-invoice" },
+				{ ...invoice, key: "filed-invoice" },
+			],
+		};
+		expect(at(rail, sidebars, "/sales-invoice").rowKey).toBe("pinned-invoice");
 	});
 });

--- a/frontend/src/navigation/tests/panelMemory.test.ts
+++ b/frontend/src/navigation/tests/panelMemory.test.ts
@@ -33,6 +33,39 @@ describe("remembering a panel", () => {
 	});
 });
 
+describe("the cap on how much it keeps", () => {
+	// Every address that opens a panel is recorded, records included, so an uncapped record
+	// grows for as long as the tab lives and every navigation re-serialises all of it.
+	it("keeps the most recent addresses and drops the oldest", () => {
+		for (let index = 0; index < 120; index += 1) {
+			rememberPanel(`/item/ITEM-${index}`, "module_def_stock");
+		}
+
+		expect(recallPanel("/item/ITEM-119")).toBe("module_def_stock");
+		expect(recallPanel("/item/ITEM-20")).toBe("module_def_stock");
+		// The first twenty fell off, which costs those addresses their continuity and nothing
+		// else: they resolve off the address again.
+		expect(recallPanel("/item/ITEM-0")).toBeUndefined();
+		expect(Object.keys(JSON.parse(sessionStorage.getItem("frappe:desk:panel")!))).toHaveLength(
+			100
+		);
+	});
+
+	it("counts re-resolving an address as recent, so browsing does not evict it", () => {
+		rememberPanel("/item", "module_def_stock");
+		for (let index = 0; index < 99; index += 1) {
+			rememberPanel(`/other/${index}`, "module_def_buying");
+		}
+		// Back to it, then fill the rest of the cap again.
+		rememberPanel("/item", "module_def_selling");
+		for (let index = 0; index < 99; index += 1) {
+			rememberPanel(`/more/${index}`, "module_def_buying");
+		}
+
+		expect(recallPanel("/item")).toBe("module_def_selling");
+	});
+});
+
 describe("when storage will not cooperate", () => {
 	// A tab that cannot remember falls back to resolving off the address alone, which is what
 	// shipped before this — never wrong, only less continuous. So none of this may throw.

--- a/frontend/src/navigation/tests/panelMemory.test.ts
+++ b/frontend/src/navigation/tests/panelMemory.test.ts
@@ -1,4 +1,4 @@
-// What this tab remembers about which panel an address opened in (#42464).
+// What this tab remembers about which panel an address opened in.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { recallPanel, rememberPanel } from "@/navigation/panelMemory";
@@ -34,8 +34,7 @@ describe("remembering a panel", () => {
 });
 
 describe("the cap on how much it keeps", () => {
-	// Every address that opens a panel is recorded, records included, so an uncapped record
-	// grows for as long as the tab lives and every navigation re-serialises all of it.
+	// Records get their own entry, so browsing alone fills this.
 	it("keeps the most recent addresses and drops the oldest", () => {
 		for (let index = 0; index < 120; index += 1) {
 			rememberPanel(`/item/ITEM-${index}`, "module_def_stock");
@@ -43,8 +42,7 @@ describe("the cap on how much it keeps", () => {
 
 		expect(recallPanel("/item/ITEM-119")).toBe("module_def_stock");
 		expect(recallPanel("/item/ITEM-20")).toBe("module_def_stock");
-		// The first twenty fell off, which costs those addresses their continuity and nothing
-		// else: they resolve off the address again.
+		// The first twenty fell off, costing those addresses continuity and nothing else.
 		expect(recallPanel("/item/ITEM-0")).toBeUndefined();
 		expect(Object.keys(JSON.parse(sessionStorage.getItem("frappe:desk:panel")!))).toHaveLength(
 			100
@@ -67,8 +65,7 @@ describe("the cap on how much it keeps", () => {
 });
 
 describe("when storage will not cooperate", () => {
-	// A tab that cannot remember falls back to resolving off the address alone, which is what
-	// shipped before this — never wrong, only less continuous. So none of this may throw.
+	// A tab that cannot remember resolves off the address, so none of this may throw.
 	it("recalls nothing rather than throwing when reading is forbidden", () => {
 		vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
 			throw new Error("SecurityError");
@@ -87,8 +84,7 @@ describe("when storage will not cooperate", () => {
 	});
 
 	it("ignores a value that is not the record it wrote", () => {
-		// `sessionStorage` is shared with anything else on the tab, and a half-written value is
-		// not worth a broken shell.
+		// Storage is shared, and a half-written value is not worth a broken shell.
 		sessionStorage.setItem("frappe:desk:panel", "not json at all");
 		expect(recallPanel("/item")).toBeUndefined();
 

--- a/frontend/src/navigation/tests/panelMemory.test.ts
+++ b/frontend/src/navigation/tests/panelMemory.test.ts
@@ -1,0 +1,68 @@
+// What this tab remembers about which panel an address opened in (#42464).
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { recallPanel, rememberPanel } from "@/navigation/panelMemory";
+
+beforeEach(() => {
+	sessionStorage.clear();
+	vi.restoreAllMocks();
+});
+
+describe("remembering a panel", () => {
+	it("reads back what it recorded", () => {
+		rememberPanel("/item", "module_def_stock");
+		expect(recallPanel("/item")).toBe("module_def_stock");
+	});
+
+	it("remembers per address, not one panel for the whole tab", () => {
+		rememberPanel("/item", "module_def_stock");
+		rememberPanel("/supplier", "module_def_buying");
+
+		expect(recallPanel("/item")).toBe("module_def_stock");
+		expect(recallPanel("/supplier")).toBe("module_def_buying");
+	});
+
+	it("keeps the latest answer for an address", () => {
+		rememberPanel("/item", "module_def_stock");
+		rememberPanel("/item", "module_def_selling");
+		expect(recallPanel("/item")).toBe("module_def_selling");
+	});
+
+	it("knows nothing about an address it has not seen", () => {
+		expect(recallPanel("/item")).toBeUndefined();
+	});
+});
+
+describe("when storage will not cooperate", () => {
+	// A tab that cannot remember falls back to resolving off the address alone, which is what
+	// shipped before this — never wrong, only less continuous. So none of this may throw.
+	it("recalls nothing rather than throwing when reading is forbidden", () => {
+		vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+			throw new Error("SecurityError");
+		});
+
+		expect(() => recallPanel("/item")).not.toThrow();
+		expect(recallPanel("/item")).toBeUndefined();
+	});
+
+	it("swallows a write that is over quota", () => {
+		vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+			throw new Error("QuotaExceededError");
+		});
+
+		expect(() => rememberPanel("/item", "module_def_stock")).not.toThrow();
+	});
+
+	it("ignores a value that is not the record it wrote", () => {
+		// `sessionStorage` is shared with anything else on the tab, and a half-written value is
+		// not worth a broken shell.
+		sessionStorage.setItem("frappe:desk:panel", "not json at all");
+		expect(recallPanel("/item")).toBeUndefined();
+
+		sessionStorage.setItem("frappe:desk:panel", JSON.stringify(["an", "array"]));
+		expect(recallPanel("/item")).toBeUndefined();
+
+		sessionStorage.setItem("frappe:desk:panel", JSON.stringify({ "/item": 42 }));
+		expect(recallPanel("/item")).toBeUndefined();
+	});
+});

--- a/frontend/src/navigation/tests/renderers.test.ts
+++ b/frontend/src/navigation/tests/renderers.test.ts
@@ -298,7 +298,14 @@ describe("Sidebar", () => {
 			],
 		};
 		expect(renderingOf(item, context([item], { sidebars }))).toEqual({
-			to: { name: "list", params: { doctype: "sales-invoice" }, query: undefined },
+			// The panel it opens rides in the link, because the first row is usually in
+			// several panels and the address alone cannot say which one this item means
+			// (#42464). The shell consumes it and strips it on arrival.
+			to: {
+				name: "list",
+				params: { doctype: "sales-invoice" },
+				query: { panel: "module_def_accounts" },
+			},
 			sidebar: "module_def_accounts",
 		});
 	});
@@ -418,7 +425,14 @@ describe("the recursion guard", () => {
 		};
 
 		expect(renderingOf(item, context([item], { sidebars }))).toEqual({
-			to: { name: "list", params: { doctype: "sales-invoice" }, query: undefined },
+			// The panel it opens rides in the link, because the first row is usually in
+			// several panels and the address alone cannot say which one this item means
+			// (#42464). The shell consumes it and strips it on arrival.
+			to: {
+				name: "list",
+				params: { doctype: "sales-invoice" },
+				query: { panel: "module_def_accounts" },
+			},
 			sidebar: "module_def_accounts",
 		});
 	});

--- a/frontend/src/navigation/tests/renderers.test.ts
+++ b/frontend/src/navigation/tests/renderers.test.ts
@@ -298,9 +298,7 @@ describe("Sidebar", () => {
 			],
 		};
 		expect(renderingOf(item, context([item], { sidebars }))).toEqual({
-			// The panel it opens rides in the link, because the first row is usually in
-			// several panels and the address alone cannot say which one this item means
-			// (#42464). The shell consumes it and strips it on arrival.
+			// The panel rides in the link; the shell consumes and strips it on arrival.
 			to: {
 				name: "list",
 				params: { doctype: "sales-invoice" },
@@ -425,9 +423,7 @@ describe("the recursion guard", () => {
 		};
 
 		expect(renderingOf(item, context([item], { sidebars }))).toEqual({
-			// The panel it opens rides in the link, because the first row is usually in
-			// several panels and the address alone cannot say which one this item means
-			// (#42464). The shell consumes it and strips it on arrival.
+			// The panel rides in the link; the shell consumes and strips it on arrival.
 			to: {
 				name: "list",
 				params: { doctype: "sales-invoice" },

--- a/frontend/src/shell/AppRail.vue
+++ b/frontend/src/shell/AppRail.vue
@@ -60,26 +60,36 @@
 			/>
 		</ul>
 
-		<button
-			v-if="arrangeable"
-			class="mt-auto rounded px-2 py-1 text-left text-xs text-ink-gray-5 hover:bg-surface-gray-2"
-			@click="emit('arrange')"
-		>
-			Arrange
-		</button>
+		<!-- One footer group, so `mt-auto` sits in one place however many controls are on. -->
+		<div class="mt-auto flex flex-col">
+			<button
+				v-if="arrangeable"
+				class="rounded px-2 py-1 text-left text-xs text-ink-gray-5 hover:bg-surface-gray-2"
+				@click="emit('arrange')"
+			>
+				Arrange
+			</button>
 
-		<a
-			href="/apps"
-			:class="arrangeable ? '' : 'mt-auto'"
-			class="rounded px-2 py-1 text-xs text-ink-gray-5 hover:bg-surface-gray-2"
-		>
-			All apps
-		</a>
+			<button
+				v-if="shareLink"
+				class="rounded px-2 py-1 text-left text-xs text-ink-gray-5 hover:bg-surface-gray-2"
+				@click="copyLink"
+			>
+				{{ copied ? "Link copied" : "Copy link" }}
+			</button>
+
+			<a
+				href="/apps"
+				class="rounded px-2 py-1 text-xs text-ink-gray-5 hover:bg-surface-gray-2"
+			>
+				All apps
+			</a>
+		</div>
 	</nav>
 </template>
 
 <script setup lang="ts">
-import { inject } from "vue";
+import { inject, onBeforeUnmount, ref } from "vue";
 import { RouterLink } from "vue-router";
 import type { Boot, NavigationItem } from "@/boot";
 import NavigationRow from "@/navigation/NavigationRow.vue";
@@ -94,15 +104,44 @@ import type { ItemContext } from "@/navigation/types";
 // the panel (#42421). The context is composed once per list and the panel draws the same rows
 // off the same one; and exactly one row is current across the rail and the panel together, so
 // neither surface can work it out alone.
+// `shareLink` is the whole address to hand someone, built by the shell because only the shell
+// knows whether the panel needs naming (#42464). The button lives down here rather than by the
+// panel it can carry: the rail's footer is the shell's only chrome that is present on every
+// page, and "copy a link to this view" is useful with no panel open at all. It is expected to
+// collect other context later, which is the other reason it is not the panel's.
 const props = defineProps<{
 	items: NavigationItem[];
 	context: ItemContext;
 	current?: string;
 	arrangeable?: boolean;
+	shareLink?: string;
 }>();
 const emit = defineEmits<{ arrange: [] }>();
 
 const boot = inject<Boot>("boot")!;
+
+// Confirmation in the button itself. A copy that silently succeeds looks identical to one that
+// silently failed, and there is no toast in the desk v2 shell to borrow.
+const copied = ref(false);
+let clearCopied: ReturnType<typeof setTimeout> | undefined;
+
+async function copyLink() {
+	if (!props.shareLink) return;
+
+	try {
+		await navigator.clipboard.writeText(props.shareLink);
+	} catch {
+		// Denied permission, or an insecure origin, where `navigator.clipboard` is undefined.
+		// Nothing was copied, so say nothing rather than claim it was.
+		return;
+	}
+
+	copied.value = true;
+	clearTimeout(clearCopied);
+	clearCopied = setTimeout(() => (copied.value = false), 1500);
+}
+
+onBeforeUnmount(() => clearTimeout(clearCopied));
 
 // `parent_key` is the whole of hierarchy (#42227), and the server sends the tree flat. A
 // cycle in it is broken and reported by `useItemTree`: every row in one has a parent that is

--- a/frontend/src/shell/AppRail.vue
+++ b/frontend/src/shell/AppRail.vue
@@ -61,7 +61,7 @@
 			/>
 		</ul>
 
-		<!-- One footer group, so `mt-auto` sits in one place however many controls are on. -->
+		<!-- One group, so `mt-auto` sits in one place however many controls are on. -->
 		<div class="mt-auto flex flex-col">
 			<button
 				v-if="arrangeable"
@@ -106,11 +106,9 @@ import type { ItemContext } from "@/navigation/types";
 // the panel (#42421). The context is composed once per list and the panel draws the same rows
 // off the same one; and exactly one row is current across the rail and the panel together, so
 // neither surface can work it out alone.
-// `shareLink` is the whole address to hand someone, built by the shell because only the shell
-// knows whether the panel needs naming (#42464). The button lives down here rather than by the
-// panel it can carry: the rail's footer is the shell's only chrome that is present on every
-// page, and "copy a link to this view" is useful with no panel open at all. It is expected to
-// collect other context later, which is the other reason it is not the panel's.
+//
+// `shareLink` is built by the shell, which is what knows whether the panel needs naming. The
+// button is here because the rail's footer is the only chrome present on every page.
 const props = defineProps<{
 	items: NavigationItem[];
 	context: ItemContext;
@@ -122,8 +120,7 @@ const emit = defineEmits<{ arrange: [] }>();
 
 const boot = inject<Boot>("boot")!;
 
-// Confirmation in the button itself. A copy that silently succeeds looks identical to one that
-// silently failed, and there is no toast in the desk v2 shell to borrow.
+// Confirmation in the button itself: there is no toast in the shell to borrow.
 const copied = ref(false);
 let clearCopied: ReturnType<typeof setTimeout> | undefined;
 
@@ -133,8 +130,8 @@ async function copyLink() {
 	try {
 		await navigator.clipboard.writeText(props.shareLink);
 	} catch {
-		// Denied permission, or an insecure origin, where `navigator.clipboard` is undefined.
-		// Nothing was copied, so say nothing rather than claim it was.
+		// Denied, or an insecure origin where `navigator.clipboard` is undefined. Nothing was
+		// copied, so claim nothing.
 		return;
 	}
 

--- a/frontend/src/shell/AppShell.vue
+++ b/frontend/src/shell/AppShell.vue
@@ -152,15 +152,23 @@ function resolve() {
 watch(
 	[() => route.fullPath, destinations],
 	() => {
+		// Repeated in the address (`?panel=a&panel=b`) it arrives as an array. Nothing we hand
+		// out looks like that, but it still has to be consumed rather than left in the bar
+		// forever, so the first one is read and the rest go with it.
 		const panel = route.query.panel;
-		asked.value = typeof panel === "string" ? panel : undefined;
+		const named = Array.isArray(panel) ? panel[0] : panel;
+		asked.value = typeof named === "string" ? named : undefined;
 
 		resolve();
 
-		if (asked.value !== undefined) {
+		if (panel !== undefined) {
 			const { panel: _consumed, ...query } = route.query;
 			asked.value = undefined;
-			router.replace({ path: route.path, query });
+			// `hash` survives: it addresses a place within the page, which has nothing to do
+			// with the panel and is not ours to drop. An aborted or redirected replace rejects,
+			// and there is nothing to do about it — the panel is already resolved and recorded,
+			// so the only loss is a parameter left in the bar.
+			router.replace({ path: route.path, query, hash: route.hash }).catch(() => {});
 		}
 	},
 	{ immediate: true }
@@ -174,7 +182,8 @@ const shareLink = computed(() => {
 	const query =
 		panel && panel !== canonical.value.sidebar ? { ...route.query, panel } : route.query;
 
-	return new URL(router.resolve({ path: route.path, query }).href, window.location.origin).href;
+	const to = router.resolve({ path: route.path, query, hash: route.hash });
+	return new URL(to.href, window.location.origin).href;
 });
 
 // The panel, or nothing. `current.sidebar` is only ever a key a rail item's renderer read out

--- a/frontend/src/shell/AppShell.vue
+++ b/frontend/src/shell/AppShell.vue
@@ -114,30 +114,21 @@ const destinations = computed(() =>
 	navigationDestinations(navigation.value.rail, navigation.value.sidebars, contexts.value)
 );
 
-// The panel the reader is in, resolved on every arrival however they got there — click, paste,
-// reload, back. Still nothing set by a click: this is a walk over resolved paths, and the only
-// thing the reader's history contributes is which of several EQUALLY correct panels to pick
-// (#42432).
-//
-// A ref driven by a watcher rather than a computed, because the resolution feeds itself: the
-// panel open now is the first preference for the next address, and remembering the answer is a
-// write. A computed that stored its own result would run on every read.
+// A ref off a watcher, not a computed: the resolution feeds itself, since the panel open now
+// is the next address's first preference and recording the answer is a write.
 const current = ref<CurrentNavigation>({});
 
-// The panel named in the address, most-wanted preference and consumed once. A pasted `?panel=`
-// is a deliberate act, so it outranks whatever this tab happens to have open.
+// The panel the address asked for, outranking the open one because a paste is deliberate.
 const asked = ref<string | undefined>(undefined);
 
-// What the address alone says, with no reader in it — the cold-load answer. Used to keep the
-// copy link honest: naming the panel a stranger would land in anyway says nothing.
+// What the address alone says. Keeps the copy link honest: naming the panel a stranger lands
+// in anyway says nothing.
 const canonical = computed(() => currentFrom(destinations.value, route.path));
 
 function resolve() {
 	const path = route.path;
-	// Most wanted first: the panel just asked for, then the one already open, then whatever
-	// this tab last resolved here. Each is only a tie-break — a panel that does not cover the
-	// address, or covers it less deeply than another, loses regardless, which is how a
-	// `?panel=` that is stale, misspelled or filtered away by permissions degrades silently.
+	// Most wanted first, and each a tie-break only — which is how a `?panel=` that is stale,
+	// misspelled or filtered away by permissions loses and degrades silently.
 	const prefer = [asked.value, current.value.sidebar, recallPanel(path)].filter(
 		(panel): panel is string => !!panel
 	);
@@ -146,15 +137,13 @@ function resolve() {
 	if (current.value.sidebar) rememberPanel(path, current.value.sidebar);
 }
 
-// The parameter seeds the same per-tab record ordinary browsing fills, then leaves the address.
-// `replace`, so the clean URL is not a second history entry the back button has to walk
-// through; and the record is already written, so back and reload still land in the same panel.
+// The parameter seeds the same record browsing fills, then leaves the address by `replace`, so
+// the bar is clean without a second history entry for back to walk through.
 watch(
 	[() => route.fullPath, destinations],
 	() => {
-		// Repeated in the address (`?panel=a&panel=b`) it arrives as an array. Nothing we hand
-		// out looks like that, but it still has to be consumed rather than left in the bar
-		// forever, so the first one is read and the rest go with it.
+		// Repeated in the address it arrives as an array, which must still be consumed or it
+		// sits in the bar for the rest of the session.
 		const panel = route.query.panel;
 		const named = Array.isArray(panel) ? panel[0] : panel;
 		asked.value = typeof named === "string" ? named : undefined;
@@ -164,19 +153,16 @@ watch(
 		if (panel !== undefined) {
 			const { panel: _consumed, ...query } = route.query;
 			asked.value = undefined;
-			// `hash` survives: it addresses a place within the page, which has nothing to do
-			// with the panel and is not ours to drop. An aborted or redirected replace rejects,
-			// and there is nothing to do about it — the panel is already resolved and recorded,
-			// so the only loss is a parameter left in the bar.
+			// `hash` addresses a place within the page, so it is not ours to drop. An aborted
+			// or redirected replace rejects, and the panel is recorded by then regardless.
 			router.replace({ path: route.path, query, hash: route.hash }).catch(() => {});
 		}
 	},
 	{ immediate: true }
 );
 
-// The link to hand someone else, or nothing to offer. The parameter goes on only where it says
-// something: in the canonical panel it is a tautology, the rule already set for `?from=` on
-// re-entering its own prefix.
+// The link to hand someone else. The parameter goes on only where it says something, matching
+// the rule `?from=` already follows on re-entering its own prefix.
 const shareLink = computed(() => {
 	const panel = current.value.sidebar;
 	const query =

--- a/frontend/src/shell/AppShell.vue
+++ b/frontend/src/shell/AppShell.vue
@@ -31,6 +31,7 @@
 			:context="contexts.rail"
 			:current="current.railKey"
 			:arrangeable="!!boot.app"
+			:share-link="shareLink"
 			@arrange="arrangeRail"
 		/>
 		<AppSidebar
@@ -59,7 +60,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject, ref } from "vue";
+import { computed, inject, ref, watch } from "vue";
 import { RouterView, useRoute, useRouter } from "vue-router";
 import type { Addresses } from "@/addresses";
 import type { Boot, Navigation, NavigationItem } from "@/boot";
@@ -68,8 +69,10 @@ import { itemContext } from "@/navigation/context";
 import {
 	currentFrom,
 	navigationDestinations,
+	type CurrentNavigation,
 	type NavigationContexts,
 } from "@/navigation/current";
+import { recallPanel, rememberPanel } from "@/navigation/panelMemory";
 import AppRail from "./AppRail.vue";
 import AppSidebar from "./AppSidebar.vue";
 import ArrangementEditor from "./ArrangementEditor.vue";
@@ -111,9 +114,68 @@ const destinations = computed(() =>
 	navigationDestinations(navigation.value.rail, navigation.value.sidebars, contexts.value)
 );
 
-// And this is recomputed on every navigation, which is the whole design: nothing here is set
-// by a click. It is a walk over resolved paths, with no router in it.
-const current = computed(() => currentFrom(destinations.value, route.path));
+// The panel the reader is in, resolved on every arrival however they got there — click, paste,
+// reload, back. Still nothing set by a click: this is a walk over resolved paths, and the only
+// thing the reader's history contributes is which of several EQUALLY correct panels to pick
+// (#42432).
+//
+// A ref driven by a watcher rather than a computed, because the resolution feeds itself: the
+// panel open now is the first preference for the next address, and remembering the answer is a
+// write. A computed that stored its own result would run on every read.
+const current = ref<CurrentNavigation>({});
+
+// The panel named in the address, most-wanted preference and consumed once. A pasted `?panel=`
+// is a deliberate act, so it outranks whatever this tab happens to have open.
+const asked = ref<string | undefined>(undefined);
+
+// What the address alone says, with no reader in it — the cold-load answer. Used to keep the
+// copy link honest: naming the panel a stranger would land in anyway says nothing.
+const canonical = computed(() => currentFrom(destinations.value, route.path));
+
+function resolve() {
+	const path = route.path;
+	// Most wanted first: the panel just asked for, then the one already open, then whatever
+	// this tab last resolved here. Each is only a tie-break — a panel that does not cover the
+	// address, or covers it less deeply than another, loses regardless, which is how a
+	// `?panel=` that is stale, misspelled or filtered away by permissions degrades silently.
+	const prefer = [asked.value, current.value.sidebar, recallPanel(path)].filter(
+		(panel): panel is string => !!panel
+	);
+
+	current.value = currentFrom(destinations.value, path, prefer);
+	if (current.value.sidebar) rememberPanel(path, current.value.sidebar);
+}
+
+// The parameter seeds the same per-tab record ordinary browsing fills, then leaves the address.
+// `replace`, so the clean URL is not a second history entry the back button has to walk
+// through; and the record is already written, so back and reload still land in the same panel.
+watch(
+	[() => route.fullPath, destinations],
+	() => {
+		const panel = route.query.panel;
+		asked.value = typeof panel === "string" ? panel : undefined;
+
+		resolve();
+
+		if (asked.value !== undefined) {
+			const { panel: _consumed, ...query } = route.query;
+			asked.value = undefined;
+			router.replace({ path: route.path, query });
+		}
+	},
+	{ immediate: true }
+);
+
+// The link to hand someone else, or nothing to offer. The parameter goes on only where it says
+// something: in the canonical panel it is a tautology, the rule already set for `?from=` on
+// re-entering its own prefix.
+const shareLink = computed(() => {
+	const panel = current.value.sidebar;
+	const query =
+		panel && panel !== canonical.value.sidebar ? { ...route.query, panel } : route.query;
+
+	return new URL(router.resolve({ path: route.path, query }).href, window.location.origin).href;
+});
 
 // The panel, or nothing. `current.sidebar` is only ever a key a rail item's renderer read out
 // of this same payload, so the rows are there — the row count is checked anyway because an

--- a/frontend/src/shell/tests/rail.test.ts
+++ b/frontend/src/shell/tests/rail.test.ts
@@ -239,9 +239,8 @@ describe("a linked item", () => {
 
 		const link = row(host, "accounts") as HTMLAnchorElement;
 		expect(link.getAttribute("data-sidebar")).toBe("module_def_accounts");
-		// And it is real navigation, not shell state — charter point 7. The panel it opens is
-		// named in the href rather than held in a click handler, so middle-click and
-		// open-in-new-tab still work and a paste lands in the same panel (#42464).
+		// Real navigation, not shell state — charter point 7. The panel is named in the href,
+		// so middle-click and open-in-new-tab still work.
 		expect(link.getAttribute("href")).toBe("/sales-invoice?panel=module_def_accounts");
 	});
 

--- a/frontend/src/shell/tests/rail.test.ts
+++ b/frontend/src/shell/tests/rail.test.ts
@@ -222,8 +222,10 @@ describe("a linked item", () => {
 
 		const link = row(host, "accounts") as HTMLAnchorElement;
 		expect(link.getAttribute("data-sidebar")).toBe("module_def_accounts");
-		// And it is real navigation, not shell state — charter point 7.
-		expect(link.getAttribute("href")).toBe("/sales-invoice");
+		// And it is real navigation, not shell state — charter point 7. The panel it opens is
+		// named in the href rather than held in a click handler, so middle-click and
+		// open-in-new-tab still work and a paste lands in the same panel (#42464).
+		expect(link.getAttribute("href")).toBe("/sales-invoice?panel=module_def_accounts");
 	});
 
 	it("is not drawn when its sidebar is absent", () => {


### PR DESCRIPTION
Builds the panel continuity settled on [One address in two panels: which one opens?](https://github.com/frappe/frappe/issues/42432), whose producer is [Panel continuity](https://github.com/frappe/frappe/issues/42464). Nothing here was open for redesign.

## Why

One destination reachable from two sidebars resolved to exactly one panel, always the same one, and the reader in the other panel was moved out of it with no signal. On ERPNext's rail that is the ordinary case, not an edge: **45 of 216 destinations sit in more than one panel**, and `Item` sits in six. The winner carried no meaning either, since the tie-break was rail authoring order — `Item` resolved to Buying, which is third, rather than Stock, which is eighth.

## What changed

**The panel, while you are browsing.** `currentFrom` takes the reader's continuity as an ordered tie-break. Among covers of equal depth the earliest preferred panel wins; deeper coverage still beats shallower, and a cold load with nothing to prefer still takes the first in rail order. A row that does not cover the address is never a candidate, however wanted its panel is.

**The tab remembers, so a reload keeps it.** The resolved panel is recorded against the address in `sessionStorage` — the first thing the desk v2 shell stores. The write happens when the panel **resolves**, not when a row is clicked: rows are plain `RouterLink`s and Vue Router's `RouterLink` cannot carry history state, so anything hung off the click would have cost the plain link and broken middle-click and open-in-new-tab.

**Copy link.** A button in the rail's footer produces `?panel=`, and only where the parameter says something — in the canonical panel it is a tautology and is left off, the rule already set for `?from=`. On arrival the shell reads it, opens that panel, records it, then rewrites the address without it and without adding a history entry, so the bar is clean while reload and back still work. A panel that does not exist, does not hold that destination, or is filtered away by permissions is simply not among the covers, so it loses and the canonical panel answers, silently.

It sits in the rail's footer rather than by the panel it can carry because that footer is the shell's only chrome present on every page, "copy a link to this view" is useful with no panel open, and it is expected to collect other context later.

**Two rows in one panel:** the first row going down the panel wins the highlight. Lighting both stays out — two rows carrying `aria-current="page"` tell a screen reader there are two current pages.

**`report_overlaps(app)`** lists this on demand: `bench execute frappe.shell.navigation.report_overlaps --kwargs "{'app': 'erpnext'}"`. Deliberately not wired to install or migrate, where it would fire 45 times on a pattern that is usually correct.

## This narrows charter point 7, on purpose

A per-tab record of the panel is a stored selection. What survives intact is that **a cold load is still a pure function of the address** — the record never invents a panel and never overrides a deeper cover, only ever choosing among panels the address itself already allows. What is given up is that within a session the same address can present two different panels depending on where the reader came from. Weighed against being yanked out of the panel you are working in, one destination in five.

## Verification

`frontend` suite **373 passing**, up from 359: fourteen new covering the preference, that it never beats a deeper cover, that an unmatched preference degrades silently, that a cold load is unchanged, first-row-wins inside one panel, and the storage module including quota and forbidden-access failures.

`report_overlaps` run against ERPNext's real fixtures independently reproduces the numbers in #42432 — **45 shared destinations, 0 intra-panel repeats, `Item` in six panels resolving to Buying**.

Walked in the browser on ERPNext's rail:

| Step | Result |
| --- | --- |
| `/stock/item?panel=module_def_stock` | opens Stock, records it, URL rewritten to `/stock/item` |
| reload on the bare URL | still Stock; exactly one rail row carries `aria-current` |
| click Material Request from Stock | stays in Stock, where it previously moved to Buying |
| back | returns to `/stock/item`, still Stock |
| copy link in Stock | `…/stock/item?panel=module_def_stock` |
| copy link in the canonical panel | `…/stock/stock-entry`, no parameter |
| `?panel=module_def_nonsense` | degrades silently to Buying, parameter stripped |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**Follow-up in this branch:** a rail item now names the panel it opens in the link it hands out. Following `Stock` from the Buying panel was moving the address to Stock Entry and leaving Buying highlighted, because Stock Entry is in both panels at equal depth and continuity won the tie. Following a rail item that opens a panel is an explicit request for that panel, so it outranks the open one — carried in the href, not a click handler, so middle-click and paste behave. It also settles the cold case: following `Stock` opens Stock rather than whichever panel rail order reached first.

>no-docs
