### PR TITLE
feat: open a shut section the address is standing in

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -38,7 +38,7 @@ yarn --cwd frontend test:run
 That is exactly what CI does (`.github/workflows/frontend-tests.yml`). The **base** file
 is the correct input, not a `bench build`-generated one: `yarn.lock` was resolved from
 `package.base.json` alone, and no test needs anything an app contributes. Baseline is
-**18 files / 328 tests**, under `recordPage/tests/`, `shell/tests/` and
+**25 files / 428 tests**, under `recordPage/tests/`, `shell/tests/` and
 `navigation/tests/`.
 
 **`vitest.config.js` runs with `css: { postcss: {} }`, and that is not cosmetic.**

--- a/frontend/src/navigation/NavigationRow.vue
+++ b/frontend/src/navigation/NavigationRow.vue
@@ -68,12 +68,12 @@
 				 that should simply be visible. -->
 		<component
 			v-else-if="heading"
-			:is="item.collapsible ? 'button' : 'p'"
-			:type="item.collapsible ? 'button' : undefined"
+			:is="collapsible ? 'button' : 'p'"
+			:type="collapsible ? 'button' : undefined"
 			:data-key="item.key"
-			:aria-expanded="item.collapsible ? String(open) : undefined"
+			:aria-expanded="collapsible ? String(open) : undefined"
 			:class="HEADING"
-			@click="item.collapsible ? toggle() : undefined"
+			@click="collapsible ? toggle() : undefined"
 		>
 			{{ label }}
 		</component>
@@ -171,6 +171,10 @@ const shippedOpen = computed(() => !item.value.keep_closed);
 
 // The one section the address is standing in opens itself, transiently and writing nothing.
 const holdsCurrent = computed(() => !!props.current && containsKey(props.node, props.current));
+
+// No control while the address is inside: the section may not shut over the row you are on,
+// and a heading that reports `aria-expanded` and refuses the click is worse than no control.
+const collapsible = computed(() => !!item.value.collapsible && !holdsCurrent.value);
 
 /** Where this section rests when the address is not inside it. */
 function settled(): boolean {

--- a/frontend/src/navigation/NavigationRow.vue
+++ b/frontend/src/navigation/NavigationRow.vue
@@ -73,7 +73,7 @@
 			:data-key="item.key"
 			:aria-expanded="item.collapsible ? String(open) : undefined"
 			:class="HEADING"
-			@click="item.collapsible ? (open = !open) : undefined"
+			@click="item.collapsible ? toggle() : undefined"
 		>
 			{{ label }}
 		</component>
@@ -86,12 +86,16 @@
 				:context="context"
 				:current="current"
 				:reserve="reserve"
+				:sections="sections"
 			/>
 		</ul>
 
 		<!-- Expanded rows sit at this row's OWN level, not under it. "N more" is an overflow
 				 of the list it is in, so indenting what it reveals would say the module contains
-				 the overflow row, which is backwards. -->
+				 the overflow row, which is backwards.
+
+				 No `sections`: these rows are fetched, not in the container's payload, so a
+				 toggle stored against one would be pruned as stale on the next read. -->
 		<NavigationRow
 			v-for="child in expandedNodes"
 			:key="child.item.key"
@@ -106,7 +110,8 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 import { RouterLink } from "vue-router";
-import { buildTree, type ItemNode } from "@/navigation/tree";
+import { buildTree, containsKey, type ItemNode } from "@/navigation/tree";
+import type { SectionMemory } from "@/navigation/sectionMemory";
 import { labelOf, renderingOf } from "@/navigation/registry";
 import Icon from "@/icons/Icon.vue";
 import type { ItemContext } from "@/navigation/types";
@@ -136,6 +141,7 @@ const props = defineProps<{
 	context: ItemContext;
 	current?: string;
 	reserve?: boolean;
+	sections?: SectionMemory;
 }>();
 
 const item = computed(() => props.node.item);
@@ -161,21 +167,29 @@ const heading = computed(
 // `keep_closed` is what makes a section START closed; `collapsible` is what lets a reader
 // close it. Neither is the same as "open", so a section that is neither stays open and has
 // no control (#42227).
-//
-// The watch is on the SHIPPED value, not on the item: a reset returns the app's own layer
-// (#42363), so the same key can come back with a different `keep_closed` while this
-// component survives — `v-for` keys on the key — and the section would sit open or closed
-// against what it now ships until a reload. Watching the value rather than the row is what
-// keeps that distinct from a reader's own toggle, which changes `open` and never
-// `keep_closed`, so a save cannot re-open what somebody just closed.
-const open = ref(!item.value.keep_closed);
+const shippedOpen = computed(() => !item.value.keep_closed);
 
-watch(
-	() => item.value.keep_closed,
-	(keepClosed) => {
-		open.value = !keepClosed;
-	}
-);
+// The one section the address is standing in opens itself, transiently and writing nothing.
+const holdsCurrent = computed(() => !!props.current && containsKey(props.node, props.current));
+
+/** Where this section rests when the address is not inside it. */
+function settled(): boolean {
+	return props.sections?.recall(item.value.key) ?? shippedOpen.value;
+}
+
+const open = ref(holdsCurrent.value || settled());
+
+// Re-derived, not assigned: a save returns the app's own layer, so the same key can come
+// back with a different `keep_closed` while this component survives.
+watch([() => item.value.keep_closed, holdsCurrent], () => {
+	open.value = holdsCurrent.value || settled();
+});
+
+/** A click on the heading, the one thing here that writes. */
+function toggle() {
+	open.value = !open.value;
+	props.sections?.remember(item.value.key, open.value);
+}
 
 const expanded = ref(false);
 const expandedNodes = ref<ItemNode[]>([]);

--- a/frontend/src/navigation/sectionMemory.ts
+++ b/frontend/src/navigation/sectionMemory.ts
@@ -1,0 +1,86 @@
+// Which sections a reader has opened or shut for themselves. `localStorage`, so the unit is
+// the BROWSER — and keyed by user, because a browser profile is shared and a disclosure is not.
+
+import type { NavigationItem } from "@/boot";
+
+const KEY = "frappe:desk:sections";
+
+/** One reader's toggles for one container: section key to open. */
+type Sections = Record<string, boolean>;
+type Stored = Record<string, Record<string, Sections>>;
+
+export type SectionMemory = {
+	/** What this reader decided about `key`, or nothing if they have not decided. */
+	recall(key: string): boolean | undefined;
+	/** Record a click on `key`'s heading. */
+	remember(key: string, open: boolean): void;
+};
+
+function read(): Stored {
+	try {
+		const raw = localStorage.getItem(KEY);
+		const parsed = raw ? JSON.parse(raw) : null;
+		return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+	} catch {
+		// Storage throws in a sandboxed frame and at zero quota. A browser that cannot
+		// remember shows every section as its app ships it.
+		return {};
+	}
+}
+
+function write(stored: Stored): void {
+	try {
+		localStorage.setItem(KEY, JSON.stringify(stored));
+	} catch {
+		// Full or forbidden. The section still opens and closes for this page.
+	}
+}
+
+/**
+ * This reader's disclosures for one container (`Rail:crm`, `Sidebar:doctype_crm_lead`), read
+ * once and pruned against the `items` that container currently ships.
+ */
+export function sectionMemory(
+	user: string,
+	container: string,
+	items: NavigationItem[]
+): SectionMemory {
+	const shippedOpen = new Map(items.map((item) => [item.key, !item.keep_closed]));
+
+	const kept: Sections = {};
+
+	for (const [key, open] of Object.entries(read()[user]?.[container] ?? {})) {
+		// `has`, not truthiness on `get`: a section that is gone and one that ships shut
+		// both answer falsey, and only the first is stale.
+		if (!shippedOpen.has(key) || typeof open !== "boolean") continue;
+		if (open !== shippedOpen.get(key)) kept[key] = open;
+	}
+
+	/** Re-reads, so a write here cannot drop another container's entry. */
+	function save() {
+		const stored = read();
+		const forUser = { ...stored[user], [container]: kept };
+		if (!Object.keys(kept).length) delete forUser[container];
+
+		const next = { ...stored, [user]: forUser };
+		// A reader who toggles everything back leaves nothing behind, not an empty shell.
+		if (!Object.keys(forUser).length) delete next[user];
+
+		write(next);
+	}
+
+	return {
+		recall(key) {
+			return kept[key];
+		},
+
+		remember(key, open) {
+			// Back to what the app ships is a decision to forget, and the only way a reader
+			// has of clearing one.
+			if (open === shippedOpen.get(key)) delete kept[key];
+			else kept[key] = open;
+
+			save();
+		},
+	};
+}

--- a/frontend/src/navigation/tests/sectionMemory.test.ts
+++ b/frontend/src/navigation/tests/sectionMemory.test.ts
@@ -1,0 +1,121 @@
+// What this browser remembers about the sections one reader has opened or shut.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { NavigationItem } from "@/boot";
+import { sectionMemory } from "@/navigation/sectionMemory";
+
+const READER = "reader@example.com";
+const PANEL = "Sidebar:doctype_crm_lead";
+
+function section(key: string, keepClosed?: 1): NavigationItem {
+	return { key, item_type: "Section", collapsible: 1, ...(keepClosed ? { keep_closed: 1 } : {}) };
+}
+
+const shipped = [section("leads-configure", 1), section("leads-more")];
+
+function memory(items = shipped, user = READER) {
+	return sectionMemory(user, PANEL, items);
+}
+
+function stored() {
+	return JSON.parse(localStorage.getItem("frappe:desk:sections") ?? "null");
+}
+
+beforeEach(() => {
+	localStorage.clear();
+	vi.restoreAllMocks();
+});
+
+describe("remembering a toggle", () => {
+	it("knows nothing until somebody decides something", () => {
+		expect(memory().recall("leads-configure")).toBeUndefined();
+	});
+
+	it("reads back a section opened against what the app ships", () => {
+		memory().remember("leads-configure", true);
+		expect(memory().recall("leads-configure")).toBe(true);
+	});
+
+	it("reads back a section shut against what the app ships", () => {
+		memory().remember("leads-more", false);
+		expect(memory().recall("leads-more")).toBe(false);
+	});
+
+	it("forgets a section toggled back to what the app ships", () => {
+		const kept = memory();
+		kept.remember("leads-configure", true);
+		kept.remember("leads-configure", false);
+
+		expect(memory().recall("leads-configure")).toBeUndefined();
+		expect(stored()).toEqual({});
+	});
+});
+
+describe("whose disclosures these are", () => {
+	it("does not hand one reader's toggle to another on the same browser", () => {
+		memory().remember("leads-configure", true);
+		expect(memory(shipped, "colleague@example.com").recall("leads-configure")).toBeUndefined();
+	});
+
+	it("does not hand one container's toggle to another", () => {
+		memory().remember("leads-configure", true);
+		expect(sectionMemory(READER, "Rail:crm", shipped).recall("leads-configure")).toBeUndefined();
+	});
+
+	it("keeps a second container's entries when the first writes", () => {
+		sectionMemory(READER, "Rail:crm", shipped).remember("leads-more", false);
+		memory().remember("leads-configure", true);
+
+		expect(sectionMemory(READER, "Rail:crm", shipped).recall("leads-more")).toBe(false);
+		expect(memory().recall("leads-configure")).toBe(true);
+	});
+});
+
+describe("what an upgrade does to it", () => {
+	it("stops counting an entry for a section that is gone", () => {
+		memory().remember("leads-configure", true);
+		expect(memory([section("leads-more")]).recall("leads-configure")).toBeUndefined();
+	});
+
+	it("lets a new shipped keep_closed beat what the reader had toggled", () => {
+		// Opened against a section that shipped shut. The app now ships it open, so the entry
+		// says nothing either way and the shipped value is what is left.
+		memory().remember("leads-configure", true);
+		expect(memory([section("leads-configure")]).recall("leads-configure")).toBeUndefined();
+	});
+
+	it("clears a stale entry out of storage at the next write", () => {
+		memory().remember("leads-configure", true);
+
+		const upgraded = memory([section("leads-more")]);
+		upgraded.remember("leads-more", false);
+
+		expect(stored()[READER][PANEL]).toEqual({ "leads-more": false });
+	});
+});
+
+describe("a browser that cannot store", () => {
+	it("keeps working when reading throws", () => {
+		vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+			throw new Error("denied");
+		});
+
+		expect(() => memory().recall("leads-configure")).not.toThrow();
+	});
+
+	it("keeps working when writing throws", () => {
+		vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+			throw new Error("quota");
+		});
+
+		const kept = memory();
+		expect(() => kept.remember("leads-configure", true)).not.toThrow();
+		// The page still shows the section open; only the reload loses it.
+		expect(kept.recall("leads-configure")).toBe(true);
+	});
+
+	it("ignores a stored value that is not the shape it wrote", () => {
+		localStorage.setItem("frappe:desk:sections", '"a string"');
+		expect(memory().recall("leads-configure")).toBeUndefined();
+	});
+});

--- a/frontend/src/navigation/tree.ts
+++ b/frontend/src/navigation/tree.ts
@@ -81,3 +81,8 @@ function descends(
 
 	return false;
 }
+
+/** Is `key` this node or anywhere beneath it? */
+export function containsKey(node: ItemNode, key: string): boolean {
+	return node.item.key === key || node.children.some((child) => containsKey(child, key));
+}

--- a/frontend/src/shell/AppRail.vue
+++ b/frontend/src/shell/AppRail.vue
@@ -58,6 +58,7 @@
 				:context="context"
 				:current="current"
 				:reserve="reserve"
+				:sections="sections"
 			/>
 		</ul>
 
@@ -94,6 +95,7 @@ import { inject, onBeforeUnmount, ref } from "vue";
 import { RouterLink } from "vue-router";
 import type { Boot, NavigationItem } from "@/boot";
 import NavigationRow from "@/navigation/NavigationRow.vue";
+import type { SectionMemory } from "@/navigation/sectionMemory";
 import { useItemTree } from "@/navigation/useItemTree";
 import { useIconSlot } from "@/navigation/iconSlot";
 import type { ItemContext } from "@/navigation/types";
@@ -113,6 +115,7 @@ const props = defineProps<{
 	items: NavigationItem[];
 	context: ItemContext;
 	current?: string;
+	sections?: SectionMemory;
 	arrangeable?: boolean;
 	shareLink?: string;
 }>();

--- a/frontend/src/shell/AppShell.vue
+++ b/frontend/src/shell/AppShell.vue
@@ -30,6 +30,7 @@
 			:items="navigation.rail"
 			:context="contexts.rail"
 			:current="current.railKey"
+			:sections="sections.rail"
 			:arrangeable="!!boot.app"
 			:share-link="shareLink"
 			@arrange="arrangeRail"
@@ -42,6 +43,7 @@
 			:context="panel.context"
 			:title="panel.title"
 			:current="current.rowKey"
+			:sections="sections.sidebars[panel.address]"
 			arrangeable
 			@arrange="arrangeSidebar"
 		/>
@@ -73,6 +75,7 @@ import {
 	type NavigationContexts,
 } from "@/navigation/current";
 import { recallPanel, rememberPanel } from "@/navigation/panelMemory";
+import { sectionMemory } from "@/navigation/sectionMemory";
 import AppRail from "./AppRail.vue";
 import AppSidebar from "./AppSidebar.vue";
 import ArrangementEditor from "./ArrangementEditor.vue";
@@ -106,6 +109,20 @@ const contexts = computed<NavigationContexts>(() => {
 		),
 	};
 });
+
+// A reader's own disclosures, one store per container and rebuilt when the payload is. A
+// container is named by what the shell knows: the rail by its app, a panel by its address.
+const sections = computed(() => ({
+	rail: boot.app
+		? sectionMemory(boot.user.name, `Rail:${boot.app}`, navigation.value.rail)
+		: undefined,
+	sidebars: Object.fromEntries(
+		Object.entries(navigation.value.sidebars).map(([address, rows]) => [
+			address,
+			sectionMemory(boot.user.name, `Sidebar:${address}`, rows),
+		])
+	),
+}));
 
 // Every route navigation can be standing on. Off the PAYLOAD, so it survives a navigation:
 // building it costs a route resolution per row and the framework's own prefix carries 194 of

--- a/frontend/src/shell/AppSidebar.vue
+++ b/frontend/src/shell/AppSidebar.vue
@@ -39,6 +39,7 @@
 				:context="context"
 				:current="current"
 				:reserve="reserve"
+				:sections="sections"
 			/>
 		</ul>
 
@@ -55,6 +56,7 @@
 <script setup lang="ts">
 import type { NavigationItem } from "@/boot";
 import NavigationRow from "@/navigation/NavigationRow.vue";
+import type { SectionMemory } from "@/navigation/sectionMemory";
 import { useItemTree } from "@/navigation/useItemTree";
 import { useIconSlot } from "@/navigation/iconSlot";
 import type { ItemContext } from "@/navigation/types";
@@ -69,6 +71,7 @@ const props = defineProps<{
 	context: ItemContext;
 	title?: string;
 	current?: string;
+	sections?: SectionMemory;
 	arrangeable?: boolean;
 }>();
 const emit = defineEmits<{ arrange: [] }>();

--- a/frontend/src/shell/tests/fixtures/crmNavigation.json
+++ b/frontend/src/shell/tests/fixtures/crmNavigation.json
@@ -1,0 +1,186 @@
+{
+	"rail": [
+		{
+			"key": "leads",
+			"item_type": "Sidebar",
+			"link_doctype": "Sidebar",
+			"link_to": "doctype_crm_lead",
+			"label": "Leads",
+			"icon": "users"
+		},
+		{
+			"key": "deals",
+			"item_type": "Sidebar",
+			"link_doctype": "Sidebar",
+			"link_to": "doctype_crm_deal",
+			"label": "Deals",
+			"icon": "handshake"
+		},
+		{
+			"key": "contacts",
+			"item_type": "Sidebar",
+			"link_doctype": "Sidebar",
+			"link_to": "doctype_contact",
+			"label": "Contacts",
+			"icon": "contact-round"
+		},
+		{
+			"key": "organizations",
+			"item_type": "Sidebar",
+			"link_doctype": "Sidebar",
+			"link_to": "doctype_crm_organization",
+			"label": "Organizations",
+			"icon": "building-2"
+		},
+		{
+			"key": "tasks",
+			"item_type": "DocType",
+			"link_doctype": "DocType",
+			"link_to": "CRM Task",
+			"label": "Tasks",
+			"icon": "list-checks"
+		},
+		{
+			"key": "notes",
+			"item_type": "DocType",
+			"link_doctype": "DocType",
+			"link_to": "FCRM Note",
+			"label": "Notes",
+			"icon": "notebook-pen"
+		}
+	],
+	"sidebars": {
+		"doctype_contact": [
+			{
+				"key": "contacts",
+				"item_type": "DocType",
+				"link_doctype": "DocType",
+				"link_to": "Contact",
+				"label": "All Contacts",
+				"icon": "contact-round"
+			},
+			{
+				"key": "call-logs",
+				"item_type": "DocType",
+				"link_doctype": "DocType",
+				"link_to": "CRM Call Log",
+				"label": "Call Logs"
+			}
+		],
+		"doctype_crm_deal": [
+			{
+				"key": "deals",
+				"item_type": "DocType",
+				"link_doctype": "DocType",
+				"link_to": "CRM Deal",
+				"label": "All Deals",
+				"icon": "handshake"
+			},
+			{
+				"key": "deals-configure",
+				"item_type": "Section",
+				"label": "Configure",
+				"collapsible": 1,
+				"keep_closed": 1
+			},
+			{
+				"key": "deal-statuses",
+				"parent_key": "deals-configure",
+				"item_type": "DocType",
+				"link_doctype": "DocType",
+				"link_to": "CRM Deal Status",
+				"label": "Statuses"
+			},
+			{
+				"key": "products",
+				"parent_key": "deals-configure",
+				"item_type": "DocType",
+				"link_doctype": "DocType",
+				"link_to": "CRM Product",
+				"label": "Products"
+			},
+			{
+				"key": "territories",
+				"parent_key": "deals-configure",
+				"item_type": "DocType",
+				"link_doctype": "DocType",
+				"link_to": "CRM Territory",
+				"label": "Territories"
+			}
+		],
+		"doctype_crm_lead": [
+			{
+				"key": "leads",
+				"item_type": "DocType",
+				"link_doctype": "DocType",
+				"link_to": "CRM Lead",
+				"label": "All Leads",
+				"icon": "users"
+			},
+			{
+				"key": "leads-configure",
+				"item_type": "Section",
+				"label": "Configure",
+				"collapsible": 1,
+				"keep_closed": 1
+			},
+			{
+				"key": "lead-statuses",
+				"parent_key": "leads-configure",
+				"item_type": "DocType",
+				"link_doctype": "DocType",
+				"link_to": "CRM Lead Status",
+				"label": "Statuses"
+			},
+			{
+				"key": "lead-sources",
+				"parent_key": "leads-configure",
+				"item_type": "DocType",
+				"link_doctype": "DocType",
+				"link_to": "CRM Lead Source",
+				"label": "Sources"
+			},
+			{
+				"key": "lost-reasons",
+				"parent_key": "leads-configure",
+				"item_type": "DocType",
+				"link_doctype": "DocType",
+				"link_to": "CRM Lost Reason",
+				"label": "Lost Reasons"
+			}
+		],
+		"doctype_crm_organization": [
+			{
+				"key": "organizations",
+				"item_type": "DocType",
+				"link_doctype": "DocType",
+				"link_to": "CRM Organization",
+				"label": "All Organizations",
+				"icon": "building-2"
+			},
+			{
+				"key": "organizations-configure",
+				"item_type": "Section",
+				"label": "Configure",
+				"collapsible": 1,
+				"keep_closed": 1
+			},
+			{
+				"key": "industries",
+				"parent_key": "organizations-configure",
+				"item_type": "DocType",
+				"link_doctype": "DocType",
+				"link_to": "CRM Industry",
+				"label": "Industries"
+			},
+			{
+				"key": "territories",
+				"parent_key": "organizations-configure",
+				"item_type": "DocType",
+				"link_doctype": "DocType",
+				"link_to": "CRM Territory",
+				"label": "Territories"
+			}
+		]
+	}
+}

--- a/frontend/src/shell/tests/sections.test.ts
+++ b/frontend/src/shell/tests/sections.test.ts
@@ -141,8 +141,31 @@ describe("the address opens the section it is standing in", () => {
 		const { host } = await shell("/crm-lead-status");
 		const { host: shut } = await shell("/crm-deal");
 
-		expect(row(host, "leads-configure")?.getAttribute("aria-expanded")).toBe("true");
+		expect(row(host, "lead-statuses")).not.toBeNull();
 		expect(row(shut, "deals-configure")?.getAttribute("aria-expanded")).toBe("false");
+		expect(row(shut, "deal-statuses")).toBeNull();
+	});
+
+	it("offers no control to shut it over the row you are on", async () => {
+		const { host } = await shell("/crm-lead-status");
+		const heading = row(host, "leads-configure")!;
+
+		// A plain heading, not a button reporting a state a click would not change.
+		expect(heading.tagName).toBe("P");
+		expect(heading.getAttribute("aria-expanded")).toBeNull();
+
+		await click(heading);
+		expect(row(host, "lead-statuses")).not.toBeNull();
+		expect(localStorage.getItem("frappe:desk:sections")).toBeNull();
+	});
+
+	it("gives the control back on the way out", async () => {
+		const { host, router } = await shell("/crm-lead-status");
+
+		await router.push("/crm-lead");
+		await flush();
+
+		expect(row(host, "leads-configure")!.tagName).toBe("BUTTON");
 	});
 
 	it("shuts it again on the way out, and records nothing", async () => {

--- a/frontend/src/shell/tests/sections.test.ts
+++ b/frontend/src/shell/tests/sections.test.ts
@@ -1,0 +1,218 @@
+// A section that ships shut, and the two things that open it: the address, and the reader.
+//
+// Driven off a real resolved payload rather than rows built here. `keep_closed` went months
+// exercised only where no route pointed inside a shut section, which is the defect this is
+// about, so the fixture is what an app actually ships.
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createApp, nextTick } from "vue";
+import { createMemoryHistory, createRouter, type Router } from "vue-router";
+
+import { Addresses } from "@/addresses";
+import type { Boot, Navigation, NavigationItem } from "@/boot";
+import { registerContributions } from "@/contributions/registry";
+import { registerShell } from "@/router/routeFor";
+import { resetNavigationReports } from "@/navigation/registry";
+import { resetSprite } from "@/icons/sprite";
+import AppShell from "../AppShell.vue";
+import navigation from "./fixtures/crmNavigation.json";
+
+const READER = "reader@example.com";
+const stub = { render: () => null };
+
+// Every doctype the fixture points at, addressable the way the server scrubs one. Derived
+// from the payload so a regenerated fixture needs no second edit here.
+const addresses = new Addresses({
+	doctypes: Object.fromEntries(
+		[...(navigation as Navigation).rail, ...Object.values((navigation as Navigation).sidebars).flat()]
+			.filter((item) => item.link_doctype === "DocType" && item.link_to)
+			.map((item) => [item.link_to!, [item.link_to!.toLowerCase().replaceAll(" ", "-"), "fcrm"]])
+	),
+	modules: { fcrm: "FCRM" },
+});
+
+async function flush() {
+	await Promise.resolve();
+	await nextTick();
+}
+
+async function shell(
+	path: string,
+	user = READER,
+	payload: unknown = navigation
+): Promise<{ host: HTMLElement; router: Router }> {
+	const boot = {
+		app: "crm",
+		shell_base: "/apps/crm",
+		prefixes: { crm: { app: "crm", modular: false } },
+		navigation: payload,
+		user: { name: user, full_name: "Reader" },
+	} as unknown as Boot;
+
+	const router = createRouter({
+		history: createMemoryHistory(),
+		routes: [
+			{ path: "/", name: "home", component: stub },
+			{ path: "/:doctype", name: "list", component: stub },
+			{ path: "/:doctype/:name", name: "record", component: stub },
+		],
+	});
+	registerShell({ boot, addresses, router });
+
+	const host = document.createElement("div");
+	document.body.appendChild(host);
+
+	const app = createApp(AppShell);
+	app.provide("boot", boot);
+	app.provide("addresses", addresses);
+	app.use(router);
+
+	await router.push(path);
+	await router.isReady();
+	app.mount(host);
+	await flush();
+
+	return { host, router };
+}
+
+function row(host: HTMLElement, key: string) {
+	return host.querySelector(`aside [data-key="${CSS.escape(key)}"]`);
+}
+
+function marked(host: HTMLElement) {
+	return Array.from(host.querySelectorAll("aside [aria-current='page']")).map((node) =>
+		node.getAttribute("data-key")
+	);
+}
+
+async function click(node: Element | null) {
+	node!.dispatchEvent(new Event("click"));
+	await flush();
+}
+
+function addressOf(item: NavigationItem) {
+	return `/${item.link_to!.toLowerCase().replaceAll(" ", "-")}`;
+}
+
+/** Every row the fixture puts behind a section that ships shut. */
+function behindShutSections(): { sidebar: string; section: string; item: NavigationItem }[] {
+	return Object.entries((navigation as Navigation).sidebars).flatMap(([sidebar, rows]) => {
+		const shut = new Set(rows.filter((item) => item.keep_closed).map((item) => item.key));
+
+		return rows
+			.filter((item) => item.parent_key && shut.has(item.parent_key))
+			.map((item) => ({ sidebar, section: item.parent_key!, item }));
+	});
+}
+
+beforeAll(async () => {
+	await registerContributions(["frappe"]);
+});
+
+beforeEach(() => {
+	document.body.innerHTML = "";
+	localStorage.clear();
+	resetNavigationReports();
+	resetSprite();
+	vi.unstubAllGlobals();
+});
+
+describe("the fixture this is driven off", () => {
+	it("ships sections shut with destinations behind them", () => {
+		// If a payload change empties this, every test below passes by testing nothing.
+		expect(behindShutSections().length).toBeGreaterThan(0);
+	});
+});
+
+describe("the address opens the section it is standing in", () => {
+	// Asserted on the ROW, not on a named section: one fixture row sits behind a shut section
+	// in two panels, and which of them the address opens is a separate open question (#42465).
+	// A row only renders at all if the section holding it is open, so this covers both.
+	it.each(behindShutSections())(
+		"shows $item.key, shipped behind $section",
+		async ({ item }) => {
+			const { host } = await shell(addressOf(item));
+
+			expect(row(host, item.key)).not.toBeNull();
+			expect(marked(host)).toEqual([item.key]);
+		}
+	);
+
+	it("leaves every other section as the app ships it", async () => {
+		const { host } = await shell("/crm-lead-status");
+		const { host: shut } = await shell("/crm-deal");
+
+		expect(row(host, "leads-configure")?.getAttribute("aria-expanded")).toBe("true");
+		expect(row(shut, "deals-configure")?.getAttribute("aria-expanded")).toBe("false");
+	});
+
+	it("shuts it again on the way out, and records nothing", async () => {
+		const { host, router } = await shell("/crm-lead-status");
+
+		await router.push("/crm-lead");
+		await flush();
+
+		expect(row(host, "leads-configure")?.getAttribute("aria-expanded")).toBe("false");
+		expect(row(host, "lead-statuses")).toBeNull();
+		expect(localStorage.getItem("frappe:desk:sections")).toBeNull();
+	});
+});
+
+describe("a reader's own toggle", () => {
+	it("survives a reload", async () => {
+		const { host } = await shell("/crm-lead");
+		await click(row(host, "leads-configure"));
+		expect(row(host, "lead-statuses")).not.toBeNull();
+
+		const { host: again } = await shell("/crm-lead");
+		expect(again.querySelector('aside [data-key="lead-statuses"]')).not.toBeNull();
+	});
+
+	it("does not reach another user on the same browser", async () => {
+		const { host } = await shell("/crm-lead");
+		await click(row(host, "leads-configure"));
+
+		const { host: colleague } = await shell("/crm-lead", "colleague@example.com");
+		expect(row(colleague, "leads-configure")?.getAttribute("aria-expanded")).toBe("false");
+	});
+
+	it("is cleared by toggling it back", async () => {
+		const { host } = await shell("/crm-lead");
+		await click(row(host, "leads-configure"));
+		await click(row(host, "leads-configure"));
+
+		const { host: again } = await shell("/crm-lead");
+		expect(row(again, "leads-configure")?.getAttribute("aria-expanded")).toBe("false");
+	});
+});
+
+// The fixture ships no section that starts open, so this one direction is over rows built
+// here: shutting one is what `settled()` answers `false` for.
+describe("shutting a section the app ships open", () => {
+	const shippedOpen = {
+		rail: [{ key: "leads", item_type: "Sidebar", link_to: "doctype_crm_lead", label: "Leads" }],
+		sidebars: {
+			doctype_crm_lead: [
+				{ key: "all", item_type: "DocType", link_doctype: "DocType", link_to: "CRM Lead" },
+				{ key: "more", item_type: "Section", collapsible: 1, label: "More" },
+				{
+					key: "sources",
+					parent_key: "more",
+					item_type: "DocType",
+					link_doctype: "DocType",
+					link_to: "CRM Lead Source",
+				},
+			],
+		},
+	};
+
+	it("survives a reload", async () => {
+		const { host } = await shell("/crm-lead", READER, shippedOpen);
+		expect(row(host, "sources")).not.toBeNull();
+
+		await click(row(host, "more"));
+
+		const { host: again } = await shell("/crm-lead", READER, shippedOpen);
+		expect(row(again, "more")?.getAttribute("aria-expanded")).toBe("false");
+		expect(row(again, "sources")).toBeNull();
+	});
+});

--- a/frontend/src/shell/tests/sidebar.test.ts
+++ b/frontend/src/shell/tests/sidebar.test.ts
@@ -47,6 +47,7 @@ async function shell(
 		shell_base: "/apps/crm",
 		prefixes: { crm: { app: "crm", modular: false } },
 		navigation: { rail, sidebars },
+		user: { name: "reader@example.com", full_name: "Reader" },
 	} as unknown as Boot;
 
 	const router = createRouter({


### PR DESCRIPTION
Builds [#42467](https://github.com/frappe/frappe/issues/42467), off the resolution on [Does the address open a section its shipped `keep_closed` holds shut?](https://github.com/frappe/frappe/issues/42434). Child of [#42226](https://github.com/frappe/frappe/issues/42226).

## The defect

`NavigationRow.vue` set a section's `open` once from `!item.keep_closed`, and nothing reopened it for the row the address was standing on. Paste `/apps/crm/crm-lead-status` into a fresh tab and the Leads panel opened with `Configure` shut, `Statuses` not in the DOM at all, and `aria-current` on the rail and on nothing inside the panel.

Measured against the payload the server actually resolves on a five-app bench: **177 rows behind 37 shut sections in ERPNext, 8 behind 3 in CRM**.

## What this does

1. **`open` is derived per route** — open if not `keep_closed`, **or** remembered open, **or** containing the current row. The tree already knows what is beneath a section, so `containsKey` answers it in a walk over rows in hand.
2. **The auto-open is transient and writes nothing.** Navigate away and the section shuts again; visiting one status page does not permanently un-shut `Configure` for that reader.
3. **A reader's own toggle is remembered**, in a new `frontend/src/navigation/sectionMemory.ts` owning one `localStorage` key, shaped `{ [user]: { [container]: { [section key]: boolean } } }`. Keyed by user because a browser profile is shared and a disclosure is not.
4. **A shipped change wins over a remembered toggle.** An entry that agrees with the `keep_closed` an app now ships, or names a section the payload no longer holds, stops counting on read — so an upgrade and an overlay reset both stay visible. Toggling a section back to its shipped state clears the entry, which is the only clearing gesture there is and the reason no reset control was added.
5. **Rail sections are covered; expandable rows are not.** `Module Contents` rows are fetched rather than in the container's payload, so they are not handed the store.

## Not merged with panel continuity

[Panel continuity](https://github.com/frappe/frappe/pull/42476) remembers the open panel in the **tab's** `sessionStorage`, so a second tab resolves off the address again. This is browser-wide and per user, because a disclosure someone opened should still be open tomorrow. Same location convention, two lifetimes, two keys.

## Testing

**428 frontend tests pass, up from 400.** Two new files:

- `navigation/tests/sectionMemory.test.ts` — 13 tests over the store: per-user and per-container separation, the upgrade cases, and a browser whose storage throws.
- `shell/tests/sections.test.ts` — 15 tests through `AppShell`, driven off `fixtures/crmNavigation.json`, **a real payload from `frappe.shell.navigation.resolve_navigation`** rather than rows the test builds. Every row the fixture puts behind a shut section is mounted at its own address and asserted visible and marked. That fixture shape is the point: `keep_closed` went months exercised only where no route pointed inside a shut section.

Also checked in a browser against the running bench, over the address the resolution names: `/apps/crm/crm-lead-status` opens the Leads panel with `Configure` disclosed and `Statuses` carrying `aria-current="page"`, storage untouched; leaving for All Leads shuts it; a click on the heading writes `{"Administrator":{"Sidebar:doctype_crm_lead":{"leads-configure":true}}}` and survives a panel remount; clicking it back empties the store.

`frontend/CLAUDE.md`'s stated test baseline was stale before this branch (328) and is refreshed to 428.

>no-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)