### PR TITLE
fix(form): duplicate intro messages on first save of a new document

### DIFF
--- a/cypress/integration/form_intro.js
+++ b/cypress/integration/form_intro.js
@@ -1,0 +1,31 @@
+context("Form Intro", () => {
+	before(() => {
+		cy.login();
+	});
+
+	it("keeps a single intro message after the first save of a new document", () => {
+		cy.new_form("ToDo");
+
+		cy.window().then((win) => {
+			win.frappe.ui.form.on("ToDo", {
+				refresh(frm) {
+					frm.set_intro("Intro set from refresh", "blue");
+				},
+			});
+			win.cur_frm.refresh();
+		});
+
+		cy.get(".form-message").should("have.length", 1);
+
+		cy.fill_field("description", "test intro dedupe", "Text Editor").blur().wait(200);
+		cy.save();
+
+		// first save renames the new document and reroutes to it; wait for that to land
+		cy.get("body").should(($body) => {
+			expect($body.attr("data-route")).to.not.match(/\/new-todo-/);
+		});
+		cy.wait(300);
+
+		cy.get(".form-message").should("have.length", 1);
+	});
+});

--- a/frappe/geo/doctype/currency/currency.js
+++ b/frappe/geo/doctype/currency/currency.js
@@ -3,7 +3,6 @@
 
 frappe.ui.form.on("Currency", {
 	refresh(frm) {
-		frm.set_intro("");
 		if (!frm.doc.enabled) {
 			frm.set_intro(__("This Currency is disabled. Enable to use in transactions"));
 		}

--- a/frappe/printing/doctype/print_format/print_format.js
+++ b/frappe/printing/doctype/print_format/print_format.js
@@ -8,7 +8,6 @@ frappe.ui.form.on("Print Format", "onload", function (frm) {
 
 frappe.ui.form.on("Print Format", {
 	refresh: function (frm) {
-		frm.set_intro("");
 		frm.toggle_enable(["html", "doc_type", "module"], false);
 		if (frappe.session.user === "Administrator" || frm.doc.standard === "No") {
 			frm.toggle_enable(["html", "doc_type", "module"], true);

--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -636,7 +636,7 @@ frappe.ui.form.Dashboard = class FormDashboard {
 
 	// TODO: Review! code related to headline should be the part of layout/form
 	set_headline(html, color, permanent = false) {
-		this.frm.layout.show_message(html, color, permanent);
+		return this.frm.layout.show_message(html, color, permanent);
 	}
 
 	clear_headline() {
@@ -658,7 +658,7 @@ frappe.ui.form.Dashboard = class FormDashboard {
 
 	set_headline_alert(text, color, permanent = false) {
 		if (text) {
-			this.set_headline(`<div>${text}</div>`, color, permanent);
+			return this.set_headline(`<div>${text}</div>`, color, permanent);
 		} else {
 			this.clear_headline();
 		}

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -32,6 +32,7 @@ frappe.ui.form.Form = class FrappeForm {
 		this.refresh_if_stale_for = 120;
 		this.opendocs = {};
 		this.custom_buttons = {};
+		this.$intro_message = null;
 		this.sections = [];
 		this.grids = [];
 		this.cscript = new frappe.ui.form.Controller({ frm: this });
@@ -1523,7 +1524,13 @@ frappe.ui.form.Form = class FrappeForm {
 	}
 
 	set_intro(txt, color) {
-		this.dashboard.set_headline_alert(txt, color);
+		if (this.$intro_message) {
+			this.$intro_message.remove();
+			this.$intro_message = null;
+		}
+		if (txt) {
+			this.$intro_message = this.dashboard.set_headline_alert(txt, color);
+		}
 	}
 
 	set_footnote(txt) {

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -136,6 +136,8 @@ frappe.ui.form.Layout = class Layout {
 
 		// Show parent container if hidden
 		this.message.removeClass("hidden");
+
+		return $html;
 	}
 
 	render(new_fields) {


### PR DESCRIPTION
## Summary
- Backports the intro message dedupe from `develop` (PR #40842) to `version-16-hotfix`
- Skips the `letter_head.js` hunk; that `refresh` no longer calls `frm.set_intro("")` on this branch