### PR TITLE
feat: weigh each boot key and log the ones over budget

### DIFF
--- a/frappe/shell/boot.py
+++ b/frappe/shell/boot.py
@@ -5,12 +5,10 @@
 # each rebuilt the generic keys by hand. v1's boot is left untouched and retires with
 # v1; this one starts small and is composed of core plus the *declaring app* only.
 
-import json
-
 import frappe
 from frappe import _
 from frappe.translate import get_translation_version
-from frappe.utils import get_system_timezone
+from frappe.utils import get_system_timezone, orjson_dumps
 
 from . import SHELL_ROOT
 from .doctypes import metadata_version
@@ -137,34 +135,32 @@ def index_boot() -> dict:
 def report_oversized_keys(boot: dict, prefix: str | None) -> None:
 	"""Weigh every top-level boot key and log the ones past `KEY_BUDGET`, shipping it whole."""
 	try:
-		sizes = {
-			key: len(json.dumps(value, separators=(",", ":"), default=str)) for key, value in boot.items()
-		}
+		# `orjson_dumps` is what serialises the response, so these are the bytes that
+		# actually go on the wire: UTF-8, and never `\uXXXX` as `json.dumps` would.
+		sizes = {key: len(orjson_dumps(value, default=str, decode=False)) for key, value in boot.items()}
 		total = sum(sizes.values())
 
 		for key, size in sorted(sizes.items()):
 			if size <= KEY_BUDGET:
 				continue
 
-			# `frappe.cache`, not `client_cache`: a per-process copy would let every
-			# gunicorn worker write its own row for the same key.
-			seen = f"boot_budget:{key}:{prefix or SHELL_ROOT}"
-			if frappe.cache.get_value(seen):
+			# An atomic `SET NX`: two workers weighing the same payload claim the day's
+			# row once between them.
+			claim = frappe.cache.make_key(f"boot_budget:{key}:{prefix or SHELL_ROOT}")
+			if not frappe.cache.set(name=claim, value=1, ex=_BUDGET_LOG_TTL, nx=True):
 				continue
 
 			where = f"prefix {prefix}" if prefix else f"the /{SHELL_ROOT} index"
-			# `Error Log` is MyISAM, so this survives the rollback `frappe.app` does on a
-			# GET and does not need deferring.
+			# Deferred because boot is a GET: `frappe.app` rolls back every request that
+			# is not an unsafe method, which on Postgres would discard the row.
 			frappe.log_error(
 				title=BUDGET_LOG_TITLE,
 				message=(
 					f"{key} is {size:,} B for {frappe.session.user} at {where}, "
 					f"over the {KEY_BUDGET:,} B key budget; boot total {total:,} B."
 				),
+				defer_insert=True,
 			)
-			# Claimed after the write, so a failed one is retried on the next boot
-			# instead of muting the alarm for a day.
-			frappe.cache.set_value(seen, 1, expires_in_sec=_BUDGET_LOG_TTL)
 	except Exception:
 		# A key that will not serialise raises at the response layer moments later; a
 		# size check that can blank the shell is worse than no size check.

--- a/frappe/shell/boot.py
+++ b/frappe/shell/boot.py
@@ -144,9 +144,10 @@ def report_oversized_keys(boot: dict, prefix: str | None) -> None:
 			if size <= KEY_BUDGET:
 				continue
 
-			# An atomic `SET NX`: two workers weighing the same payload claim the day's
-			# row once between them.
+			# An atomic `SET NX`: two workers weighing one payload claim the day's row
+			# once between them. `make_key` applies the site prefix `set_value` would.
 			claim = frappe.cache.make_key(f"boot_budget:{key}:{prefix or SHELL_ROOT}")
+			# nosemgrep: frappe-cache-breaks-multitenancy
 			if not frappe.cache.set(name=claim, value=1, ex=_BUDGET_LOG_TTL, nx=True):
 				continue
 

--- a/frappe/shell/boot.py
+++ b/frappe/shell/boot.py
@@ -5,6 +5,8 @@
 # each rebuilt the generic keys by hand. v1's boot is left untouched and retires with
 # v1; this one starts small and is composed of core plus the *declaring app* only.
 
+import json
+
 import frappe
 from frappe import _
 from frappe.translate import get_translation_version
@@ -15,6 +17,17 @@ from .doctypes import metadata_version
 from .navigation import resolve_navigation
 from .permissions import has_app_permission
 from .registry import get_prefix_registry, prefix_map, shell_base, split_shell_path
+
+# Bytes one top-level boot key may reach before boot logs it. Per key: the payload total
+# rides in the message as context and is never a second threshold.
+KEY_BUDGET = 100_000
+
+# At most one row per key per prefix per day. Never keyed on the user, or a 200-user site
+# writes 200 rows for one oversized payload.
+_BUDGET_LOG_TTL = 24 * 60 * 60
+
+# Fixed, so the rows group in the Error Log list. The key is the first word of the message.
+BUDGET_LOG_TITLE = "Boot key over budget"
 
 
 def core_boot() -> dict:
@@ -121,6 +134,43 @@ def index_boot() -> dict:
 	return {**core_boot(), "shell_base": f"/{SHELL_ROOT}", "app": None, "apps": apps}
 
 
+def report_oversized_keys(boot: dict, prefix: str | None) -> None:
+	"""Weigh every top-level boot key and log the ones past `KEY_BUDGET`, shipping it whole."""
+	try:
+		sizes = {
+			key: len(json.dumps(value, separators=(",", ":"), default=str)) for key, value in boot.items()
+		}
+		total = sum(sizes.values())
+
+		for key, size in sorted(sizes.items()):
+			if size <= KEY_BUDGET:
+				continue
+
+			# `frappe.cache`, not `client_cache`: a per-process copy would let every
+			# gunicorn worker write its own row for the same key.
+			seen = f"boot_budget:{key}:{prefix or SHELL_ROOT}"
+			if frappe.cache.get_value(seen):
+				continue
+
+			where = f"prefix {prefix}" if prefix else f"the /{SHELL_ROOT} index"
+			# `Error Log` is MyISAM, so this survives the rollback `frappe.app` does on a
+			# GET and does not need deferring.
+			frappe.log_error(
+				title=BUDGET_LOG_TITLE,
+				message=(
+					f"{key} is {size:,} B for {frappe.session.user} at {where}, "
+					f"over the {KEY_BUDGET:,} B key budget; boot total {total:,} B."
+				),
+			)
+			# Claimed after the write, so a failed one is retried on the next boot
+			# instead of muting the alarm for a day.
+			frappe.cache.set_value(seen, 1, expires_in_sec=_BUDGET_LOG_TTL)
+	except Exception:
+		# A key that will not serialise raises at the response layer moments later; a
+		# size check that can blank the shell is worse than no size check.
+		pass
+
+
 @frappe.whitelist()
 def get_boot(path: str | None = None) -> dict:
 	"""Boot for the prefix this request arrived at.
@@ -134,44 +184,48 @@ def get_boot(path: str | None = None) -> dict:
 		path = None
 	path = path or (frappe.local.request.path if frappe.local.request else "")
 	split = split_shell_path(path)
+	prefix = split[0] if split else None
 
-	if not split:
-		return index_boot()
+	if not prefix:
+		boot = index_boot()
+	else:
+		app = get_prefix_registry().get(prefix)
+		if not app:
+			frappe.throw(
+				_("No app is installed at {0}").format(f"/{SHELL_ROOT}/{prefix}"), frappe.DoesNotExistError
+			)
 
-	prefix, _rest = split
-	app = get_prefix_registry().get(prefix)
-	if not app:
-		frappe.throw(
-			_("No app is installed at {0}").format(f"/{SHELL_ROOT}/{prefix}"), frappe.DoesNotExistError
-		)
+		# The document gate is a courtesy; this re-check is the mandatory one, because a
+		# whitelisted endpoint is directly callable whatever the page did (#42112).
+		if not has_app_permission(app):
+			frappe.throw(_("You are not permitted to access this page."), frappe.PermissionError)
 
-	# The document gate is a courtesy; this re-check is the mandatory one, because a
-	# whitelisted endpoint is directly callable whatever the page did (#42112).
-	if not has_app_permission(app):
-		frappe.throw(_("You are not permitted to access this page."), frappe.PermissionError)
+		# Core LAST, so a contributed key cannot overwrite `csrf_token`, `user` or
+		# `shell_base`. "Merged under core" is what #42070 decided and what `app_boot`'s
+		# docstring says; spreading it last would have made an app able to break every save
+		# at its own prefix with a bare 400, by accident.
+		boot = {
+			**app_boot(app),
+			**core_boot(),
+			"shell_base": shell_base(prefix),
+			"app": app,
+			# The rail and every sidebar in this prefix, resolved server-side. A framework key
+			# and not an `app_boot` contribution: apps shape navigation through the rows and
+			# the item types they ship, and a code-level second route in would be two
+			# mechanisms for one thing (#42232).
+			#
+			# It rides boot because #42070 already makes boot a blocking pre-mount fetch, so a
+			# separate navigation request would be a second blocking round trip for the same
+			# wait — and because a rail click that costs a request is the thing this payload
+			# exists to prevent. What an app *contains* is still fetched, by the app home and
+			# the module page that show it (`doctypes.get_contents`, #42357).
+			"navigation": resolve_navigation(app),
+			# No `doctype_slugs` here any more. It is full-bench and byte-identical for
+			# every user and prefix, so it moved to `get_addresses` and a year-long cache.
+		}
 
-	# Core LAST, so a contributed key cannot overwrite `csrf_token`, `user` or
-	# `shell_base`. "Merged under core" is what #42070 decided and what `app_boot`'s
-	# docstring says; spreading it last would have made an app able to break every save
-	# at its own prefix with a bare 400, by accident.
-	return {
-		**app_boot(app),
-		**core_boot(),
-		"shell_base": shell_base(prefix),
-		"app": app,
-		# The rail and every sidebar in this prefix, resolved server-side. A framework key
-		# and not an `app_boot` contribution: apps shape navigation through the rows and
-		# the item types they ship, and a code-level second route in would be two
-		# mechanisms for one thing (#42232).
-		#
-		# It rides boot because #42070 already makes boot a blocking pre-mount fetch, so a
-		# separate navigation request would be a second blocking round trip for the same
-		# wait — and because a rail click that costs a request is the thing this payload
-		# exists to prevent. What an app *contains* is still fetched, by the app home and
-		# the module page that show it (`doctypes.get_contents`, #42357).
-		"navigation": resolve_navigation(app),
-		# No `doctype_slugs` here any more. It was prefix-scoped and sat in boot
-		# because it was small; the lens made it full-bench, which broke the 40 KB
-		# budget — and byte-identical for every user and every prefix, which is what
-		# let it move to `get_addresses` instead of being trimmed (#42210).
-	}
+	# One exit, so the `/apps` index payload is weighed on the same call site as a
+	# prefix's.
+	report_oversized_keys(boot, prefix)
+
+	return boot

--- a/frappe/shell/doctypes.py
+++ b/frappe/shell/doctypes.py
@@ -139,8 +139,8 @@ def get_addresses(v: str | None = None) -> dict:
 	`#42070`'s translations treatment, for the same reason: the payload varies with
 	the site's schema and with nothing else, so `metadata_version` in the query string
 	is the only thing that may ever invalidate it. Measured on this bench: 19,235 B as
-	`{doctype: slug}`, 25,530 B widened (+33%) — comfortable on a fetch and
-	unaffordable inside a 40 KB boot.
+	`{doctype: slug}`, 25,530 B widened (+33%) — free on a fetch cached for a year, and a
+	quarter of `boot.KEY_BUDGET` on every boot.
 
 	`methods=["GET"]` is not decoration: `http_cache` only sets its header on a GET,
 	so a POST would silently answer uncached forever.

--- a/frappe/shell/navigation.py
+++ b/frappe/shell/navigation.py
@@ -431,8 +431,8 @@ def on_the_wire(item: dict) -> dict:
 	"""One resolved item as the browser gets it: the fields it renders, and only those set.
 
 	Blank fields are omitted rather than sent as `null`. Navigation is the largest thing in a
-	payload #42232 measured at 5,684 B against a 40 KB ceiling, and most fields on most rows are
-	blank — a derived rail row sets four of eleven.
+	payload measured at 19,064 B of 21,576 B against `boot.KEY_BUDGET`, and most fields on most
+	rows are blank — a derived rail row sets four of eleven.
 
 	`payload` is parsed here rather than sent as the string it is stored as, so the type-specific
 	tail is a JSON object on both sides of the wire and no renderer parses it again. A payload

--- a/frappe/tests/test_shell.py
+++ b/frappe/tests/test_shell.py
@@ -496,8 +496,8 @@ class TestShellBoot(IntegrationTestCase):
 	def test_boot_is_small(self):
 		"""v1's boot is 147,711 bytes, ~120 KB of it desk workspace furniture.
 
-		A generous ceiling: the point is to fail loudly if v1's furniture ever creeps
-		back in, not to police a few hundred bytes.
+		A total, and tighter than the per-key `boot.KEY_BUDGET`: this fails loudly if v1's
+		furniture creeps back in.
 		"""
 		import json
 
@@ -632,7 +632,7 @@ class TestShellBoot(IntegrationTestCase):
 
 		Since #42210 the slug table is not in here at all, which is most of why this
 		passes with room to spare. Child tables are excluded from that table too — they
-		have no page and no address.
+		have no page and no address. A total, and tighter than `boot.KEY_BUDGET`.
 		"""
 		import json
 

--- a/frappe/tests/test_shell_navigation.py
+++ b/frappe/tests/test_shell_navigation.py
@@ -13,6 +13,7 @@ import json
 from unittest.mock import patch
 
 import frappe
+from frappe.deferred_insert import queue_prefix
 from frappe.shell.boot import BUDGET_LOG_TITLE as TITLE
 from frappe.shell.boot import KEY_BUDGET, get_boot
 from frappe.shell.navigation import resolve_navigation
@@ -475,16 +476,18 @@ class TestBootBudget(NavigationTestCase):
 
 	def _clear(self):
 		frappe.cache.delete_keys("boot_budget:")
-		frappe.db.delete("Error Log", {"method": TITLE})
+		frappe.cache.delete_value(f"{queue_prefix}Error Log")
 
 	def _logged(self) -> list[str]:
-		"""The rows this check has written, oldest first; MyISAM, so `_clear` deletes them."""
-		return [
-			row.error
-			for row in frappe.get_all(
-				"Error Log", filters={"method": TITLE}, fields=["error"], order_by="creation asc"
-			)
-		]
+		"""The rows this check has queued, oldest first. Read from redis, not the table.
+
+		Boot is a GET, so `frappe.app` rolls the request back and a direct insert would
+		never land on a transactional engine.
+		"""
+		queued = frappe.cache.lrange(f"{queue_prefix}Error Log", 0, -1) or []
+		records = [json.loads(raw.decode()) for raw in queued]
+
+		return [record["error"] for record in records if record.get("method") == TITLE]
 
 	def test_navigation_for_frappes_own_prefix_is_inside_the_budget(self):
 		"""Administrator at `frappe`'s prefix, the worst case frappe's own CI can measure: 19,064 B."""
@@ -534,13 +537,33 @@ class TestBootBudget(NavigationTestCase):
 		self.assertIn("at prefix desk", logged[0])
 		self.assertIn("at the /apps index", logged[1])
 
-	def test_a_failed_write_is_retried_rather_than_muting_the_alarm_for_a_day(self):
+	def test_the_row_is_queued_rather_than_inserted_into_a_rolled_back_request(self):
+		"""Boot is a GET, so a direct insert would be discarded on a transactional engine."""
 		with patch("frappe.shell.boot.app_boot", return_value={"huge": "x" * (KEY_BUDGET + 1)}):
-			with patch("frappe.log_error", side_effect=ValueError("nope")):
-				get_boot("/apps/desk")
 			get_boot("/apps/desk")
 
 		self.assertEqual(len(self._logged()), 1)
+		self.assertEqual(frappe.db.count("Error Log", {"method": TITLE}), 0)
+
+	def test_the_daily_claim_is_atomic(self):
+		"""`SET NX`, so two workers weighing one payload write one row between them."""
+		with patch("frappe.shell.boot.app_boot", return_value={"huge": "x" * (KEY_BUDGET + 1)}):
+			get_boot("/apps/desk")
+
+		claim = frappe.cache.make_key("boot_budget:huge:desk")
+
+		self.assertFalse(frappe.cache.set(name=claim, value=1, ex=60, nx=True))
+		self.assertGreater(frappe.cache.ttl(claim), 0)
+
+	def test_a_non_ascii_key_is_weighed_as_the_wire_carries_it(self):
+		"""`json.dumps` would escape each character to `\\uXXXX` and over-report by 3x."""
+		# 30,000 three-byte characters: 90,000 B as UTF-8, 180,000 B escaped.
+		under_budget_as_utf8 = "\u0928" * 30_000
+
+		with patch("frappe.shell.boot.app_boot", return_value={"devanagari": under_budget_as_utf8}):
+			get_boot("/apps/desk")
+
+		self.assertEqual(self._logged(), [])
 
 	def test_the_index_payload_is_weighed_too(self):
 		"""The index belongs to no app, and shares `get_boot`'s exit and so its alarm."""

--- a/frappe/tests/test_shell_navigation.py
+++ b/frappe/tests/test_shell_navigation.py
@@ -13,6 +13,8 @@ import json
 from unittest.mock import patch
 
 import frappe
+from frappe.shell.boot import BUDGET_LOG_TITLE as TITLE
+from frappe.shell.boot import KEY_BUDGET, get_boot
 from frappe.shell.navigation import resolve_navigation
 from frappe.tests import IntegrationTestCase
 from frappe.tests.classes.context_managers import set_user
@@ -451,10 +453,134 @@ class TestNavigationInBoot(NavigationTestCase):
 	def test_boot_stays_under_the_ceiling_with_navigation_in_it(self):
 		"""The framework's own prefix is the biggest one, and Administrator is the worst
 		case: every doctype on the site is readable, so the derived rail is as long as it
-		can get."""
+		can get. A total; the shipped per-key budget is `TestBootBudget` below."""
 		from frappe.shell.boot import get_boot
 
 		self.assertLess(len(json.dumps(get_boot("/apps/desk"), default=str)), 40_000)
+
+
+class TestBootBudget(NavigationTestCase):
+	"""The per-key growth alarm at `get_boot`'s exit."""
+
+	def setUp(self):
+		super().setUp()
+		frappe.set_user("Administrator")
+		set_request(method="GET", path="/apps/desk")
+		self._clear()
+
+	def tearDown(self):
+		self._clear()
+		if hasattr(frappe.local, "request"):
+			delattr(frappe.local, "request")
+
+	def _clear(self):
+		frappe.cache.delete_keys("boot_budget:")
+		frappe.db.delete("Error Log", {"method": TITLE})
+
+	def _logged(self) -> list[str]:
+		"""The rows this check has written, oldest first; MyISAM, so `_clear` deletes them."""
+		return [
+			row.error
+			for row in frappe.get_all(
+				"Error Log", filters={"method": TITLE}, fields=["error"], order_by="creation asc"
+			)
+		]
+
+	def test_navigation_for_frappes_own_prefix_is_inside_the_budget(self):
+		"""Administrator at `frappe`'s prefix, the worst case frappe's own CI can measure: 19,064 B."""
+		payload = json.dumps(resolve_navigation(APP), separators=(",", ":"), default=str)
+
+		self.assertLess(len(payload), KEY_BUDGET)
+
+	def test_a_key_over_budget_is_logged_and_shipped_whole(self):
+		"""An over-budget payload ships whole; the row is the only thing the check adds."""
+		oversized = "x" * (KEY_BUDGET + 1)
+
+		with patch("frappe.shell.boot.app_boot", return_value={"huge": oversized}):
+			boot = get_boot("/apps/desk")
+
+		self.assertEqual(boot["huge"], oversized)
+		self.assertEqual(len(self._logged()), 1)
+		self.assertIn("huge is 100,003 B", self._logged()[0])
+		self.assertIn("Administrator", self._logged()[0])
+		self.assertIn("at prefix desk", self._logged()[0])
+		self.assertIn("over the 100,000 B key budget", self._logged()[0])
+
+	def test_a_key_inside_the_budget_logs_nothing(self):
+		with patch("frappe.shell.boot.app_boot", return_value={"snug": "x" * 10}):
+			get_boot("/apps/desk")
+
+		self.assertEqual(self._logged(), [])
+
+	def test_one_row_per_key_per_prefix_per_day_however_many_users_trip_it(self):
+		"""The user is named in the message and never in the cache key."""
+		with patch("frappe.shell.boot.app_boot", return_value={"huge": "x" * (KEY_BUDGET + 1)}):
+			get_boot("/apps/desk")
+			get_boot("/apps/desk")
+			with set_user(self.a_second_user()):
+				get_boot("/apps/desk")
+
+		self.assertEqual(len(self._logged()), 1)
+
+	def test_the_same_key_at_two_addresses_gets_a_row_each(self):
+		"""The guard is keyed on the key and the prefix, so one address cannot mute another."""
+		with patch("frappe.shell.boot.core_boot", return_value={"huge": "x" * (KEY_BUDGET + 1)}):
+			get_boot("/apps/desk")
+			get_boot("/apps")
+
+		logged = self._logged()
+
+		self.assertEqual(len(logged), 2)
+		self.assertIn("at prefix desk", logged[0])
+		self.assertIn("at the /apps index", logged[1])
+
+	def test_a_failed_write_is_retried_rather_than_muting_the_alarm_for_a_day(self):
+		with patch("frappe.shell.boot.app_boot", return_value={"huge": "x" * (KEY_BUDGET + 1)}):
+			with patch("frappe.log_error", side_effect=ValueError("nope")):
+				get_boot("/apps/desk")
+			get_boot("/apps/desk")
+
+		self.assertEqual(len(self._logged()), 1)
+
+	def test_the_index_payload_is_weighed_too(self):
+		"""The index belongs to no app, and shares `get_boot`'s exit and so its alarm."""
+		with patch("frappe.shell.boot.core_boot", return_value={"huge": "x" * (KEY_BUDGET + 1)}):
+			get_boot("/apps")
+
+		self.assertEqual(len(self._logged()), 1)
+		self.assertIn("at the /apps index", self._logged()[0])
+
+	def test_the_boot_total_is_context_and_never_a_second_threshold(self):
+		"""Two keys inside the budget summing past it is not an alarm."""
+		half = "x" * (KEY_BUDGET - 10)
+
+		with patch("frappe.shell.boot.app_boot", return_value={"a": half, "b": half}):
+			get_boot("/apps/desk")
+
+		self.assertEqual(self._logged(), [])
+
+	def test_a_key_that_will_not_serialise_drops_the_check_rather_than_the_shell(self):
+		"""The response layer raises the real error moments later; the check stays silent."""
+
+		class Unserialisable:
+			def __repr__(self):
+				raise ValueError("nope")
+
+		with patch("frappe.shell.boot.app_boot", return_value={"bad": Unserialisable()}):
+			boot = get_boot("/apps/desk")
+
+		self.assertIn("bad", boot)
+		self.assertEqual(self._logged(), [])
+
+	def a_second_user(self) -> str:
+		user = frappe.get_doc(
+			doctype="User",
+			email="boot-budget@example.com",
+			first_name="Boot Budget",
+			roles=[{"role": "System Manager"}],
+		).insert(ignore_if_duplicate=True)
+
+		return user.name
 
 
 # Extension — one app's rows on another app's rail
@@ -589,7 +715,7 @@ class TestExtendedRail(NavigationTestCase):
 	def test_the_stored_columns_never_reach_the_browser(self):
 		"""`anchors` is spent at merge and `switches_app` becomes a `url`. Both are read into the
 		merge because `overrides` may name any field a layer has an opinion about, and neither is
-		anything the client renders — navigation is 88% of a payload with a 40 KB ceiling."""
+		anything the client renders — navigation is 88% of the payload."""
 		make_rail([doctype_item("user", "User")], standard=1)
 		make_extension([anchored("calls", "Role", {"after": "user"})])
 

--- a/frappe/tests/test_shell_navigation.py
+++ b/frappe/tests/test_shell_navigation.py
@@ -552,6 +552,7 @@ class TestBootBudget(NavigationTestCase):
 
 		claim = frappe.cache.make_key("boot_budget:huge:desk")
 
+		# nosemgrep: frappe-cache-breaks-multitenancy
 		self.assertFalse(frappe.cache.set(name=claim, value=1, ex=60, nx=True))
 		self.assertGreater(frappe.cache.ttl(claim), 0)
 


### PR DESCRIPTION
Builds the boot budget check decided by [What is the navigation payload's budget, and what happens over it?](https://github.com/frappe/frappe/issues/42437) — that ticket settled the whole design and built none of it. Ticket: [Weigh each boot key and log the ones over budget](https://github.com/frappe/frappe/issues/42475), under [Desk v2 — the rail and the sidebar](https://github.com/frappe/frappe/issues/42226).

Before this, the "40 KB budget" existed only in comments. Nothing in `frappe/shell/` measured anything.

## What it does

`get_boot` now weighs every top-level key at its single exit and queues one `Error Log` row per key past **100 KB**:

```
navigation is 110,412 B for Administrator at prefix erpnext, over the 100,000 B key budget; boot total 118,900 B.
```

- **Per key, not per payload.** A key is what an app or a decision adds, so it is the grain an alarm can name a culprit at. The boot total rides in the message as context and is never a second threshold — two keys of 60 KB are two separate answers, not one.
- **Not site-configurable.** A budget a site can raise is a budget that gets raised.
- **One exit**, so the `/apps` index payload is weighed on the same call site as a prefix's. Restructuring `get_boot` to one exit is most of the diff's line count; the logic inside is unchanged.
- **Over budget ships whole and untruncated.** A rail silently missing its tail is a bug report nobody can write; a complete payload plus a log row is one somebody can act on.
- **Measured with `orjson_dumps`**, the same call `frappe/utils/response.py:157` makes, so the number is the bytes that actually go on the wire.
- **One row per key per prefix per day**, claimed with an atomic `SET NX`. The user who tripped it is named in the message and never in the key, or a 200-user site writes 200 rows for one payload.
- **Wrapped and dropped silently on failure.** A key that will not serialise raises at the response layer moments later; a size check that can blank the shell is worse than no size check.

## Measured on this bench

`/apps/desk` as Administrator, the worst case frappe's own suite can reach — every doctype readable, so the derived rail is as long as it gets:

| | |
|---|---|
| `navigation` | 19,064 B |
| boot total | 21,576 B |
| the check | 0.029 ms per boot |
| resolving that navigation, warm | 6.78 ms |

So the check costs 0.4% of one call boot already makes. That is why it is always on: no `developer_mode` gate and no sampling, because gating it would guarantee the number is never measured on the sites that actually grow.

**This gates nothing and fixes nothing.** ERPNext's rail renders at 48.7 KB and would not trip a 100 KB ceiling. It is a growth alarm, not a repair.

## The stale number appeared seven times, not three

Four of them are in tests. The three comments are reworded. The three test assertions keep their tighter 40 KB *total* as an anti-regression guard on frappe's own boot, and now say that is what they are — distinct from the per-key budget, which nothing at runtime enforces as a total.

## On whether a GET can log at all

The ticket flagged this and told me to match `report_unfilterable`, which logs from the same path. Boot is a GET and `frappe/app.py:404` rolls back every request that is not an unsafe method, so a direct insert looked doomed — but measuring showed the row surviving, because `Error Log` is declared `"engine": "MyISAM"` and MariaDB cannot roll a MyISAM write back. Confirmed on two sites. That explains why the eight other `log_error` calls under `get_boot` have been working all along.

It is **not** a safe thing to rely on, though, and Greptile caught that below: MyISAM is a MariaDB storage engine, so on Postgres the table is transactional and the rollback discards the row while the redis claim survives — an alarm silently lost for a day. The row is therefore deferred, which is engine-independent, and the claim sits in redis beside it so the two are lost or kept together.

## Review

`/quality-code-review` found the redis claim being taken *after* the write, so a duplicate was possible; Greptile then found three more, all real — the `json.dumps` byte divergence, the Postgres rollback above, and the claim being a non-atomic check-then-act. All four are fixed in `4b12843c98` with a test each, and answered inline.

## Tests

Eleven new tests in `TestBootBudget`, and **451 green** across the ten neighbouring suites (`test_shell_navigation` 62, `test_shell` 49, `test_boot` 9, `test_dock_preferences` 121, `test_module_sidebar_boot` 63, `test_navigation_arrangement` 51, `test_navigation_filter` 44, `test_new_navigation_nudge` 10, `test_rail_extension` 22, `test_sidebar_fixture_conversion` 20).

The budget test measures `resolve_navigation("frappe")` and deliberately not CRM's or ERPNext's payload: frappe's CI installs frappe alone, so a test needing another app would either skip or pass without measuring anything — the falsely-green app/framework pairing in another form.

>no-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
