### PR TITLE
fix(utils): escape in get_csv_bytes too

### DIFF
--- a/frappe/desk/utils.py
+++ b/frappe/desk/utils.py
@@ -88,11 +88,13 @@ def get_csv_bytes(data: list[list], csv_params: dict) -> bytes:
 	from csv import writer
 	from io import StringIO
 
+	from frappe.utils.csvutils import escape_formula_injection
+
 	decimal_sep = csv_params.pop("decimal_sep", None)
 
-	_data = data.copy()
+	_data = [[escape_formula_injection(v) for v in row] for row in data]
 	if decimal_sep:
-		_data = apply_csv_decimal_sep(data, decimal_sep)
+		_data = apply_csv_decimal_sep(_data, decimal_sep)
 
 	file = StringIO()
 	csv_writer = writer(file, **csv_params)


### PR DESCRIPTION
Escape in `get_csv_bytes` too.

**Note:** When opening file, some cells might have a prepended ' character, that is used to escape. When editing that cell and clicking away that should disappear as expected.

<img width="1826" height="468" alt="image" src="https://github.com/user-attachments/assets/3bd9c137-91de-4b97-a2ce-61523ab20fa4" />


related to Ticket 77686
