### PR TITLE
feat: keep the user on the same tab while navigating using prev / next buttons in form view

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1550,10 +1550,17 @@ frappe.ui.form.Form = class FrappeForm {
 			.call({ method: "frappe.desk.form.utils.get_next", args, freeze: true })
 			.then((r) => {
 				if (r.message) {
+					frappe.route_hash = this.get_active_tab_hash();
 					frappe.set_route("Form", this.doctype, r.message);
 					this.focus_on_first_input();
 				}
 			});
+	}
+
+	get_active_tab_hash() {
+		const fieldname = this.get_active_tab()?.df?.fieldname;
+		if (!fieldname || fieldname === "__details") return "";
+		return "#" + fieldname;
 	}
 
 	rename_doc() {

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -484,7 +484,7 @@ frappe.ui.form.Layout = class Layout {
 		// Set active tab based on hash (for regular forms only)
 		const tab_from_hash = window.location.hash.replace("#", "");
 		const tab = this.tabs.find((tab) => tab.df.fieldname === tab_from_hash);
-		if (tab) {
+		if (tab && !tab.is_hidden()) {
 			tab.set_active();
 			return;
 		}

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -490,7 +490,7 @@ frappe.ui.form.Layout = class Layout {
 		}
 
 		let frm_active_tab = this.frm?.get_active_tab?.();
-		if (frm_active_tab) {
+		if (frm_active_tab && !frm_active_tab.is_hidden()) {
 			frm_active_tab.set_active();
 		} else if (this.tabs.length) {
 			// set first tab as active when opening for first time, or new doc


### PR DESCRIPTION
User had to manually navigate to last active tab while scrolling using the prev / next buttons in the form view

> Screenshots/GIFs

before
<img width="1280" height="720" alt="Screen-Now-20260903T110408" src="https://github.com/user-attachments/assets/981254bc-1bdc-4906-a7b5-2e48f490f7f1" />

after
<img width="1280" height="720" alt="Screen-Now-20260903T105500" src="https://github.com/user-attachments/assets/36be96e4-1971-43af-a7fb-89c505796772" />

Note:
Render the default tab if the active tab is hidden (display depends on or similar) in the target document

closes https://github.com/frappe/frappe/issues/42492
no-docs