### PR TITLE
chore(desk-v2): record-page engine comments under the rule

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -171,9 +171,11 @@ Do not "fix" these:
 - **The router cannot be a module-scope singleton** — boot must resolve first, because the
   router's base comes from boot (`main.ts`). Contributions register before the router's
   first resolution.
-- **`createRecordPage.ts` exempts the `doc` getter from the read-only rule**, and hands
-  `router` straight through as the single exception. The file says in a comment not to
-  delete the member and not to hand a second one through on its precedent.
+- **`createRecordPage.ts` exempts the `doc` getter from the read-only rule** (mutating
+  the document is the API), and hands `router` straight through as the single
+  exception: it is vue-router's object, so neither the inbound nor the outbound
+  compatibility rule covers it. Do not delete the member, and do not hand a second one
+  through on its precedent.
 - **`generated.ts` defines 4 routes for any number of doctypes** — `doctype` is a param,
   and `view`/`layout`/`from` are query params by decision.
 - **The shared library list is `SINGLETONS` (`frappe/shell/manifest.py:22`)** — `vue`,

--- a/frontend/src/recordPage/createRecordPage.ts
+++ b/frontend/src/recordPage/createRecordPage.ts
@@ -1,7 +1,5 @@
-// Builds the curated `page` and the controller that fires events into it.
-// Handlers run serially in run order, each in its own try/catch: a thrower is
-// skipped half-applied, never taking the page or another source down with it.
-// The one exception is `beforeSave`, the veto point: its throw aborts the save.
+// Builds the curated `page` and the controller that fires events into it. Handlers
+// run serially, each in its own try/catch; only a `beforeSave` throw aborts anything.
 import { computed, ref, type ComputedRef, type Ref } from "vue";
 import type { Router } from "vue-router";
 import { call, toast } from "frappe-ui";
@@ -33,7 +31,7 @@ import type {
   TabsApi,
 } from "./types";
 
-/** The closed event vocabulary (wayfinder ticket 14); every other key is a fieldname. */
+/** The closed event vocabulary; every other key is a fieldname. */
 export const RECORD_PAGE_EVENTS = [
   "onRefresh",
   "beforeSave",
@@ -42,9 +40,7 @@ export const RECORD_PAGE_EVENTS = [
   "onFormTabChange",
 ];
 
-// Everything `page` hands back is read-only (ticket 47), and each member names
-// the verb that does support what the write was reaching for — a refusal that
-// names nothing is a removal wearing a Proxy.
+// Each refusal names the verb that does support what the write was reaching for.
 const META_IS_READ_ONLY: ReadOnlyAdvice = {
   path: "page.meta",
   instead: "page.fields.update('qty', { hidden: 1 })",
@@ -61,10 +57,8 @@ const ROLES_ARE_READ_ONLY: ReadOnlyAdvice = {
     "a copy: [...page.roles], since roles belong to the session, not the page",
 };
 
-// The two differ by one letter and hold structurally identical objects, so
-// `page.saved.qty = 5` is a plausible typo for `page.doc.qty = 5` — and it would
-// otherwise silently rewrite the baseline `isDirty`, the layout conditions and
-// the conflict path all read.
+// `page.saved.qty = 5` is a plausible typo for `page.doc.qty = 5`, and would
+// otherwise silently rewrite the baseline `isDirty` reads.
 const SAVED_IS_READ_ONLY: ReadOnlyAdvice = {
   path: "page.saved",
   instead: "page.doc, which is the draft this is the saved counterpart of",
@@ -90,48 +84,20 @@ export interface RecordPageHost {
   isDirty: () => boolean;
   /** The name of the tab the reader is on, as the host's strip resolves it. */
   activeTab: () => string;
-  /**
-   * Move the reader to a named tab of the record's strip — `activeTab`'s
-   * symmetric partner, and the host's half of `page.tabs.activate`. The engine
-   * has already resolved the name against the strip, so this is handed only
-   * tabs that are there and on screen; how a strip *records* where the reader is
-   * — a URL query here, a ref elsewhere — stays the host's business, which is
-   * what keeps activation from having to be spelled as a `page.router` edit.
-   */
+  /** Moves the reader to a tab of the record's strip; the engine has already resolved the name. */
   activateTab: (name: string) => void;
-  /**
-   * The record's Details layout, which is the strip `page.formTabs` addresses.
-   * Absent for a host that renders no form.
-   */
+  /** The record's Details layout, which `page.formTabs` addresses; absent for a host with no form. */
   formLayout?: () => FormLayoutSchema | undefined;
-  /**
-   * The **identity** of the Form Layout tab the reader is on, as `FormLayout`
-   * resolves it and the host's strip reports it, or `''` when the reader is not
-   * looking at the form.
-   */
+  /** The identity of the Form Layout tab the reader is on, or `''` outside the form. */
   activeFormTab?: () => string;
-  /**
-   * Move the reader to a tab of the form, by identity. Optional on the same
-   * terms as `activeFormTab`: a host that renders no form has no strip to move,
-   * and one absent here simply never receives an activation, because the
-   * identity will have missed against an empty layout first.
-   */
+  /** Moves the reader to a tab of the form, by identity; absent for a host with no form. */
   activateFormTab?: (identity: string) => void;
   save: () => Promise<void>;
   reload: () => Promise<void>;
   router: Router;
-  /**
-   * The per-field UI overlay hook the host also passes its layout source. Only
-   * `page.fields.get` reads it here, and only so its answer cannot disagree
-   * with what the host actually renders.
-   */
+  /** The host's per-field overlay hook; `page.fields.get` reads it to match what renders. */
   decorate?: Decorator;
-  /**
-   * A child doctype's meta fields, by doctype name — what makes the row half of
-   * the event vocabulary knowable. Absent while the metas load, and for a host
-   * that has none: the tables then speak `.onAdd` / `.onRemove` only, which is
-   * what the vocabulary check assumes rather than warns about.
-   */
+  /** A child doctype's meta fields, by doctype name; absent while the metas load. */
   childFields?: (doctype: string) => RawMetaField[] | undefined;
   /** Resolves when sources that register after mount (Page Scripts) are in. */
   sourcesReady?: () => Promise<void>;
@@ -153,11 +119,7 @@ export interface RecordPageController {
   fireEvent: (event: string, row?: RowAddress) => Promise<void>;
   /** True once the first replay has run — before it, surfaces are only built-ins. */
   ready: Ref<boolean>;
-  /**
-   * True while a replay is staging. Reactive because a host that announces a
-   * *settled* strip has to wait for the commit, and the commit is the moment
-   * this goes false.
-   */
+  /** True while a replay is staging; a host announcing a settled strip waits for it to go false. */
   isReplaying: ComputedRef<boolean>;
   /** The `open`/`form` dialogs on screen, for the host's `<PageDialogs>`. */
   dialogs: Ref<PageDialogEntry[]>;
@@ -187,8 +149,7 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
     childFields: host.childFields,
     dispatch: (event, row) => fireEvent(event, row),
   });
-  // Every overlay a replay stages. `fields` and `formTabs` are not `Surface`s —
-  // they override properties rather than arranging items — but they stage here.
+  // Every overlay a replay stages; `fields` and `formTabs` are not `Surface`s but stage here.
   const surfaces: { beginReplay: () => void; commitReplay: () => void }[] = [
     quickActions,
     headerActions,
@@ -199,8 +160,6 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
   ];
 
   Object.defineProperty(tabs, "active", { get: () => host.activeTab() });
-  // The same shape as the record strip's: `active` is stored nowhere here
-  // either, it is a read into whichever strip the host is drawing.
   Object.defineProperty(formTabs, "active", {
     get: () => host.activeFormTab?.() ?? "",
   });
@@ -210,17 +169,8 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
   const replaying = ref(0);
   const isReplaying = computed(() => replaying.value > 0);
 
-  // An activation made while a replay is in flight, held until it commits — one
-  // name per strip, so a second call replaces the first the way the reader's own
-  // last move would. This is not the queueing `activate` refuses: the name is
-  // resolved at the moment of the call, against the strip the caller can see
-  // (`isVisible` reads the staged ops, as `has` does). Only the *delivery*
-  // waits, because until the commit the host is still rendering last replay's
-  // strip, and moving the reader to a tab that is not on it yet would show them
-  // the fallback for a tick — the replay's middle, leaking through the one
-  // channel ticket 71's staging does not cover. That is true of any activation
-  // made in the window, not only the ones the replay's own handlers make, which
-  // is why the gate is `isReplaying` and not "am I inside `onRefresh`".
+  // Resolved at the call, delivered on commit: until then the host still renders the
+  // last replay's strip, and a move onto a tab not yet on it shows the fallback for a tick.
   const heldActivations = new Map<TabStrip, string>();
 
   Object.defineProperty(tabs, "activate", {
@@ -235,8 +185,7 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
   const capabilities: RecordPageApi = {
     doctype: host.doctype,
     docname: host.docname,
-    // Exempt from the read-only rule below, and deliberately: mutating the
-    // document *is* the API. Do not "fix" this.
+    // Exempt from the read-only rule: mutating the document *is* the API.
     get doc() {
       return host.doc.value;
     },
@@ -246,8 +195,8 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
     get meta() {
       return readOnly(host.meta.value, META_IS_READ_ONLY);
     },
-    // Read-only goes outermost, so a write is refused before the DEV-only
-    // unknown-right advisory inside `permissions.perms()` gets to fire.
+    // Read-only goes outermost, so a write is refused before the unknown-right
+    // advisory inside `permissions.perms()` gets to fire.
     get perms() {
       return readOnly(permissions.perms(), PERMS_ARE_READ_ONLY);
     },
@@ -274,19 +223,11 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
     },
     dialog: dialogs.api,
     call: (method, params) => call(method, params),
-    // The one member handed straight through: it is vue-router's object, not
-    // ours, so neither the inbound nor the outbound rule catches it. That is a
-    // real cost, not a technicality, and COMPATIBILITY.md's "The one
-    // hand-through" section now states it and the two rules that bound it —
-    // chiefly that no capability may *require* the router. Do not "fix" this
-    // by deleting the member, and do not hand a second one through on its
-    // precedent.
+    // The one member handed straight through, and the only one; see frontend/CLAUDE.md.
     router: host.router,
   };
 
-  // Nothing has been removed yet, so this hands the same object straight back:
-  // the guard, and its cost on every member read in every handler, exists only
-  // once the removals list has something to say (ticket 20 §4).
+  // With an empty removals list this hands the same object straight back.
   const page = withRemovals(capabilities);
 
   async function refresh() {
@@ -294,21 +235,17 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
     warnUnknownHandlers();
     // Counted, not a boolean: a script's own `page.refresh()` re-enters this.
     replaying.value += 1;
-    // Staged, not cleared: clearing here and re-adding one microtask later is
-    // what tore the rendered strip down between the two, taking the reader's
-    // place in it with them (ticket 70). The surfaces publish on commit, in one
-    // flush, so the host only ever sees a replay's result.
+    // Staged, not cleared: clearing here and re-adding a microtask later tears the
+    // rendered strip down between the two, and the reader's place in it with them.
     for (const surface of surfaces) surface.beginReplay();
     try {
       await fireEvent("onRefresh");
     } finally {
-      // In `finally` so a throwing handler cannot leave the page staged, which
-      // would freeze the overlay on the previous replay for good.
+      // In `finally` so a throwing handler cannot leave the page staged for good.
       for (const surface of surfaces) surface.commitReplay();
       replaying.value -= 1;
-      // After the commit, so the strip the reader is being moved onto is the one
-      // on screen; and inside the same `finally`, so a throwing handler cannot
-      // strand a move that had already been decided.
+      // After the commit, so the strip the reader lands on is the one on screen;
+      // inside the `finally`, so a throwing handler cannot strand a decided move.
       if (!isReplaying.value) releaseActivations();
     }
     ready.value = true;
@@ -318,11 +255,8 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
     const held = [...heldActivations];
     heldActivations.clear();
     for (const [strip, name] of held) {
-      // Re-read, not replayed. The strip a held move was decided against is not
-      // the one that necessarily settled: a later source can hide the tab an
-      // earlier one activated, and delivering that move would land the reader on
-      // the strip's fallback — the very outcome a miss exists to prevent. A tab
-      // that left before the strip settled is a miss like any other.
+      // Re-read, not replayed: a later source can hide the tab an earlier one
+      // activated, and delivering that move would land the reader on the fallback.
       if (!surfaceFor(strip).isVisible(name)) {
         warnActivate(strip, name, "it left the strip before the replay settled");
         continue;
@@ -335,13 +269,7 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
     return strip === "tabs" ? tabs : formTabs;
   }
 
-  /**
-   * `page.tabs.activate` and `page.formTabs.activate`, both of them, because the
-   * interesting miss is the one that names the *other* strip: the two are not
-   * interchangeable, an author will mix them up, and only a caller holding both
-   * can say which one they wanted. The engine resolves the name and the host
-   * moves the reader — activation never reaches for `page.router`.
-   */
+  /** Both strips' `activate`: the interesting miss names the other strip, and only a caller holding both can say so. */
   function activate(strip: TabStrip, name: string) {
     if (!canReach(strip, name)) return;
     if (isReplaying.value) heldActivations.set(strip, name);
@@ -349,11 +277,8 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
   }
 
   function canReach(strip: TabStrip, name: string) {
-    // The Details layout can land after the first replay has run, and until it
-    // does, "the administrator never authored this" and "it is not here yet"
-    // are the same answer — which is why `FormTabsSurface.warnIfAbsent` holds
-    // its tongue in the same window. The move is dropped either way: an
-    // activation is resolved at the moment of the call and is not queued.
+    // Until the Details layout lands, "never authored" and "not here yet" are the
+    // same answer; an activation is never queued, so the move is dropped either way.
     if (strip === "formTabs" && !host.formLayout?.()?.length) return false;
     const here = surfaceFor(strip);
     const there = surfaceFor(strip === "tabs" ? "formTabs" : "tabs");
@@ -367,8 +292,7 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
       );
       return false;
     }
-    // Hidden is a miss and not an invitation: `show()` is the verb that reveals
-    // a tab, and one call should not quietly perform two.
+    // Hidden is a miss: `show()` is the verb that reveals a tab.
     if (!here.isVisible(name)) {
       warnActivate(strip, name, "it is hidden — show() reveals a tab");
       return false;
@@ -378,9 +302,7 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
 
   /** The host's half, and the only place the engine hands a strip a name. */
   function move(strip: TabStrip, name: string) {
-    // A host that draws the form's strip but cannot move it would otherwise
-    // swallow an activation that passed every check — the one silent failure
-    // this verb exists to abolish.
+    // A host that draws the form's strip but cannot move it must not swallow the move silently.
     if (strip === "formTabs" && !host.activateFormTab) {
       warnActivate(strip, name, "this host cannot move the reader on that strip");
       return;
@@ -389,10 +311,8 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
       if (strip === "tabs") host.activateTab(name);
       else host.activateFormTab?.(name);
     } catch (error) {
-      // Reported, never rethrown: a released move runs inside `refresh`'s
-      // `finally`, so a throwing host hook would take the rest of the release
-      // with it and leave `ready` false — a page stuck on its skeleton because
-      // a router guard said no.
+      // Reported, never rethrown: a released move runs inside `refresh`'s `finally`,
+      // and a throw here would leave `ready` false and the page stuck on its skeleton.
       console.error(
         `[record-page] page.${strip}.activate("${name}") — the host threw`,
         error,
@@ -400,11 +320,7 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
     }
   }
 
-  /**
-   * Said every time, not once: a miss here is an act the script just performed —
-   * the reader was not moved — rather than a standing fault in its text, and the
-   * second failed move is not the first one repeated.
-   */
+  /** Said every time, not once: a miss is an act just performed, not a standing fault in the script. */
   function warnActivate(strip: TabStrip, name: string, because: string) {
     if (!import.meta.env.DEV) return;
     console.warn(
@@ -413,8 +329,7 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
   }
 
   async function fireEvent(event: string, row?: RowAddress) {
-    // One handle for the whole dispatch, and the same object `page.rows()` hands
-    // back: it is an address, so every source is looking at the same live row.
+    // One handle for the whole dispatch, and the same object `page.rows()` hands back.
     const handle = row ? rows.handle(row) : undefined;
     for (const { source, handlers } of registrationsFor(host.doctype)) {
       const handler = handlers[event];
@@ -423,17 +338,15 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
         try {
           await handler(page, handle);
         } catch (error) {
-          // `beforeSave` rethrows to abort the save, and is the one catch site
-          // that does not report: the user is looking straight at a failed save,
-          // so logging it would file a working veto as an error.
+          // `beforeSave` rethrows to abort the save and is not reported: the user
+          // is looking straight at a failed save, and a working veto is not an error.
           if (event === "beforeSave") throw error;
           console.error(
             `[record-page] ${source}.${event} on ${host.doctype} threw`,
             error,
           );
-          // No `route`: the reporter reads `location`, which is the URL an admin
-          // can paste. `router.fullPath` drops the app's base and would make this
-          // one site disagree with the other three.
+          // No `route`: the reporter reads `location`, the URL an admin can paste;
+          // `router.fullPath` drops the app's base.
           reportCustomizationError(error, {
             source,
             event,
@@ -451,15 +364,10 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
     const fields = host.meta.value?.fields;
     if (!fields) return;
     const registrations = registrationsFor(host.doctype);
-    // Nothing to shadow and no keys to check when no source is registered — and
-    // saying so anyway would fire the warning on every record a plain app opens.
+    // With no source registered, warning would fire on every record a plain app opens.
     if (!registrations.length) return;
-    // Deliberately *not* behind the latch below: this one reads the **child**
-    // meta, which can land after the parent's — `handlerVocabulary`'s
-    // `unresolved` list exists for exactly that window — so latching on the
-    // parent alone would drop the collision warning for the whole session.
-    // Re-attempting it costs a loop over the tables, and `warnRowIssue`
-    // remembers what it has already said.
+    // Not behind the latch below: this reads the child meta, which can land after
+    // the parent's, and `warnRowIssue` remembers what it has already said.
     warnShadowedChildFields(fields);
     if (vocabularyChecked) return;
     vocabularyChecked = true;
@@ -468,8 +376,7 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
     for (const { source, handlers } of registrations)
       for (const key of Object.keys(handlers)) {
         if (known.has(key)) continue;
-        // A whole block written under a fieldname that holds no rows is one
-        // mistake, not one per handler in it — so it is named by its table.
+        // A block under a fieldname that holds no rows is one mistake, named by its table.
         const [table] = key.split(".");
         const nested = key.includes(".") && !known.isTable(table);
         const message = nested
@@ -482,18 +389,8 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
   }
 
   /**
-   * The three child fieldnames the table vocabulary occupies, named at load
-   * because the engine knows the child's fields where v1 could only warn on
-   * every access. Frappe reserves none of them (`RESERVED_KEYWORDS` is five
-   * names plus the cached properties), so a child doctype may legitimately
-   * carry any — and ticket 54 traded a guarantee for this warning knowingly.
-   *
-   * 54 called the result "an announced capability hole, never a misfire", and
-   * for `trigger` that is exact. For the two lifecycle names it is not: a child
-   * field named `onAdd` commits as `<table>.onAdd`, which is the *same string*
-   * the row-added event dispatches, so the author's `onAdd` handler runs — with
-   * a live row — on that field being edited. The hole is announced, but it is a
-   * misfire, and the warning says so rather than the comfortable thing.
+   * Frappe reserves none of the three names the row vocabulary occupies. A child
+   * field named `onAdd` commits as the string the row-added event dispatches, so it misfires.
    */
   function warnShadowedChildFields(fields: RawMetaField[]) {
     for (const field of fields) {
@@ -502,16 +399,11 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
       if (!child) continue;
       const has = (fieldname: string) =>
         child.some((one) => one.fieldname === fieldname);
-      // The verb wins and the field stays reachable through `page.doc`.
       if (has("trigger"))
-        // Warned per child doctype for the session, not per controller: the same
-        // shadow is the same fact on every record of the doctype, and navigating
-        // between them must not restate it.
+        // Once per child doctype for the session; navigating between records must not restate it.
         warnRowIssue(
           `${field.options}.trigger is shadowed by the row handle's own trigger() — read it from page.doc.${field.fieldname} instead`,
         );
-      // One string cannot be two events, and the field's commit is the one that
-      // arrives unannounced — so the warning names the direction that bites.
       for (const lifecycle of Object.values(ROW_EVENTS))
         if (has(lifecycle))
           warnRowIssue(
@@ -538,26 +430,17 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
 }
 
 /**
- * The whole vocabulary a handler key may be drawn from (tickets 44, 45): the
- * four events, every parent fieldname, and — for a child table — the dotted
- * family and nothing else.
- *
- * A Table fieldtype's **bare** fieldname is deliberately not here. It was only
- * ever firable because the deleted deep watch could not tell one row's edit from
- * another's, so a table has no control that commits under its own name; leaving
- * it in would accept `products() {}` silently and never fire it.
+ * The whole vocabulary a handler key may be drawn from. A Table's bare fieldname is
+ * not in it: nothing commits under a table's own name, so `products() {}` would never fire.
  */
 function handlerVocabulary(
   fields: RawMetaField[],
   childFields?: (doctype: string) => RawMetaField[] | undefined,
 ) {
   const known = new Set(RECORD_PAGE_EVENTS);
-  // Every child table on the doctype, so a nested block written under something
-  // that is not one can be named as that rather than as a generic typo.
   const tables = new Set<string>();
-  // Tables whose child doctype we cannot see. A host with no `childFields`, or
-  // one whose child meta has not landed, must not accuse a correct key of being
-  // a typo — so those tables are answered by prefix instead.
+  // Tables whose child meta has not landed must not make a correct key look like
+  // a typo, so they are answered by prefix.
   const unresolved: string[] = [];
   for (const field of fields) {
     if (!holdsChildRows(field.fieldtype)) {
@@ -567,13 +450,11 @@ function handlerVocabulary(
     tables.add(field.fieldname);
     known.add(`${field.fieldname}.${ROW_EVENTS.add}`);
     known.add(`${field.fieldname}.${ROW_EVENTS.remove}`);
-    // A Table MultiSelect has no per-cell editing, so its vocabulary is add and
-    // remove alone — an honest gap rather than keys that would never fire.
+    // A Table MultiSelect has no per-cell editing, so its vocabulary is add and remove alone.
     if (field.fieldtype !== "Table") continue;
     const child = field.options && childFields?.(field.options);
     if (!child) unresolved.push(field.fieldname);
-    // A layout break has no value and so no commit; `page.fields` excludes them
-    // for the same reason, and accepting one here would be a key that never fires.
+    // A layout break has no value and so no commit; `page.fields` excludes them too.
     else
       for (const one of child)
         if (!LAYOUT_BREAKS.has(one.fieldtype))

--- a/frontend/src/recordPage/dialog.ts
+++ b/frontend/src/recordPage/dialog.ts
@@ -1,14 +1,5 @@
-// `page.dialog` — the one dialog surface scripts are taught. `confirm` and
-// `danger` are frappe-ui's own imperative dialogs, narrowed; `open` and `form`
-// render on this page's own stack, which `<PageDialogs>` mounts.
-//
-// What the facade buys over importing frappe-ui's `dialog` directly:
-//   - every verb is a promise, `null` meaning dismissed, so `if (!result) return`
-//   - the page owns the stack, so navigating off the record cannot strand an
-//     awaiting script behind a dialog the reader can no longer see
-//   - opens are tagged with the running source, so a stuck dialog has a name
-//   - nothing an author writes is forwarded to frappe-ui unnamed, so an option
-//     whose meaning frappe-ui changes cannot change what a stored script does
+// `page.dialog`: `confirm` and `danger` are frappe-ui's own dialogs, narrowed;
+// `open` and `form` render on this page's own stack, which `<PageDialogs>` mounts.
 import { shallowRef, type Component, type Ref } from "vue";
 import { dialog as frappeDialog } from "frappe-ui";
 import { runningSource } from "./context";
@@ -34,10 +25,8 @@ export interface PageDialogEntry {
   /** `form`: what the form host renders. */
   form?: PageDialogFormOptions;
   /**
-   * Resolves the opener's promise. Idempotent, and deliberately separate from
-   * `dismiss`: the promise settles the moment the answer is known, not when the
-   * leave transition ends, so a page that unmounts mid-transition cannot turn a
-   * submitted dialog into a cancelled one.
+   * Resolves the opener's promise. Separate from `dismiss` so a page unmounting
+   * mid-transition cannot turn a submitted dialog into a cancelled one.
    */
   settle: (result?: any) => void;
   /** Takes the dialog off the stack — the host calls it after the leave transition. */
@@ -47,11 +36,7 @@ export interface PageDialogEntry {
 }
 
 export interface PageDialogHost {
-  /**
-   * True while a replay is running. A dialog opened from `refresh` re-opens on
-   * every replay, so dev builds name the source rather than block the call —
-   * a deliberate on-load gate stays possible.
-   */
+  /** True while a replay is running; a dialog opened from `refresh` re-opens on every replay. */
   isReplaying: () => boolean;
 }
 
@@ -59,16 +44,11 @@ export interface PageDialogs {
   api: PageDialog;
   /** The renderable stack, oldest first. */
   entries: Ref<PageDialogEntry[]>;
-  /**
-   * The page is gone: close every open dialog newest-first, each promise
-   * resolving `null`, and refuse every later open — with nothing left to render
-   * them, a script awaiting one would wait forever.
-   */
+  /** Closes every open dialog newest-first, each resolving `null`, and refuses every later open. */
   closeAll: () => void;
 }
 
-// frappe-ui's `ConfirmArgs`, named key by key: `page` forwards an option it names
-// and drops one it does not (COMPATIBILITY.md, ticket 20 §2).
+// frappe-ui's `ConfirmArgs`, named key by key: an option not named here is dropped.
 const CONFIRM_OPTIONS = [
   "title",
   "message",
@@ -83,15 +63,12 @@ const CONFIRM_OPTIONS = [
   "actions",
 ];
 
-// `DangerArgs` is `Omit<ConfirmArgs, 'theme' | 'icon'>` — frappe-ui forces red and
-// its own icon — so passing either here is the mistake the warning exists for.
+// frappe-ui forces red and its own icon on `danger`, so passing either is the mistake warned about.
 const DANGER_OPTIONS = CONFIRM_OPTIONS.filter(
   (option) => option !== "theme" && option !== "icon",
 );
 
-// frappe-ui's `DialogAction` is `Omit<ButtonProps, 'onClick' | 'loading'>`: a whole
-// component's prop surface, moving on frappe-ui's cadence. These five are the ones
-// `page` means by an action.
+// frappe-ui's `DialogAction` is a whole button's prop surface; these five are what `page` means by an action.
 const ACTION_OPTIONS = ["label", "variant", "theme", "icon", "onClick"];
 
 let nextId = 0;
@@ -194,9 +171,7 @@ export function createPageDialogs(host: PageDialogHost): PageDialogs {
     });
   }
 
-  // `confirm`/`danger` are curated three layers deep — the options, the nested
-  // actions, and the object each callback receives — so that no part of what an
-  // author writes reaches frappe-ui, or comes back from it, unnamed by `page`.
+  // Curated three layers deep: the options, the nested actions, and the object each callback receives.
   function native(
     verb: "confirm" | "danger",
     args: PageDialogConfirmOptions,
@@ -265,9 +240,7 @@ export function createPageDialogs(host: PageDialogHost): PageDialogs {
   };
 }
 
-// The engine's own object rather than frappe-ui's `DialogControl` — the subtlest
-// of the three layers, and the one that matters most to a stored script: a rename
-// under us must not change what the script does on an upgrade nobody reviewed.
+// The engine's own object, not frappe-ui's `DialogControl`: a rename underneath must not change a stored script.
 function controlFor(control: any): PageDialogControl {
   return {
     close: () => control?.close?.(),

--- a/frontend/src/recordPage/dialog.ts
+++ b/frontend/src/recordPage/dialog.ts
@@ -193,7 +193,7 @@ export function createPageDialogs(host: PageDialogHost): PageDialogs {
         resolve(result);
       };
       // Navigating away closes the dialog without frappe-ui firing `onCancel`,
-      // so the promise is settled here rather than left to that callback.
+      // so the promise is settled here, not in that callback.
       const untrack = track(() => {
         handle?.close();
         settle(null);

--- a/frontend/src/recordPage/evaluatePageScript.ts
+++ b/frontend/src/recordPage/evaluatePageScript.ts
@@ -1,7 +1,5 @@
-// A stored script is literally a file script: it is evaluated as a real ES module
-// through a blob URL, so `export default {…}` is the same text in both places and
-// bare imports resolve through the page's import map — the four shared deps and
-// nothing else.
+// A stored script is evaluated as a real ES module through a blob URL, so `export
+// default {…}` is the same text as a file script and bare imports resolve through the import map.
 import type { PageScriptRow } from "./pageScriptTypes";
 import type { AuthoredHandlers } from "./types";
 

--- a/frontend/src/recordPage/fields.ts
+++ b/frontend/src/recordPage/fields.ts
@@ -58,7 +58,7 @@ const PATCH_KEYS: Record<string, Landing> = {
   options: { on: "meta", as: "options" },
   link_filters: { on: "meta", as: "filters" },
   precision: { on: "meta", as: "precision", coerce: asPrecision },
-  // The stamp is also what tells the outbound read-only wrapper to leave the component alone.
+  // The stamp is what tells the outbound read-only wrapper to leave the component alone.
   component: { on: "ui", as: "component", coerce: markRaw, opaque: true },
   props: { on: "ui", as: "props" },
 };

--- a/frontend/src/recordPage/fields.ts
+++ b/frontend/src/recordPage/fields.ts
@@ -1,15 +1,5 @@
-// The fields surface (wayfinder ticket 42) — clause 2 of the v1-parity map.
-//
-// Not a `Surface`. The four list surfaces arrange items a script may also
-// create; fields are a set authored elsewhere whose *properties* a script
-// overrides, so the verbs are a strict subset and the key is a fieldname
-// rather than an item name.
-//
-// Ops are recorded, not applied: `resolve()` folds them into one patch per
-// field, which the host hands to `useFormLayout` as plain data. That keeps the
-// override a render-time overlay — nothing is written into the layout, the Form
-// Layout row or the doctype meta — and makes `reset()` the whole of the replay
-// clear, so an authored script is a plain `if` with no `else`.
+// The fields surface: a script overrides properties of fields authored elsewhere.
+// Ops are recorded, not applied; `resolve()` folds them into one patch per field.
 import { markRaw, shallowReactive } from "vue";
 import { mapField } from "@framework/ui/components/FormLayout/buildLayoutFromMeta";
 import type { Decorator } from "@framework/ui/components/FormLayout/buildLayoutFromMeta";
@@ -41,11 +31,7 @@ interface Landing {
   /** Its name there — the pipeline is camelCase, the script vocabulary is not. */
   as: string;
   coerce?: (value: any) => any;
-  /**
-   * A reference rather than data, so it is handed back as itself: comparing and
-   * re-feeding it is the point, and a read-only view of a component's options
-   * breaks both. `markRaw` is how that is said to the rest of Vue.
-   */
+  /** Handed back as itself, not a read-only view: comparing and re-feeding it is the point. */
   opaque?: boolean;
 }
 
@@ -59,14 +45,8 @@ function asPrecision(value: any): number | undefined {
 }
 
 /**
- * The enumerated vocabulary and where each key goes: v1's ten minus
- * `button_color` (nothing renders it), plus `component`/`props`, which
- * `FieldUI` already carries through the render path.
- *
- * The split is not cosmetic. `hidden`/`read_only`/`reqd` are recomputed on
- * every keystroke from the `depends_on` family, so they ride the carrier
- * `resolveFieldConditionals` applies last; the rest are computed once when the
- * node is built, so they are merged there.
+ * The vocabulary and where each key lands. `hidden`/`read_only`/`reqd` are recomputed
+ * on every keystroke from `depends_on`, so they ride the slot applied last.
  */
 const PATCH_KEYS: Record<string, Landing> = {
   hidden: { on: "override", as: "hidden", coerce: asBoolean },
@@ -78,17 +58,12 @@ const PATCH_KEYS: Record<string, Landing> = {
   options: { on: "meta", as: "options" },
   link_filters: { on: "meta", as: "filters" },
   precision: { on: "meta", as: "precision", coerce: asPrecision },
-  // Belt and braces beside `shallowReactive` — and the stamp is also what tells
-  // the outbound read-only wrapper to leave the component alone.
+  // The stamp is also what tells the outbound read-only wrapper to leave the component alone.
   component: { on: "ui", as: "component", coerce: markRaw, opaque: true },
   props: { on: "ui", as: "props" },
 };
 
-/**
- * The reader's key list, derived from the writer's rather than written twice —
- * and carrying each key's whole landing, so a key added above is read back from
- * the right slot without anyone remembering to come here.
- */
+/** The reader's keys, derived from the writer's so a key added above is read back from the right slot. */
 const SNAPSHOT_KEYS = Object.entries(PATCH_KEYS);
 
 export interface FieldsSurfaceHost {
@@ -97,11 +72,7 @@ export interface FieldsSurfaceHost {
   /** The draft document conditional expressions resolve against. */
   doc: () => Record<string, any>;
   fieldAccess: (fieldname: string) => FieldAccess;
-  /**
-   * The same per-field UI overlay hook the host passes its layout source. `get`
-   * needs it or it would report `component`/`props` the renderer disagrees
-   * with, which is the asymmetry `get` exists to abolish.
-   */
+  /** The host's per-field overlay hook; without it `get` would report a `component` the renderer disagrees with. */
   decorate?: Decorator;
 }
 
@@ -110,16 +81,11 @@ type Op =
   | { verb: "update"; fieldname: string; patch: FieldPatch };
 
 export class FieldsSurface implements PageFields {
-  // Reactive so the host's layout re-joins when a replay changes the overlay,
-  // exactly as the four list surfaces re-resolve. *Shallow*: a deep proxy would
-  // reach inside a patch's `props` and hand `v-bind` a Proxy of whatever a
-  // script put there — a nested component, a `Date`, a class instance — which
-  // is the internal-slots hazard `readOnly.ts` documents for its own wrapper.
+  // Reactive so the host's layout re-joins on a replay. Shallow: a deep proxy would
+  // hand `v-bind` a Proxy of whatever a script put in `props`, breaking a class instance.
   private ops: Op[] = shallowReactive([]);
-  // The replay's ops until it commits, so the host's overlay never carries a
-  // half-applied replay — which is what made a script-hidden field flash into
-  // view for a tick on every save. Non-null only inside a replay; see
-  // `Surface.beginReplay`, which this mirrors.
+  // The replay's ops until it commits, so a script-hidden field does not flash into
+  // view for a tick on every save. Non-null only inside a replay.
   private pending: Op[] | null = null;
   private replaying = 0;
 
@@ -136,8 +102,7 @@ export class FieldsSurface implements PageFields {
   }
 
   update(fieldname: string, patch: PageFieldPatch) {
-    // Named before the keys are read, so an author who mistyped the fieldname
-    // hears that first rather than after a list of keys it would never reach.
+    // Named before the keys are read, so a mistyped fieldname is heard first.
     this.warnIfAbsent(fieldname, "update");
     this.record({ verb: "update", fieldname, patch: translate(fieldname, patch) });
   }
@@ -152,16 +117,14 @@ export class FieldsSurface implements PageFields {
       this.warnIfAbsent(fieldname, "get");
       return null;
     }
-    // The same three calls the join makes for one field, in the same order, so
-    // the reader cannot drift from what the renderer decided.
+    // The same calls the join makes, in the same order, so the reader cannot drift from the renderer.
     const node = mapField(
       withAccess(raw, (field) => this.host.fieldAccess(field.fieldname)),
       {},
       this.host.decorate,
     );
-    // Over the replay in flight when there is one, the same way `Surface.has`
-    // reads: a source that hides a field and then reads it back inside its own
-    // `refresh` handler is told about its own work, not about last replay's.
+    // Over the replay in flight when there is one, as `Surface.has` reads: a source
+    // reading back its own `refresh` work is told about it, not about last replay's.
     const patched = applyFieldPatch(node, this.fold(this.pending ?? this.ops)[fieldname]);
     const resolved = resolveFieldConditionals(patched, this.host.doc());
     return readOnly(snapshot(resolved), SNAPSHOT_IS_READ_ONLY);
@@ -169,12 +132,7 @@ export class FieldsSurface implements PageFields {
 
   // Host side, below: not part of what a script may call.
 
-  /**
-   * Open a replay: ops recorded from here are staged, not applied. The clear is
-   * the replay clear `reset()` used to be — the next commit starts from the
-   * authored layout alone. Counted, so a nested `page.refresh()` re-enters
-   * without publishing a half-built overlay.
-   */
+  /** Opens a replay: ops from here are staged. Counted, so a nested `page.refresh()` re-enters. */
   beginReplay() {
     this.pending = [];
     this.replaying += 1;
@@ -200,12 +158,8 @@ export class FieldsSurface implements PageFields {
   }
 
   /**
-   * One patch per field, in op order — later verbs win, key by key.
-   *
-   * Folded in a `Map`, not an object literal: a fieldname is a string a script
-   * chooses, and `patches["__proto__"] ??= {}` would leave `into` pointing at
-   * `Object.prototype`, so the next `override.hidden` would be inherited by
-   * every field object in the application for the rest of the session.
+   * One patch per field, in op order, later keys winning. A `Map`, not an object
+   * literal: a script-chosen `"__proto__"` would otherwise land on `Object.prototype`.
    */
   private fold(ops: Op[]): Record<string, FieldPatch> {
     const patches = new Map<string, FieldPatch>();
@@ -218,11 +172,7 @@ export class FieldsSurface implements PageFields {
     return Object.fromEntries(patches);
   }
 
-  /**
-   * Layout breaks are excluded: `joinLayout` drops them before any patch is
-   * applied, so an override on one could never render, and sections and tabs
-   * have their own surfaces anyway.
-   */
+  /** Layout breaks are excluded: `joinLayout` drops them before any patch could apply. */
   private raw(fieldname: string): RawMetaField | undefined {
     const field = this.host
       .fields()
@@ -231,10 +181,8 @@ export class FieldsSurface implements PageFields {
   }
 
   /**
-   * The op is recorded either way — a patch keyed by a fieldname the layout
-   * does not carry is simply never applied, and dropping it here would lose it
-   * for good in the window before the meta lands, when "absent" and "not here
-   * yet" are indistinguishable. This only says so when it can tell.
+   * The op is recorded either way: before the meta lands, "absent" and "not here
+   * yet" are indistinguishable, and dropping it would lose it for good.
    */
   private warnIfAbsent(fieldname: string, verb: string) {
     const fields = this.host.fields();
@@ -247,8 +195,7 @@ export class FieldsSurface implements PageFields {
 function translate(fieldname: string, patch: PageFieldPatch): FieldPatch {
   const translated: FieldPatch = {};
   for (const [key, value] of Object.entries(patch)) {
-    // `hasOwn`, or `toString` and `constructor` would each resolve to a truthy
-    // `Object.prototype` member and slip through the enumeration unwarned.
+    // `hasOwn`, or `toString` and `constructor` would slip through as truthy prototype members.
     const landing = Object.hasOwn(PATCH_KEYS, key) ? PATCH_KEYS[key] : undefined;
     if (!landing) {
       warnOnce(
@@ -269,12 +216,7 @@ function mergeInto(into: FieldPatch, from: FieldPatch) {
   if (from.ui) into.ui = { ...into.ui, ...from.ui };
 }
 
-/**
- * Read a resolved node back out in the vocabulary `update` writes. Curated the
- * same way, and for the same reason: the internal node also carries the child
- * doctype's whole layout, the raw conditional expressions and the permission
- * bookkeeping, none of which is a field property a script asked about.
- */
+/** Reads a resolved node back in the vocabulary `update` writes; the internal node carries far more. */
 function snapshot(resolved: Record<string, any>): PageField {
   const field: PageField = {
     fieldname: resolved.fieldname,
@@ -283,8 +225,7 @@ function snapshot(resolved: Record<string, any>): PageField {
   for (const [key, { on, as, opaque }] of SNAPSHOT_KEYS) {
     const value = on === "ui" ? resolved.ui?.[as] : resolved[as];
     if (value === undefined) continue;
-    // A decorator's component arrives unstamped, unlike one a script passed
-    // through `update` — stamp it here so the wrapper below leaves it alone.
+    // A decorator's component arrives unstamped; stamp it so the wrapper leaves it alone.
     (field as Record<string, any>)[key] = opaque ? markRaw(value) : value;
   }
   return field;

--- a/frontend/src/recordPage/flattenHandlers.ts
+++ b/frontend/src/recordPage/flattenHandlers.ts
@@ -1,21 +1,11 @@
-// A table's handlers nest under its fieldname (ticket 54), and the engine
-// dispatches against one flat keyspace — so the authored shape is flattened
-// here, once, at the choke point every script passes through.
-//
-//   products: { onAdd, onRemove, qty }  →  'products.onAdd', 'products.onRemove',
-//                                          'products.qty'
-//
-// The lifecycle events are spelled `onAdd` / `onRemove` rather than `add` /
-// `remove` because `add` is a legal, unreserved fieldname: `products.add` is the
-// same string as the commit event of a child field called `add`, which is the
-// collision ticket 45 rejected the underscore spelling for and then shipped one
-// level down. `on`-prefixing moves the lifecycle keys out of the fieldname
-// namespace, and the two child fields that could still collide are warned about
-// by name at load (`createRecordPage`) — an announced capability hole rather
-// than a silent misfire.
+// A table's handlers nest under its fieldname and the engine dispatches against one
+// flat keyspace, so `products: { onAdd, qty }` becomes `'products.onAdd'`, `'products.qty'`.
 import type { AuthoredHandlers, Handler, RecordPageHandlers } from "./types";
 
-/** The lifecycle half of a table's vocabulary, in the one spelling used end to end. */
+/**
+ * The lifecycle half of a table's vocabulary. `on`-prefixed because `add` is a
+ * legal fieldname, and `products.add` would be a child field's commit event.
+ */
 export const ROW_EVENTS = { add: "onAdd", remove: "onRemove" } as const;
 
 export function flattenHandlers(
@@ -23,17 +13,14 @@ export function flattenHandlers(
   source: string,
   doctype: string,
 ): RecordPageHandlers {
-  // Null-prototype, so `handlers[event]` can only answer with what the author
-  // wrote: a doctype may have a field called `constructor` or `toString`, and
-  // an inherited hit there would dispatch an event to `Object.prototype`.
+  // Null-prototype: a doctype may have a field called `constructor` or `toString`,
+  // and an inherited hit would dispatch an event to `Object.prototype`.
   const flat: RecordPageHandlers = Object.create(null);
   const said = (key: string, message: string) =>
     warn(`${source}.${key} on ${doctype} ${message}`);
 
   const put = (key: string, handler: Handler) => {
-    // Both spellings are accepted, so one can quietly land on the other. Last
-    // wins, as it would anywhere else — but not in silence, in a module that
-    // names every other authoring mistake.
+    // Both spellings are accepted, so one can land on the other; last wins, but not in silence.
     if (key in flat) said(key, "is written twice — the later one wins");
     flat[key] = handler;
   };
@@ -49,8 +36,7 @@ export function flattenHandlers(
       continue;
     }
     const nested = Object.entries(value);
-    // Vacuously a block of functions, and the one authoring mistake this would
-    // otherwise wave through.
+    // Vacuously a block of functions, so it would otherwise pass unnoticed.
     if (!nested.length) said(key, "is an empty block — it registers nothing");
     for (const [child, handler] of nested) put(`${key}.${child}`, handler);
   }
@@ -58,15 +44,8 @@ export function flattenHandlers(
 }
 
 /**
- * The spelling this replaced, named at the one moment the engine can say what to
- * write instead. It is a *legal* key — a child field may genuinely be called
- * `add`, which is the whole reason the lifecycle names moved — so this is advice
- * rather than a refusal, and it belongs here rather than in the vocabulary
- * check, which has no reason to doubt a key it can resolve.
- *
- * The underscore spelling is deliberately not named here: `<parent>_add` is an
- * ordinary parent fieldname, and accusing one would be a warning that lies. The
- * vocabulary check already names it if it is not a fieldname at all.
+ * Names the retired `.add`/`.remove` spelling; advice, not a refusal, since a child
+ * field may be called `add`. `<parent>_add` is not named: it is an ordinary fieldname.
  */
 function warnRetiredSpelling(
   key: string,
@@ -81,11 +60,7 @@ function warnRetiredSpelling(
   );
 }
 
-/**
- * A plain object of functions and nothing else. Anything else nested under a
- * fieldname is a mistake the author wants named rather than a shape to guess
- * at — and a non-function value would flatten to a key that could never fire.
- */
+/** A plain object of functions and nothing else; a non-function value would flatten to a key that never fires. */
 function isHandlerBlock(value: unknown): value is Record<string, Handler> {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const proto = Object.getPrototypeOf(value);

--- a/frontend/src/recordPage/formLayoutSource/fieldAccess.ts
+++ b/frontend/src/recordPage/formLayoutSource/fieldAccess.ts
@@ -2,21 +2,8 @@ import type { RawMetaField } from "@framework/ui/components/FormLayout/types";
 import type { FieldAccess } from "@framework/ui/composables/useDocPermissions";
 
 /**
- * Bake a permlevel decision into a raw meta field: `read` demotes it to
- * read-only, `none` hides it. Applied *before* `mapField`, in DocField
- * vocabulary, so both layout sources hand the same shape forward.
- *
- * The denial is expressed as a plain `hidden` / `read_only` flag — which reads
- * exactly like a meta-hidden or meta-read-only field — so it is also stamped
- * `perm_denied`. That stamp, not the `permlevel`, is what
- * `resolveFieldConditionals` treats as a floor an override may not lift: a
- * reader who *has* the level leaves here untouched, and so must stay
- * overridable.
- *
- * Note this is fail-open while permissions load: `useDocPermissions.fieldAccess`
- * deliberately answers `"write"` until the roles land (better a field the server
- * refuses to save than a form that flashes empty), so during that window nothing
- * is stamped and nothing is floored. It re-joins when they arrive.
+ * Bakes a permlevel decision into a raw meta field before `mapField`: `read` demotes it,
+ * `none` hides it, and either stamps `perm_denied`, the floor an override may not lift.
  */
 export function withAccess(
 	field: RawMetaField,

--- a/frontend/src/recordPage/formLayoutSource/fieldPatch.ts
+++ b/frontend/src/recordPage/formLayoutSource/fieldPatch.ts
@@ -1,10 +1,4 @@
-// One field's per-render property override, and the three places it lands.
-//
-// Ticket 48 built the carrier for the three properties the render path
-// *recomputes* (`FieldOverride`). The other properties an app may override are
-// computed once, when `mapField` builds the node, and never touched again — so
-// they are applied there instead, and a single carrier would have hidden that
-// difference behind one flat object that half worked.
+// One field's per-render property override, split by when each half applies.
 import type {
 	FieldMeta,
 	FieldNode,
@@ -13,24 +7,15 @@ import type {
 } from "@framework/ui/components/FormLayout/types";
 
 /**
- * The build-time half: properties `mapField` sets once and nothing recomputes,
- * so overriding them is a plain merge onto the built node.
- *
- * `options` is the one with a caveat — on a `Table` it names the child doctype,
- * and the node's `childFields`/`childLayout` were already resolved from the
- * original. Overriding a `Link`'s target or a `Select`'s choices (what v1's
- * `options` is for) is unaffected.
+ * The build-time half: properties `mapField` sets once. `options` on a `Table` names
+ * the child doctype, whose `childFields`/`childLayout` were already resolved from the original.
  */
 export type FieldMetaPatch = Pick<
 	FieldMeta,
 	"label" | "options" | "placeholder" | "description" | "precision" | "filters"
 >;
 
-/**
- * Everything an app may override on one field, split by *when* it applies.
- * Plain data throughout: `FormLayout` reads the result off the schema and knows
- * nothing about who wrote it.
- */
+/** Everything an app may override on one field, split by when it applies. Plain data throughout. */
 export interface FieldPatch {
 	/** Merged onto the built node (see `FieldMetaPatch`). */
 	meta?: FieldMetaPatch;
@@ -47,8 +32,7 @@ export function applyFieldPatch(
 ): FieldNode {
 	if (!patch) return node;
 	const patched: FieldNode = { ...node, ...patch.meta };
-	// Both halves merge rather than replace: nothing upstream writes `override`
-	// today, but a patch that names one key should not silently drop another.
+	// Both halves merge, so a patch naming one key does not silently drop another.
 	if (patch.override)
 		patched.override = { ...node.override, ...patch.override };
 	if (patch.ui) patched.ui = { ...node.ui, ...patch.ui };

--- a/frontend/src/recordPage/formTabs.ts
+++ b/frontend/src/recordPage/formTabs.ts
@@ -1,16 +1,5 @@
-// The Form Layout tabs surface (wayfinder ticket 73) — the second tab strip,
-// the one inside the record's Details form.
-//
-// Not a `Surface`, and modelled on `FieldsSurface` instead: these tabs are
-// authored elsewhere, in a Form Layout an administrator edits, so a script only
-// overrides their properties. That makes the verbs a strict subset — no `add`,
-// `move` or `order`, since a tab here is a container of *fields* and inventing
-// fields is `page.dialog`'s job — and the key an identity rather than a name.
-//
-// Ops are recorded, not applied: `resolve()` folds them into one override per
-// tab, which the host hands to its layout source as plain data. Nothing is
-// written into the Form Layout row or the doctype meta, and the replay clear is
-// the whole of the undo, so an authored script is a plain `if` with no `else`.
+// The Form Layout tabs surface: the strip inside the record's Details form, whose
+// tabs a script overrides but cannot add. Modelled on `FieldsSurface`.
 import { shallowReactive } from "vue";
 import {
   applyTabOverride,
@@ -35,11 +24,7 @@ const SNAPSHOT_IS_READ_ONLY: ReadOnlyAdvice = {
 };
 
 export interface FormTabsSurfaceHost {
-  /**
-   * The record's Details layout, as joined and before this surface's ops — the
-   * whole authored strip, hidden tabs included, so `has()` answers "did the
-   * administrator author this" rather than "is it on screen".
-   */
+  /** The record's Details layout before this surface's ops, hidden tabs included. */
   tabs: () => FormLayoutSchema | undefined;
   /** The draft document conditional expressions resolve against. */
   doc: () => Record<string, any>;
@@ -50,19 +35,16 @@ type Op =
   | { verb: "update"; identity: string; patch: TabOverride };
 
 export class FormTabsSurface implements PageFormTabs {
-  // Reactive so the host's layout re-joins when a replay changes the overlay,
-  // shallow for the reason `FieldsSurface` gives.
+  // Reactive so the host's layout re-joins on a replay; shallow for the reason `FieldsSurface` gives.
   private ops: Op[] = shallowReactive([]);
-  // The replay's ops until it commits, so the host never renders a replay's
-  // middle — which on this surface would tear the strip down and take the
-  // reader's place in it with them (ticket 70).
+  // The replay's ops until it commits: rendering a replay's middle tears the strip
+  // down and takes the reader's place in it with them.
   private pending: Op[] | null = null;
   private replaying = 0;
 
   /** Installed by `createRecordPage`, which reads it from the host's strip. */
   declare readonly active: string;
-  /** Installed there too: a miss on one strip wants to name the other, and
-   *  `createRecordPage` is the one place that holds both. */
+  /** Installed there too: a miss on one strip wants to name the other. */
   declare activate: (identity: string) => void;
 
   constructor(private host: FormTabsSurfaceHost) {}
@@ -78,8 +60,7 @@ export class FormTabsSurface implements PageFormTabs {
   }
 
   update(identity: string, patch: PageFormTabPatch) {
-    // Named before the keys are read, so an author who mistyped the identity
-    // hears that first rather than after a list of keys it would never reach.
+    // Named before the keys are read, so a mistyped identity is heard first.
     this.warnIfAbsent(identity, "update");
     this.record({ verb: "update", identity, patch: translate(identity, patch) });
   }
@@ -90,8 +71,7 @@ export class FormTabsSurface implements PageFormTabs {
 
   get(identity: string): PageFormTab | null {
     // Every tab, not just the one asked for: the strip's label fallback depends
-    // on how many tabs are visible beside it, and a `get` that reported a label
-    // the button does not carry is the asymmetry `get` exists to abolish.
+    // on how many tabs are visible beside it.
     const strip = this.resolved();
     const tab = strip.find((one) => one.identity === identity);
     if (!tab) {
@@ -112,11 +92,7 @@ export class FormTabsSurface implements PageFormTabs {
 
   // Host side, below: not part of what a script may call.
 
-  /**
-   * Whether the tab is on the strip right now — `depends_on` and this surface's
-   * ops both folded in, the replay in flight included. What `activate` asks to
-   * tell a hidden tab from one the administrator never authored.
-   */
+  /** Whether the tab is on the strip right now, the replay in flight included. */
   isVisible(identity: string) {
     const tab = this.resolved().find((one) => one.identity === identity);
     return !!tab && !tab.hidden;
@@ -147,12 +123,7 @@ export class FormTabsSurface implements PageFormTabs {
     (this.pending ?? this.ops).push(op);
   }
 
-  /**
-   * One override per tab, in op order — later verbs win, key by key. Folded in
-   * a `Map` for the reason `FieldsSurface.fold` gives: an identity is a string
-   * a script chooses, and `"__proto__"` would otherwise be written onto
-   * `Object.prototype`.
-   */
+  /** One override per tab, in op order. A `Map`, not an object, for the reason `FieldsSurface.fold` gives. */
   private fold(ops: Op[]): Record<string, TabOverride> {
     const overrides = new Map<string, TabOverride>();
     for (const op of ops) {
@@ -169,10 +140,8 @@ export class FormTabsSurface implements PageFormTabs {
   }
 
   /**
-   * The strip as it stands: `depends_on` baked against the doc, then the ops
-   * over the replay in flight when there is one — the same way `Surface.has`
-   * reads, so a source that hides a tab and reads it back inside its own
-   * `onRefresh` handler is told about its own work, not about last replay's.
+   * The strip as it stands: `depends_on` against the doc, then the ops over the
+   * replay in flight, so a source reading back its own `onRefresh` work is told about it.
    */
   private resolved() {
     const overrides = this.fold(this.pending ?? this.ops);
@@ -186,20 +155,14 @@ export class FormTabsSurface implements PageFormTabs {
     });
   }
 
-  /**
-   * The same identities `FormLayout` resolves: the join leaves every tab's
-   * `name` and authored `label` alone, and this reads the layout the form is
-   * handed, so the two cannot disagree about what a script's address means.
-   */
+  /** The same identities `FormLayout` resolves, so the two cannot disagree about an address. */
   private identified() {
     return identifyTabs(this.host.tabs() ?? []);
   }
 
   /**
-   * The op is recorded either way — an override keyed by a tab the layout does
-   * not carry is simply never applied, and dropping it here would lose it for
-   * good in the window before the layout lands, when "absent" and "not here
-   * yet" are indistinguishable. This only says so when it can tell.
+   * The op is recorded either way: before the layout lands, "absent" and "not
+   * here yet" are indistinguishable, and dropping it would lose it for good.
    */
   private warnIfAbsent(identity: string, verb: string) {
     const tabs = this.host.tabs();
@@ -209,10 +172,8 @@ export class FormTabsSurface implements PageFormTabs {
 }
 
 /**
- * `label` and nothing else. `hidden` is `hide`/`show`'s, and `dependsOn` is
- * deliberately not patchable: rewriting the administrator's expression *string*
- * is the two-authorities objection in its one genuinely bad form, and a script
- * wanting conditional visibility already has a real `if` in `onRefresh`.
+ * `label` and nothing else: `hidden` is `hide`/`show`'s, and `dependsOn` is not
+ * patchable, since a script wanting conditional visibility has an `if` in `onRefresh`.
  */
 function translate(identity: string, patch: PageFormTabPatch): TabOverride {
   const translated: TabOverride = {};

--- a/frontend/src/recordPage/headerRenderings.ts
+++ b/frontend/src/recordPage/headerRenderings.ts
@@ -1,5 +1,5 @@
-// How the header's one flat list becomes its renderings (tickets 65 and 77),
-// and what happens when it asks for more top-level controls than fit (66).
+// How the header's one flat list becomes its renderings, and what happens when
+// it asks for more top-level controls than fit.
 import { Surface, type ResolvedItem } from "./surface";
 import type { HeaderAction, Position } from "./types";
 
@@ -7,31 +7,17 @@ import type { HeaderAction, Position } from "./types";
 export type ContainerDisplay = "dropdown" | "section";
 
 /**
- * How many containers may be stacked (ticket 76 §3). Ours to choose, but half
- * of it is forced: `MenuGroupOption.options` is `MenuOption[]` and `MenuOption`
- * excludes `MenuGroupOption`, so a section inside a band cannot keep its title
- * at any depth. A *submenu* could nest further — `MenuSubmenuOption.submenu` is
- * `MenuOptions`, which does admit groups — and is capped anyway, so `order` and
- * the overflow projection stay unambiguous.
+ * Half of this is forced: `MenuOption` excludes `MenuGroupOption`, so a section
+ * inside a band cannot keep its title at any depth.
  */
 export const MAX_CONTAINER_DEPTH = 2;
 
-/**
- * One row of a rendered list: an action, or a container holding more rows.
- *
- * The *authored* vocabulary stays flat — every item is still addressable by its
- * one name — and the nesting appears only here, where the rendering is decided
- * (ticket 77 §3).
- */
+/** One row of a rendered list: an action, or a container holding more rows. */
 export interface HeaderNode {
   item: HeaderAction;
   /** Set when this row holds others; absent on a plain action row. */
   container?: ContainerDisplay;
-  /**
-   * Set when this container could not render where it was declared. It is then
-   * a band of the `⋯` menu and never a top-level control, so a `group` cycle
-   * cannot win a slot in the header row (ticket 77 §3).
-   */
+  /** Set when this container could not render where declared; it is then a band of `⋯`, never a control. */
   clamped?: boolean;
   members: HeaderNode[];
 }
@@ -41,11 +27,7 @@ export type HeaderControl =
   | { kind: "button"; item: HeaderAction }
   | { kind: "dropdown"; item: HeaderAction; members: HeaderNode[] };
 
-/**
- * One band of the `⋯` menu. A band shows a heading iff its container was
- * declared — a `section` the author wrote, or a dropdown that did not fit and
- * collapsed whole (ticket 77 §7, restating 66 §4).
- */
+/** One band of the `⋯` menu; it shows a heading iff its container was declared. */
 export interface HeaderBand {
   group: string;
   label?: string;
@@ -58,16 +40,8 @@ export interface HeaderProjection {
 }
 
 /**
- * Project the resolved items into the header's controls and the `⋯` menu's
- * bands, given how many top-level controls the host has room for.
- *
- * Takes the resolved list rather than the visible one because a **hidden
- * container takes its members with it**, however deep: it is a floor above them,
- * as a hidden `panelSection` is above its fields, and `hide('telephony')` is how
- * a script removes the whole control (tickets 66 §5 and 77).
- *
- * Overflow is host-side and unobservable: a script cannot read back that its
- * button was demoted, so nothing here writes to the surface.
+ * Projects the resolved items into the header's controls and the `⋯` menu's bands.
+ * Takes the resolved list, not the visible one: a hidden container takes its members with it.
  */
 export function projectHeaderActions(
   resolved: ResolvedItem<HeaderAction>[],
@@ -77,8 +51,7 @@ export function projectHeaderActions(
   const items = surviving(resolved);
   const containers = containersOf(items);
   const tree = prune(build(items, containers));
-  // An empty dropdown is a button that opens nothing, so it is dropped before
-  // the budget applies and its slot passes to the next control in order.
+  // An empty dropdown is a button that opens nothing, so it is dropped before the budget applies.
   const controls = tree
     .filter(isControl)
     .map(asControl)
@@ -103,13 +76,7 @@ function containersOf(items: HeaderAction[]) {
   return containers;
 }
 
-/**
- * The items a hidden container has not taken with it.
- *
- * Only a *container* is a floor: a `group` naming a plain item names no
- * container at all, which is the undeclared branch, so that item's own
- * visibility says nothing about the band.
- */
+/** The items a hidden container has not taken with it; a `group` naming a plain item is no floor. */
 function surviving(resolved: ResolvedItem<HeaderAction>[]): HeaderAction[] {
   const containers = containersOf(resolved.map((entry) => entry.item));
   const hidden = new Set(
@@ -148,12 +115,8 @@ function depthOf(name: string, containers: Map<string, HeaderAction>): number {
 }
 
 /**
- * Where a container actually renders. One that nests too deep is **clamped to
- * the deepest level it can reach, never ignored**: ignoring its `group` would
- * promote it to a top-level control, where it would eat a budget slot and
- * compete with the record's title (ticket 77 §3). A cycle reaches no level at
- * all, so it lands in `⋯` as a band of its own — reachable, titled, and costing
- * nothing.
+ * Where a container renders. One nesting too deep is clamped to the deepest level
+ * it can reach, never promoted to a control; a cycle lands in `⋯` as a band of its own.
  */
 function placeContainer(
   item: HeaderAction,
@@ -162,9 +125,7 @@ function placeContainer(
   const depth = depthOf(item.name, containers);
   if (depth <= MAX_CONTAINER_DEPTH) {
     const group = declaredGroup(item, containers);
-    // Legal depth, but a band cannot hold a band, so this one renders with its
-    // title dropped. Said out loud because it is the author's own declaration
-    // losing, not the viewport taking it (which is demotion, and silent).
+    // A band cannot hold a band, so this one renders with its title dropped.
     if (group && containerDisplay(item) === "section")
       if (containers.get(group)!.display === "section")
         warnOnce(
@@ -190,11 +151,7 @@ function declaredGroup(
   return item.group && containers.has(item.group) ? item.group : undefined;
 }
 
-/**
- * The one rule, with its default: `group: 'x'` puts an item inside the item
- * named `x`; an undeclared `x` synthesises an anonymous, untitled container,
- * which is the adjacency band a script has always got (ticket 77 §2).
- */
+/** `group: 'x'` puts an item inside the item named `x`; an undeclared `x` synthesises an anonymous container. */
 function build(items: HeaderAction[], containers: Map<string, HeaderAction>) {
   const nodes = new Map<string, HeaderNode>();
   const top: HeaderNode[] = [];
@@ -214,8 +171,7 @@ function build(items: HeaderAction[], containers: Map<string, HeaderAction>) {
     if (placed.clamped) node.clamped = true;
     parents.push(placed.group);
   }
-  // A member joins its container wherever the container sits: a container is
-  // placed by its own item, never by its first member (ticket 65).
+  // A container is placed by its own item, never by its first member.
   items.forEach((item, index) => {
     const node = nodes.get(item.name)!;
     const parent = parents[index];
@@ -226,11 +182,8 @@ function build(items: HeaderAction[], containers: Map<string, HeaderAction>) {
 }
 
 /**
- * Drop every dropdown left with nothing in it, at any depth: it is a trigger
- * that opens nothing, which is 66 §5's rule about a top-level control applied
- * where clamping actually produces the case — a container whose only member was
- * lifted out from under it. A *section* needs no such rule; an empty group is
- * dropped by frappe-ui's own normalization.
+ * Drops every dropdown left empty, at any depth. A section needs no such rule:
+ * frappe-ui drops an empty group itself.
  */
 function prune(nodes: HeaderNode[]): HeaderNode[] {
   return nodes.flatMap((node) => {
@@ -253,10 +206,8 @@ function asControl(node: HeaderNode): HeaderControl {
     : { kind: "button", item: node.item };
 }
 
-// A demoted control keeps a band of its own, ahead of the built-ins and in
-// top-level order, with no signal that it wanted to be a button (ticket 66 §4).
-// Banding by its own name, not by its `group`, is what keeps a demoted button
-// from reading as a member of a dropdown that was demoted beside it.
+// A demoted control keeps a band of its own, ahead of the built-ins. Banded by its
+// own name, not its `group`, so it does not read as a member of a dropdown demoted beside it.
 function demotedBands(controls: HeaderControl[]): HeaderBand[] {
   return controls.map((control) =>
     control.kind === "button"
@@ -273,21 +224,15 @@ function row(item: HeaderAction): HeaderNode {
   return { item, members: [] };
 }
 
-/**
- * A band's rows. A submenu survives here — `MenuSubmenuOption` is a legal
- * `MenuOption` — but a section cannot keep its title inside a band, so it
- * flattens and its members are spliced in where it sat (ticket 77 §4). That is
- * demotion being lossy, silent and unobservable, as 66 already had it.
- */
+/** A band's rows: a section cannot keep its title inside a band, so it flattens in place. */
 function bandRows(nodes: HeaderNode[]): HeaderNode[] {
   return nodes.flatMap((node) =>
     node.container === "section" ? bandRows(node.members) : [node]
   );
 }
 
-// Bands are derived from the one flat list by adjacency, except where an author
-// declared a container: a top-level `section` titles a band and consumes no
-// budget slot, since it is not a control (ticket 77 §2).
+// Bands are derived by adjacency, except where an author declared a container:
+// a top-level `section` titles a band and consumes no budget slot.
 function menuBands(top: HeaderNode[]): HeaderBand[] {
   const bands: HeaderBand[] = [];
   for (const node of top) {
@@ -311,11 +256,8 @@ function menuBands(top: HeaderNode[]): HeaderBand[] {
 }
 
 /**
- * Which list an item is ordered within, as a comparable key. Read off the
- * **declared** `display` and never off the effective one, so nothing computed
- * from it can become width-dependent (ticket 66 §5): a demoted control is still
- * `row` here, because demotion is the host's answer to a width, not the
- * author's to a question.
+ * Which list an item is ordered within. Read off the declared `display`, never
+ * the effective one, so nothing computed from it can become width-dependent.
  */
 export function renderingOf(item: HeaderAction, items: HeaderAction[]): string {
   const containers = containersOf(items);
@@ -328,20 +270,14 @@ export function renderingOf(item: HeaderAction, items: HeaderAction[]): string {
 type AnchorClaim = { verb: string; name: string; anchor: string };
 
 /**
- * The header's surface, which is an ordinary `Surface` plus one warning: an
- * anchor naming an item in a different rendering still splices where it always
- * did, and says so (ticket 65).
- *
- * The check runs over the *resolved* list rather than at call time, because a
- * member can be added before the container that decides its rendering.
+ * An ordinary `Surface` plus one warning: an anchor naming an item in a different
+ * rendering. Checked over the resolved list, since a member can be added before its container.
  */
 export class HeaderActionsSurface extends Surface<HeaderAction> {
   private claims: AnchorClaim[] = [];
   private said = new Set<string>();
 
-  // One claim per **block**, not per item: a block splices as a unit, so only
-  // its head is anchored where the caller asked. Claiming the rest would
-  // report an anchor they were never given.
+  // One claim per block: a block splices as a unit, so only its head is anchored.
   add(item: HeaderAction | HeaderAction[], position?: Position) {
     const block = Array.isArray(item) ? item : [item];
     if (block.length) this.claim("add", block[0].name, position);
@@ -353,8 +289,7 @@ export class HeaderActionsSurface extends Surface<HeaderAction> {
     super.move(name, position);
   }
 
-  // Claims are staged with the ops they belong to: a replay rebuilds the list
-  // from built-ins, so the claims that produced the old one go with it.
+  // Claims are staged with the ops they belong to; a replay rebuilds the list from built-ins.
   beginReplay() {
     this.claims = [];
     super.beginReplay();
@@ -378,9 +313,7 @@ export class HeaderActionsSurface extends Surface<HeaderAction> {
       const anchor = items.find((one) => one.name === claim.anchor);
       if (!item || !anchor) continue;
       if (renderingOf(item, items) === renderingOf(anchor, items)) continue;
-      // Anchoring a member at its own container is how an author says "first
-      // in this dropdown", and it does exactly that. The two sit in different
-      // lists, but one of them *is* the other's list.
+      // Anchoring a member at its own container means "first in this dropdown", and does that.
       if (renderingOf(item, items) === `container:${claim.anchor}`) continue;
       if (renderingOf(anchor, items) === `container:${claim.name}`) continue;
       const message =
@@ -411,9 +344,7 @@ function describe(item: HeaderAction, items: HeaderAction[]) {
   return "an entry in the ⋯ menu";
 }
 
-// Said once per message, for the same reason the anchor warning is: a
-// projection runs on every render, and a warning that repeats with the frame
-// rate is a warning nobody reads.
+// Once per message: a projection runs on every render.
 const warned = new Set<string>();
 
 function warnOnce(message: string) {
@@ -438,11 +369,8 @@ function warnClamp(item: HeaderAction, depth: number) {
   );
 }
 
-// What an item declared about itself, checked before anything is placed —
-// including for a hidden item, since these are complaints about the
-// declaration and not about the rendering. `display` type-checks whatever it is
-// given (`SurfaceItem` carries an index signature), so an unknown value is
-// silently the default: 65's trap a second time, and worth a word.
+// Checked before anything is placed, hidden items included. `display` type-checks
+// anything (`SurfaceItem` has an index signature), so an unknown value is silently the default.
 function warnItem(item: HeaderAction) {
   const display = item.display;
   if (display && !containerDisplay(item) && display !== "button")
@@ -455,9 +383,7 @@ function warnItem(item: HeaderAction) {
       `headerActions: '${item.name}' is a ${display}, a container, so its ` +
         `\`run\` never fires; the items inside it run.`
     );
-  // `group` decides *where* an item goes and `display` only decides what it
-  // looks like once it is there, so a button inside a container is an ordinary
-  // row. Two declarations that disagree should not be settled in silence.
+  // `group` decides where an item goes; `display` only what it looks like once there.
   if (display === "button" && item.group)
     warnOnce(
       `headerActions: '${item.name}' is a button inside '${item.group}', and a ` +

--- a/frontend/src/recordPage/iconClasses.ts
+++ b/frontend/src/recordPage/iconClasses.ts
@@ -1,12 +1,5 @@
-// Script-named icons, bridged to CSS classes at runtime.
-//
-// The host renders an item's `icon` as a `lucide-*` class, and those classes are
-// generated at build time by frappe-ui's `iconPackPlugin` — so only the icons the
-// host bundle already mentions exist. A third-party app can ship CSS for the rest,
-// but a Page Script is a string in a table and can never ship a file: unbridged,
-// `icon: 'lucide-flag'` renders a silent blank box. So we generate the missing rule
-// from the lucide sprite frappe-ui's `spritePlugin` already put in the DOM, in
-// exactly the shape `iconPackPlugin` emits.
+// Script-named icons bridged to CSS classes at runtime: `lucide-*` classes are built
+// at build time and a Page Script can never ship a file, so the rule is built from the sprite.
 import type { SurfaceItem } from "./types";
 
 const PREFIX = "lucide-";
@@ -72,9 +65,7 @@ function styleElement() {
 	if (existing) return existing;
 	const style = document.createElement("style");
 	style.id = STYLE_ID;
-	// Prepended so utilities loaded later — `size-4` at the call site — still beat the
-	// `width: 1em` here, the same way Tailwind's utilities layer beats its components
-	// layer for the build-time classes this mirrors.
+	// Prepended so utilities loaded later (`size-4` at the call site) still beat the `width: 1em` here.
 	document.head.prepend(style);
 	return style;
 }

--- a/frontend/src/recordPage/index.ts
+++ b/frontend/src/recordPage/index.ts
@@ -1,14 +1,4 @@
-// The record-page engine's one entry, so a call site imports from `@/recordPage` and
-// nothing deeper.
-//
-// The engine lives in the shell rather than in `@framework/ui` because it is desk
-// layer, not generic layer: `@framework/ui` holds self-contained components an app may
-// use however it likes, while this is one opinionated record-page runtime that speaks
-// doctype, `page.save()` and Page Script. It CONSUMES the generic layer -- FormLayout,
-// Fields, useDocPermissions -- which is what places it on this side of the boundary.
-//
-// A contributed `record.js` imports nothing at all: its default export IS the
-// registration, and the shell's contribution registry is what reaches this file.
+// The record-page engine's one entry, so a call site imports from `@/recordPage` and nothing deeper.
 export {
   ALL_DOCTYPES,
   registerRecordPage,

--- a/frontend/src/recordPage/pageCompatibility.ts
+++ b/frontend/src/recordPage/pageCompatibility.ts
@@ -1,14 +1,8 @@
-// What happens to a script that reaches for a name we removed (wayfinder ticket
-// 20 §4, §5). Two nets over one list: a removal still inside its tombstone major
-// stays on `page` as a function that throws, naming the removal and what replaced
-// it; a removal past that is gone, and reading the name is all there is left to
-// catch.
+// What happens to a script that reaches for a removed `page` name: a tombstone
+// throws naming the replacement, a gone name warns once on read.
 //
-// The list is empty — nothing has been removed yet — and an empty list installs no
-// Proxy at all, so the mechanism costs the replay nothing until it has something
-// to say. That is also why the warning is narrowed to this list rather than firing
-// on any unknown key: `if (page.dialog.prompt)` is the feature detection
-// COMPATIBILITY.md tells authors to write, and it must stay silent.
+// Narrowed to the list, never any unknown key: `if (page.dialog.prompt)` is the
+// feature detection authors are told to write, and it must stay silent.
 import { runningSource } from "./context";
 import { toastScriptError } from "./pageScripts";
 import { reportCustomizationError } from "./reportError";
@@ -20,10 +14,7 @@ export interface Removal {
   removedIn: string;
   /** What to write instead — the other half. */
   instead: string;
-  /**
-   * `tombstone` while the name is still there as a thrower (one major), `gone`
-   * once it has been deleted and only the read can be seen.
-   */
+  /** `tombstone` while the name is still there as a thrower (one major); `gone` once deleted. */
   stage: "tombstone" | "gone";
 }
 
@@ -33,10 +24,7 @@ export const REMOVALS: Removal[] = [];
 const throwers = new Map<Removal, () => never>();
 const warned = new Set<string>();
 
-/**
- * Wraps `page` so the removals list is answered rather than read past. Returns
- * the object itself when there is nothing to answer.
- */
+/** Wraps `page` so the removals list is answered; returns the object itself when the list is empty. */
 export function withRemovals<Page extends object>(
   page: Page,
   removals: Removal[] = REMOVALS,
@@ -50,9 +38,8 @@ export function resetRemovalNotices() {
   throwers.clear();
 }
 
-// One Proxy per object that owns a removed name, built from the top down: the
-// nested ones are installed on the way in, so `page.dialog` is a guarded object
-// before anything reads a member off it.
+// One Proxy per object that owns a removed name, built top down so `page.dialog`
+// is guarded before anything reads a member off it.
 function guard(target: any, prefix: string, removals: Removal[]): any {
   const here = new Map<string, Removal>();
   const below = new Map<string, Removal[]>();
@@ -92,9 +79,7 @@ function tombstone(removal: Removal) {
   return thrower;
 }
 
-// Not dev-gated, deliberately (20 §5): a removal firing is an upgrade breaking a
-// customer's customization on a site no developer is watching, and no production
-// site runs a dev build.
+// Not dev-gated: a removal firing is an upgrade breaking a site no developer is watching.
 function reportAndThrow(removal: Removal): never {
   const source = runningSource();
   const error = new Error(`page.${removal.path} was ${detail(removal)}`);
@@ -112,8 +97,7 @@ function reportAndThrow(removal: Removal): never {
   throw error;
 }
 
-// Console only, always on: probing is legitimate, so this has to be cheap enough
-// to be wrong about — an Error Log row per probe is not.
+// Console only: probing is legitimate, and an Error Log row per probe is not cheap enough to be wrong about.
 function warnRemoved(removal: Removal) {
   const source = runningSource();
   const message = `[record-page] ${source} read page.${removal.path}, ${detail(removal)}`;

--- a/frontend/src/recordPage/pageCompatibility.ts
+++ b/frontend/src/recordPage/pageCompatibility.ts
@@ -1,8 +1,5 @@
 // What happens to a script that reaches for a removed `page` name: a tombstone
 // throws naming the replacement, a gone name warns once on read.
-//
-// Narrowed to the list, never any unknown key: `if (page.dialog.prompt)` is the
-// feature detection authors are told to write, and it must stay silent.
 import { runningSource } from "./context";
 import { toastScriptError } from "./pageScripts";
 import { reportCustomizationError } from "./reportError";
@@ -59,6 +56,7 @@ function guard(target: any, prefix: string, removals: Removal[]): any {
   return new Proxy(target, {
     get(owner, key, receiver) {
       const removal = typeof key === "string" ? here.get(key) : undefined;
+      // Never any unknown key: `if (page.dialog.prompt)` is feature detection and must stay silent.
       if (!removal) return Reflect.get(owner, key, receiver);
       if (removal.stage === "gone") {
         warnRemoved(removal);

--- a/frontend/src/recordPage/pageCompatibility.ts
+++ b/frontend/src/recordPage/pageCompatibility.ts
@@ -56,7 +56,7 @@ function guard(target: any, prefix: string, removals: Removal[]): any {
   return new Proxy(target, {
     get(owner, key, receiver) {
       const removal = typeof key === "string" ? here.get(key) : undefined;
-      // Never any unknown key: `if (page.dialog.prompt)` is feature detection and must stay silent.
+      // Only a listed name: `if (page.dialog.prompt)` is feature detection and must stay silent.
       if (!removal) return Reflect.get(owner, key, receiver);
       if (removal.stage === "gone") {
         warnRemoved(removal);

--- a/frontend/src/recordPage/pagePermissions.ts
+++ b/frontend/src/recordPage/pagePermissions.ts
@@ -1,6 +1,4 @@
-// What a script may ask about permissions (wayfinder ticket 18): the rights
-// dict, the session's roles, and a field's access — one vocabulary with the
-// host, since both sides come from `useDocPermissions`.
+// What a script may ask about permissions: the rights dict, the session's roles, and a field's access.
 import { watch, type ComputedRef, type Ref } from "vue";
 import {
   useDocPermissions,

--- a/frontend/src/recordPage/pageScripts.ts
+++ b/frontend/src/recordPage/pageScripts.ts
@@ -1,6 +1,5 @@
 // The Page Script tier: the doctype's stored scripts, fetched once per doctype,
-// evaluated as modules and registered as sources in creation order — after the
-// host's file scripts and app extensions, because this runs at page mount.
+// evaluated as modules and registered as sources after file scripts and extensions.
 import { readonly, ref } from "vue";
 import { call, toast } from "frappe-ui";
 import { withRegisteringSource } from "./context";
@@ -19,24 +18,18 @@ const TIER_SOURCE = "page-scripts";
 const tiers = new Map<string, Promise<void>>();
 const sources = new Map<string, string[]>();
 const toasted = new Set<string>();
-// 08 §6's toast as a shared channel: the compatibility layer reports a
-// removal hit through it, keyed by source and removed name.
+// The shared toast channel; the compatibility layer reports a removal hit through it.
 const notified = new Set<string>();
 // Two saves in quick succession overlap: the later build must win, and the
 // earlier one must not register its now-stale scripts behind it.
 const builds = new Map<string, number>();
-// Whether this session may write Page Scripts — the permission is on the
-// doctype, so it is one answer for every doctype, and the tier's fetch already
-// carries it. Gates the failure toast below and the editor's entry affordance.
+// Whether this session may write Page Scripts; the permission is on the doctype,
+// so it is one answer for every doctype. Gates the failure toast and the editor.
 const writable = ref(false);
 
 export const canWritePageScripts = readonly(writable);
 
-/**
- * Tells a script author, and only a script author, about a customization failure
- * — once per key per page session. A reader who cannot edit Page Scripts is being
- * told about somebody else's bug, so they are not told at all.
- */
+/** Tells a script author, and only a script author, about a customization failure, once per key. */
 export function toastScriptError(key: string, message: string) {
   if (!writable.value || notified.has(key)) return;
   notified.add(key);

--- a/frontend/src/recordPage/readOnly.ts
+++ b/frontend/src/recordPage/readOnly.ts
@@ -1,5 +1,4 @@
 // Every object `page` hands back is read-only: reads pass through, writes throw.
-//
 // Not deep-freeze: a frozen object is non-extensible, so Vue's `reactive()` hands
 // back the raw object and `meta` stops being deeply reactive.
 import { runningSource } from "./context";

--- a/frontend/src/recordPage/readOnly.ts
+++ b/frontend/src/recordPage/readOnly.ts
@@ -1,29 +1,12 @@
-// The outbound half of the compatibility policy (wayfinder ticket 47): every
-// object `page` hands back is read-only. Ticket 20 curated what goes *in* to
-// `page`; nothing said what a script may do to what comes back out, and the
-// answer was "corrupt the application" — `page.roles` is a module-level array
-// shared by the whole session, `page.perms` a memoised view shared by every
-// source, `page.meta` a cached resource that outlives navigation to another
-// doctype.
+// Every object `page` hands back is read-only: reads pass through, writes throw.
 //
-// A write is refused, not softened: it reports on the tombstone channel and
-// throws, which aborts the rest of the handler. The engine already skips a
-// throwing handler half-applied and this is not the exception (47 §3) —
-// report-but-continue is the silent no-op wearing a report.
-//
-// Not deep-freeze. A frozen object is non-extensible, Vue 3's `getTargetType`
-// returns INVALID for a non-extensible target, and `reactive()` then hands the
-// raw object back — meta would stop being deeply reactive. That is a repo-wide
-// reactivity change, and it stays addable underneath this Proxy later.
+// Not deep-freeze: a frozen object is non-extensible, so Vue's `reactive()` hands
+// back the raw object and `meta` stops being deeply reactive.
 import { runningSource } from "./context";
 import { toastScriptError } from "./pageScripts";
 import { reportCustomizationError } from "./reportError";
 
-/**
- * What to write instead, per wrapped member. A bare `TypeError` names nothing;
- * the whole reason this is a redirect rather than a removal is that there is a
- * supported verb to point at.
- */
+/** What to write instead, per wrapped member. */
 export interface ReadOnlyAdvice {
   /** Dotted path to the member: `"page.meta"`. Nested writes extend it. */
   path: string;
@@ -31,33 +14,20 @@ export interface ReadOnlyAdvice {
   instead: string;
 }
 
-// Raw object to wrapper. Mandatory, not an optimisation: without it every read
-// allocates a fresh Proxy, `page.meta.fields[0] !== page.meta.fields[0]`, and
-// `.indexOf()` / `.includes()` / any identity comparison quietly misbehaves.
-//
-// It also fixes the reported path to the one the object was *first* reached
-// through, when the same object is reachable two ways. That is the price of the
-// identity guarantee, and identity is the one that breaks working scripts.
+// Mandatory, not an optimisation: without it every read allocates a fresh Proxy,
+// `page.meta.fields[0] !== page.meta.fields[0]`, and identity comparisons misbehave.
 const wrappers = new WeakMap<object, any>();
 
 // Wrapping a wrapper would nest two Proxies and report the inner path twice.
-// Nothing does it today — every wrap starts from a raw host value — but this is
-// one lookup to make it impossible rather than a rule to remember.
 const wrapped = new WeakSet<object>();
 
-/**
- * Wraps `value` so reads pass through and writes throw. Lazy and recursive: a
- * nested object is wrapped when it is read, not walked up front, so an untouched
- * meta costs nothing.
- */
+/** Wraps `value` so reads pass through and writes throw. Lazy and recursive. */
 export function readOnly<T>(value: T, advice: ReadOnlyAdvice): T {
   return wrap(value, advice.path, advice) as T;
 }
 
-// `member` is the wrap's root, fixed for the whole descent: the message names
-// the full path, because the author has to find the line, but the report and the
-// toast are keyed on the member, so a script that walks an array writing to
-// every row of it files one row rather than one per row.
+// The report and the toast are keyed on the member, not the path, so a script
+// writing to every row of an array files one row.
 function wrap(value: unknown, path: string, member: ReadOnlyAdvice): unknown {
   if (!wrappable(value)) return value;
   const target = value as object;
@@ -73,11 +43,8 @@ function wrap(value: unknown, path: string, member: ReadOnlyAdvice): unknown {
   const wrapper = new Proxy(target, {
     get(owner, key, receiver) {
       const read = Reflect.get(owner, key, receiver);
-      // A Proxy must hand back a non-configurable, non-writable property
-      // exactly as the target holds it, or the engine throws on the read. That
-      // is not hypothetical here: deep-freezing meta at source stays on the
-      // table (ticket 47 §1), and the day it happens this would start throwing
-      // TypeErrors on every read instead of quietly staying correct.
+      // A Proxy must hand back a non-configurable, non-writable property exactly
+      // as the target holds it, or the engine throws on the read.
       if (fixed(owner, key)) return read;
       return wrap(read, step(owner, path, key), member);
     },
@@ -90,12 +57,8 @@ function wrap(value: unknown, path: string, member: ReadOnlyAdvice): unknown {
     deleteProperty(_owner, key) {
       return refuse(refusal(key));
     },
-    // The other two mutating operations. They take no key, so they are not
-    // reachable through `set` — and an operation with no trap forwards to the
-    // target, so without these `Object.setPrototypeOf(page.roles, ...)` swaps
-    // the prototype of the shared array (every later `roles.includes` answers
-    // the script) and `Object.freeze(page.meta)` locks shared cached state.
-    // Same hole as `page.roles.push`, reached by a door `set` does not watch.
+    // These take no key, so `set` never sees them, and an untrapped operation
+    // forwards to the target: `Object.freeze(page.meta)` would lock shared state.
     setPrototypeOf() {
       return refuse({ path: `${path}'s prototype`, member });
     },
@@ -114,44 +77,29 @@ function fixed(target: object, key: string | symbol) {
   return !!descriptor && !descriptor.configurable && !descriptor.writable;
 }
 
-// Arrays and plain objects only. A `Date`, a `Map` or any class instance keeps
-// its internal slots, which a Proxy receiver breaks the moment a method is
-// called on it — and nothing `page` hands back is one of those. Functions pass
-// through as themselves: `roles.push` is reached as a function and called on the
-// wrapper, so its writes land in the `set` trap anyway. That is the whole of the
-// `page.roles.push('System Manager')` fix — no array special case exists.
+// Arrays and plain objects only: a `Date`, a `Map` or a class instance keeps
+// internal slots that a Proxy receiver breaks the moment a method is called.
 function wrappable(value: unknown): boolean {
   if (typeof value !== "object" || value === null) return false;
-  // `markRaw`'s stamp. A component's options object is a plain object, so it
-  // would otherwise be descended into: identity would stop holding
-  // (`get('x').component === MyComponent` false), and Vue's own render-time
-  // caches onto those options (`__vccOpts`, normalized props) would start
-  // throwing from inside a render effect.
-  //
-  // Asked as an own-property question, not a read: `page.perms` is itself a
-  // Proxy that warns about any key it does not recognise, and probing it for
-  // `__v_skip` would file that probe as the author's typo.
+  // `markRaw`'s stamp; descending into a marked object breaks Vue's render caches.
+  // Asked as an own-property question: `page.perms` files an unknown key as a typo.
   if (Object.hasOwn(value, "__v_skip")) return false;
   if (Array.isArray(value)) return true;
   const proto = Object.getPrototypeOf(value);
   return proto === Object.prototype || proto === null;
 }
 
-// `page.meta.fields[3].hidden`, not `page.meta` — the author has to be able to
-// find the line.
+// `page.meta.fields[3].hidden`, not `page.meta`.
 function step(target: object, path: string, key: string | symbol) {
   const name = String(key);
   return Array.isArray(target) ? `${path}[${name}]` : `${path}.${name}`;
 }
 
-// Not dev-gated, for the reason `pageCompatibility.ts` gives and this inherits
-// unchanged: no production site runs a dev build, and this fires on a site no
-// developer is watching.
+// Not dev-gated: this fires on a production site no developer is watching.
 function refuse(refusal: { path: string; member: ReadOnlyAdvice }): never {
   const { path, member } = refusal;
   const source = runningSource();
-  // The thrown message stands alone — it is what a `catch` and the Error Log row
-  // carry. The console line and the toast add the attribution around it.
+  // The thrown message stands alone: it is what a `catch` and the Error Log row carry.
   const error = new Error(`${path} is read-only — use ${member.instead}`);
   const sentence = `${source} wrote to ${path}, which is read-only — use ${member.instead}`;
   console.error(`[record-page] ${sentence}`);

--- a/frontend/src/recordPage/registry.ts
+++ b/frontend/src/recordPage/registry.ts
@@ -19,9 +19,7 @@ export function registerRecordPage(
   handlers: AuthoredHandlers,
 ) {
   const source = registeringSource();
-  // The one place a nested table block is flattened: file scripts and stored
-  // scripts both land here, so neither the loader nor the evaluator has to know
-  // the authored shape from the dispatched one.
+  // The one place a nested table block is flattened; every delivery lands here.
   registrations.push({
     source,
     doctype,

--- a/frontend/src/recordPage/reportError.ts
+++ b/frontend/src/recordPage/reportError.ts
@@ -1,8 +1,5 @@
-// The third destination for a customization failure (ticket 19): console always,
-// toast for script editors, and — from here — one Error Log row an admin can read
-// without being in the room. Fire-and-forget in every direction: a failed report
-// never toasts, never logs, never retries, because an error channel that can
-// itself error is a loop.
+// A customization failure's Error Log row, which an admin can read without being in
+// the room. Fire-and-forget: an error channel that can itself error is a loop.
 import { call } from "frappe-ui";
 import { HOST_SOURCE } from "./context";
 
@@ -14,13 +11,10 @@ const STACK_LIMIT = 4000;
 
 export type CustomizationTier = "page_script" | "extension" | "file_script";
 
-// One report per (source, event) per page session. This is the layer that kills
-// the replay storm before a request is made, and still yields one row per user
-// per visit — "50 people hit this today" at a volume the log can hold.
+// One report per (source, event) per page session, which kills a replay storm before a request is made.
 const reported = new Set<string>();
-// An error already filed where more was known about it — a tombstone hit names
-// the removal and its replacement — must not be filed a second time by the
-// handler catch that sees it on the way out.
+// An error already filed where more was known about it must not be filed again
+// by the handler catch that sees it on the way out.
 const filed = new WeakSet<object>();
 
 export interface CustomizationErrorContext {
@@ -53,8 +47,7 @@ export function reportCustomizationError(
   if (reported.has(key)) return;
   reported.add(key);
   // Every call site is already inside a catch, so a throw from here would escape
-  // as the failure of whatever it was reporting. `call` is guarded both ways:
-  // synchronously, and for whatever it hands back.
+  // as the failure of whatever it was reporting.
   try {
     const sent = call(REPORT_METHOD, {
       source: context.source,

--- a/frontend/src/recordPage/rows.ts
+++ b/frontend/src/recordPage/rows.ts
@@ -1,18 +1,5 @@
-// How a script addresses a child row (wayfinder ticket 43) — `page.rows('products')`
-// and the handle it hands back.
-//
-// A handle holds `(parentfield, key)` and **re-finds its row on every access**.
-// Nothing about a row's position is ever captured, which is the whole of the
-// staleness answer: a script that captures a row, `await`s a server call and then
-// writes to it is doing the dangerous thing the ported script actually does, and
-// v1 loses those writes silently by wrapping the row object. Here a removed row
-// throws, attributed, aborting the handler — 47's precedent, for 47's reason.
-//
-// Fields are read and written bare (`row.amount = row.qty * row.rate`), and there
-// is exactly one engine member, `trigger`, spelled as v1 spells it. That set is
-// deliberately one: 43 designed a `$` prefix to keep engine members out of the
-// fieldname namespace and then retired it by cutting the members it protected, and
-// recorded that adding a second bare member is the moment to reopen it.
+// How a script addresses a child row: `page.rows('products')` and the handle it hands
+// back, which re-finds its row on every access and throws once the row is gone.
 import { runningSource } from "./context";
 import {
   holdsChildRows,
@@ -36,18 +23,11 @@ const ROWS_ARE_READ_ONLY: ReadOnlyAdvice = {
 /** The one engine member on a handle; everything else is a child fieldname. */
 const TRIGGER = "trigger";
 
-// `markRaw`'s stamp, answered by the traps below rather than stored on the target.
-// It is what tells both Vue's reactivity and the outbound read-only guard that a
-// handle is not data to descend into — the guard wraps every object it hands back,
-// and a read-only handle would refuse the writes that are the whole point of one.
+// `markRaw`'s stamp, answered by the traps below: it tells both Vue and the
+// outbound read-only guard that a handle is not data to descend into.
 const RAW = "__v_skip";
 
-/**
- * What `trigger` will not dispatch: the structural half of the vocabulary. Note
- * these are the `on`-prefixed spellings (ticket 54) — a child field genuinely
- * called `add` is triggerable like any other, which is the whole reason the
- * lifecycle keys left the fieldname namespace.
- */
+/** What `trigger` will not dispatch: the `on`-prefixed lifecycle keys, not any child fieldname. */
 const STRUCTURAL: string[] = Object.values(ROW_EVENTS);
 
 export interface RowsHost {
@@ -69,12 +49,8 @@ export interface Rows {
 }
 
 export function createRows(host: RowsHost): Rows {
-  // One handle per address, for the page's life. Not an optimisation and not
-  // optional: without it `page.rows('products')[0] !== page.rows('products')[0]`,
-  // so `indexOf`, `includes`, `filter(r => r !== row)` and every `===` a script
-  // writes are quietly wrong — and a handler comparing the row it was handed
-  // against the table would find it nowhere. `readOnly.ts` keeps its own wrappers
-  // for exactly this reason; a handle is the same kind of object.
+  // One handle per address, for the page's life. Mandatory: without it
+  // `page.rows('products')[0] !== page.rows('products')[0]` and every `===` a script writes is wrong.
   const handles = new Map<string, PageRow>();
 
   function rows(parentfield: string): PageRow[] {
@@ -88,16 +64,8 @@ export function createRows(host: RowsHost): Rows {
   }
 
   /**
-   * Every row's key, minted here as well as at the two mutation sites so a row a
-   * script pushed onto `page.doc.products` itself is still addressable. A read
-   * that writes, and safe because a painted document carries a server `name` on
-   * every row: nothing is minted unless a script added the row.
-   *
-   * Two rows sharing a key would read as one — the grid selects and deletes them
-   * together, and a handle would write into whichever comes first, silently.
-   * A server name is unique by construction, so the only way it happens is a
-   * script copying a row (`{ ...products[0] }`), which copies the `__row_id`
-   * with it; that copy is re-minted rather than left aliasing the original.
+   * Every row's key, minted here too so a row a script pushed onto `page.doc` is
+   * addressable. A copied row (`{ ...products[0] }`) carries the original's key and is re-minted.
    */
   function keysOf(table: Record<string, any>[]): string[] {
     const seen = new Set<string>();
@@ -139,18 +107,15 @@ export function createRows(host: RowsHost): Rows {
         : undefined;
     }
 
-    // A bare child fieldname, because the handle already knows its table and
-    // forms the dotted key itself: the author spells the table once, when they
-    // acquire the row (ticket 45 §3).
+    // A bare child fieldname: the handle knows its table and forms the dotted key itself.
     const trigger = (fieldname: string) => {
       required(TRIGGER);
       if (!triggerable(parentfield, fieldname)) return Promise.resolve();
       return host.dispatch(`${parentfield}.${fieldname}`, { parentfield, key });
     };
 
-    // The target is an empty object rather than the row: a Proxy may only lie
-    // about a target's properties while the target is extensible and owns none,
-    // and the row it would otherwise wrap is a different object on every access.
+    // The target is an empty object, not the row: a Proxy may only lie about a
+    // target's properties while the target is extensible and owns none.
     return new Proxy({} as PageRow, {
       get(_target, prop) {
         if (prop === TRIGGER) return trigger;
@@ -170,12 +135,8 @@ export function createRows(host: RowsHost): Rows {
         if (probe(prop)) return !!resolve() && prop in resolve()!;
         return prop in required(prop);
       },
-      // `{ ...row }` and `Object.keys(row)` answer with the row's own fields:
-      // `trigger` and the stamp are not among them, so a spread copies data.
-      // A removed row throws here rather than spreading to `{}` — silently
-      // copying nothing is the v1 failure this whole handle exists to end.
-      // `*` rather than a fieldname: enumerating asks about the whole row, and
-      // naming a field the doctype does not have would be a worse message.
+      // A spread copies the row's own fields, not `trigger` or the stamp, and a
+      // removed row throws instead of spreading to `{}`; `*` names the whole row.
       ownKeys() {
         return Reflect.ownKeys(required("*"));
       },
@@ -190,11 +151,7 @@ export function createRows(host: RowsHost): Rows {
     });
   }
 
-  /**
-   * Only the meta can say a fieldname is not a child table, and it lands after
-   * the first paint — so this stays quiet until it can tell, exactly as
-   * `page.fields` does about a fieldname it cannot find yet.
-   */
+  /** Quiet until the meta lands: only the meta can say a fieldname is not a child table. */
   function holdsRows(parentfield: string): boolean {
     const field = tableField(parentfield);
     if (!host.fields() || field) return true;
@@ -203,12 +160,8 @@ export function createRows(host: RowsHost): Rows {
   }
 
   /**
-   * `trigger` dispatches a *field* event, so it refuses the structural keys —
-   * `'products.onAdd'` fired from here would hand a live row to a handler 45 §3
-   * gives none, and `'products.onRemove'` would announce a removal that did not
-   * happen. It also refuses a dotted argument, since the handle spells the
-   * table itself, and warns about a fieldname the child doctype does not have:
-   * the same typo written as a handler key is already named at load.
+   * `trigger` dispatches a field event: it refuses the structural keys and a dotted
+   * argument, and warns about a fieldname the child doctype does not have.
    */
   function triggerable(parentfield: string, fieldname: string): boolean {
     const said = `row.trigger("${fieldname}") on ${parentfield}`;
@@ -239,11 +192,8 @@ export function createRows(host: RowsHost): Rows {
   return { rows, handle };
 }
 
-// Vue's reactivity flags are plain strings, not symbols (`__v_isRef`, `__v_raw`,
-// …), so the symbol test alone would let a `ref(row)` or an `isRef` in a template
-// throw from inside a render effect. Neither kind is a fieldname a script wrote,
-// and answering a probe with a throw makes a removed row blow up on being *looked
-// at* rather than on being used.
+// Vue's reactivity flags are plain strings (`__v_isRef`, `__v_raw`), so the symbol
+// test alone would let an `isRef` in a template throw on a removed row inside a render effect.
 function probe(prop: string | symbol): boolean {
   return typeof prop === "symbol" || prop.startsWith("__v_");
 }
@@ -255,12 +205,7 @@ const RAW_DESCRIPTOR: PropertyDescriptor = {
   configurable: true,
 };
 
-/**
- * The tombstone channel, as [47] fixed its shape: the thrown `Error` carries the
- * standalone sentence, the console line and the toast add the attribution, and
- * the throw aborts the rest of the handler — report-but-continue is the silent
- * no-op wearing a report, which is the one thing v1 does here.
- */
+/** The thrown `Error` carries the standalone sentence; the console line and the toast add the attribution. */
 function refuseRemovedRow(parentfield: string, prop: string | symbol): never {
   const path = `${parentfield}.${String(prop)}`;
   const advice = `re-acquire it with page.rows("${parentfield}")`;
@@ -275,9 +220,7 @@ function refuseRemovedRow(parentfield: string, prop: string | symbol): never {
   throw error;
 }
 
-/** A refused `trigger` is a dev warning and a no-op, not a throw: the row is
- *  fine, the argument is wrong, and the rest of the handler is still worth
- *  running — unlike a write that has nowhere to land. */
+/** A refused `trigger` is a dev warning and a no-op: the row is fine, only the argument is wrong. */
 function refuseTrigger(message: string): false {
   warnOnce(message);
   return false;

--- a/frontend/src/recordPage/surface.ts
+++ b/frontend/src/recordPage/surface.ts
@@ -24,18 +24,13 @@ export const BUILTIN = "builtin";
 export class Surface<Item extends SurfaceItem = SurfaceItem> implements SurfaceVerbs<Item> {
 	private ops: Op<Item>[] = reactive([]);
 	// Where a replay's ops accumulate until it commits. Non-null only inside a
-	// replay: ops recorded anywhere else -- a `run` handler, `onTabChange`, a
-	// quick-action callback -- go straight to `ops` and render immediately, as
-	// they always have. Staging is a property of the replay, not of the surface.
+	// replay; ops recorded anywhere else render immediately.
 	private pending: Op<Item>[] | null = null;
 	private replaying = 0;
 	private builtins: () => Item[] = () => [];
 
-	// A block splices as a unit at the anchor, in list order: the first item
-	// takes the caller's position and each one after it follows the one before,
-	// so `add([a, b, c], { before: 'delete' })` reads in the list the way it
-	// reads in the call (ticket 77 §5). No new op: an array is the sugar, the
-	// flat namespace underneath is unchanged.
+	// A block splices as a unit at the anchor: the first item takes the caller's
+	// position and each one after it follows the one before.
 	add(item: Item | Item[], position?: Position) {
 		let anchor = position;
 		for (const one of Array.isArray(item) ? item : [item]) {
@@ -68,17 +63,13 @@ export class Surface<Item extends SurfaceItem = SurfaceItem> implements SurfaceV
 		this.record({ verb: "order", source: runningSource(), names });
 	}
 
-	// The one read a script makes, and the one that resolves over the replay in
-	// flight: a source that calls `add('x')` and then `has('x')` in its own
-	// `refresh` handler is told the truth about its own work. Outside a replay
-	// there is no pending list and this is the committed answer.
+	// Resolves over the replay in flight: a source that calls `add('x')` and then
+	// `has('x')` in its own `refresh` handler is told about its own work.
 	has(name: string) {
 		return this.fold(this.pending ?? this.ops).some((entry) => entry.item.name === name);
 	}
 
-	// Host side, but reading the way `has` reads and for its reason: `activate`
-	// asks this to tell a hidden tab from an absent one, and a source that adds a
-	// tab and activates it in its own replay must be answered about its own work.
+	// Host side, reading the way `has` reads: `activate` asks this to tell a hidden tab from an absent one.
 	isVisible(name: string) {
 		return this.fold(this.pending ?? this.ops).some(
 			(entry) => entry.item.name === name && !entry.hidden,
@@ -92,14 +83,8 @@ export class Surface<Item extends SurfaceItem = SurfaceItem> implements SurfaceV
 	}
 
 	/**
-	 * Open a replay: from here until the matching commit, ops are staged instead
-	 * of rendered.
-	 *
-	 * Emptying the staged list is the replay clear that `reset()` used to be --
-	 * a replay rebuilds from built-ins alone. A nested replay (a script calling
-	 * `page.refresh()` from a `refresh` handler) clears it the same way, but
-	 * only the outermost commit publishes, so an inner one cannot put a
-	 * half-built outer list on screen.
+	 * Opens a replay: ops are staged until the matching commit, and a replay
+	 * rebuilds from built-ins alone. Only the outermost commit publishes.
 	 */
 	beginReplay() {
 		this.pending = [];
@@ -113,9 +98,7 @@ export class Surface<Item extends SurfaceItem = SurfaceItem> implements SurfaceV
 		if (this.replaying > 0) return;
 		const staged = this.pending ?? [];
 		this.pending = null;
-		// One splice, not a clear and a refill: `ops` is reactive and this is
-		// the whole point of staging -- the host renders the replay's result
-		// without ever rendering its middle.
+		// One splice, not a clear and a refill: `ops` is reactive, and the host must never render the replay's middle.
 		this.ops.splice(0, this.ops.length, ...staged);
 	}
 
@@ -145,9 +128,8 @@ export class Surface<Item extends SurfaceItem = SurfaceItem> implements SurfaceV
 	}
 }
 
-// `ops` is reactive, so a component stored on an item would be deep-reactified
-// on its way in -- which Vue warns about, and pays for proxying a whole render
-// function. The item's own keys stay reactive; only the component opts out.
+// `ops` is reactive, so a component stored on an item would be deep-reactified on
+// its way in, which Vue warns about. Only the component opts out.
 function keepComponentRaw<Item extends SurfaceItem>(item: Partial<Item>) {
 	if (item.component) item.component = markRaw(item.component);
 }

--- a/frontend/src/recordPage/surface.ts
+++ b/frontend/src/recordPage/surface.ts
@@ -1,6 +1,5 @@
 // One customizable region of a Record page. Verbs record ops; the rendered list
-// is those ops replayed over the host's built-ins, so a refresh replay and a
-// built-in that changed underneath both resolve to the same answer.
+// is those ops replayed over the host's built-ins.
 import { markRaw, reactive } from "vue";
 import { runningSource } from "./context";
 import { ensureIcons } from "./iconClasses";

--- a/frontend/src/recordPage/tests/compatibility.test.ts
+++ b/frontend/src/recordPage/tests/compatibility.test.ts
@@ -1,6 +1,5 @@
-// The compatibility mechanisms (wayfinder ticket 20 §4, §5) as executable claims:
-// a name we removed is answered by name, and a name that never existed is left
-// alone — because probing for one is the feature detection the policy recommends.
+// The compatibility mechanisms as executable claims: a removed name is answered
+// by name, and a name that never existed is left alone.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { call, toast } = vi.hoisted(() => ({

--- a/frontend/src/recordPage/tests/events.test.ts
+++ b/frontend/src/recordPage/tests/events.test.ts
@@ -1,4 +1,4 @@
-// The event vocabulary's firing semantics (wayfinder ticket 14) as executable claims.
+// The event vocabulary's firing semantics as executable claims.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ref } from "vue";
 
@@ -106,9 +106,8 @@ describe("fireEvent", () => {
   });
 });
 
-// Ticket 74 respelled the four top-level keys to camelCase, a hard break with no
-// dual-accept: the old spellings are legal *fieldnames*, which is the collision the
-// rename exists to remove. Both halves are claims, not conventions.
+// The four top-level keys are camelCase with no dual-accept: the old spellings
+// are legal fieldnames, which is the collision the rename removes.
 describe("the event vocabulary is camelCase (ticket 74)", () => {
   beforeEach(() => resetRegistry());
 
@@ -205,8 +204,7 @@ describe("unknown handler keys", () => {
     warnings.mockRestore();
   });
 
-  // 45 §5: only reachable because the deleted deep watch could not tell one
-  // row's edit from another's, and retiring it is what makes the warning useful.
+  // Nothing commits under a table's own name, so its bare fieldname is not a key.
   it("rejects a Table fieldname, its underscore keys, and an unknown child field", async () => {
     const warnings = vi.spyOn(console, "warn").mockImplementation(() => {});
     registerRecordPage("CRM Deal", {
@@ -223,8 +221,7 @@ describe("unknown handler keys", () => {
     warnings.mockRestore();
   });
 
-  // 45 §7: a Table MultiSelect has no per-cell editing, so a child-field key on
-  // one could never fire — and naming that is what the warning is for.
+  // A Table MultiSelect has no per-cell editing, so a child-field key on one could never fire.
   it("gives a Table MultiSelect add and remove only", async () => {
     const warnings = vi.spyOn(console, "warn").mockImplementation(() => {});
     registerRecordPage("CRM Deal", {
@@ -294,8 +291,7 @@ describe("unknown handler keys", () => {
     warnings.mockRestore();
   });
 
-  // 54 §3: the convention is not a construction, so the two fieldnames that can
-  // still collide are named at load — an announced hole, not a silent misfire.
+  // The two child fieldnames that can still collide are named at load.
   it("warns when a child doctype has a field named onAdd or onRemove (ticket 54)", async () => {
     const warnings = vi.spyOn(console, "warn").mockImplementation(() => {});
     resetRowWarnings();
@@ -318,9 +314,8 @@ describe("unknown handler keys", () => {
     warnings.mockRestore();
   });
 
-  // The collision is a *misfire*, not an inert gap — the thing the warning has
-  // to say, and the reason it says it. Editing the child field commits under
-  // the same string the row-added event dispatches.
+  // The collision is a misfire: editing the child field commits under the same
+  // string the row-added event dispatches.
   it("routes a colliding child field's commit into the table's lifecycle handler", async () => {
     const fired: string[] = [];
     registerRecordPage("CRM Deal", { items: { onAdd: () => fired.push("onAdd") } });
@@ -331,9 +326,8 @@ describe("unknown handler keys", () => {
     expect(fired).toEqual(["onAdd"]);
   });
 
-  // 48/50's lesson in its own shape: the shadow check reads the *child* meta,
-  // which can land after the parent's, so latching on the parent alone dropped
-  // the warning for the session.
+  // The shadow check reads the child meta, which can land after the parent's,
+  // so latching on the parent alone would drop the warning for the session.
   it("still warns when the child meta lands after the parent's", async () => {
     const warnings = vi.spyOn(console, "warn").mockImplementation(() => {});
     resetRowWarnings();
@@ -414,9 +408,8 @@ describe("the replay clears the field overlay too (ticket 42)", () => {
     expect(controller.fields.resolve()).toEqual({});
   });
 
-  // Ticket 71: the replay stages its ops now, so the commit has to happen on
-  // the way out of a failed replay too — otherwise the overlay would be frozen
-  // on the previous replay for the rest of the session.
+  // The replay stages its ops, so the commit has to happen on the way out of a
+  // failed replay too, or the overlay freezes on the previous one for good.
   it("commits what a failed replay managed to record", async () => {
     registerRecordPage("CRM Deal", {
       onRefresh: (page) => {

--- a/frontend/src/recordPage/tests/fields.test.ts
+++ b/frontend/src/recordPage/tests/fields.test.ts
@@ -106,7 +106,7 @@ describe("names that are not names", () => {
     // such write would hide a field in every form for the rest of the session.
     expect(({} as any).override).toBeUndefined();
     // Recorded as an ordinary own key instead — inert, since no field can be
-    // named this, and attributable rather than invisible.
+    // named this, and attributable, not invisible.
     expect(Object.hasOwn(patches, "__proto__")).toBe(true);
     expect(Object.getPrototypeOf(patches)).toBe(Object.prototype);
   });

--- a/frontend/src/recordPage/tests/fields.test.ts
+++ b/frontend/src/recordPage/tests/fields.test.ts
@@ -1,6 +1,5 @@
-// The fields surface (wayfinder ticket 42) as executable claims: an enumerated
-// snake_case patch, a render-time overlay cleared by the replay, a reader that
-// speaks the writer's vocabulary, and a permlevel floor an override cannot lift.
+// The fields surface as executable claims: an enumerated snake_case patch, a
+// render-time overlay cleared by the replay, and a permlevel floor.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("frappe-ui", () => ({
@@ -103,9 +102,8 @@ describe("names that are not names", () => {
     fields.hide("__proto__");
     const patches = fields.resolve();
 
-    // The damage this avoids: `resolveFieldConditionals` reads `override` off
-    // the prototype chain, so one such write would hide a field in every form
-    // in the application for the rest of the session.
+    // `resolveFieldConditionals` reads `override` off the prototype chain, so one
+    // such write would hide a field in every form for the rest of the session.
     expect(({} as any).override).toBeUndefined();
     // Recorded as an ordinary own key instead — inert, since no field can be
     // named this, and attributable rather than invisible.
@@ -168,9 +166,8 @@ describe("the verbs", () => {
     expect(fields.resolve()).toEqual({});
   });
 
-  // Ticket 71: the overlay used to empty on `reset()` and refill a microtask
-  // later, which is the `page.fields` flash — a script-hidden field visible for
-  // a tick on every save.
+  // The overlay used to empty on `reset()` and refill a microtask later: a
+  // script-hidden field visible for a tick on every save.
   it("keeps the applied overlay whole while a replay is in flight", () => {
     const fields = makeSurface();
     fields.hide("status");
@@ -208,8 +205,8 @@ describe("get — the reader", () => {
     });
   });
 
-  // The other half of ticket 71's read split: the host renders the committed
-  // overlay, but a source reading its own work back mid-replay must see it.
+  // The host renders the committed overlay, but a source reading its own work
+  // back mid-replay must see it.
   it("reads the replay in flight, not the overlay the host is still rendering", () => {
     const fields = makeSurface();
     fields.update("status", { label: "Stage" });

--- a/frontend/src/recordPage/tests/flattenHandlers.test.ts
+++ b/frontend/src/recordPage/tests/flattenHandlers.test.ts
@@ -1,5 +1,4 @@
-// The authored shape (ticket 54) against the flat keyspace the engine dispatches
-// on: what a script writes, and what `registerRecordPage` stores.
+// The authored shape against the flat keyspace the engine dispatches on.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { flattenHandlers } from "../flattenHandlers";
@@ -90,8 +89,7 @@ describe("flattenHandlers", () => {
     warnings.mockRestore();
   });
 
-  // 51's lesson, one level down: a keyspace argument about fieldnames says
-  // nothing about strings that were never fieldnames.
+  // A keyspace argument about fieldnames says nothing about strings that were never fieldnames.
   it("cannot be made to write onto Object.prototype", () => {
     const flat = flattenHandlers(
       { ["__proto__"]: noop, evil: { ["__proto__"]: noop } } as any,

--- a/frontend/src/recordPage/tests/formTabs.test.ts
+++ b/frontend/src/recordPage/tests/formTabs.test.ts
@@ -1,6 +1,5 @@
-// The Form Layout tabs surface (wayfinder ticket 73) as executable claims: a
-// tab addressed by identity, an overlay that beats `depends_on` in both
-// directions, a reader that resolves both, and a replay that stages.
+// The Form Layout tabs surface as executable claims: a tab addressed by
+// identity, an overlay that beats `depends_on`, and a replay that stages.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("frappe-ui", () => ({

--- a/frontend/src/recordPage/tests/headerRenderings.test.ts
+++ b/frontend/src/recordPage/tests/headerRenderings.test.ts
@@ -1,5 +1,4 @@
-// The three renderings (ticket 65) and the fitting rule (ticket 66) as
-// executable claims.
+// The three header renderings and the fitting rule as executable claims.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   HeaderActionsSurface,
@@ -96,8 +95,7 @@ describe("the three renderings", () => {
     ).toEqual(["call", "sms"]);
   });
 
-  // A member never relocates the button it hangs off: the container's own
-  // position places it (ticket 65).
+  // A member never relocates the button it hangs off: the container's own position places it.
   it("places a dropdown by its own item, not by its first member", () => {
     const items = [
       action("sms", { group: "telephony" }),
@@ -195,8 +193,7 @@ describe("the fitting rule", () => {
     ]);
   });
 
-  // A promoted built-in overflows on the same rule and does not return to its
-  // home band: provenance orders nothing here (ticket 66 §4).
+  // A promoted built-in overflows on the same rule and does not return to its home band.
   it("demotes a promoted built-in to the front, not back to its own band", () => {
     const items = [
       button("one"),
@@ -207,7 +204,7 @@ describe("the fitting rule", () => {
     expect(bandNames(items)).toEqual(["delete[delete]", "actions[copy_url]"]);
   });
 
-  // An empty dropdown is a button that opens nothing (ticket 66 §5).
+  // An empty dropdown is a button that opens nothing.
   it("drops a dropdown with no visible members before the budget applies", () => {
     const items = [dropdown("telephony"), button("one"), button("two")];
     expect(controlNames(items)).toEqual(["button:one", "button:two"]);
@@ -245,8 +242,8 @@ describe("the fitting rule", () => {
   });
 });
 
-// Ticket 77 §1-§4: a section is a container spelled the way a dropdown is, a
-// submenu is a container inside a container, and both fall out of one rule.
+// A section is a container spelled the way a dropdown is, and a submenu is a
+// container inside a container; both fall out of one rule.
 describe("sections and submenus", () => {
   const section = (name: string, extra: Partial<HeaderAction> = {}) =>
     action(name, { display: "section", ...extra });
@@ -295,8 +292,8 @@ describe("sections and submenus", () => {
     ).toEqual(["share{share_email,share_link}"]);
   });
 
-  // Ticket 77 §4: `MenuOption` excludes `MenuGroupOption`, so a band cannot hold
-  // a titled group — but `MenuSubmenuOption` is a legal `MenuOption`.
+  // `MenuOption` excludes `MenuGroupOption`, so a band cannot hold a titled
+  // group; `MenuSubmenuOption` is a legal `MenuOption`.
   it("flattens a demoted dropdown's section and keeps its submenu", () => {
     const items = [
       button("one"),
@@ -350,8 +347,7 @@ describe("sections and submenus", () => {
     warn.mockRestore();
   });
 
-  // Ticket 77 §6: `MenuSubmenuOption` forbids `onClick` outright, so what was
-  // incidental for a dropdown is now a rule in the dependency.
+  // `MenuSubmenuOption` forbids `onClick` outright.
   it("warns that a container's run never fires", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const items = [
@@ -364,8 +360,7 @@ describe("sections and submenus", () => {
   });
 });
 
-// Ticket 77 §3: clamped, never ignored — ignoring `group` would promote the
-// container to a top-level control, where it would eat a budget slot.
+// Clamped, never ignored: ignoring `group` would promote the container to a top-level control.
 describe("the depth cap", () => {
   const section = (name: string, extra: Partial<HeaderAction> = {}) =>
     action(name, { display: "section", ...extra });
@@ -389,9 +384,8 @@ describe("the depth cap", () => {
     warn.mockRestore();
   });
 
-  // Clamping is what actually produces an empty container, and a dropdown with
-  // nothing in it is a trigger that opens nothing — 66 §5's rule, applied at
-  // every level and not only to a top-level control.
+  // Clamping is what produces an empty container, and an empty dropdown is a
+  // trigger that opens nothing, at every level.
   it("drops the dropdown clamping emptied, at any depth", () => {
     const items = [
       dropdown("e1", { label: "One" }),
@@ -442,8 +436,7 @@ describe("the depth cap", () => {
   });
 });
 
-// Ticket 77 §5. `order(names[])` was the precedent; this is the same shape for
-// the verb that made a dropdown four calls.
+// A block splices as a unit, the same shape `order(names[])` set.
 describe("add takes a block", () => {
   it("splices the block as a unit at the anchor, in list order", () => {
     const built = new HeaderActionsSurface();
@@ -491,8 +484,7 @@ describe("add takes a block", () => {
     ]);
   });
 
-  // Ticket 77 §5: the icon bridge and the raw-component guard run per item, or
-  // only the head of a block gets them.
+  // The icon bridge and the raw-component guard run per item, or only the head of a block gets them.
   it("bridges every item's icon, not just the head's", () => {
     const built = new HeaderActionsSurface();
     built.provideBuiltins(() => []);
@@ -539,7 +531,7 @@ describe("add takes a block", () => {
     built.provideBuiltins(() => [action("copy_url")]);
     built.beginReplay();
     built.add([action("a"), action("b")]);
-    // The self-read resolves over the replay in flight (ticket 70).
+    // The self-read resolves over the replay in flight.
     expect(built.has("b")).toBe(true);
     built.commitReplay();
     expect(built.visible().map((item) => item.name)).toEqual([
@@ -634,9 +626,8 @@ describe("the cross-rendering anchor warning", () => {
     warn.mockRestore();
   });
 
-  // A container and its own members sit in different lists, but one of them
-  // *is* the other's list: anchoring a member at its container is how an author
-  // says "first in this dropdown", and it does exactly that.
+  // Anchoring a member at its own container is how an author says "first in
+  // this dropdown", and it does exactly that.
   it("says nothing when a member is anchored at its own container", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const built = surface([dropdown("telephony", { label: "Telephony" })]);
@@ -647,7 +638,7 @@ describe("the cross-rendering anchor warning", () => {
   });
 
   // ...and the converse: a dropdown button and a bare button are ordered
-  // together by the fitting rule, so they are one rendering (ticket 77).
+  // together by the fitting rule, so they are one rendering.
   it("says nothing between a bare button and a dropdown button", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const built = surface([dropdown("telephony", { label: "Telephony" })]);
@@ -676,11 +667,8 @@ describe("the cross-rendering anchor warning", () => {
   });
 });
 
-// Ticket 77 §2. `group: 'x'` now means "put me inside the item named `x`", and
-// an undeclared `x` synthesises an anonymous, untitled container. Every shipped
-// script points at a name it never declared, so it lands on that branch and must
-// render exactly as it did before sections existed: same bands, same order, no
-// headings anywhere.
+// An undeclared `group` synthesises an anonymous container, so every shipped
+// script renders exactly as it did before sections existed.
 describe("the undeclared branch renders as it always did", () => {
   const shipped = [
     button("refresh_quote"),
@@ -726,7 +714,7 @@ describe("the undeclared branch renders as it always did", () => {
 
 describe("renderingOf", () => {
   // Read off the declared display, never the effective one, so nothing
-  // computed from it can become width-dependent (ticket 66 §5).
+  // computed from it can become width-dependent.
   it("answers from the declared display alone", () => {
     const items = [button("one"), button("two"), button("three")];
     expect(renderingOf(items[2], items)).toBe("row");

--- a/frontend/src/recordPage/tests/iconClasses.test.ts
+++ b/frontend/src/recordPage/tests/iconClasses.test.ts
@@ -1,5 +1,5 @@
-// The icon bridge (wayfinder ticket 21): a script may name any lucide icon, and
-// the class is generated from the sprite already in the page.
+// The icon bridge: a script may name any lucide icon, and the class is
+// generated from the sprite already in the page.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const STYLE_ID = "record-page-icon-classes";

--- a/frontend/src/recordPage/tests/pageScripts.test.ts
+++ b/frontend/src/recordPage/tests/pageScripts.test.ts
@@ -1,4 +1,4 @@
-// The Page Script tier (wayfinder ticket 15) as executable claims.
+// The Page Script tier as executable claims.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { call, toast, evaluatePageScript } = vi.hoisted(() => ({
@@ -114,7 +114,7 @@ describe("the Page Script tier", () => {
   });
 
   // The editor's entry affordance is gated on this, and the tier's fetch is the
-  // only thing that asks the server the question (ticket 16).
+  // only thing that asks the server the question.
   it("publishes whether the session may write Page Scripts", async () => {
     expect(canWritePageScripts.value).toBe(false);
 

--- a/frontend/src/recordPage/tests/permissions.test.ts
+++ b/frontend/src/recordPage/tests/permissions.test.ts
@@ -1,6 +1,5 @@
-// The script-side permission API (wayfinder ticket 18) as executable claims:
-// what `page.perms` holds, what `page.roles` answers, and how `fieldAccess`
-// treats a permlevel and a typo.
+// The script-side permission API as executable claims: what `page.perms` holds,
+// what `page.roles` answers, and how `fieldAccess` treats a permlevel and a typo.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { computed, ref } from "vue";
 
@@ -101,9 +100,8 @@ describe("page.perms", () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
-  // Two Proxies on one object (ticket 49 §2): read-only is the outer one, so a
-  // write is refused before the advisory underneath it gets a say, and a read
-  // still reaches the advisory.
+  // Two Proxies on one object: read-only is the outer one, so a write is refused
+  // before the advisory underneath gets a say, and a read still reaches it.
   it("still warns on an unknown right through the read-only wrapper", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});

--- a/frontend/src/recordPage/tests/readOnly.test.ts
+++ b/frontend/src/recordPage/tests/readOnly.test.ts
@@ -1,7 +1,5 @@
-// The outbound half of the compatibility policy (wayfinder ticket 47) as
-// executable claims: nothing `page` hands back may be mutated into shared
-// state, the refusal names the path and the supported verb, and `page.doc` is
-// the one exception.
+// The outbound half of the compatibility policy: nothing `page` hands back may
+// be mutated into shared state, and `page.doc` is the one exception.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ref } from "vue";
 
@@ -145,8 +143,7 @@ describe("readOnly", () => {
   });
 
   // A Proxy `get` must hand back a non-configurable, non-writable property
-  // exactly as the target holds it. Deep-freezing meta at source is still on the
-  // table (ticket 47 §1); without this, the day it lands every read throws.
+  // exactly as the target holds it, or every read throws.
   it("reads a frozen property without the engine refusing the read", () => {
     const frozen = { fields: Object.freeze([{ fieldname: "qty" }]) };
     const held = readOnly(frozen as any, ADVICE);
@@ -251,8 +248,8 @@ describe("page.meta and page.perms at the door", () => {
   });
 });
 
-// The saved mirror (wayfinder ticket 46): the v2 answer to "what was the
-// previous value", and one letter away from the draft you may edit.
+// The saved mirror: the answer to "what was the previous value", one letter
+// away from the draft you may edit.
 describe("page.saved", () => {
   beforeEach(reset);
 

--- a/frontend/src/recordPage/tests/reportError.test.ts
+++ b/frontend/src/recordPage/tests/reportError.test.ts
@@ -1,5 +1,5 @@
-// The reporter (wayfinder ticket 19 §3) as executable claims: it caps itself, and
-// it never becomes the failure it is reporting.
+// The reporter as executable claims: it caps itself, and it never becomes the
+// failure it is reporting.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { call } = vi.hoisted(() => ({ call: vi.fn() }));

--- a/frontend/src/recordPage/tests/rows.test.ts
+++ b/frontend/src/recordPage/tests/rows.test.ts
@@ -1,4 +1,4 @@
-// `page.rows`, the row handle and the dotted vocabulary (wayfinder tickets 43, 45).
+// `page.rows`, the row handle and the dotted vocabulary.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { isRef, reactive, ref, toRaw } from "vue";
 
@@ -114,8 +114,8 @@ describe("page.rows", () => {
     expect(host.doc.value.products[2].qty).toBe(99);
   });
 
-  // 47's rule, and its exemption: pushing to the array is meaningless, while
-  // writing through a handle is the whole point of having one.
+  // Pushing to the array is meaningless, while writing through a handle is the
+  // whole point of having one.
   it("refuses a write to the array but not to a handle", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     const { controller } = makePage();
@@ -245,8 +245,8 @@ describe("row.trigger", () => {
     expect(() => row.trigger("rate")).toThrow("no longer in the document");
   });
 
-  // 45 §3 gives `.onRemove` no row, so a verb that could fire it from a live row
-  // would hand a handler the grenade that decision exists to withhold.
+  // `.onRemove` gets no row, so a verb that could fire it from a live row would
+  // hand a handler one anyway.
   it("refuses the structural keys, a dotted argument and an unknown field", async () => {
     const fired: string[] = [];
     registerRecordPage("CRM Deal", {
@@ -270,9 +270,8 @@ describe("row.trigger", () => {
     warnings.mockRestore();
   });
 
-  // The whole reason the lifecycle keys are `on`-prefixed (ticket 54): `add` is
-  // a legal, unreserved fieldname, so under the old spelling this row's own
-  // field was unaddressable and `products.add` meant two different events.
+  // `add` is a legal fieldname, so under the old spelling this row's own field
+  // was unaddressable and `products.add` meant two different events.
   it("triggers a child field genuinely called add", async () => {
     const fired: string[] = [];
     registerRecordPage("CRM Deal", { products: { add: () => fired.push("add") } });

--- a/frontend/src/recordPage/tests/surface.test.ts
+++ b/frontend/src/recordPage/tests/surface.test.ts
@@ -1,4 +1,4 @@
-// The merge & ordering rules (wayfinder ticket 06) as executable claims.
+// The merge & ordering rules as executable claims.
 import { describe, expect, it } from "vitest";
 import { nextTick, watchEffect } from "vue";
 import { Surface } from "../surface";
@@ -93,10 +93,8 @@ describe("surface verbs", () => {
 	});
 });
 
-// Ticket 71: a replay used to clear the ops synchronously and re-add them a
-// microtask later, so the host rendered the strip without its scripted items in
-// between -- and a keyless `v-for` rebuilt everything under it, losing the
-// reader's place. The staged replay is the fix, and these are its rules.
+// A replay used to clear the ops and re-add them a microtask later, so a keyless
+// `v-for` rebuilt the strip and lost the reader's place. These are the staged replay's rules.
 describe("staged replay", () => {
 	it("never renders the middle of a replay", async () => {
 		const surface = new Surface();

--- a/frontend/src/recordPage/tests/tabActivation.test.ts
+++ b/frontend/src/recordPage/tests/tabActivation.test.ts
@@ -36,7 +36,7 @@ const LAYOUT: FormLayoutSchema = [
   },
 ];
 
-/** The host's two halves of activation, recorded rather than performed. */
+/** The host's two halves of activation, recorded, not performed. */
 function makeHost(overrides: Partial<RecordPageHost> = {}) {
   const moved: string[] = [];
   const movedInForm: string[] = [];

--- a/frontend/src/recordPage/tests/tabActivation.test.ts
+++ b/frontend/src/recordPage/tests/tabActivation.test.ts
@@ -1,6 +1,5 @@
-// `activate` on both tab strips (wayfinder ticket 75) as executable claims: a
-// verb rather than a writable `active`, three ways to miss, a name resolved at
-// the moment of the call, and a replay's move delivered when the strip settles.
+// `activate` on both tab strips as executable claims: three ways to miss, a name
+// resolved at the call, and a replay's move delivered when the strip settles.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ref } from "vue";
 
@@ -37,11 +36,7 @@ const LAYOUT: FormLayoutSchema = [
   },
 ];
 
-/**
- * The host's two halves of activation, recorded rather than performed: where
- * the reader is *kept* is the host's business, and the engine's claim is only
- * about what it hands over and when.
- */
+/** The host's two halves of activation, recorded rather than performed. */
 function makeHost(overrides: Partial<RecordPageHost> = {}) {
   const moved: string[] = [];
   const movedInForm: string[] = [];
@@ -113,10 +108,8 @@ describe("moving the reader", () => {
   });
 
   it("resolves during load against the strip the host has, not the one it draws", () => {
-    // The gap the pre-ready window opens: the host renders nothing until the
-    // first replay commits, while the surface already holds the built-ins. The
-    // strip a name resolves against is the surface's, so an activation before
-    // `ready` lands — and the reader arrives on it when the strip paints.
+    // The host renders nothing until the first replay commits, while the surface
+    // already holds the built-ins, so an activation before `ready` lands.
     const { controller, page, moved } = makePage();
 
     expect(controller.ready.value).toBe(false);
@@ -184,9 +177,8 @@ describe("the three ways to miss", () => {
   });
 
   it("says nothing about the form's strip while its layout is still loading", () => {
-    // "The administrator never authored this" and "it has not arrived yet" are
-    // the same answer in that window, and `hide`/`show`/`update` already keep
-    // quiet in it. The move is dropped, not queued.
+    // "Never authored" and "not arrived yet" are the same answer in that window;
+    // the move is dropped, not queued.
     const { page, movedInForm } = makePage({ formLayout: () => [] });
 
     page.formTabs.activate("lead_details");
@@ -215,9 +207,8 @@ describe("the three ways to miss", () => {
 
 describe("why this is a verb and not a writable `active`", () => {
   it("leaves `active` reading the tab the reader is really on", () => {
-    // The round trip an assignment could not survive: `active` is derived from
-    // what the strip can show, so `page.tabs.active = 'nope'` would read back
-    // as something the script never wrote. A verb can say so instead.
+    // `active` is derived from what the strip can show, so an assignment naming
+    // a missing tab would read back as something the script never wrote.
     const { page } = makePage();
 
     page.tabs.activate("nope");
@@ -229,9 +220,8 @@ describe("why this is a verb and not a writable `active`", () => {
 
 describe("a replay's activation", () => {
   it("is delivered once the strip has settled, not from the middle", async () => {
-    // The name resolves against the staged strip — the script can see its own
-    // work — but the reader is moved only after the commit, since until then
-    // the host is still rendering the strip the tab is not on yet.
+    // The name resolves against the staged strip, but the reader is moved only
+    // after the commit: until then the host renders the strip the tab is not on yet.
     const seen: boolean[] = [];
     registerRecordPage("CRM Deal", {
       onRefresh: (page) => {
@@ -282,10 +272,8 @@ describe("a replay's activation", () => {
   });
 
   it("is dropped when a later source takes the tab off the strip", async () => {
-    // The held move is re-read against the strip that settled, not delivered on
-    // the strength of the strip it was decided against — otherwise the reader
-    // lands on `?tab=emails` with no `emails` to resolve it, which is the
-    // fallback-tab dumping a miss exists to prevent.
+    // The held move is re-read against the strip that settled: otherwise the
+    // reader lands on `?tab=emails` with no `emails` to resolve it.
     registerRecordPage("CRM Deal", {
       onRefresh: (page) => {
         page.tabs.activate("emails");

--- a/frontend/src/recordPage/types.ts
+++ b/frontend/src/recordPage/types.ts
@@ -21,32 +21,13 @@ export interface QuickAction extends SurfaceItem {
 }
 
 /**
- * An action in the record's header. `display` picks how it renders: a top-level
- * button of its own, a top-level dropdown button of its own, a titled section,
- * or — omitted, the default — an ordinary entry.
- *
- * A `dropdown` and a `section` are **containers**: ordinary addressable items
- * that carry the label and the icon, differing only in when their members are
- * visible — a dropdown hides them behind a trigger, a section shows them under
- * a grey title. Either way the members point at the container with `group`, and
- * a container that points at another container renders inside it.
- *
- * The list a script writes stays flat, so every item is reachable by its one
- * name; only the rendering nests, and only two containers deep.
- *
- * How many top-level controls fit is the host's business and a script cannot
- * observe it: one that does not fit is demoted into `⋯`, which is `add`'s
- * promise — that the item is *reachable* — being kept.
+ * An action in the record's header. A `dropdown` or a `section` is a container:
+ * its members point at it with `group`, and containers nest two deep.
  */
 export interface HeaderAction extends SurfaceItem {
   label: string;
   display?: "button" | "dropdown" | "section";
-  /**
-   * Put me inside the item named this. If an item of that name is declared, you
-   * get what it declares; if nothing of that name exists, the engine
-   * synthesises an anonymous, untitled container — the adjacency band inside
-   * `⋯` that an omitted `group` (meaning `actions`) has always given.
-   */
+  /** The container this sits in; an undeclared name gets an anonymous one inside `⋯`. */
   group?: string;
   run?: (page: RecordPageApi) => any;
 }
@@ -86,19 +67,8 @@ export interface SurfaceVerbs<Item extends SurfaceItem = SurfaceItem> {
 export interface TabsApi extends SurfaceVerbs<TabItem> {
   readonly active: string;
   /**
-   * Move the reader to a tab on *this* strip. A verb rather than a writable
-   * `active` because `active` is derived from what the strip can currently show:
-   * an assignment naming a hidden or unknown tab would read back as something
-   * the script never wrote, where a verb can say so. Hidden, unknown, or on the
-   * other strip all warn in a development build and do nothing — activation
-   * does not reveal a hidden tab, since `show()` is that verb already.
-   *
-   * The name resolves against the strip as it stands at the moment of the call;
-   * an activation fired before its tab is added misses, and is not queued.
-   *
-   * A *hit* is not synchronous either: the reader arrives by way of the host's
-   * own navigation, so `active` still reads the old tab on the line after the
-   * call. Read it in the next handler, not this one.
+   * Moves the reader to a tab on this strip. Resolved at the call, never queued,
+   * and `active` still reads the old tab on the next line: read it in the next handler.
    */
   activate(name: string): void;
 }
@@ -122,22 +92,15 @@ export interface PageDialogField {
   mandatory_depends_on?: string;
   read_only_depends_on?: string;
   description?: string;
-  /** Closed on purpose: `page.fields`' patch vocabulary is enumerated too, so
-   *  the two script-facing field types agree on what a script may write. */
+  /** Closed on purpose: it agrees with `PageFieldPatch` on what a script may write. */
 }
 
 /**
- * What a script may override on one of the record's fields — v1's
- * `setFieldProperty` vocabulary, enumerated and spelled as a DocField spells it
- * (`PageDialogField`'s precedent: an author reads DocType Customize and writes
- * what they read there). Closed, like every other curated forward: a key not
- * named here is dropped with a dev-mode warning.
- *
- * v1's `button_color` is absent — no renderer here honours it.
+ * What a script may override on one of the record's fields, spelled as a
+ * DocField spells it. Closed: a key not named here is dropped with a dev warning.
  */
 export interface PageFieldPatch {
-  // `0 | 1` alongside the boolean, as `PageDialogField` has it: a DocField
-  // spells these as ints, and `page.meta`'s own refusal advises `{ hidden: 1 }`.
+  // `0 | 1` alongside the boolean: a DocField spells these as ints.
   hidden?: boolean | 0 | 1;
   read_only?: boolean | 0 | 1;
   reqd?: boolean | 0 | 1;
@@ -156,12 +119,7 @@ export interface PageFieldPatch {
   props?: Record<string, any>;
 }
 
-/**
- * What `get` hands back: the same keys `update` writes, resolved as the renderer
- * resolves them, plus the two that identify the field. Deliberately the *same*
- * vocabulary rather than the internal `FieldMeta` — v1's `getField` cannot read
- * back what its own setter wrote, and that asymmetry is the bug this avoids.
- */
+/** What `get` hands back: the keys `update` writes, resolved, plus the two that identify the field. */
 export interface PageField extends PageFieldPatch {
   fieldname: string;
   fieldtype: string;
@@ -172,19 +130,8 @@ export interface PageField extends PageFieldPatch {
 }
 
 /**
- * The fields surface: a script overriding the properties of fields authored
- * elsewhere. It speaks a strict subset of the surface verbs — there is no `add`,
- * `move` or `order`, because a script that adds a field is inventing a docfield
- * and ordering is the Form Layout's job.
- *
- * Overrides are a render-time overlay: never written into the layout, the Form
- * Layout row, or the doctype meta, and cleared by the ordinary replay before
- * every re-fire — so a conditional override is a plain `if` with no `else`.
- *
- * Two floors an override cannot cross: a permlevel denial (a `show()` on a
- * denied field is a no-op with a dev warning), and a hidden `panelSection`,
- * which is a container above its fields. Between an override and `depends_on`,
- * the override wins.
+ * The fields surface: a render-time overlay on fields authored elsewhere, cleared
+ * before every replay. No `add`, `move` or `order`; ordering is the Form Layout's job.
  */
 export interface PageFields {
   hide(fieldname: string): void;
@@ -212,21 +159,8 @@ export interface PageFormTab {
 }
 
 /**
- * The Form Layout tabs surface: the strip *inside* the record's Details form,
- * which `page.tabs` has never reached — that one is the record's own strip, and
- * it stays what `page.tabs` means. Reaches the Details form and no other place
- * `FormLayout` renders (a `page.dialog` form's tabs are the script's own).
- *
- * A strict subset of the surface verbs, on the clause that already governs
- * `page.fields`: these tabs are authored in a doctype an administrator edits, so
- * a script overrides their properties and there is no `add`, `move` or `order`
- * to mean anything.
- *
- * A tab is addressed by its **identity** (`name` if the author wrote one, else
- * the label slugified, else its position), never by its position, and never by
- * its label — a relabelled tab keeps its address. Between an override and
- * `depends_on` the override wins, in both directions: `show()` lifts a tab the
- * expression hides.
+ * The Form Layout's own tab strip, inside the Details form. A tab is addressed
+ * by its identity (`name`, else the slugified label, else its position), never by label.
  */
 export interface PageFormTabs {
   hide(identity: string): void;
@@ -236,47 +170,18 @@ export interface PageFormTabs {
   has(identity: string): boolean;
   /** The tab as it currently resolves — post-override, post-`depends_on`. */
   get(identity: string): PageFormTab | null;
-  /**
-   * The identity of the tab the reader is on, or `''` when they are not in the
-   * form at all. Deliberately asymmetric with `page.tabs.active`, which returns
-   * a **name**: the record strip's tabs are named by their author, while a Form
-   * Layout tab's address is a resolved identity.
-   */
+  /** The identity of the tab the reader is on, or `''` outside the form; not a name. */
   readonly active: string;
-  /**
-   * Move the reader to a tab of the form, on `TabsApi.activate`'s terms and
-   * missing in the same three ways. What it writes is the reader's *intent*,
-   * which is what this strip has always run on — so activating while the reader
-   * is elsewhere on the record is not a queued activation but an answer to a
-   * question the form will ask when it mounts: the identity resolves now, and
-   * that is where they arrive.
-   */
+  /** Moves the reader to a tab of the form, on `TabsApi.activate`'s terms. */
   activate(identity: string): void;
 }
 
 /**
- * A child row, as a script addresses it (ticket 43): an object holding
- * `(parentfield, key)` that **re-finds its row on every access**, so nothing
- * about a row's position is ever captured. Fields are read and written bare —
- * `row.amount = row.qty * row.rate`, character for character what a v1 script
- * writes — and a write through it is identical in effect to writing
- * `page.doc.products[2].amount`: the handle is an address, not a write channel,
- * and per ticket 44 neither fires anything.
- *
- * Reading or writing a row that has been removed **throws**, naming the path and
- * aborting the handler. v1 loses those writes silently.
+ * A child row as a script addresses it: re-finds its row on every access, with
+ * fields read and written bare. Access to a removed row throws.
  */
 export interface PageRow {
-  /**
-   * Fires this row's handler for one child field — `row.trigger('rate')`
-   * dispatches `'products.rate'` — across every registered source, and resolves
-   * when they have all run. The fieldname is bare: the handle knows its table.
-   *
-   * The one engine member on a row. It shares a namespace with the child
-   * doctype's fieldnames, and a child field literally named `trigger` is legal
-   * (Frappe reserves five names, and this is not one), so the collision is
-   * warned about once at load rather than defended against on every access.
-   */
+  /** Fires this row's handler for one child field: `row.trigger('rate')` dispatches `'products.rate'`. */
   trigger(fieldname: string): Promise<void>;
   [fieldname: string]: any;
 }
@@ -360,11 +265,7 @@ export interface PageDialogOpenOptions {
   dismissible?: boolean;
 }
 
-/**
- * What a `confirm`/`danger` callback receives: the engine's own object, not
- * frappe-ui's `DialogControl`. A rename underneath must not change what a stored
- * script does on an upgrade nobody reviewed.
- */
+/** What a `confirm`/`danger` callback receives: the engine's own object, not frappe-ui's. */
 export interface PageDialogControl {
   /** Closes the dialog; the verb's promise settles from the verb, as ever. */
   close(): void;
@@ -404,12 +305,7 @@ export type PageDialogDangerOptions = Omit<
   "theme" | "icon"
 >;
 
-/**
- * The dialog capability. Every verb resolves `null` when the reader dismissed
- * the dialog — by Esc, the backdrop, the close button, or by navigating off the
- * record — so `if (!result) return` is the idiom. Un-awaited promises are
- * ignored: fire-and-forget stays legal.
- */
+/** The dialog capability. Every verb resolves `null` on dismissal, so `if (!result) return` is the idiom. */
 export interface PageDialog {
   /** Renders `component` in a dialog, passing it a `close(result)` prop. */
   open(
@@ -430,18 +326,10 @@ export interface RecordPageApi {
   doctype: string;
   docname: string;
   doc: Record<string, any>;
-  /**
-   * The document as the server last showed it — the v2 answer to "what was the
-   * previous value": `page.saved.status !== page.doc.status`. Defined on the
-   * first paint, readable in any handler, and read-only (`page.doc` is the
-   * draft you edit).
-   */
+  /** The document as the server last showed it; read-only, `page.doc` is the draft. */
   saved: Record<string, any>;
   meta: Record<string, any> | null;
-  /**
-   * Every right frappe would check for this doctype — the 15 standard ones plus
-   * any `Permission Type` registered against it — valued `0` or `1`.
-   */
+  /** Every right frappe would check for this doctype, valued `0` or `1`. */
   perms: Record<string, any>;
   /** The session user's roles, resolved before any handler runs. */
   roles: string[];
@@ -455,11 +343,7 @@ export interface RecordPageApi {
   fields: PageFields;
   /** The Form Layout's own tab strip, inside the Details form. */
   formTabs: PageFormTabs;
-  /**
-   * The child table's rows as handles, in array order. Not a surface — there is
-   * nothing here to arrange or override; it is how a row is *addressed*. A
-   * fieldname that is not a child table dev-warns and answers empty.
-   */
+  /** The child table's rows as handles, in array order; a non-table fieldname answers empty. */
   rows(parentfield: string): PageRow[];
   save(): Promise<void>;
   reload(): Promise<void>;
@@ -473,33 +357,16 @@ export interface RecordPageApi {
 export type { FieldAccess };
 
 /**
- * A handler's arguments are determined by its key (tickets 45 §3, 54). A
- * top-level key — an event or a parent fieldname — receives `(page)`. One
- * nested under a child table receives the row it happened to:
- *
- * ```js
- * products: { onAdd(page, row) {}, qty(page, row) {} }
- * ```
- *
- * `onRemove` is the exception, and gets `(page)` alone: its row is gone.
- *
- * The row is an address, not a payload: it carries no event data, and the same
- * handle is obtainable from `page.rows()` in any handler at all. That is why
- * ticket 14's rule against invisible arguments survives — the key announces it.
+ * A top-level key receives `(page)`; one nested under a child table receives
+ * `(page, row)`, except `onRemove`, whose row is gone.
  */
 export type Handler = (page: RecordPageApi, row?: PageRow) => any;
 
-/**
- * What an author writes: named event handlers, plus — for a child table — a
- * block of them nested under the table's fieldname (ticket 54).
- */
+/** What an author writes: event handlers, plus a block nested under a child table's fieldname. */
 export type AuthoredHandlers = Record<
   string,
   Handler | Record<string, Handler>
 >;
 
-/**
- * What the engine dispatches against: one flat keyspace, a nested block having
- * been flattened onto dotted keys at registration.
- */
+/** What the engine dispatches against: nested blocks flattened onto dotted keys. */
 export type RecordPageHandlers = Record<string, Handler>;


### PR DESCRIPTION
Brings `frontend/src/recordPage/` under the comment rule in the root `AGENTS.md`. Comment-only: `.github/helper/comment_equivalence.py upstream/desk-v2 HEAD` reports every changed file comment-only, and `frontend`'s vitest run is green (26 files, 442 tests).

Wayfinder ticket: #42415, on map #42413.

**Numbers.** 36 files, 1,451 comment lines in 6,906 → 714 in 6,169 (21% → 11%). 68 ticket citations and 139 "rather than" arguments in the folder → 0. Densest files:

| File | Before | After |
| --- | --- | --- |
| `types.ts` | 230 / 470 (48%) | 97 / 337 (28%) |
| `createRecordPage.ts` | 192 / 558 (34%) | 73 / 439 (16%) |
| `headerRenderings.ts` | 130 / 430 (30%) | 56 / 356 (15%) |
| `fields.ts` | 102 / 273 (37%) | 43 / 214 (20%) |
| `rows.ts` | 95 / 273 (34%) | 38 / 216 (17%) |
| `readOnly.ts` | 76 / 149 (51%) | 23 / 96 (23%) |

**What survives** is the one-line file note and the constraints a reader would otherwise undo: the freeze-vs-proxy reactivity trap in `readOnly.ts`, the Proxy invariant on non-configurable properties, the `__proto__` hazard behind folding patches in a `Map`, the null-prototype handler map, the `hasOwn` probe on `page.perms`, why the row handle's Proxy target is an empty object, why held activations are delivered on commit, and so on. Every ticket-number citation is gone; the reasoning lives in the wayfinder tickets, which is where the map put it.

**`frontend/CLAUDE.md`** no longer says the record-page factory "says in a comment" not to delete the `router` hand-through. The bullet now states the constraint itself, and the code carries one line pointing at it.

**Not done here**, per the ticket: the directory is still 20 files (36 with `tests/`) and `createRecordPage.ts` is still 439 lines. With the comments gone the shape is visible: the tab-activation half of `createRecordPage.ts` (`activate`/`canReach`/`move`/`releaseActivations`/`warnActivate`) is one module, and the `warnOnce`/`reset*Warnings` triplet is copied into four files. That is the map's out-of-scope shape work, noted for whoever picks it up.
