### PR TITLE
chore(desk-v2): shell, router and contribution seam comments under the rule

### DIFF
--- a/.github/helper/comment_equivalence.py
+++ b/.github/helper/comment_equivalence.py
@@ -108,9 +108,9 @@ class CurlySource:
 		return "".join(self.output).split("\n"), self.protected
 
 	def quotes(self):
-		"""An apostrophe in template text is not a string; only `"` delimits one there."""
+		"""In template text an apostrophe is not a string; `'` delimits one only as an attribute value."""
 		if self.template and self.template[0] <= self.position < self.template[1]:
-			return '"'
+			return "\"'" if self.source.endswith("=", 0, self.position) else '"'
 		return JS_STRING_QUOTES
 
 	def starts(self, text):
@@ -182,6 +182,13 @@ SELF_TEST_CASES = [
 		"x.vue",
 		"<template>\n\t<p>the app's home</p>\n\t<!-- a -->\n</template>\n<script>\nconst a = 1 // t\n</script>\n",
 		"<template>\n\t<p>the app's home</p>\n</template>\n<script>\nconst a = 1\n</script>\n",
+	),
+	(
+		"vue single-quoted attribute",
+		False,
+		"x.vue",
+		"<template>\n\t<a href='https://a.example/x'>the app's home</a>\n</template>\n",
+		"<template>\n\t<a href='https://b.example/x'>the app's home</a>\n</template>\n",
 	),
 	(
 		"vue template comment only",

--- a/.github/helper/comment_equivalence.py
+++ b/.github/helper/comment_equivalence.py
@@ -110,7 +110,7 @@ class CurlySource:
 	def quotes(self):
 		"""In template text an apostrophe is not a string; `'` delimits one only as an attribute value."""
 		if self.template and self.template[0] <= self.position < self.template[1]:
-			return "\"'" if self.source.endswith("=", 0, self.position) else '"'
+			return "\"'" if self.source[: self.position].rstrip().endswith("=") else '"'
 		return JS_STRING_QUOTES
 
 	def starts(self, text):
@@ -189,6 +189,13 @@ SELF_TEST_CASES = [
 		"x.vue",
 		"<template>\n\t<a href='https://a.example/x'>the app's home</a>\n</template>\n",
 		"<template>\n\t<a href='https://b.example/x'>the app's home</a>\n</template>\n",
+	),
+	(
+		"vue single-quoted attribute with spaces around =",
+		False,
+		"x.vue",
+		"<template>\n\t<a href = 'https://a.example/x'>the app's home</a>\n</template>\n",
+		"<template>\n\t<a href = 'https://b.example/x'>the app's home</a>\n</template>\n",
 	),
 	(
 		"vue template comment only",

--- a/.github/helper/comment_equivalence.py
+++ b/.github/helper/comment_equivalence.py
@@ -38,7 +38,7 @@ def read(ref, path):
 
 
 def strip(path, source):
-	lines, protected = strip_python(source) if path.endswith(".py") else strip_curly(source)
+	lines, protected = strip_python(source) if path.endswith(".py") else strip_curly(source, path)
 	return "\n".join(normalised(lines, protected))
 
 
@@ -68,15 +68,23 @@ def strip_python(source):
 	return lines, protected
 
 
-def strip_curly(source):
-	return CurlySource(source).without_comments()
+def strip_curly(source, path=""):
+	return CurlySource(source, template_span(source) if path.endswith(".vue") else None).without_comments()
+
+
+def template_span(source):
+	"""The outer `<template>` block of a Vue file, where only `"` delimits a string."""
+	start = source.find("<template")
+	end = source.rfind("</template>")
+	return (start, end) if 0 <= start < end else None
 
 
 class CurlySource:
 	"""Comment removal for JS, TS and Vue templates, aware of strings, template literals and regexes."""
 
-	def __init__(self, source):
+	def __init__(self, source, template=None):
 		self.source = source
+		self.template = template
 		self.position = 0
 		self.line = 0
 		self.output = []
@@ -85,7 +93,7 @@ class CurlySource:
 	def without_comments(self):
 		while self.position < len(self.source):
 			character = self.source[self.position]
-			if character in JS_STRING_QUOTES:
+			if character in self.quotes():
 				self.copy_string(character)
 			elif self.starts("//"):
 				self.skip_to("\n")
@@ -98,6 +106,12 @@ class CurlySource:
 			else:
 				self.emit(character)
 		return "".join(self.output).split("\n"), self.protected
+
+	def quotes(self):
+		"""An apostrophe in template text is not a string; only `"` delimits one there."""
+		if self.template and self.template[0] <= self.position < self.template[1]:
+			return '"'
+		return JS_STRING_QUOTES
 
 	def starts(self, text):
 		return self.source.startswith(text, self.position)
@@ -162,6 +176,13 @@ SELF_TEST_CASES = [
 		"const a = 1\nconst b = 2\n",
 	),
 	("js code change", False, "x.ts", "const b = 2\n", "const b = 3\n"),
+	(
+		"vue apostrophe in template text",
+		True,
+		"x.vue",
+		"<template>\n\t<p>the app's home</p>\n\t<!-- a -->\n</template>\n<script>\nconst a = 1 // t\n</script>\n",
+		"<template>\n\t<p>the app's home</p>\n</template>\n<script>\nconst a = 1\n</script>\n",
+	),
 	(
 		"vue template comment only",
 		True,

--- a/.github/helper/comment_equivalence.py
+++ b/.github/helper/comment_equivalence.py
@@ -73,7 +73,7 @@ def strip_curly(source):
 
 
 class CurlySource:
-	"""Comment removal for JS, TS and Vue, aware of strings, template literals and regexes."""
+	"""Comment removal for JS, TS and Vue templates, aware of strings, template literals and regexes."""
 
 	def __init__(self, source):
 		self.source = source
@@ -91,6 +91,8 @@ class CurlySource:
 				self.skip_to("\n")
 			elif self.starts("/*"):
 				self.skip_past("*/")
+			elif self.starts("<!--"):
+				self.skip_past("-->")
 			elif character == "/" and self.regex_may_start():
 				self.copy_regex()
 			else:
@@ -160,6 +162,13 @@ SELF_TEST_CASES = [
 		"const a = 1\nconst b = 2\n",
 	),
 	("js code change", False, "x.ts", "const b = 2\n", "const b = 3\n"),
+	(
+		"vue template comment only",
+		True,
+		"x.vue",
+		"<template>\n\t<!-- a\n\t\tb -->\n\t<p>x</p>\n</template>\n",
+		"<template>\n\t<!-- c -->\n\t<p>x</p>\n</template>\n",
+	),
 	("js trailing space outside a string", True, "x.ts", "const a = 1\n", "const a = 1   \n"),
 	(
 		"js blank line in a template literal",

--- a/.github/helper/comment_equivalence.py
+++ b/.github/helper/comment_equivalence.py
@@ -110,8 +110,12 @@ class CurlySource:
 	def quotes(self):
 		"""In template text an apostrophe is not a string; `'` delimits one only as an attribute value."""
 		if self.template and self.template[0] <= self.position < self.template[1]:
-			return "\"'" if self.source[: self.position].rstrip().endswith("=") else '"'
+			return "\"'" if self.in_attribute_value() else '"'
 		return JS_STRING_QUOTES
+
+	def in_attribute_value(self):
+		before = self.source[: self.position]
+		return before.rstrip().endswith("=") and before.rfind("<") > before.rfind(">")
 
 	def starts(self, text):
 		return self.source.startswith(text, self.position)
@@ -196,6 +200,13 @@ SELF_TEST_CASES = [
 		"x.vue",
 		"<template>\n\t<a href = 'https://a.example/x'>the app's home</a>\n</template>\n",
 		"<template>\n\t<a href = 'https://b.example/x'>the app's home</a>\n</template>\n",
+	),
+	(
+		"vue apostrophe after = in template text",
+		True,
+		"x.vue",
+		"<template>\n\t<p>a = '<!-- note -->'</p>\n</template>\n",
+		"<template>\n\t<p>a = '<!-- changed -->'</p>\n</template>\n",
 	),
 	(
 		"vue template comment only",

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -113,7 +113,7 @@ returns **200, never 404** — a 404 loses the asset preloads.
 - **`@/` → `frontend/src`.** That is the *only* alias, in both `vite.config.js` and
   `tsconfig.json`.
 - **`@framework/ui` is not an alias** — it is a real dependency, `link:../ui`. Aliasing it
-  was rejected on purpose (`frontend/vite.config.js:63-67`): aliasing a package to a
+  was rejected on purpose (`frontend/vite.config.js`): aliasing a package to a
   directory bypasses its `exports` map and breaks every subpath import. `resolve.dedupe`
   was rejected for the same class of reason — it silently picks a winner. Singleton
   identity is established earlier, by `enforce_singletons`, which is what
@@ -157,8 +157,8 @@ fall out of the path. Enumerated in both languages, in `frappe/shell/manifest.py
   Ownership is structural, derived from which folder the file is in, with no registry
   lookup.
 
-`frontend/src/contributions/registry.ts` is the seam. Its own comment says it is
-deliberately tiny and that its size is the argument — keep it that way (`DP2`).
+`frontend/src/contributions/registry.ts` is the seam: an index over a generated module,
+deliberately tiny, and its size is the argument. Keep it that way (`DP2`).
 
 ## Things that look wrong and are deliberate
 
@@ -167,7 +167,7 @@ Do not "fix" these:
 - **`frontend/index.html` has no boot island**, no `__FRONTEND_ROUTE__`, no
   `__SOCKETIO_PORT__` and no import map. It is supposed to look under-populated.
 - **`frappeui()` is called with `jinjaBootData: false` and `buildConfig: false`, and no
-  `frontendRoute`** (`vite.config.js:43-48`). Turning any of them back on is a regression.
+  `frontendRoute`** (`vite.config.js`). Turning any of them back on is a regression.
 - **The router cannot be a module-scope singleton** — boot must resolve first, because the
   router's base comes from boot (`main.ts`). Contributions register before the router's
   first resolution.

--- a/frontend/PHILOSOPHY.md
+++ b/frontend/PHILOSOPHY.md
@@ -115,9 +115,9 @@ that was never designed to be extended — and the result is a tier apps route *
 rather than through. An optional customization API is one that rots, because the
 framework's own pressure never lands on it.
 
-The tell that this is holding: `frontend/src/contributions/registry.ts` is tiny, and its
-size is the argument. Its own comment says so. The tell that it is slipping is a growing
-list of things the framework can do that a contribution cannot name.
+The tell that this is holding: `frontend/src/contributions/registry.ts` is tiny, an index
+over a module generated at build time, and its size is the argument. The tell that it is
+slipping is a growing list of things the framework can do that a contribution cannot name.
 
 ---
 

--- a/frontend/plugin/contributions.js
+++ b/frontend/plugin/contributions.js
@@ -36,8 +36,8 @@ function isFile(path) {
 }
 
 /**
-  * `crm_deal` -> `CRM Deal`, read from the doctype's own JSON: title-casing the folder
-  * yields "Crm Deal".
+ * `crm_deal` -> `CRM Deal`, read from the doctype's own JSON: title-casing the folder
+ * yields "Crm Deal".
  */
 function buildDoctypeNames(sourceDirs) {
 	const names = new Map();

--- a/frontend/plugin/contributions.js
+++ b/frontend/plugin/contributions.js
@@ -1,13 +1,5 @@
-// The vite plugin that synthesises `virtual:frappe/contributions`.
-//
-// Why synthesise rather than glob: `import.meta.glob` needs a static literal pattern
-// and would sweep every app on the bench, installed or not -- and a raw glob loses
-// the app name, which is the one attribution the whole contract needs (#42068). The
-// Python manifest supplies both: which apps are in the bundle, and what each is
-// called.
-//
-// App, module, doctype and kind all fall out of the PATH. Nothing is parsed out of
-// file contents, so a file that fails to import cannot break discovery.
+// Synthesises `virtual:frappe/contributions` from the Python manifest, since a raw glob would
+// sweep every app on the bench and lose the app name. Everything falls out of the path.
 
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { basename, join } from "node:path";
@@ -44,12 +36,8 @@ function isFile(path) {
 }
 
 /**
- * `crm_deal` -> `CRM Deal`.
- *
- * Title-casing the folder cannot do this -- it yields "Crm Deal", and acronyms are
- * common in doctype names. The real name is on disk in the doctype's own JSON, which
- * is readable at build time with no site, so the index is built from the definitions
- * rather than guessed from the folder.
+  * `crm_deal` -> `CRM Deal`, read from the doctype's own JSON: title-casing the folder
+  * yields "Crm Deal".
  */
 function buildDoctypeNames(sourceDirs) {
 	const names = new Map();
@@ -64,8 +52,7 @@ function buildDoctypeNames(sourceDirs) {
 					const { name } = JSON.parse(readFileSync(definition, "utf-8"));
 					if (name) names.set(scrubbed, name);
 				} catch {
-					// A malformed definition is the doctype loader's problem to report, not
-					// the bundler's. Fall back to the folder.
+					// A malformed definition is the doctype loader's to report. Fall back to the folder.
 				}
 			}
 		}
@@ -86,10 +73,8 @@ export function discover(manifest, allSourceDirs = manifest.map((entry) => entry
 	const pages = [];
 	const itemTypes = [];
 	const warnings = [];
-	// Every app on the bench, not just the ones in the manifest. A `custom/` folder can
-	// name a FOREIGN doctype owned by an app that contributes nothing itself -- and
-	// title-casing the folder would then answer "Hd Ticket" where the registry says
-	// "HD Ticket", so the contribution would bundle, register and silently never run.
+	// Every app on the bench, not just the manifest: a `custom/` folder can name a doctype
+	// owned by an app that contributes nothing.
 	const names = buildDoctypeNames(allSourceDirs);
 	const unscrub = (scrubbed) => names.get(scrubbed) ?? titleCase(scrubbed);
 
@@ -97,7 +82,7 @@ export function discover(manifest, allSourceDirs = manifest.map((entry) => entry
 		for (const module of directories(source_dir)) {
 			const modulePath = join(source_dir, module);
 
-			// 1 & 2. Your own doctype: <module>/doctype/<scrubbed>/frontend/{record,list}.js
+			// Your own doctype: <module>/doctype/<scrubbed>/frontend/{record,list}.js
 			const doctypeRoot = join(modulePath, "doctype");
 			for (const scrubbed of directories(doctypeRoot)) {
 				for (const kind of ["record", "list"]) {
@@ -107,9 +92,7 @@ export function discover(manifest, allSourceDirs = manifest.map((entry) => entry
 				}
 			}
 
-			// 3. A foreign doctype: <module>/custom/<scrubbed>/record.js
-			//    Same shape as your own; only the folder differs, mirroring the split
-			//    frappe already makes for schema customizations (`custom/contact.json`).
+			// A foreign doctype: <module>/custom/<scrubbed>/record.js
 			const customRoot = join(modulePath, "custom");
 			for (const scrubbed of directories(customRoot)) {
 				const file = join(customRoot, scrubbed, "record.js");
@@ -117,26 +100,15 @@ export function discover(manifest, allSourceDirs = manifest.map((entry) => entry
 					doctypes.push({ kind: "custom", app, doctype: unscrub(scrubbed), file });
 			}
 
-			// 4. A genuinely new page: <module>/frontend/pages/<slug>.js
-			//    The `frontend/` segment is load-bearing: `<module>/page/` is already desk
-			//    v1's Page doctype and `templates/pages/` is already website templates, so
-			//    a bare `<module>/pages/` would sit one character from a different meaning
-			//    (#42072).
+			// A new page: <module>/frontend/pages/<slug>.js. The `frontend/` segment is load-bearing:
+			// `<module>/page/` is desk v1's Page doctype and `templates/pages/` is website templates.
 			const pagesRoot = join(modulePath, "frontend", "pages");
 			for (const file of files(pagesRoot)) {
 				pages.push({ app, slug: basename(file, ".js"), file: join(pagesRoot, file) });
 			}
 
-			// 5. An item kind for the rail and the sidebar:
-			//    <module>/navigation_item_type/<scrubbed>/frontend/item.js
-			//
-			//    Colocated with the type RECORD, in the record's own folder, which is the
-			//    doctype pattern rather than the page one. The reason is the same reason
-			//    `buildDoctypeNames` exists: the type's real name has to come off the JSON
-			//    beside it, never from title-casing the folder. `doctype` title-cases to
-			//    "Doctype", and the framework's own first kind is called `DocType` — so the
-			//    guessed form is wrong on the very first row, and a renderer registered
-			//    under a name no item carries never runs and says nothing.
+			// An item kind: <module>/navigation_item_type/<scrubbed>/frontend/item.js. Its name comes
+			// off the JSON beside it: `doctype` title-cases to "Doctype" and the kind is `DocType`.
 			const typeRoot = join(modulePath, "navigation_item_type");
 			for (const scrubbed of directories(typeRoot)) {
 				const file = join(typeRoot, scrubbed, "frontend", "item.js");
@@ -145,9 +117,7 @@ export function discover(manifest, allSourceDirs = manifest.map((entry) => entry
 				const definition = join(typeRoot, scrubbed, `${scrubbed}.json`);
 				const name = recordName(definition);
 				if (!name) {
-					// A renderer with no type record beside it names nothing. Guessing would
-					// register it under a string no item can carry, which is a contribution that
-					// silently never runs -- the failure the whole file is arranged to avoid.
+					// A guessed name would register the renderer under a string no item carries.
 					warnings.push(
 						`[frappe] ${file} has no ${scrubbed}.json beside it; the item type it renders cannot be named, so it is ignored.`
 					);
@@ -168,8 +138,7 @@ function recordName(definition) {
 	try {
 		return JSON.parse(readFileSync(definition, "utf-8")).name ?? null;
 	} catch {
-		// A malformed record is `import_file`'s problem to report at migrate, not the
-		// bundler's. It is still not a name, so the renderer is dropped either way.
+		// A malformed record is `import_file`'s to report at migrate; it is still not a name.
 		return null;
 	}
 }
@@ -206,10 +175,8 @@ function generate({ doctypes, pages, itemTypes, warnings }) {
 				`handlers: d${index}, __file: ${JSON.stringify(entry.file)} },`
 		);
 	});
-	// Entries with no usable default export are dropped with a warning naming the file,
-	// NOT allowed to throw: this module is imported by main.ts before anything renders,
-	// so one app's typo would otherwise fail the mount for every prefix on the bench.
-	// Same degrade-don't-fail asymmetry `app_boot` chose on the Python side.
+	// Dropped with a warning, never a throw: `main.ts` imports this before anything renders,
+	// so one app's typo must not fail the mount bench-wide.
 	lines.push("  ].filter(usable),");
 
 	lines.push("  pages: [");
@@ -222,10 +189,7 @@ function generate({ doctypes, pages, itemTypes, warnings }) {
 	});
 	lines.push("  ].filter(usable),");
 
-	// The renderer for one item kind. `handlers` is the same key the other two carry, so
-	// the `usable` filter that drops a file with no default export covers this one too --
-	// and it has to, because `registerContributions` indexes these by type NAME and an
-	// undefined entry would take a whole kind of item off the rail with no line said.
+	// `handlers` is the same key the other two carry, so `usable` covers item types too.
 	lines.push("  itemTypes: [");
 	itemTypes.forEach((entry, index) => {
 		lines.push(
@@ -239,10 +203,7 @@ function generate({ doctypes, pages, itemTypes, warnings }) {
 
 	lines.push("}");
 
-	// Discovery's own complaints, replayed in the browser rather than at build time: a
-	// `vite build` scrolls past and nobody reads it, while this reaches the console of the
-	// person whose kind is not appearing. Same channel `usable` already uses, for the same
-	// audience.
+	// Discovery's warnings are replayed in the browser, where the person missing a kind looks.
 	for (const warning of warnings) {
 		lines.push(`console.warn(${JSON.stringify(warning)})`);
 	}

--- a/frontend/plugin/manifest.js
+++ b/frontend/plugin/manifest.js
@@ -1,10 +1,5 @@
-// Reads the Python-assembled build manifest.
-//
-// Assembly and singleton enforcement both live in Python (`frappe/shell/manifest.py`),
-// not here. #42069 put the check "at manifest assembly, before vite starts" — and
-// assembly is Python's, so a conflict fails before vite is even spawned. Keeping a
-// second implementation on this side would be one of the hand-synced copies the map
-// has been retiring.
+// Reads the build manifest Python assembles; singleton enforcement lives there too,
+// in `frappe/shell/manifest.py`.
 
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -30,7 +25,7 @@ export function readManifest() {
 	return read().apps;
 }
 
-/** Every app on the bench, contributing or not -- see the plugin's doctype-name index. */
+/** Every app on the bench, contributing or not; see the plugin's doctype-name index. */
 export function readAllSourceDirs() {
 	return read().source_dirs;
 }

--- a/frontend/plugin/oneTree.js
+++ b/frontend/plugin/oneTree.js
@@ -1,19 +1,5 @@
-// Resolve app source's bare imports against the framework's ONE tree.
-//
-// This is the piece "the framework installs one tree under frappe/frontend/" (#42069)
-// actually costs. An app's contributed files live in the app's own repo, so node
-// resolution walks up from `apps/crm/...` and never reaches
-// `apps/frappe/frontend/node_modules` — where the app's declared dependency was in
-// fact installed, alongside the framework's own.
-//
-// Real node resolution from the framework's directory, not an alias table: aliasing a
-// package name to a directory bypasses its `exports` map and breaks every subpath
-// import, which is exactly how `frappe-ui/code-editor` failed here first time.
-//
-// The consequence worth naming: an app cannot import something it did not declare and
-// quietly get the framework's copy — resolution is restricted to what the manifest
-// says the app asked for. An undeclared import fails the build, which is the same
-// answer the singleton check gives for a disagreement.
+// Resolve an app's bare imports from the framework's tree, which node resolution walking up
+// from the app's own repo never reaches. Only what the app declared resolves; nothing is aliased.
 
 import { createRequire } from "node:module";
 import { join } from "node:path";
@@ -44,9 +30,7 @@ export default function oneTree(manifest) {
 				(entry) => entry.app !== "frappe" && importer.startsWith(entry.source_dir)
 			);
 			if (!owner) return;
-			// A scoped package's NAME is its first two segments: '@scope/pkg'. Taking one
-			// segment yields the bare scope, which is never a key in `declared`, so every
-			// scoped subpath import would fall through unresolved.
+			// A scoped package's name is its first two segments, '@scope/pkg'.
 			const segments = source.split("/");
 			const packageName = source.startsWith("@")
 				? segments.slice(0, 2).join("/")
@@ -56,8 +40,7 @@ export default function oneTree(manifest) {
 			try {
 				return requireFromFrameworkTree.resolve(source);
 			} catch {
-				// Fall through to vite's own resolution, so the error it reports is the
-				// ordinary "failed to resolve" rather than one from in here.
+				// Fall through so vite reports the ordinary "failed to resolve".
 				return;
 			}
 		},

--- a/frontend/src/addresses.ts
+++ b/frontend/src/addresses.ts
@@ -1,22 +1,10 @@
-// The address table: every doctype on the bench, and how each one is spelled in a URL.
-//
-// Fetched, not booted. It used to be `boot.doctype_slugs`, scoped to one app because
-// a doctype was addressable only inside its owner's prefix. The prefix is a LENS
-// (#42210) -- every doctype is addressable under every prefix -- so the table went
-// full-bench, broke the 40 KB boot budget on an ERPNext bench, and became
-// byte-identical for every user and every prefix in the same move. That last property
-// is what let it leave boot rather than be trimmed: it is now cacheable, keyed on
-// `metadata_version`, exactly as translations are keyed on `translations_version`
-// (#42070).
-//
-// It carries the module too (#42211), because a modular app's address is
-// `/<module>/<doctype>/<name>` and the two halves must not be able to disagree. The
-// server sends the module SLUG, so `frappe.scrub` is never re-implemented here.
+// The address table: every doctype on the bench and its URL spelling. Full-bench and the
+// same for every user, so it is fetched and cached by `metadata_version`, not booted.
 
 export type AddressPayload = {
 	/** `{doctype: [slug, moduleSlug]}` */
 	doctypes: Record<string, [string, string]>;
-	/** `{moduleSlug: moduleName}` -- display data, 35 entries against 553 doctypes. */
+	/** `{moduleSlug: moduleName}`, display data. */
 	modules: Record<string, string>;
 };
 
@@ -34,9 +22,8 @@ export class Addresses {
 
 	/** The real doctype behind a URL segment, or null. */
 	doctypeOf(slug: string): string | null {
-		// `Object.hasOwn`, not a bare read: a plain object inherits from
-		// Object.prototype, so `/apps/crm/constructor` would otherwise pass the guard
-		// and hand the page a function.
+		// `Object.hasOwn`, not a bare read: `/apps/crm/constructor` would otherwise pass the
+		// guard and hand the page a function.
 		return Object.hasOwn(this.bySlug, slug) ? this.bySlug[slug] : null;
 	}
 
@@ -47,7 +34,7 @@ export class Addresses {
 			: null;
 	}
 
-	/** The slug a doctype NAME resolves to, case-insensitively -- the de-slug path. */
+	/** The slug a doctype name resolves to, case-insensitively. */
 	slugOfName(segment: string): string | null {
 		const match = Object.entries(this.payload.doctypes).find(
 			([doctype]) => doctype.toLowerCase() === segment.toLowerCase()
@@ -56,13 +43,7 @@ export class Addresses {
 	}
 
 	/**
-	 * The slug a module NAME is spelled with, or null.
-	 *
-	 * The reverse of `moduleName`, and the reason it exists rather than a `frappe.scrub`
-	 * here: a navigation item names a module by its `Module Def` name, and the address is
-	 * its slug. Re-implementing the scrub would put a second, divergent spelling of every
-	 * module address in the browser -- which is the trap this file already refuses for
-	 * doctypes.
+	 * The slug a module name is spelled with, or null. The scrub is never re-implemented here.
 	 */
 	slugOfModule(name: string): string | null {
 		const match = Object.entries(this.payload.modules).find(
@@ -83,8 +64,7 @@ export class Addresses {
 }
 
 export async function fetchAddresses(version: string): Promise<Addresses> {
-	// `v=` in the query string is the ONLY thing that invalidates this: the endpoint
-	// carries `@http_cache(max_age=31536000)`, a full year, private.
+	// Cached server-side for a year; `v=` is the only invalidator.
 	const res = await fetch(
 		`/api/method/frappe.shell.doctypes.get_addresses?v=${encodeURIComponent(
 			version

--- a/frontend/src/arrangement.ts
+++ b/frontend/src/arrangement.ts
@@ -1,36 +1,21 @@
-// ARRANGING — the client half of desk v2's first user-state write.
-//
-// The whole ordered list goes up; the reduction to what actually changed happens on the server
-// (#42363). That division is not an accident of where the code was easier to write. A client
-// that sent anchors would be computing identity and difference against a copy of the base it
-// may already be holding stale, which is the mistake desk v1 makes in the other direction: its
-// sidebar manager recomputes the server's item key in JS and gets it wrong two ways, leaving
-// `filters` out of a key the server includes and returning a raw `"type|label"` where the server
-// returns a hash. Desk v2's key is authored, arrives on the wire, and is never computed here.
-//
-// Nothing in this file is a store. A save returns the whole `{rail, sidebars}` for the prefix and
-// the caller swaps it into `boot.navigation` wholesale, so the arrangement a person is looking at
-// and the navigation the shell renders never drift into two copies that have to be reconciled.
+// The client half of arranging: the whole ordered list goes up and the server reduces it.
+// Nothing here is a store; a save returns the prefix's navigation and the caller swaps it in.
 
 import { call } from "frappe-ui";
 import type { Navigation, NavigationItem } from "@/boot";
 
-/** Which of the two containers is being arranged. They are two presentations of one model. */
+/** Which of the two containers is being arranged. */
 export type Container = "Rail" | "Sidebar";
 
 /**
- * Whose layer. `user` is always the session user — the endpoints take no user argument, so
- * arranging somebody else's navigation is not a request this client could make even by mistake.
- * `site` is what everyone sees and needs a System Manager.
+  * Whose layer. `user` is always the session user; `site` is what everyone sees and needs a
+  * System Manager.
  */
 export type Scope = "user" | "site";
 
 /**
- * A row as the editor holds it: what the payload carries, plus the hidden flag.
- *
- * `hidden` is absent from `boot.navigation` — boot drops hidden rows, because the browser cannot
- * render a row it must not show. The editor asks for them back, since a hide nobody can see is a
- * hide nobody can undo.
+  * A row as the editor holds it. `hidden` is absent from `boot.navigation`, so the editor
+  * asks for it back.
  */
 export type ArrangedItem = NavigationItem & { hidden?: 1 };
 
@@ -73,14 +58,8 @@ export async function resetArrangement(
 }
 
 /**
- * Move one row one place among its own siblings, and give back a new list.
- *
- * Siblings, not neighbours in the flat list. The payload is flat and the rail draws it as a
- * tree, so the row above a section's first child is the section itself — stepping onto it would
- * read as "move out of this section", which is a different edit and not the one the arrow means.
- *
- * A row already at the end of its group does not move, and does not wrap. The list is short
- * enough to see all of, so wrapping would look like a bug rather than a feature.
+  * Move one row one place among its siblings, not its neighbours in the flat list. At the
+  * end of its group it stays put.
  */
 export function move(items: ArrangedItem[], key: string, by: 1 | -1): ArrangedItem[] {
 	const item = items.find((entry) => entry.key === key);
@@ -99,12 +78,8 @@ export function move(items: ArrangedItem[], key: string, by: 1 | -1): ArrangedIt
 }
 
 /**
- * Move one row to where another sits, which is what a drag means.
- *
- * Only between siblings. Dropping onto a row under a different parent would mean two edits at
- * once — a reparent and a reorder — and a drag that silently did the first is how somebody's
- * whole section ends up somewhere they did not put it. A drop that is not a sibling's is
- * refused by returning the list unchanged, which reads as the row springing back.
+  * Move one row to where another sits. Refused, list unchanged, unless they share a parent:
+  * a drop must never reparent.
  */
 export function dropOn(items: ArrangedItem[], key: string, onto: string): ArrangedItem[] {
 	const item = items.find((entry) => entry.key === key);
@@ -115,8 +90,7 @@ export function dropOn(items: ArrangedItem[], key: string, onto: string): Arrang
 
 	const order = siblings(items);
 	const group = [...(order.get(parentOf(item)) ?? [])];
-	// Dragged downwards a row lands after the row it was dropped on, upwards before it — which
-	// is the same rule either way: it takes the place the target is standing in.
+	// Downwards lands after the target, upwards before it: the row takes the target's place.
 	const downwards = group.indexOf(key) < group.indexOf(onto);
 
 	group.splice(group.indexOf(key), 1);
@@ -144,18 +118,8 @@ function siblings(items: ArrangedItem[]): Map<string | null, string[]> {
 }
 
 /**
- * Rebuild the flat list from the sibling order, depth first, so a section's children travel
- * with it.
- *
- * The list is flat and the tree is `parent_key`, so moving a section by swapping two rows leaves
- * its children where they were — the saved arrangement is still right, because the reduction
- * compares each parent's children separately, but the editor would draw rows under a heading
- * they do not belong to. Re-flattening makes what is on screen and what is in the list the same
- * thing, which is the only version anybody can check by looking.
- *
- * A row whose parent is not in the list is appended rather than dropped. The server promotes
- * orphans before sending, so this should not arise; losing a row to a rule about drawing it
- * would be much worse than showing it at the end.
+  * Rebuild the flat list from the sibling order, depth first, so a section's children travel
+  * with it. A row whose parent is missing is appended, never dropped.
  */
 function flatten(items: ArrangedItem[], order: Map<string | null, string[]>): ArrangedItem[] {
 	const byKey = new Map(items.map((item) => [item.key, item]));

--- a/frontend/src/arrangement.ts
+++ b/frontend/src/arrangement.ts
@@ -8,14 +8,14 @@ import type { Navigation, NavigationItem } from "@/boot";
 export type Container = "Rail" | "Sidebar";
 
 /**
-  * Whose layer. `user` is always the session user; `site` is what everyone sees and needs a
-  * System Manager.
+ * Whose layer. `user` is always the session user; `site` is what everyone sees and needs a
+ * System Manager.
  */
 export type Scope = "user" | "site";
 
 /**
-  * A row as the editor holds it. `hidden` is absent from `boot.navigation`, so the editor
-  * asks for it back.
+ * A row as the editor holds it. `hidden` is absent from `boot.navigation`, so the editor
+ * asks for it back.
  */
 export type ArrangedItem = NavigationItem & { hidden?: 1 };
 
@@ -58,8 +58,8 @@ export async function resetArrangement(
 }
 
 /**
-  * Move one row one place among its siblings, not its neighbours in the flat list. At the
-  * end of its group it stays put.
+ * Move one row one place among its siblings, not its neighbours in the flat list. At the
+ * end of its group it stays put.
  */
 export function move(items: ArrangedItem[], key: string, by: 1 | -1): ArrangedItem[] {
 	const item = items.find((entry) => entry.key === key);
@@ -78,8 +78,8 @@ export function move(items: ArrangedItem[], key: string, by: 1 | -1): ArrangedIt
 }
 
 /**
-  * Move one row to where another sits. Refused, list unchanged, unless they share a parent:
-  * a drop must never reparent.
+ * Move one row to where another sits. Refused, list unchanged, unless they share a parent:
+ * a drop must never reparent.
  */
 export function dropOn(items: ArrangedItem[], key: string, onto: string): ArrangedItem[] {
 	const item = items.find((entry) => entry.key === key);
@@ -118,8 +118,8 @@ function siblings(items: ArrangedItem[]): Map<string | null, string[]> {
 }
 
 /**
-  * Rebuild the flat list from the sibling order, depth first, so a section's children travel
-  * with it. A row whose parent is missing is appended, never dropped.
+ * Rebuild the flat list from the sibling order, depth first, so a section's children travel
+ * with it. A row whose parent is missing is appended, never dropped.
  */
 function flatten(items: ArrangedItem[], order: Map<string | null, string[]>): ArrangedItem[] {
 	const byKey = new Map(items.map((item) => [item.key, item]));

--- a/frontend/src/boot.ts
+++ b/frontend/src/boot.ts
@@ -1,20 +1,8 @@
-// The v2 boot: a NEW small payload, not `frappe.sessions.get()`.
-//
-// #42070 measured the existing boot at 147,711 bytes, ~120 KB of it desk v1 workspace
-// furniture. That is why CRM and Gameplan each rebuilt the generic keys by hand. This
-// one starts small; v1's is left untouched and retires with v1.
+// The shell's boot payload: small, per prefix, separate from desk v1's `frappe.sessions.get()`.
 
 /**
- * One resolved navigation item, on the rail or in a sidebar. The SAME shape in both:
- * they are two presentations of one model, not two models (charter point 1).
- *
- * Everything but `key` and `item_type` is optional because the server omits a blank
- * field rather than sending `null` — navigation is the largest thing in a payload with
- * a 40 KB ceiling, and most fields on most rows are blank.
- *
- * `item_type` decides what the item does; the client does not branch on it beyond
- * picking a renderer (#42228). An item with no `label` was never labelled by anyone, so
- * a renderer falls back to its destination.
+  * One resolved navigation item; the rail and a sidebar share this shape. A blank field
+  * is omitted, never sent as `null`.
  */
 export type NavigationItem = {
 	key: string;
@@ -23,11 +11,8 @@ export type NavigationItem = {
 	link_doctype?: string;
 	link_to?: string;
 	/**
-	 * An absolute href, for the two rows that are not a route in this prefix: a `Link`
-	 * item, which points off the desk entirely, and a contributed item marked
-	 * `switches_app`, whose URL the server finishes because the router this document
-	 * holds cannot build one into another prefix (#42364). Either way, following it is
-	 * a full document load, so a row carrying one is an `<a>` and not a `RouterLink`.
+	 * An absolute href off this prefix (a `Link` item, or a contributed item that switches
+	 * app). Following it is a full document load, so the row is an `<a>`, not a `RouterLink`.
 	 */
 	url?: string;
 	payload?: Record<string, unknown>;
@@ -40,14 +25,8 @@ export type NavigationItem = {
 export type Navigation = {
 	rail: NavigationItem[];
 	/**
-	 * Every sidebar in this prefix, keyed by SCRUBBED ADDRESS — `module_def_accounts`,
-	 * not a record name. A resolved sidebar is the merge of up to three records with
-	 * three different names, so no one name identifies it; the address is what they
-	 * share. A rail item of type `Sidebar` already carries that string in `link_to`, so
-	 * opening one is a dictionary lookup on a value the item is holding (#42356).
-	 *
-	 * An address that resolved to nothing is absent rather than empty, and a linked rail
-	 * item whose sidebar is absent renders as an independent one (#42357).
+	 * Keyed by scrubbed address, the string a `Sidebar` rail item holds in `link_to`, never
+	 * by record name. An address that resolved to nothing is absent, not empty.
 	 */
 	sidebars: Record<string, NavigationItem[]>;
 };
@@ -69,35 +48,24 @@ export type Boot = {
 
 	// --- routing ---
 	//
-	// `shell_base` is the router's base: the COMPOSED path (`/apps/crm`), not the bare
-	// segment. Boot carries it composed so the literal `/apps` never has to appear in
-	// JS at all (#42125). It is `/apps` itself on the index, which belongs to no app.
+	// `shell_base` is the composed path (`/apps/crm`), so the literal `/apps` never appears
+	// in JS. It is `/apps` itself on the index, which belongs to no app.
 	shell_base: string;
 	app: string | null;
 
-	// #42066's `{prefix: app}` registry, widened to carry #42211's modularity boolean.
-	// Every active app, not just this one: a link to a foreign app's doctype needs that
-	// app's shape, and one boolean per app is five entries on this bench.
+	// Every active app, not just this one: a link into a foreign app needs that app's shape.
 	prefixes: Record<string, { app: string; modular: boolean }>;
 
-	// The key that invalidates the ADDRESS TABLE, which is fetched separately and is
-	// not in here -- it went full-bench when the prefix became a lens and broke the
-	// 40 KB budget (#42210). Same treatment as `translations_version`.
+	// Invalidates the address table, which is fetched separately; see `addresses.ts`.
 	metadata_version: string;
 
 	// --- navigation ---
 	//
-	// The rail and every sidebar in this prefix, already resolved: the app's own rows,
-	// then the site's arrangement, then this person's, merged server-side. The browser
-	// never restacks those layers and never re-filters the list (#42232).
-	//
-	// It is here rather than fetched because a rail click must cost no request. What an
-	// app CONTAINS is still fetched, by the pages that show it -- see `contents.ts`.
-	//
-	// Absent on the index, which belongs to no app.
+	// The rail and every sidebar in this prefix, resolved and merged server-side so a rail
+	// click costs no request. Absent on the index. What an app contains is `contents.ts`.
 	navigation?: Navigation;
 
-	// Present on the index only (#42124).
+	// Present on the index only.
 	apps?: {
 		app: string;
 		prefix: string;
@@ -106,16 +74,14 @@ export type Boot = {
 		route: string;
 	}[];
 
-	// --- the declaring app's contribution, merged under core (#42070) ---
+	// --- the declaring app's contribution, merged under core ---
 	[appKey: string]: unknown;
 };
 
 export class BootUnauthorized extends Error {}
 
 export async function fetchBoot(): Promise<Boot> {
-	// `location.pathname` is the only input the client has: the document carries
-	// nothing. Composition is prefix-dependent, so the server needs the path to know
-	// which app's contribution to merge in.
+	// The server needs the path to know which app's contribution to merge in.
 	const res = await fetch(
 		`/api/method/frappe.shell.boot.get_boot?path=${encodeURIComponent(
 			location.pathname
@@ -123,8 +89,8 @@ export async function fetchBoot(): Promise<Boot> {
 		{ headers: { Accept: "application/json" } }
 	);
 
-	// 401 as well as 403: an expired session answers 401, and treating it as a generic
-	// failure would show "something went wrong" where the user needs a way back to login.
+	// 401 as well as 403: an expired session answers 401, and the user needs the way back
+	// to login, not a generic failure.
 	if (res.status === 401 || res.status === 403)
 		throw new BootUnauthorized("Not permitted");
 	if (!res.ok) throw new Error(`Boot failed with ${res.status}`);

--- a/frontend/src/boot.ts
+++ b/frontend/src/boot.ts
@@ -1,8 +1,8 @@
 // The shell's boot payload: small, per prefix, separate from desk v1's `frappe.sessions.get()`.
 
 /**
-  * One resolved navigation item; the rail and a sidebar share this shape. A blank field
-  * is omitted, never sent as `null`.
+ * One resolved navigation item; the rail and a sidebar share this shape. A blank field
+ * is omitted, never sent as `null`.
  */
 export type NavigationItem = {
 	key: string;

--- a/frontend/src/contents.ts
+++ b/frontend/src/contents.ts
@@ -1,30 +1,12 @@
-// CONTENTS -- what an app CONTAINS. Deliberately a different list from the address
-// table beside it, and a different list from the rail.
-//
-// #42210 split what `boot.doctype_slugs` conflated. ADDRESSABILITY is full-bench and
-// permission-independent: two colleagues must resolve a pasted URL identically, so
-// the address space cannot change shape per user. CONTENTS are per app and
-// permission-filtered: a doctype you cannot read is still addressable -- you are
-// refused at the record by ordinary permissions -- it is simply not offered to you.
-//
-// The rail read this until #42357, and no longer does. The rail is AUTHORED
-// navigation, resolved server-side and delivered in boot, because a rail click must
-// not cost a request. This list is DERIVED, and it is fetched by the two pages that
-// show it -- the app home and a module page -- because arriving somewhere and paying
-// one request for what is there is ordinary. The two lists disagree on purpose:
-// measured across ERPNext, 107 doctypes sit on a module page and not in that module's
-// sidebar, while 101 sidebar links point outside their module. The page answers what
-// does this contain; the rail answers what do you do here.
+// What an app contains: per app and permission-filtered, unlike the address table beside
+// it. Fetched by the pages that show it, never by the rail, which arrives in boot.
 
 import { ref, watchEffect, type Ref } from "vue";
 
 export type ContentEntry = { doctype: string; slug: string; module: string };
 
 /**
- * THROWS rather than answering empty. A swallowed failure is indistinguishable from
- * "you can read nothing here", which is a real answer — so the caller would render a
- * confident, false "0 doctypes you can read" over a request that never landed, and an
- * empty rail that looks like an empty app.
+  * Throws on failure: an empty list is a real answer here and must not be forged.
  */
 export async function fetchContents(
 	app: string,
@@ -43,10 +25,7 @@ export async function fetchContents(
 /**
  * Reactive contents for a prefix, optionally narrowed to one module.
  *
- * `loading` and `failed` are not decoration. An empty list is a REAL answer here — a
- * module you can read nothing in — so a caller that cannot tell "none" from "not yet"
- * or from "the request failed" has to assert one of them, and "0 doctypes you can
- * read" is a false statement to put under either.
+  * `loading` and `failed` let a caller tell "none" from "not yet" and "failed".
  */
 export function useContents(
 	app: string | null,
@@ -56,18 +35,13 @@ export function useContents(
 	const loading = ref(false);
 	const failed = ref(false);
 
-	// Which fetch is current. Moving between modules leaves the previous one in
-	// flight, and without this the slower response wins: the page would settle on the
-	// module the reader has left. The same guard `List.vue` and `Record.vue` already
-	// carry, for the same reason.
+	// The slower of two in-flight fetches must not win after the reader has moved on.
 	let generation = 0;
 
 	watchEffect(async () => {
 		const mine = ++generation;
 
-		// Cleared BEFORE the await, not after it. Keeping the old entries on screen
-		// while the new ones load puts the new module's heading above the previous
-		// module's links -- briefly, and clickably, which is worse than empty.
+		// Cleared before the await: the old links under the new heading are clickable.
 		entries.value = [];
 		failed.value = false;
 
@@ -78,17 +52,14 @@ export function useContents(
 
 		loading.value = true;
 
-		// `module?.value` is read HERE, synchronously, so `watchEffect` tracks it.
-		// Reading it after the await would register no dependency and the list would
-		// never update again.
+		// `module?.value` is read synchronously so `watchEffect` tracks it; a read after the
+		// await registers no dependency.
 		try {
 			const fetched = await fetchContents(app, module?.value);
 			if (mine !== generation) return;
 			entries.value = fetched;
 		} catch {
 			if (mine !== generation) return;
-			// Reported, not swallowed. The list stays empty either way; what changes is
-			// that the caller can say "could not load" instead of "there is nothing".
 			failed.value = true;
 		}
 

--- a/frontend/src/contents.ts
+++ b/frontend/src/contents.ts
@@ -23,9 +23,8 @@ export async function fetchContents(
 }
 
 /**
- * Reactive contents for a prefix, optionally narrowed to one module.
- *
-  * `loading` and `failed` let a caller tell "none" from "not yet" and "failed".
+  * Reactive contents for a prefix, optionally narrowed to one module. `loading` and `failed`
+  * let a caller tell "none" from "not yet" and "failed".
  */
 export function useContents(
 	app: string | null,

--- a/frontend/src/contents.ts
+++ b/frontend/src/contents.ts
@@ -6,7 +6,7 @@ import { ref, watchEffect, type Ref } from "vue";
 export type ContentEntry = { doctype: string; slug: string; module: string };
 
 /**
-  * Throws on failure: an empty list is a real answer here and must not be forged.
+ * Throws on failure: an empty list is a real answer here and must not be forged.
  */
 export async function fetchContents(
 	app: string,
@@ -23,8 +23,8 @@ export async function fetchContents(
 }
 
 /**
-  * Reactive contents for a prefix, optionally narrowed to one module. `loading` and `failed`
-  * let a caller tell "none" from "not yet" and "failed".
+ * Reactive contents for a prefix, optionally narrowed to one module. `loading` and `failed`
+ * let a caller tell "none" from "not yet" and "failed".
  */
 export function useContents(
 	app: string | null,

--- a/frontend/src/contributions/registry.ts
+++ b/frontend/src/contributions/registry.ts
@@ -18,8 +18,8 @@ export function listHandlersFor(doctype: string) {
 }
 
 /**
-  * Run order per doctype: the owning app first, then the site's `app_order`. Ownership is
-  * structural: a file under `custom/` is somebody else's doctype.
+ * Run order per doctype: the owning app first, then the site's `app_order`. Ownership is
+ * structural: a file under `custom/` is somebody else's doctype.
  */
 function ordered<T extends { app: string }>(
   all: T[],
@@ -40,8 +40,8 @@ function ordered<T extends { app: string }>(
 }
 
 /**
-  * Runs before the router's first resolution. App identity comes from the generated
-  * module, never from a path inspected at runtime.
+ * Runs before the router's first resolution. App identity comes from the generated
+ * module, never from a path inspected at runtime.
  */
 export async function registerContributions(appOrder: string[]) {
   registerItemTypes(appOrder)
@@ -72,7 +72,7 @@ export async function registerContributions(appOrder: string[]) {
 }
 
 /**
-  * One renderer per kind; the first app in the site's order wins and the collision is logged.
+ * One renderer per kind; the first app in the site's order wins and the collision is logged.
  */
 function registerItemTypes(appOrder: string[]) {
   const owner: Record<string, string> = {}

--- a/frontend/src/contributions/registry.ts
+++ b/frontend/src/contributions/registry.ts
@@ -1,8 +1,4 @@
-// THE SEAM. Everything the charter rests on passes through this file.
-//
-// It is deliberately tiny, and its size is the argument: the framework's side of the
-// contribution contract is an index over a generated module. All the machinery lives
-// in plugin/contributions.js, at build time, where it costs nothing at runtime.
+// The contribution seam: an index over the module `plugin/contributions.js` generates at build time.
 
 import contributions from 'virtual:frappe/contributions'
 import { registerRecordPage, withRegisteringSource } from '@/recordPage'
@@ -14,8 +10,7 @@ export const pages: PageContribution[] = contributions.pages
 /** Item kind -> renderer, filled by `registerContributions` in the site's app order. */
 export const itemRenderers: Record<string, ItemRenderer> = {}
 
-/** List customizations, indexed by doctype. No registrar exists for these in
- *  the record-page engine yet, so the shell's own index holds them. */
+/** List customizations by doctype; the record-page engine has no registrar for these. */
 const listHandlers = new Map<string, { app: string; handlers: ListHandlers }[]>()
 
 export function listHandlersFor(doctype: string) {
@@ -23,18 +18,8 @@ export function listHandlersFor(doctype: string) {
 }
 
 /**
- * Run order, per doctype: the doctype's OWNING app first, then every other app in the
- * site's `app_order` (#42113).
- *
- * Ownership needs no registry lookup here, because it is structural. A file at
- * `<module>/doctype/<x>/frontend/` is colocated in the owner's own tree, so it IS the
- * owner's; a file at `<module>/custom/<x>/` is by construction somebody else's. The
- * arrow rule 1 actually wanted was "baseline first, more-specific intent last", not
- * "framework first" -- and this is that, derived rather than declared.
- *
- * Item renderers pass no `isForeign`, because a kind has no owning app to be foreign to:
- * the type record and the JS ship together, so `app_order` alone decides, and what it
- * decides is which app wins a collision rather than what runs after what.
+  * Run order per doctype: the owning app first, then the site's `app_order`. Ownership is
+  * structural: a file under `custom/` is somebody else's doctype.
  */
 function ordered<T extends { app: string }>(
   all: T[],
@@ -55,11 +40,8 @@ function ordered<T extends { app: string }>(
 }
 
 /**
- * Registration runs before the router's first resolution (see main.ts).
- *
- * App identity comes from the generated module, NOT from a path inspected at runtime
- * -- which is the whole reason the plugin synthesises rather than globs: a raw
- * `import.meta.glob` loses the app (#42068).
+  * Runs before the router's first resolution. App identity comes from the generated
+  * module, never from a path inspected at runtime.
  */
 export async function registerContributions(appOrder: string[]) {
   registerItemTypes(appOrder)
@@ -71,8 +53,7 @@ export async function registerContributions(appOrder: string[]) {
     byDoctype.set(contribution.doctype, own)
   }
 
-  // Doctype by doctype, because the ordering is per doctype rather than one global
-  // sequence -- an app can be the owner of one and a foreigner to the next.
+  // Ordering is per doctype: an app can own one and be foreign to the next.
   for (const [doctype, all] of byDoctype) {
     for (const contribution of ordered(all, appOrder, (c) => c.kind === 'custom')) {
       if (contribution.kind === 'list') {
@@ -82,8 +63,7 @@ export async function registerContributions(appOrder: string[]) {
         continue
       }
 
-      // Tagged with the contributing app, so a later `unregisterSource` can drop
-      // exactly one app's handlers.
+      // Tagged with the app, so `unregisterSource` can drop exactly one app's handlers.
       await withRegisteringSource(contribution.app, async () =>
         registerRecordPage(doctype, contribution.handlers),
       )
@@ -92,13 +72,7 @@ export async function registerContributions(appOrder: string[]) {
 }
 
 /**
- * One renderer per item kind, and the FIRST app in the site's order wins.
- *
- * Two apps claiming one type name is a conflict rather than an override: the type record
- * itself is one row that one app ships, so a second renderer for it is aimed at somebody
- * else's kind. Last-wins is what #42228 rejected in `override_doctype_class`, whose
- * `[-1]` means the winner is decided by install order and nothing says so; first-wins
- * plus a line naming both apps is the same determinism with the collision visible.
+  * One renderer per kind; the first app in the site's order wins and the collision is logged.
  */
 function registerItemTypes(appOrder: string[]) {
   const owner: Record<string, string> = {}

--- a/frontend/src/contributions/types.ts
+++ b/frontend/src/contributions/types.ts
@@ -1,9 +1,6 @@
 import type { ItemRenderer } from "@/navigation/types"
 
-// The public contribution surface -- the COMPLETE list of what an app may contribute.
-// If it is not in this file, an app cannot do it. That closure is charter item 1:
-// there is no optional escape hatch to route around, because that is exactly how
-// desk v1's Client Script tier rotted.
+// The complete list of what an app may contribute; if it is not here, an app cannot do it.
 
 export type RecordHandlers = {
   actions?: { name: string; label: string; icon?: string; run: (page: unknown) => unknown }[]
@@ -23,42 +20,22 @@ export type PageContribution = {
 }
 
 export type DoctypeContribution =
-  // 1. Customize your own doctype's record page.
-  //    <module>/doctype/<scrubbed>/frontend/record.js
+  // Your own doctype's record page: <module>/doctype/<scrubbed>/frontend/record.js
   | { kind: 'record'; app: string; doctype: string; handlers: RecordHandlers }
-  // 2. Customize your own doctype's list.
-  //    <module>/doctype/<scrubbed>/frontend/list.js
+  // Your own doctype's list: <module>/doctype/<scrubbed>/frontend/list.js
   | { kind: 'list'; app: string; doctype: string; handlers: ListHandlers }
-  // 3. Customize a FOREIGN doctype. <module>/custom/<scrubbed>/record.js
-  //    Same two kinds; only the folder differs. Applies globally, so customizing
-  //    Contact does NOT move Contact into your prefix (#42068).
+  // A foreign doctype: <module>/custom/<scrubbed>/record.js. Applies globally; it does not
+  // move the doctype into your prefix.
   | { kind: 'custom'; app: string; doctype: string; handlers: RecordHandlers }
 
-// 4. Add a genuinely new page. <module>/frontend/pages/<slug>.js -- see
-//    PageContribution above.
-//
-// 5. Add an item kind for the rail and the sidebar -- see ItemTypeContribution below.
-//
-// NOT contributable, each for a decided reason:
-//   - a route table          -> generated from doctypes; pages are flat files
-//   - a doctype opt-out      -> it hides nothing and would be misread as a
-//                               permission control (#42068)
-//   - shell chrome, incl. every error state -> the shell owns it (#42072)
-//   - a vite plugin or config -> the framework owns the build (#42069)
-//   - a boot key, from JS    -> boot is Python (#42070)
-//
-// Five entries, three of them the same mechanism pointed at different folders. That
-// is the test of whether the seam is small enough.
+// Not contributable: a route table, a doctype opt-out, shell chrome (every error state
+// included), a vite plugin or config, and a boot key from JS.
 
-// The item kind, entry 5.
-//    <module>/navigation_item_type/<scrubbed>/frontend/item.js, beside the type record.
-//
-//    The framework's own eight kinds are exactly this and nothing more -- there is no
-//    built-in table anywhere for them to be in (DP2). What that buys is checkable: if the
-//    framework could draw a kind an app cannot, this entry would be the difference.
+// An item kind: <module>/navigation_item_type/<scrubbed>/frontend/item.js, beside the type
+// record. The framework's own kinds go through this and nothing else.
 export type ItemTypeContribution = {
   app: string
-  /** The type record's own `name`, read from the JSON beside the file -- never guessed. */
+  /** The type record's own `name`, read from the JSON beside the file, never guessed. */
   type: string
   renderer: ItemRenderer
 }

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -1,26 +1,16 @@
-// Separate, NON-blocking, keyed on `translations_version` (#42070).
-//
-// Desk v1 already works this way (`www/desk.html:59-70`); CRM regressed it by putting
-// `translated_messages` inside `get_boot()`, which forfeits cacheability -- boot
-// varies per user and per request, translations vary per language and per build.
+// Translations: fetched apart from boot, never awaited, keyed on `translations_version`.
 
 let messages: Record<string, string> = {}
 
 export function loadTranslations(version: string, lang = 'en') {
-  // `get_boot_translations`, the same endpoint desk v1 uses, and for the same reason:
-  // it carries `@http_cache(max_age=31536000)`, so the version in the query string is
-  // the only thing that ever invalidates it.
-  //
-  // Deliberately not awaited by the caller. Untranslated text is a survivable first
-  // frame; a missing CSRF token is not.
+  // Cached server-side for a year; the version in the query string is the only invalidator.
   return fetch(`/api/method/frappe.translate.get_boot_translations?lang=${lang}&v=${version}`)
     .then((res) => (res.ok ? res.json() : null))
     .then((body) => {
       if (body?.message) messages = body.message
     })
     .catch(() => {
-      // A failed translation fetch leaves English on screen. It must never take the
-      // shell down with it.
+      // A failed fetch leaves English on screen; it must never take the shell down.
     })
 }
 

--- a/frontend/src/icons/Icon.vue
+++ b/frontend/src/icons/Icon.vue
@@ -1,8 +1,6 @@
 <!--
-  One icon, drawn from a name.
-
-  `fieldtype: Icon` stores an emoji glyph or a bare sprite symbol name, and its picker
-  writes both. A name the sprite does not hold draws nothing and logs once.
+  One icon from a name: an emoji glyph or a bare sprite symbol name, which is what `fieldtype: Icon`
+  stores. A name the sprite does not hold draws nothing and logs once.
 -->
 <template>
 	<span v-if="emoji" :class="SLOT" aria-hidden="true">{{ name }}</span>
@@ -31,8 +29,7 @@ import { hasSymbol, isEmoji, reportMissingIcon, spriteLoaded, symbolId } from ".
 // `shrink-0` because a row truncates its label and must never truncate the icon instead.
 const SLOT = "size-4 shrink-0 text-center leading-4";
 
-// Every shape is `aria-hidden`: the icon sits beside the label it illustrates, and naming
-// it would read the row twice.
+// Every shape is `aria-hidden`: the icon sits beside the label it illustrates.
 const props = defineProps<{
 	/** An emoji glyph, or a sprite symbol name. */
 	name?: string;

--- a/frontend/src/icons/sprite.ts
+++ b/frontend/src/icons/sprite.ts
@@ -48,7 +48,7 @@ export function symbolId(name: string): string {
 	return `icon-${name}`;
 }
 
-/** Whether an `Icon` field's value is an emoji glyph rather than a symbol name. */
+/** Whether an `Icon` field's value is an emoji glyph, not a symbol name. */
 // The same test as `frappe.utils.is_emoji`, since one picker writes for both.
 export function isEmoji(value: string): boolean {
 	return /^\p{Extended_Pictographic}(‍\p{Extended_Pictographic}|️|⃣)*$/u.test(value);

--- a/frontend/src/icons/sprite.ts
+++ b/frontend/src/icons/sprite.ts
@@ -1,7 +1,5 @@
 // The shell's runtime icon source: the sprite desk v1 loads through `app_include_icons`.
-//
-// Both of frappe-ui's lucide paths are build-time and cannot draw a name that arrives
-// with boot, and `tailwind.config.js` gives nobody a safelist.
+// frappe-ui's lucide paths are build-time and cannot draw a name that arrives with boot.
 
 import { ref } from "vue";
 
@@ -10,9 +8,7 @@ const SPRITE_URL = "/assets/frappe/icons/lucide/icons.svg";
 // `recordPage/iconClasses.ts` reads it.
 const CONTAINER_ID = "frappe-icon-sprite";
 
-/** Flips once the sprite is in the document. */
-// A ref and not a plain flag: `<use>` picking up a symbol that arrives later is not
-// something every browser agrees on, so arrival has to be a reactive dependency.
+/** Flips once the sprite is in the document. A ref: not every browser lets a `<use>` pick up a symbol that arrives later. */
 export const spriteLoaded = ref(false);
 
 let loading: Promise<void> | null = null;

--- a/frontend/src/icons/tests/icon.test.ts
+++ b/frontend/src/icons/tests/icon.test.ts
@@ -1,7 +1,5 @@
-// What an authored icon name draws, and what an unknown one does not.
-//
-// Mounted with Vue's own `createApp` into happy-dom: this package has no
-// `@vue/test-utils`, and a shared devDependency for one component is a cost every app pays.
+// What an authored icon name draws, and what an unknown one does not. Mounted with Vue's
+// own `createApp`: this package has no `@vue/test-utils`.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createApp, h, nextTick } from "vue";
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,9 +1,4 @@
-// The mount sequence. Read top to bottom: it is the whole lifecycle.
-//
-// The ordering constraint that shapes everything: boot must land BEFORE the router is
-// created, because the router's base comes out of boot. That is stronger than "the
-// shell blocks on boot" -- it means the router cannot be a module-scope singleton the
-// way CRM's is today (#42072).
+// The mount sequence. Boot resolves first: the router's base and shape come out of it.
 
 import "@/index.css";
 import { createApp, h } from "vue";
@@ -23,33 +18,25 @@ import BootError from "@/shell/BootError.vue";
 setConfig("resourceFetcher", frappeRequest);
 
 async function start() {
-	// 1. BLOCK on boot. Nothing renders first -- not a spinner, not chrome. Nothing
-	//    useful exists before the user, the timezone and the CSRF token do. An
-	//    unauthorized user gets the shell HTML at 200 and is refused HERE (#42112).
+	// Nothing renders before boot: the user, the timezone and the CSRF token are in it.
 	let boot: Boot;
 	try {
 		boot = await fetchBoot();
 	} catch (error) {
-		// The shell owns every error state, including this one. An app cannot brand it.
+		// The shell owns every error state; an app cannot brand it.
 		const fallback =
 			error instanceof BootUnauthorized ? Unauthorized : BootError;
 		createApp(h(fallback, { error: String(error) })).mount("#app");
 		return;
 	}
 
-	// 2. Translations are fired, NOT awaited (#42070).
+	// Translations and the icon sprite are fired, not awaited.
 	loadTranslations(boot.translations_version, boot.lang);
 
-	// 2a. The icon sprite, fired and not awaited for the same reason.
 	loadSprite();
 
-	// 2b. The address table, which IS awaited -- unlike translations, because the route
-	//     table cannot resolve a single URL without it and an untranslated first frame
-	//     is survivable where a mis-resolved one is not. It costs a second sequential
-	//     round trip on a cold load, and only a cold one: the endpoint is cached for a
-	//     year and `boot.metadata_version` is the only thing that busts it. It cannot
-	//     be fired in parallel with boot, since boot is where that version comes from,
-	//     and the document is not allowed to carry it (#42072).
+	// The address table is awaited: the route table cannot resolve a URL without it, and
+	// it is keyed on `boot.metadata_version`, so it cannot be fetched alongside boot.
 	let addresses: Addresses;
 	try {
 		addresses = await fetchAddresses(boot.metadata_version);
@@ -58,21 +45,13 @@ async function start() {
 		return;
 	}
 
-	// 3. Contributions register before the router's first resolution -- the same
-	//    invariant CRM's main.ts holds today, but the framework now owns it for every
-	//    app. No per-app register.ts, and no `extend_frontend` list to walk: everything
-	//    is already in this bundle (#42068, #42071).
+	// Contributions register before the router's first resolution.
 	await registerContributions(boot.app_order);
 
-	// 4. NOW the router, because only now is the base known -- and the SHAPE too: a
-	//    modular app's route table is one segment deeper, and `boot.prefixes` is what
-	//    says which (#42211).
+	// Only now is the base known, and the shape: a modular app's route table is one segment deeper.
 	const router = createShellRouter(boot, addresses);
 
-	// 5. Fill the shell slot before anything can call `routeFor`. Not a module-scope
-	//    router (#42072 forbids one) -- a slot holding the single shell this document
-	//    owns, which is what lets a contributed script build an address without being
-	//    handed the router.
+	// Fill the shell slot before anything can call `routeFor`.
 	registerShell({ boot, addresses, router });
 
 	const app = createApp(AppShell);

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -32,7 +32,6 @@ async function start() {
 
 	// Translations and the icon sprite are fired, not awaited.
 	loadTranslations(boot.translations_version, boot.lang);
-
 	loadSprite();
 
 	// The address table is awaited: the route table cannot resolve a URL without it, and

--- a/frontend/src/navigation/NavigationRow.vue
+++ b/frontend/src/navigation/NavigationRow.vue
@@ -1,23 +1,6 @@
 <!--
-  One row of navigation, and whatever hangs under it.
-
-  The rail and the sidebar panel are two presentations of one model (charter point 1), so
-  they draw their rows with one component. It was `shell/RailItem.vue` until the panel
-  arrived (#42421) and there was a second consumer to name it for.
-
-  Recursive, because `parent_key` puts no limit on depth and a two-level component would
-  silently swallow the third — the same class of quiet drop the tree builder's cycle guard
-  exists to prevent. Nothing here decides what a row DOES: it asks the renderer, and draws
-  one of the four shapes it can come back with (`navigation/types.ts`).
-
-  An icon is drawn on every shape that goes somewhere, and never on a heading; a heading
-  that carries one has it ignored.
-
-  A row with no rendering and no children is not drawn at all. That is #42228's degrade for
-  a kind with no renderer, widened to every reason an item cannot be placed here — a
-  `Module` under a non-modular prefix, a `Page` whose slug this prefix does not serve. Its
-  children are still drawn, so a heading whose renderer is missing loses the heading and
-  not its contents, which is the choice `_promote_orphans` already makes on the server.
+  One row of navigation and whatever hangs under it, shared by the rail and the panel.
+  A row with no rendering is skipped but its children still draw, as the server does for orphans.
 -->
 <template>
 	<li>
@@ -34,9 +17,7 @@
 			<span class="truncate">{{ label }}</span>
 		</RouterLink>
 
-		<!-- A destination outside it. Following this is a full document load, so it is an
-				 `<a>` and never a `RouterLink`: the router this document holds is scoped to one
-				 prefix and cannot resolve the other (#42364). -->
+		<!-- A destination outside this prefix: a full document load, so an `<a>`, never a `RouterLink`. -->
 		<a
 			v-else-if="destination && 'href' in destination"
 			:href="destination.href"
@@ -49,8 +30,7 @@
 			<span class="truncate">{{ label }}</span>
 		</a>
 
-		<!-- Rows that are not known until they are asked for. A BUTTON, not a link: it goes
-				 nowhere, and a keyboard reader who meets it as a link has been told it does. -->
+		<!-- Rows fetched on demand. A button, not a link: it goes nowhere. -->
 		<button
 			v-else-if="expander"
 			type="button"
@@ -63,9 +43,7 @@
 			<span class="truncate">{{ label }}</span>
 		</button>
 
-		<!-- A heading. Collapsible ones are a button, because a heading a reader can close is
-				 a control; the rest are not, because most sections are decoration around a list
-				 that should simply be visible. -->
+		<!-- A heading; a collapsible one is a control, so a button. -->
 		<component
 			v-else-if="heading"
 			:is="collapsible ? 'button' : 'p'"
@@ -90,12 +68,8 @@
 			/>
 		</ul>
 
-		<!-- Expanded rows sit at this row's OWN level, not under it. "N more" is an overflow
-				 of the list it is in, so indenting what it reveals would say the module contains
-				 the overflow row, which is backwards.
-
-				 No `sections`: these rows are fetched, not in the container's payload, so a
-				 toggle stored against one would be pruned as stale on the next read. -->
+		<!-- Expanded rows sit at this row's own level: an overflow of the list, not its children.
+					 No `sections`: fetched rows are not in the payload, so a toggle against one would be pruned. -->
 		<NavigationRow
 			v-for="child in expandedNodes"
 			:key="child.item.key"
@@ -118,24 +92,14 @@ import type { ItemContext } from "@/navigation/types";
 
 const ROW =
 	"flex w-full items-center gap-2 truncate rounded px-2 py-1 text-left text-sm text-ink-gray-7 hover:bg-surface-gray-2";
-// A step past `hover:bg-surface-gray-2` rather than the same shade, or a reader could not
-// tell the row they are on from the row under the pointer.
-//
-// Marked on the row itself and not left to `router-link-active`: a linked rail item points at
-// the first row INSIDE its sidebar, so its own link is inactive from the second row on. The
-// explicit `aria-current` binding also SUPPRESSES the one `RouterLink` sets on an exactly
-// active link, which is what keeps the count at one row — the rail and the panel can hold the
-// same destination, and two independent highlights would light both.
+// A step past the hover shade, or the current row and the hovered row look the same. Bound
+// explicitly so `RouterLink`'s own `aria-current` is suppressed and only one row is marked.
 const CURRENT = "bg-surface-gray-3 font-medium text-ink-gray-9";
 const HEADING =
 	"w-full truncate px-2 pb-0.5 pt-3 text-left text-xs font-medium uppercase text-ink-gray-5";
 
-// `current` is the key of the one row the address is standing on, in THIS container
-// (`navigation/current.ts`). It is passed down rather than computed here because exactly one
-// row wins across the rail and the open panel together, and no row can know that alone.
-//
-// `reserve` is decided once for a whole container and handed to every row in it, so a
-// container where only some rows carry an icon still reads as one list.
+// `current` is passed down: one row wins across the rail and the open panel together.
+// `reserve` is decided once per container.
 const props = defineProps<{
 	node: ItemNode;
 	context: ItemContext;
@@ -157,23 +121,18 @@ const expander = computed(() => {
 	const value = rendering.value;
 	return value && "expand" in value ? value : null;
 });
-// A row with children and no destination of its own reads as a heading whether or not its
-// renderer said `group`, which is what keeps an unrenderable parent from turning its
-// children into an unexplained indent.
+// Children with no destination read as a heading whether or not the renderer said `group`.
 const heading = computed(
 	() => (rendering.value && "group" in rendering.value) || props.node.children.length > 0
 );
 
-// `keep_closed` is what makes a section START closed; `collapsible` is what lets a reader
-// close it. Neither is the same as "open", so a section that is neither stays open and has
-// no control (#42227).
+// `keep_closed` starts a section closed; `collapsible` lets a reader close it. Neither is "open".
 const shippedOpen = computed(() => !item.value.keep_closed);
 
 // The one section the address is standing in opens itself, transiently and writing nothing.
 const holdsCurrent = computed(() => !!props.current && containsKey(props.node, props.current));
 
-// No control while the address is inside: the section may not shut over the row you are on,
-// and a heading that reports `aria-expanded` and refuses the click is worse than no control.
+// No control while the address is inside: the section may not shut over the row you are on.
 const collapsible = computed(() => !!item.value.collapsible && !holdsCurrent.value);
 
 /** Where this section rests when the address is not inside it. */
@@ -198,15 +157,8 @@ function toggle() {
 const expanded = ref(false);
 const expandedNodes = ref<ItemNode[]>([]);
 
-// A save returns the whole `{rail, sidebars}` and the shell swaps it in (#42363), which
-// gives this a fresh context over a different list — while the component instance survives,
-// because `v-for` keys on the item's key. What it revealed was "what is left of the module"
-// measured against the OLD list, so a doctype the save has just added to the rail by hand
-// would now be on screen twice. Collapsing is the honest state: the answer it was showing
-// was computed about a list that no longer exists.
-// Which expansion is current. A fetch left in flight by the reset below would otherwise
-// land afterwards and put its rows back, with the button already saying collapsed — the
-// same guard `contents.ts`, `List.vue` and `Record.vue` each carry, for the same reason.
+// A new context is a new list, and what an expansion showed was measured against the old
+// one, so it collapses; `generation` keeps a fetch left in flight from putting rows back.
 let generation = 0;
 
 watch(
@@ -221,8 +173,7 @@ watch(
 async function expand() {
 	if (!expander.value || expanded.value) return;
 
-	// Set before the await, so a second click while the first is in flight cannot fire a
-	// second request against the same row.
+	// Set before the await, so a second click cannot fire a second request.
 	expanded.value = true;
 	const mine = generation;
 
@@ -230,9 +181,7 @@ async function expand() {
 		const nodes = buildTree(await expander.value.expand());
 		if (mine === generation) expandedNodes.value = nodes;
 	} catch (error) {
-		// Back to unexpanded, so it can be tried again. Expanding is the one thing on the
-		// rail that costs a request, so it is the one thing that can fail from a dropped
-		// connection rather than from a bad row.
+		// Back to unexpanded, so it can be tried again.
 		if (mine === generation) expanded.value = false;
 		console.error(`[frappe] could not expand navigation item '${item.value.key}'`, error);
 	}

--- a/frontend/src/navigation/context.ts
+++ b/frontend/src/navigation/context.ts
@@ -1,8 +1,5 @@
-// The world one renderer is handed.
-//
-// Composed once per list rather than once per item: `items` and `sidebars` are the same
-// for every row, and `renderingOf` has to close over the finished context so that a
-// `Sidebar` item can resolve rows it did not author.
+// The world one renderer is handed, composed once per list so `renderingOf` closes over
+// the finished context and a `Sidebar` item can resolve rows it did not author.
 
 import type { Router } from "vue-router";
 import type { Boot, NavigationItem } from "@/boot";
@@ -25,13 +22,9 @@ export function itemContext(
 		router,
 		items,
 		sidebars,
-		// This prefix's pages only, which is the same filter the route table applies: a
-		// `Page` item can only point at a page this document can actually route to.
+		// This prefix's pages only, the same filter the route table applies.
 		pages: pages.filter((page) => page.app === boot.app),
-		// Rejects rather than answering empty off the index, which belongs to no app. `[]`
-		// is a REAL answer here — a module whose contents this person may not read — so
-		// returning it for a question that was never asked would put "nothing left in this
-		// module" on screen over a request that never happened (`contents.ts`).
+		// Rejects off the index: `[]` is a real answer here and must not be forged.
 		contentsOf: (moduleSlug) =>
 			boot.app
 				? fetchContents(boot.app, moduleSlug)

--- a/frontend/src/navigation/current.ts
+++ b/frontend/src/navigation/current.ts
@@ -1,16 +1,5 @@
-// Which row the address is on, and therefore which sidebar is open.
-//
-// Charter point 7: navigation follows the address, never the reverse. Among panels covering
-// it EQUALLY the reader's open one wins, but a cold load is still the path alone.
-//
-// It is not `router-link-active`. Two reasons, and both are real rather than tidiness. A
-// rail item of type `Sidebar` resolves to the first destination INSIDE its sidebar
-// (`sidebar/frontend/item.js`), so standing on the third row of that sidebar leaves the
-// rail item's own link inactive while the panel it opens is exactly where you are; and
-// `router-link-active` is prefix-based per link, so a list and one of its saved views both
-// match `/sales-invoice/view/open` and two rows light up. One winner, chosen here, is the
-// only version of "the rail and the panel highlight whatever the current URL resolves to"
-// that a reader can act on.
+// Which row the address is on, and so which sidebar is open. Not `router-link-active`: a
+// `Sidebar` rail item's link resolves to a row inside its panel, and prefix matching lights two rows.
 
 import type { NavigationItem } from "@/boot";
 import type { ItemContext, Rendering } from "./types";
@@ -19,11 +8,8 @@ import type { ItemContext, Rendering } from "./types";
 export type Destination = { path: string; found: CurrentNavigation };
 
 /**
- * One item context per container, because a context is composed once per LIST and there are
- * two kinds of list here. `Module Contents` is what makes the difference real: it measures
- * "what is left of this module" against `context.items`, so a row in a sidebar handed the
- * rail's context would hide the doctypes the RAIL already shows and repeat the ones its own
- * panel does.
+  * One context per container: `Module Contents` measures against `context.items`, and a
+  * sidebar row handed the rail's list would hide the wrong doctypes.
  */
 export type NavigationContexts = {
 	rail: ItemContext;
@@ -33,19 +19,15 @@ export type NavigationContexts = {
 export type CurrentNavigation = {
 	/** The rail row to highlight: the destination itself, or the item that opens the panel. */
 	railKey?: string;
-	/** The scrubbed address of the sidebar to show, if the address is inside one (#42356). */
+	/** The scrubbed address of the sidebar to show, if the address is inside one. */
 	sidebar?: string;
 	/** The row inside that sidebar to highlight. */
 	rowKey?: string;
 };
 
 /**
- * How specifically `itemPath` covers `currentPath` — its segment count, or -1 for no cover.
- *
- * Segment-wise rather than `startsWith`, which would read `/sales-orders` as sitting under
- * `/sales-order`. A list covers its own records and its saved views, so `/sales-invoice`
- * stays lit while you read `/sales-invoice/SI-001`; and where a list and a view both cover
- * the address, the view is deeper and wins.
+  * How specifically `itemPath` covers `currentPath`: its segment count, or -1 for no cover.
+  * Segment-wise, or `/sales-orders` would sit under `/sales-order`.
  */
 export function coverage(currentPath: string, itemPath: string): number {
 	const current = currentPath.split("/").filter(Boolean);
@@ -60,25 +42,8 @@ export function coverage(currentPath: string, itemPath: string): number {
 }
 
 /**
- * Every route in this prefix that navigation can be standing on, and what each one means.
- *
- * Separate from the match because the two change at different rates. Resolving a
- * destination costs a `renderingOf` and a `router.resolve`, twice over — the registry
- * resolves once to keep an unresolvable route out of `RouterLink` — and the framework's own
- * prefix carries 194 rail items (#42362). Doing that per navigation would put hundreds of
- * route resolutions in the way of every click. The payload changes only on a save, so this
- * is computed against the payload and the match against the path.
- *
- * Everything with a route competes: the rail's own rows, and the rows of every sidebar the
- * rail can open. A rail item that opens a sidebar competes THROUGH that sidebar's rows
- * rather than through its own destination, because its own destination is one of those rows
- * already (`sidebar/frontend/item.js`) and counting it twice would let the linked item beat
- * the panel it opens — the panel would then open with nothing marked inside it.
- *
- * Order is the order the person is looking at: the rail top to bottom, and a linked item's
- * panel where the item sits. That is what breaks a tie, and ties are ordinary rather than
- * exotic — #42357 counted 101 rows in ERPNext linking outside their own module, so one
- * address really does sit in two places.
+  * Every route navigation can stand on, computed once per payload, not per click. A rail
+  * item that opens a sidebar competes through that sidebar's rows, not its own destination.
  */
 export function navigationDestinations(
 	rail: NavigationItem[],
@@ -89,8 +54,7 @@ export function navigationDestinations(
 	const router = contexts.rail.router;
 
 	const add = (rendering: Rendering | null, found: CurrentNavigation) => {
-		// `href` rows leave the prefix and `group`/`expand` rows go nowhere, so neither can be
-		// where you are standing.
+		// `href` rows leave the prefix and `group`/`expand` rows go nowhere.
 		if (!rendering || !("to" in rendering)) return;
 
 		// Resolvable, because `renderingOf` already resolved it once (`registry.ts`).
@@ -102,8 +66,7 @@ export function navigationDestinations(
 		const sidebar = rendering && "sidebar" in rendering ? rendering.sidebar : undefined;
 
 		if (sidebar) {
-			// Its own rows, through their own context — the one the panel will draw them with,
-			// so what is a destination here is a destination there.
+			// Through the sidebar's own context, the one the panel draws them with.
 			const inside = contexts.sidebars[sidebar] ?? contexts.rail;
 			for (const row of sidebars[sidebar] ?? []) {
 				add(inside.renderingOf(row), { railKey: item.key, sidebar, rowKey: row.key });
@@ -118,10 +81,8 @@ export function navigationDestinations(
 }
 
 /**
- * The rail row, the sidebar and the row inside it that `path` is standing on.
- *
- * `prefer` holds the reader's panels, most wanted first, and breaks ties only: deeper
- * coverage still wins, and an address nothing covers returns `{}`.
+  * The rail row, sidebar and row inside it that `path` is standing on. `prefer` breaks ties
+  * only: deeper coverage still wins, and an address nothing covers returns `{}`.
  */
 export function currentFrom(
 	destinations: Destination[],
@@ -143,8 +104,7 @@ export function currentFrom(
 		// compare or a preferred panel wins on an address it does not hold.
 		if (covers < 0 || covers < depth) continue;
 
-		// Strictly more wanted, so list order still breaks a tie nothing prefers: the rail top
-		// to bottom, and the first of two rows one panel points at the same place.
+		// Strictly more wanted, so list order still breaks a tie nothing prefers.
 		const place = rank(destination.found);
 		if (covers > depth || place < wanted) {
 			depth = covers;

--- a/frontend/src/navigation/current.ts
+++ b/frontend/src/navigation/current.ts
@@ -8,8 +8,8 @@ import type { ItemContext, Rendering } from "./types";
 export type Destination = { path: string; found: CurrentNavigation };
 
 /**
-  * One context per container: `Module Contents` measures against `context.items`, and a
-  * sidebar row handed the rail's list would hide the wrong doctypes.
+ * One context per container: `Module Contents` measures against `context.items`, and a
+ * sidebar row handed the rail's list would hide the wrong doctypes.
  */
 export type NavigationContexts = {
 	rail: ItemContext;
@@ -26,8 +26,8 @@ export type CurrentNavigation = {
 };
 
 /**
-  * How specifically `itemPath` covers `currentPath`: its segment count, or -1 for no cover.
-  * Segment-wise, or `/sales-orders` would sit under `/sales-order`.
+ * How specifically `itemPath` covers `currentPath`: its segment count, or -1 for no cover.
+ * Segment-wise, or `/sales-orders` would sit under `/sales-order`.
  */
 export function coverage(currentPath: string, itemPath: string): number {
 	const current = currentPath.split("/").filter(Boolean);
@@ -42,8 +42,8 @@ export function coverage(currentPath: string, itemPath: string): number {
 }
 
 /**
-  * Every route navigation can stand on, computed once per payload, not per click. A rail
-  * item that opens a sidebar competes through that sidebar's rows, not its own destination.
+ * Every route navigation can stand on, computed once per payload, not per click. A rail
+ * item that opens a sidebar competes through that sidebar's rows, not its own destination.
  */
 export function navigationDestinations(
 	rail: NavigationItem[],
@@ -81,8 +81,8 @@ export function navigationDestinations(
 }
 
 /**
-  * The rail row, sidebar and row inside it that `path` is standing on. `prefer` breaks ties
-  * only: deeper coverage still wins, and an address nothing covers returns `{}`.
+ * The rail row, sidebar and row inside it that `path` is standing on. `prefer` breaks ties
+ * only: deeper coverage still wins, and an address nothing covers returns `{}`.
  */
 export function currentFrom(
 	destinations: Destination[],

--- a/frontend/src/navigation/iconSlot.ts
+++ b/frontend/src/navigation/iconSlot.ts
@@ -1,7 +1,4 @@
-// Whether a container holds an icon slot open on the rows that have no icon.
-//
-// Decided once for a whole container, so a list where only some rows carry an icon still
-// reads as one list.
+// Whether a container holds an icon slot open on rows without one; decided once per container.
 
 import { computed, type ComputedRef, type MaybeRefOrGetter, toValue } from "vue";
 import type { NavigationItem } from "@/boot";
@@ -18,8 +15,7 @@ export function useIconSlot(
 	);
 }
 
-// Asked of the renderer rather than of `item_type`: a heading is whatever resolves to no
-// destination, which is `NavigationRow`'s own rule and not a list of kinds.
+// Asked of the renderer: a heading is whatever resolves to no destination.
 function drawsIcon(item: NavigationItem, context: ItemContext): boolean {
 	const rendering = renderingOf(item, context);
 	return !!rendering && !("group" in rendering);

--- a/frontend/src/navigation/registry.ts
+++ b/frontend/src/navigation/registry.ts
@@ -9,8 +9,8 @@ import type { ItemContext, ItemRenderer, Rendering } from "./types";
 const reported = new Set<string>();
 
 /**
-  * A `Sidebar` item resolves rows inside its sidebar, so two sidebars pointing at each other
-  * would recurse. A depth, not a key set: a key is unique only within one container.
+ * A `Sidebar` item resolves rows inside its sidebar, so two sidebars pointing at each other
+ * would recurse. A depth, not a key set: a key is unique only within one container.
  */
 const MAX_DEPTH = 8;
 let depth = 0;
@@ -60,7 +60,7 @@ export function renderingOf(
 }
 
 /**
-  * An authored label wins and is never translated; then the renderer's fallback; then the destination.
+ * An authored label wins and is never translated; then the renderer's fallback; then the destination.
  */
 export function labelOf(item: NavigationItem, context: ItemContext): string {
 	if (item.label) return item.label;

--- a/frontend/src/navigation/registry.ts
+++ b/frontend/src/navigation/registry.ts
@@ -1,19 +1,5 @@
-// Type name -> renderer, and what happens when there is no renderer to find.
-//
-// There is no built-in table here. The framework's eight kinds arrive through
-// `contributions/registry.ts` exactly as an app's would, so this file cannot tell one
-// from the other and has no case to grow when a ninth lands (DP2).
-//
-// It also owns the two failure paths, because both must be answered once rather than in
-// eight renderers:
-//
-//   - **No renderer.** #42228 chose skip-and-log over failing the render, which is
-//     #42070's degrade rather than #42069's fail-hard. The item is silently absent from
-//     the rail today; this is what makes it loud.
-//   - **A renderer that throws.** `routeFor` throws for a doctype the address table has
-//     never heard of, which is a real state for an item pointing at an app that has since
-//     been uninstalled. A renderer is app code, so it is treated exactly as a missing one:
-//     skip the item, log once. One app's bad row must not blank the rail.
+// Type name -> renderer, and the two failure paths: no renderer, and a renderer that throws.
+// Both skip the item and log once; one app's bad row must not blank the rail.
 
 import type { NavigationItem } from "@/boot";
 import { itemRenderers } from "@/contributions/registry";
@@ -23,16 +9,8 @@ import type { ItemContext, ItemRenderer, Rendering } from "./types";
 const reported = new Set<string>();
 
 /**
- * A `Sidebar` item's destination is the first destination INSIDE its sidebar, so resolving
- * one item can resolve others, and two sidebars pointing at each other would otherwise be
- * a stack overflow that takes the shell down with it.
- *
- * A DEPTH count rather than a set of keys, and the difference is a real bug rather than
- * taste: a key identifies a row within one container, so the rail and a sidebar may each
- * hold a row called `accounts` without either being a cycle. Guarding on the key would
- * read the second as a repeat of the first and quietly render the rail item as
- * independent — a link silently missing, with nothing said. Depth cannot confuse two rows
- * for one, and the ceiling is far above any real nesting.
+  * A `Sidebar` item resolves rows inside its sidebar, so two sidebars pointing at each other
+  * would recurse. A depth, not a key set: a key is unique only within one container.
  */
 const MAX_DEPTH = 8;
 let depth = 0;
@@ -64,10 +42,7 @@ export function renderingOf(
 	try {
 		const rendering = renderer.render(item, context);
 
-		// A route that does not resolve throws inside `RouterLink`, during render, where
-		// nothing catches it — so one contributed renderer returning a name the route table
-		// does not hold would blank the whole rail. Resolving it HERE puts that failure back
-		// inside the handler this file already promises, which is skip-and-log (#42228).
+		// Resolved here so an unresolvable route fails in this handler, not inside `RouterLink`.
 		if (rendering && "to" in rendering) context.router.resolve(rendering.to);
 
 		return rendering;
@@ -85,12 +60,7 @@ export function renderingOf(
 }
 
 /**
- * What a reader sees on this item.
- *
- * An authored label always wins and is rendered literally — never translated, because
- * whoever typed it typed it in the language they meant (#42230). Only the fallback is the
- * renderer's, and only when it has one: the last resort is the item's own destination,
- * which is what a derived rail row is — an address and no authored presentation.
+  * An authored label wins and is never translated; then the renderer's fallback; then the destination.
  */
 export function labelOf(item: NavigationItem, context: ItemContext): string {
 	if (item.label) return item.label;
@@ -101,8 +71,7 @@ export function labelOf(item: NavigationItem, context: ItemContext): string {
 		const fallback = renderer?.label?.(item, context);
 		if (fallback) return fallback;
 	} catch {
-		// A renderer that cannot even name the item still gets its destination drawn, if
-		// `render` managed one. Falling through is the whole handler.
+		// A renderer that cannot name the item still gets its destination drawn.
 	}
 
 	return item.link_to ?? item.key;
@@ -111,11 +80,7 @@ export function labelOf(item: NavigationItem, context: ItemContext): string {
 function report(itemType: string, message: string, error?: unknown) {
 	if (reported.has(itemType)) return;
 	reported.add(itemType);
-	// Console only. #42228 asked for `frappe.log_error` as well, and the client's one
-	// channel to the Error Log — `reportCustomizationError`, which posts to
-	// `frappe.desk.customization_error.report_customization_error` — has no Python side on
-	// this branch at all; the endpoint exists in no app on the bench. Calling it would be a
-	// line that reads as reporting and does nothing, so this says what it does.
+	// Console only: the client has no working Error Log channel on this branch.
 	if (error) console.error(message, error);
 	else console.error(message);
 }

--- a/frontend/src/navigation/sectionMemory.ts
+++ b/frontend/src/navigation/sectionMemory.ts
@@ -22,8 +22,7 @@ function read(): Stored {
 		const parsed = raw ? JSON.parse(raw) : null;
 		return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
 	} catch {
-		// Storage throws in a sandboxed frame and at zero quota. A browser that cannot
-		// remember shows every section as its app ships it.
+		// Storage throws in a sandboxed frame and at zero quota.
 		return {};
 	}
 }
@@ -37,8 +36,7 @@ function write(stored: Stored): void {
 }
 
 /**
- * This reader's disclosures for one container (`Rail:crm`, `Sidebar:doctype_crm_lead`), read
- * once and pruned against the `items` that container currently ships.
+  * This reader's disclosures for one container, read once and pruned against what it ships.
  */
 export function sectionMemory(
 	user: string,
@@ -63,7 +61,6 @@ export function sectionMemory(
 		if (!Object.keys(kept).length) delete forUser[container];
 
 		const next = { ...stored, [user]: forUser };
-		// A reader who toggles everything back leaves nothing behind, not an empty shell.
 		if (!Object.keys(forUser).length) delete next[user];
 
 		write(next);
@@ -75,8 +72,7 @@ export function sectionMemory(
 		},
 
 		remember(key, open) {
-			// Back to what the app ships is a decision to forget, and the only way a reader
-			// has of clearing one.
+			// Back to what the app ships is a decision to forget.
 			if (open === shippedOpen.get(key)) delete kept[key];
 			else kept[key] = open;
 

--- a/frontend/src/navigation/sectionMemory.ts
+++ b/frontend/src/navigation/sectionMemory.ts
@@ -36,7 +36,7 @@ function write(stored: Stored): void {
 }
 
 /**
-  * This reader's disclosures for one container, read once and pruned against what it ships.
+ * This reader's disclosures for one container, read once and pruned against what it ships.
  */
 export function sectionMemory(
 	user: string,

--- a/frontend/src/navigation/sidebarMemory.ts
+++ b/frontend/src/navigation/sidebarMemory.ts
@@ -3,8 +3,7 @@
 
 const KEY = "frappe:desk:sidebar";
 
-// Every address that opens a sidebar is recorded and records get their own, so an uncapped
-// record grows for the life of the tab and every navigation re-serialises all of it.
+// Uncapped, the record would grow for the life of the tab.
 const KEEP = 100;
 
 /** The whole record, or an empty one. */
@@ -14,8 +13,7 @@ function read(): Record<string, string> {
 		const parsed = raw ? JSON.parse(raw) : null;
 		return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
 	} catch {
-		// Storage throws on access in a sandboxed frame and at zero quota. A tab that cannot
-		// remember resolves off the address, which is never wrong, only less continuous.
+		// Storage throws in a sandboxed frame and at zero quota.
 		return {};
 	}
 }

--- a/frontend/src/navigation/tests/current.test.ts
+++ b/frontend/src/navigation/tests/current.test.ts
@@ -1,4 +1,4 @@
-// Which row the address is standing on (#42421).
+// Which row the address is standing on.
 import { describe, expect, it } from "vitest";
 import { createMemoryHistory, createRouter } from "vue-router";
 
@@ -90,8 +90,7 @@ describe("the rail alone", () => {
 	});
 
 	it("keeps the list marked while you read one of its records", () => {
-		// A record has no row of its own and never will — a rail cannot list 553 doctypes'
-		// records — so the list it belongs to is the honest answer.
+		// A record has no row of its own, so the list it belongs to is the answer.
 		expect(at([deal, invoice], {}, "/crm-deal/CRM-DEAL-01")).toEqual({ railKey: "deal" });
 	});
 
@@ -119,8 +118,7 @@ describe("the rail alone", () => {
 	});
 
 	it("marks nothing when no row covers the address", () => {
-		// And so shows no panel. There is no last panel to fall back to, because falling back
-		// is storing a selection (charter point 7).
+		// And so shows no panel: falling back would be storing a selection.
 		expect(at([deal], {}, "/sales-invoice")).toEqual({});
 	});
 });
@@ -149,10 +147,8 @@ describe("a rail item that opens a sidebar", () => {
 	});
 
 	it("wins a tie against a later rail row on the same doctype", () => {
-		// Sidebars link outside their own module all the time — #42357 counted 101 rows doing
-		// it in ERPNext — so one address really can sit in two places. The tie-break is the
-		// order the person is looking at: the rail top to bottom, and a linked item's panel
-		// where the item sits. Accounts is above Deals here and contains it.
+		// One address really can sit in two places. The tie-break is reading order: the rail top
+		// to bottom, and a linked item's panel where the item sits. Accounts is above Deals here.
 		expect(at(rail, sidebars, "/crm-deal")).toEqual({
 			railKey: "accounts",
 			sidebar: "module_def_accounts",
@@ -167,13 +163,13 @@ describe("a rail item that opens a sidebar", () => {
 	});
 
 	it("is absent when its sidebar has no rows", () => {
-		// #42356 leaves a sidebar that resolved to nothing out of the payload, and the renderer
-		// then draws the rail item as an independent one — which here means not at all.
+		// A sidebar that resolved to nothing is left out of the payload, and its rail item is
+		// drawn as independent, which here means not at all.
 		expect(at(rail, { module_def_accounts: [] }, "/sales-invoice")).toEqual({});
 	});
 });
 
-// One in five ERPNext destinations sits in more than one panel, and `Item` sits in six.
+// Many destinations sit in more than one panel; `Item` sits in six on ERPNext.
 describe("the panel the reader is already in", () => {
 	// Two panels both listing Sales Invoice, Buying above Stock. Rail order answers Buying.
 	const rail: NavigationItem[] = [

--- a/frontend/src/navigation/tests/renderers.test.ts
+++ b/frontend/src/navigation/tests/renderers.test.ts
@@ -1,11 +1,5 @@
-// The eight kinds the framework ships, through the door an app would use (#42420).
-//
-// Nothing is stubbed in place of the renderers: `vitest.config.js` runs the real
-// contributions plugin over frappe's own source, so these tests fail if a renderer file is
-// misplaced, if its type record's `name` stops matching the item rows, or if the plugin
-// stops finding either. That is the point — a mocked registry would test the mock, and the
-// claim being made here is that the framework's own kinds go through the contribution
-// mechanism with no built-in table anywhere (DP2).
+// The framework's own kinds, through the door an app would use. Nothing is stubbed: the real
+// contributions plugin runs over frappe's source, so a misplaced renderer or a name mismatch fails here.
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createMemoryHistory, createRouter, type Router } from "vue-router";
 
@@ -89,9 +83,7 @@ describe("what the framework ships", () => {
 	});
 
 	it("names DocType exactly, which title-casing the folder cannot", () => {
-		// `doctype` title-cases to "Doctype". The name is read off the record's own JSON, so
-		// the framework's very first kind is the case that proves the guess would be wrong —
-		// a renderer under a name no row carries never runs and says nothing about it.
+		// `doctype` title-cases to "Doctype"; the name is read off the record's own JSON.
 		expect(rendererFor("DocType")).toBeDefined();
 		expect(rendererFor("Doctype")).toBeUndefined();
 	});
@@ -111,8 +103,7 @@ describe("DocType", () => {
 	});
 
 	it("goes one segment deeper under a modular prefix", () => {
-		// The trap `routeFor` exists for: a hand-built `/crm-deal` resolves HERE, to the
-		// module route, and shows a page that is not the list (#42211).
+		// The trap `routeFor` exists for: a hand-built `/crm-deal` resolves here, to the module route.
 		const modular = boot({
 			prefixes: { crm: { app: "crm", modular: true } },
 		});
@@ -290,8 +281,7 @@ describe("Sidebar", () => {
 	};
 
 	it("navigates to the first destination inside the sidebar it opens", () => {
-		// Charter point 7: selecting a rail item is ordinary navigation. A click that only
-		// changed shell state would be a selection no address could express.
+		// Selecting a rail item is ordinary navigation, so an address can express it.
 		const sidebars = {
 			module_def_accounts: [
 				{ key: "Sales Invoice", item_type: "DocType", link_to: "Sales Invoice" },
@@ -321,7 +311,7 @@ describe("Sidebar", () => {
 	});
 
 	it("renders as an independent item when its sidebar is absent", () => {
-		// An address that resolved to nothing is absent rather than empty (#42356).
+		// An address that resolved to nothing is absent, not empty.
 		expect(renderingOf(item, context([item], { sidebars: {} }))).toBeNull();
 	});
 
@@ -370,8 +360,8 @@ describe("a renderer that throws", () => {
 });
 
 describe("what a bad renderer cannot do", () => {
-	// A contributed renderer is another app's code, and the registry promises that one of
-	// them cannot take the rail down (#42228's degrade). These are the two ways it could.
+	// A contributed renderer is another app's code and must not take the rail down. These are
+	// the two ways it could.
 	function withRenderer(type: string, renderer: ItemRenderer, run: () => void) {
 		itemRenderers[type] = renderer;
 		try {
@@ -382,9 +372,8 @@ describe("what a bad renderer cannot do", () => {
 	}
 
 	it("cannot blank the rail by naming a route that does not exist", () => {
-		// The failure this catches happens INSIDE `RouterLink`, during render, where nothing
-		// catches it — so checking the route here is what keeps the promise true for a value
-		// a renderer returns rather than only for one it throws on.
+		// The failure would happen inside `RouterLink` during render, where nothing catches it;
+		// checking the route here keeps the promise for a returned value too.
 		const logged = vi.spyOn(console, "error").mockImplementation(() => {});
 		const item: NavigationItem = { key: "x", item_type: "Widget" };
 
@@ -407,10 +396,8 @@ describe("what a bad renderer cannot do", () => {
 
 describe("the recursion guard", () => {
 	it("does not confuse two containers' rows that share a key", () => {
-		// A `key` identifies a row within ONE container, so a rail item and a row in the
-		// sidebar it opens may both be called `accounts` without either being a cycle.
-		// Reading the second as a repeat of the first would render the rail item as
-		// independent — a link silently missing, with nothing said.
+		// A `key` identifies a row within one container, so a rail item and a sidebar row may
+		// both be called `accounts` without either being a cycle.
 		const item: NavigationItem = {
 			key: "accounts",
 			item_type: "Sidebar",
@@ -436,8 +423,7 @@ describe("the recursion guard", () => {
 
 describe("off the index, which belongs to no app", () => {
 	it("refuses a contents fetch rather than answering that a module is empty", async () => {
-		// `[]` is a REAL answer — a module whose contents this person may not read — so it
-		// must not also be what "there was no app to ask about" looks like (`contents.ts`).
+		// `[]` is a real answer, so it must not also be what "no app to ask about" looks like.
 		const ctx = itemContext(boot({ app: null }), addresses, router, [], {});
 		await expect(ctx.contentsOf("accounts")).rejects.toThrow();
 	});

--- a/frontend/src/navigation/tests/tree.test.ts
+++ b/frontend/src/navigation/tests/tree.test.ts
@@ -1,9 +1,5 @@
-// The flat list becoming a tree (#42420).
-//
-// The server sends one flat, ordered list and `parent_key` is the whole of hierarchy
-// (#42227), so everything about shape is rebuilt here. #42403's whole review was defects
-// in code that edited one of the two orders a flat list carries and forgot the other;
-// these are the reading half of that.
+// The flat list becoming a tree. The list carries two orders, the list's and the tree's;
+// these tests are the reading half.
 import { describe, expect, it, vi } from "vitest";
 import { buildTree, type ItemNode } from "../tree";
 import type { NavigationItem } from "@/boot";
@@ -45,8 +41,7 @@ describe("building the tree", () => {
 	});
 
 	it("leaves an orphan at the top level", () => {
-		// The server promotes these already (`_promote_orphans`), so this is the belt to
-		// that braces: a row whose parent never arrived is drawn, never dropped.
+		// The server promotes these already; a row whose parent never arrived is drawn, never dropped.
 		expect(shape(buildTree([item("a", "gone")]))).toEqual(["a"]);
 	});
 
@@ -66,18 +61,16 @@ describe("a parent_key cycle", () => {
 	});
 
 	it("lifts every row in a two-row cycle rather than rendering neither", () => {
-		// Both rows have a parent that is PRESENT, so the server's orphan promotion passes
-		// them through untouched; each attaches to the other and neither reaches a root.
-		// Rendering the tree would then simply omit authored navigation with nothing said.
+		// Both rows have a parent that is present, so the server's orphan promotion passes them;
+		// each attaches to the other and neither reaches a root.
 		const onCycle = vi.fn();
 		expect(shape(buildTree([item("a", "b"), item("b", "a")], onCycle))).toEqual(["a", "b"]);
 		expect(onCycle.mock.calls.flat()).toEqual(["a", "b"]);
 	});
 
 	it("lifts every row of a longer ring too", () => {
-		// Breaking only the row that closes the ring would leave the rest hanging off a row
-		// that is now a root, which reads as a nesting somebody authored. Three flat rows are
-		// visibly the odd ones out, which is what a reader needs in order to go and fix it.
+		// Breaking only the row that closes the ring would leave the rest hanging off a new root,
+		// which reads as authored nesting. Three flat rows are visibly the odd ones out.
 		expect(shape(buildTree([item("a", "c"), item("b", "a"), item("c", "b")]))).toEqual([
 			"a",
 			"b",

--- a/frontend/src/navigation/tree.ts
+++ b/frontend/src/navigation/tree.ts
@@ -9,8 +9,8 @@ export type ItemNode = {
 };
 
 /**
-  * Build the tree. The server promotes orphans, but a `parent_key` cycle passes its check, so
-  * every row in one is lifted to the top level here and reported through `onCycle`.
+ * Build the tree. The server promotes orphans, but a `parent_key` cycle passes its check, so
+ * every row in one is lifted to the top level here and reported through `onCycle`.
  */
 export function buildTree(
 	items: NavigationItem[],

--- a/frontend/src/navigation/tree.ts
+++ b/frontend/src/navigation/tree.ts
@@ -1,11 +1,5 @@
-// The flat list, as a tree.
-//
-// `parent_key` is the whole of hierarchy (#42227), and the server sends one flat,
-// ordered list — so the shape has to be rebuilt here. Two orders live in that list, the
-// list's and the tree's, and #42403 found every one of its defects in code that edited
-// one and forgot the other. This module reads rather than edits, and it keeps both: a
-// child follows its parent in the flat order, so walking the tree depth-first yields the
-// list back.
+// The flat list as a tree. A child follows its parent in the flat order, so walking the
+// tree depth-first yields the list back; this module reads and never edits.
 
 import type { NavigationItem } from "@/boot";
 
@@ -15,39 +9,21 @@ export type ItemNode = {
 };
 
 /**
- * Build the tree the rail draws.
- *
- * The server has already promoted an item whose parent is GONE to the top level
- * (`_promote_orphans`), so nothing here has to. What it cannot have fixed is a `parent_key`
- * chain that closes on itself: every row in a cycle has a parent that is present, so the
- * server's check passes and the rows attach to each other and to no root. Rendering the
- * tree would then simply omit them, which is a silent drop of authored navigation — so a
- * cycle is broken here, at the row that closes it, and that row is lifted to the top level.
- *
- * Every row in the cycle is lifted, not just one. Breaking only the first would leave the
- * rest hanging off a row that is now a root, which reads as a deliberate nesting nobody
- * authored; a flat row is visibly the odd one out, which is what a reader needs.
- *
- * `onCycle` reports it. The caller logs; this stays a pure function, because the tree is
- * rebuilt on every render of a reactive list and a logger inside it would fire per frame.
+  * Build the tree. The server promotes orphans, but a `parent_key` cycle passes its check, so
+  * every row in one is lifted to the top level here and reported through `onCycle`.
  */
 export function buildTree(
 	items: NavigationItem[],
 	onCycle?: (key: string) => void
 ): ItemNode[] {
 	const nodes = new Map<string, ItemNode>();
-	// Last one wins, matching the server's own merge: a duplicate key is one item that was
-	// written twice, not two items. Building the index first is also what lets a child
-	// appear BEFORE its parent in the flat list without being orphaned.
+	// Last one wins, as in the server's merge. Indexing first lets a child precede its parent.
 	for (const item of items) nodes.set(item.key, { item, children: [] });
 
 	const roots: ItemNode[] = [];
 
-	// Over the INDEX, not over `items`. A key that appears twice is one node in the map, so
-	// walking the list would place that one node twice — the same object under two parents,
-	// or twice at the top level, which Vue then renders as duplicate rows under a duplicate
-	// `:key`. A `Map` keeps first-seen order while `set` overwrites the value, so this is
-	// the list's order with the later row's content, which is what "written twice" means.
+	// Over the index, not `items`: a duplicate key is one node, and walking the list would
+	// place it twice, which Vue renders as duplicate rows under one `:key`.
 	for (const node of nodes.values()) {
 		const item = node.item;
 		const parent = item.parent_key ? nodes.get(item.parent_key) : undefined;

--- a/frontend/src/navigation/types.ts
+++ b/frontend/src/navigation/types.ts
@@ -1,16 +1,5 @@
-// What a navigation item DOES, and who gets to say so.
-//
-// #42228 decided a kind is two files — a `Navigation Item Type` record, and the JS that
-// says what an item of that kind does on click — and named a path without naming the
-// contract. This file is the contract.
-//
-// The framework's own eight kinds go through it unmodified: `DocType`, `Record`,
-// `Module`, `Module Contents`, `Page`, `Section`, `Sidebar` and `Link` each ship a
-// renderer at the ordinary contribution path, discovered by the ordinary plugin, and the
-// registry holds no built-in table at all. That is DP2 taken literally — if the framework
-// needed a back door to draw its own rail, the front door would not be finished — and it
-// is what makes "an app contributes a kind" (#42424) a matter of writing two files rather
-// than of the framework growing a case.
+// The contract a navigation item kind's `item.js` implements. The framework's own kinds go
+// through it unmodified; the registry holds no built-in table.
 
 import type { RouteLocationRaw, Router } from "vue-router";
 import type { Boot, NavigationItem } from "@/boot";
@@ -18,20 +7,8 @@ import type { Addresses } from "@/addresses";
 import type { ContentEntry } from "@/contents";
 
 /**
- * What one item resolves to. Four shapes, and every kind on the branch is one of them:
- *
- * - `to` — a route in THIS prefix, rendered as a `RouterLink`.
- * - `href` — an absolute URL, rendered as a plain `<a>`, because following it is a full
- *   document load. A `Link` item points off the desk entirely, and a contributed item
- *   whose app said `switches_app` carries a URL the server finished (#42364).
- * - `group` — no destination of its own; it draws whatever names it as `parent_key`.
- * - `expand` — rows that are not known until they are asked for. `Module Contents` is
- *   the only kind of this shape, and the only one whose row count resolution cannot fix.
- *
- * `sidebar` rides alongside a destination rather than being a fifth shape. An item that
- * opens a sidebar is still ordinary navigation — charter point 7 — so it has a real
- * destination and the sidebar key is an annotation on it, which is what lets #42421 mount
- * a panel without this file learning what a panel is.
+  * What one item resolves to: a route in this prefix, an absolute href (a full document
+  * load, so an `<a>`), a heading, or rows fetched on demand. `sidebar` annotates a destination.
  */
 export type Rendering =
 	| { to: RouteLocationRaw; sidebar?: string }
@@ -40,50 +17,35 @@ export type Rendering =
 	| { expand: () => Promise<NavigationItem[]> };
 
 /**
- * Everything a renderer is allowed to know. It is a parameter rather than a set of
- * imports on purpose: a contributed renderer lives in another app's repo, and the only
- * module it may import from the framework is `@shell`, which publishes address arithmetic
- * and deliberately nothing else. So what a renderer needs BEYOND an address arrives here,
- * where it is also trivially substitutable in a test.
+  * Everything a renderer may know, as a parameter: a contributed renderer imports only `@shell`.
  */
 export type ItemContext = {
 	boot: Boot;
 	addresses: Addresses;
 	/**
-	 * The router this document holds. A renderer does not need it — `routeFor` builds every
-	 * address there is — but the registry does, to check that what a renderer handed back
-	 * actually resolves before `RouterLink` meets it and throws mid-render.
+	 * For the registry to resolve what a renderer returns before `RouterLink` throws mid-render.
 	 */
 	router: Router;
-	/** Every sidebar in this prefix, keyed by scrubbed address (#42356). */
+	/** Every sidebar in this prefix, keyed by scrubbed address. */
 	sidebars: Record<string, NavigationItem[]>;
 	/**
-	 * The whole list this item belongs to. `Module Contents` is what needs it: "what is
-	 * left of a module" is measured against what the list already shows, and only the
-	 * list can answer that.
+	 * The whole list this item belongs to; `Module Contents` measures what is left against it.
 	 */
 	items: NavigationItem[];
-	/** The contributed pages this prefix serves — a `Page` item's destination space. */
+	/** The contributed pages this prefix serves. */
 	pages: { slug: string; title?: string }[];
 	/** What a module contains, permission-filtered (`contents.ts`). */
 	contentsOf(moduleSlug: string): Promise<ContentEntry[]>;
 	/**
-	 * Another item's rendering. A `Sidebar` item is the caller: its own destination is the
-	 * first destination inside the sidebar it opens, so it has to resolve rows it did not
-	 * author. Recursion is depth-guarded by the registry, not by the renderer.
+	 * Another item's rendering; a `Sidebar` item resolves its sidebar's first row through it.
+	 * Recursion is depth-guarded by the registry, not by the renderer.
 	 */
 	renderingOf(item: NavigationItem): Rendering | null;
 };
 
 /**
- * A renderer, as an app's `item.js` default-exports it.
- *
- * `render` returning `null` means the item cannot be drawn HERE — a `Module` under a
- * non-modular prefix has no module route to land on — and the rail skips it, the same
- * treatment #42228 chose for a kind with no renderer at all.
- *
- * `label` is the fallback for an item nobody labelled, and only that: an authored label
- * always wins, and is never translated (#42230).
+  * A renderer, as an app's `item.js` default-exports it. `render` returns `null` when the
+  * item cannot be drawn here and the row is skipped; `label` is only the unlabelled fallback.
  */
 export type ItemRenderer = {
 	render(item: NavigationItem, context: ItemContext): Rendering | null;

--- a/frontend/src/navigation/types.ts
+++ b/frontend/src/navigation/types.ts
@@ -7,8 +7,8 @@ import type { Addresses } from "@/addresses";
 import type { ContentEntry } from "@/contents";
 
 /**
-  * What one item resolves to: a route in this prefix, an absolute href (a full document
-  * load, so an `<a>`), a heading, or rows fetched on demand. `sidebar` annotates a destination.
+ * What one item resolves to: a route in this prefix, an absolute href (a full document
+ * load, so an `<a>`), a heading, or rows fetched on demand. `sidebar` annotates a destination.
  */
 export type Rendering =
 	| { to: RouteLocationRaw; sidebar?: string }
@@ -17,7 +17,7 @@ export type Rendering =
 	| { expand: () => Promise<NavigationItem[]> };
 
 /**
-  * Everything a renderer may know, as a parameter: a contributed renderer imports only `@shell`.
+ * Everything a renderer may know, as a parameter: a contributed renderer imports only `@shell`.
  */
 export type ItemContext = {
 	boot: Boot;
@@ -44,8 +44,8 @@ export type ItemContext = {
 };
 
 /**
-  * A renderer, as an app's `item.js` default-exports it. `render` returns `null` when the
-  * item cannot be drawn here and the row is skipped; `label` is only the unlabelled fallback.
+ * A renderer, as an app's `item.js` default-exports it. `render` returns `null` when the
+ * item cannot be drawn here and the row is skipped; `label` is only the unlabelled fallback.
  */
 export type ItemRenderer = {
 	render(item: NavigationItem, context: ItemContext): Rendering | null;

--- a/frontend/src/navigation/useItemTree.ts
+++ b/frontend/src/navigation/useItemTree.ts
@@ -1,24 +1,13 @@
-// The tree a container draws, with the cycle report attached.
-//
-// A composable rather than a call to `buildTree`, because the reporting is what has to be
-// shared and it is the part with state in it. `buildTree` stays pure — it is recomputed on
-// every render of a reactive list, so a logger inside it would fire per frame — and the
-// "once per key" set has to live somewhere that outlives one computation.
-//
-// One set per instance, which is one set per container. A key identifies a row within ONE
-// container (`registry.ts` learned this the hard way, on the depth guard), so a rail and a
-// sidebar may each hold a row called `accounts` and a shared set would report the second as
-// a repeat of the first and say nothing.
+// The tree a container draws, with the once-per-key cycle report; `buildTree` stays pure.
+// One set per container: a key is unique only within one container.
 
 import { computed, type ComputedRef, type MaybeRefOrGetter, toValue } from "vue";
 import type { NavigationItem } from "@/boot";
 import { buildTree, type ItemNode } from "./tree";
 
 /**
- * The tree for one container's rows, rebuilt whenever they change.
- *
- * @param items The container's flat, ordered list — a ref or a getter.
- * @param container What to call it in a cycle report: `the rail`, `the <address> sidebar`.
+  * The tree for one container's rows, rebuilt whenever they change. `container` names it in
+  * a cycle report: `the rail`, `the <address> sidebar`.
  */
 export function useItemTree(
 	items: MaybeRefOrGetter<NavigationItem[]>,
@@ -28,8 +17,6 @@ export function useItemTree(
 
 	return computed(() =>
 		buildTree(toValue(items), (key) => {
-			// A list that is wrong stays wrong, so the line would repeat on every save without
-			// saying anything new.
 			if (reported.has(key)) return;
 			reported.add(key);
 			console.error(

--- a/frontend/src/navigation/useItemTree.ts
+++ b/frontend/src/navigation/useItemTree.ts
@@ -6,8 +6,8 @@ import type { NavigationItem } from "@/boot";
 import { buildTree, type ItemNode } from "./tree";
 
 /**
-  * The tree for one container's rows, rebuilt whenever they change. `container` names it in
-  * a cycle report: `the rail`, `the <address> sidebar`.
+ * The tree for one container's rows, rebuilt whenever they change. `container` names it in
+ * a cycle report: `the rail`, `the <address> sidebar`.
  */
 export function useItemTree(
 	items: MaybeRefOrGetter<NavigationItem[]>,

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -1,14 +1,5 @@
 <!--
-  Three things behind one route, because `/apps`, `/apps/<prefix>` and a modular
-  `/apps/<prefix>` are the same document with different boots.
-
-  At `/apps` this is the index: every app whose prefix passes `app_permission`,
-  derived from the prefix registry and never from `add_to_apps_screen` -- which means
-  tile *visibility*, strictly narrower than access. The index is not a member of its
-  own list (#42124).
-
-  Under a MODULAR prefix it lists modules rather than doctypes, which is what makes
-  the address walk all the way up (#42211).
+  Three things behind one route: the index at `/apps`, an app's home, and a modular app's module list.
 -->
 <template>
 	<div class="overflow-y-auto p-8">
@@ -19,8 +10,7 @@
 				>.
 			</p>
 
-			<!-- Same rule as the rail and the module page: an empty grid and a grid that
-					 failed to load are indistinguishable, and one of them misdescribes the app. -->
+			<!-- An empty grid and one that failed to load must not look the same. -->
 			<p v-if="failed" class="mt-6 text-sm text-ink-gray-6">
 				Could not load this app's navigation.
 			</p>
@@ -52,8 +42,7 @@
 			<h1 class="text-xl font-semibold">Apps</h1>
 			<ul class="mt-6 grid max-w-2xl grid-cols-2 gap-2">
 				<li v-for="app in boot.apps ?? []" :key="app.app">
-					<!-- A real navigation, not a router.push: crossing a prefix needs a boot
-               re-fetch, and the router's base is fixed at construction (#42102). -->
+					<!-- A real navigation, not a `router.push`: crossing a prefix needs a boot re-fetch. -->
 					<a
 						:href="app.route"
 						class="flex items-center gap-2 rounded border border-outline-gray-2 px-3 py-2 text-sm hover:bg-surface-gray-2"
@@ -82,8 +71,7 @@ const addresses = inject<Addresses>("addresses")!;
 const modular = computed(() => isModular(boot));
 const { entries, failed } = useContents(boot.app);
 
-// The modules a user can reach, derived from what they can read rather than from the
-// module list -- an empty module is a tile that leads nowhere.
+// Derived from what the reader can read: an empty module is a tile that leads nowhere.
 const modules = computed(() => {
 	const seen = new Map<string, string>();
 	for (const entry of entries.value) {

--- a/frontend/src/pages/List.vue
+++ b/frontend/src/pages/List.vue
@@ -10,9 +10,8 @@
 			<tbody>
 				<tr v-for="row in rows" :key="row.name" class="border-b border-outline-gray-1">
 					<td class="py-1.5">
-						<!-- `routeFor`, never a template literal. Under a modular prefix the
-							hand-built form resolves -- to the module route -- and shows a page
-							that is not the record (#42225). -->
+						<!-- `routeFor`, never a template literal: under a modular prefix the hand-built form
+													resolves to the wrong page. -->
 						<RouterLink
 							:to="routeFor(doctype!, row.name)"
 							class="text-ink-blue-3 hover:underline"
@@ -42,8 +41,7 @@ const rows = ref<Record<string, string>[]>([]);
 
 const doctype = computed(() => addresses.doctypeOf(String(route.params.doctype)));
 
-// A contributed `list.js` is read here and nowhere else. It cannot add a route, only
-// shape the view it was colocated with.
+// A contributed `list.js` is read here and nowhere else; it shapes the view, never adds a route.
 const columns = computed(() => {
 	if (!doctype.value) return [];
 	return listHandlersFor(doctype.value).flatMap(({ handlers }) =>
@@ -51,17 +49,14 @@ const columns = computed(() => {
 	);
 });
 
-// Which fetch is current: navigating away leaves the previous one in flight, and
-// without this a slower response repaints the list of the doctype the reader left.
+// The slower of two in-flight fetches must not repaint the list the reader left.
 let generation = 0;
 
 watchEffect(async () => {
 	if (!doctype.value) return;
 	const mine = ++generation;
-	// Same reason as `Record.vue`: the heading switches doctype synchronously, so the
-	// previous doctype's rows would otherwise sit under the new one's title until the
-	// fetch lands. Writing `rows` does not re-trigger this effect -- watchEffect tracks
-	// reads, and nothing here reads it.
+	// Cleared before the fetch: the heading switches synchronously. Writing `rows` does not
+	// re-trigger this effect, since nothing here reads it.
 	rows.value = [];
 	const params = new URLSearchParams({
 		doctype: doctype.value,

--- a/frontend/src/pages/Module.vue
+++ b/frontend/src/pages/Module.vue
@@ -1,21 +1,12 @@
 <!--
-  A module's landing page -- framework-generated, and reachable only under a prefix
-  whose app declares `app_modular`.
-
-  It exists because an addressable level that 404s is a navigation dead end. A reader
-  who deletes the tail of `/apps/erpnext/accounts/sales-invoice/SI-001` expects to
-  land somewhere, and now does, all the way up: record, module, app, /apps (#42211 §6).
-
-  PERMISSION-FILTERED, and that is the line #42210 drew held exactly: addressability
-  is permission-independent, navigation is filtered. Nobody pastes a module page as a
-  record link, so filtering it changes no address's shape.
+  A module's landing page, reachable only under a modular prefix. Permission-filtered, unlike the
+  address space.
 -->
 <template>
 	<div class="overflow-y-auto p-8">
 		<h1 class="text-xl font-semibold">{{ title }}</h1>
 		<p class="mt-1 text-sm text-ink-gray-6">
-			<!-- "0 doctypes you can read" is a real answer for a module you can read
-					 nothing in, so it must not also be what a pending fetch looks like. -->
+			<!-- "0 doctypes you can read" is a real answer, so it must not also be what a pending fetch looks like. -->
 			<template v-if="loading">Loading…</template>
 			<template v-else-if="failed"> Could not load this module's doctypes. </template>
 			<template v-else>
@@ -50,7 +41,6 @@ const route = useRoute();
 
 const moduleSlug = computed(() => String(route.params.module ?? ""));
 const { entries, loading, failed } = useContents(boot.app, moduleSlug);
-// The slug is the address; the name is what a human reads. The server sends both, so
-// neither side has to guess the other.
+// The slug is the address; the name is what a human reads.
 const title = computed(() => addresses.moduleName(moduleSlug.value) ?? moduleSlug.value);
 </script>

--- a/frontend/src/pages/Record.vue
+++ b/frontend/src/pages/Record.vue
@@ -1,16 +1,6 @@
 <!--
-  The generated record page: what every app gets at /apps/<prefix>/<slug>/<name> with
-  no declaration at all. Charter item 2's "default first" made literal.
-
-  It hosts the REAL record-page engine (`@/recordPage`), which is what makes a
-  contributed `record.js` run rather than merely be discovered. Deliberately a MINIMAL
-  host: no form layout, no tabs, no panel. `RecordPageHost` documents `formLayout` and
-  friends as "absent for a host that renders no form", so this is a supported shape
-  rather than a fork of the engine.
-
-  What it is NOT is a port of `crm/frontend2`'s record page. That is 1,962 lines across
-  a dozen components plus a 400-line composable, and migrating it wholesale is a later
-  map. The skeleton's job is to prove the seam carries a contribution end to end.
+  The generated record page every app gets at /apps/<prefix>/<slug>/<name>: a minimal host for
+  the record-page engine, with no form layout, tabs or panel.
 -->
 <template>
 	<div class="overflow-y-auto p-8">
@@ -64,15 +54,12 @@ const doc = ref<Record<string, any>>({});
 const saved = ref<Record<string, any>>({});
 const meta = ref<any>(null);
 const error = ref("");
-// Kept apart from `error`: a failed ACTION must not blank the record the reader is
-// looking at, which sharing one ref would do (the field list renders in its v-else).
+// Apart from `error`: a failed action must not blank the record (the field list is in its v-else).
 const actionError = ref("");
 const controller = shallowRef<RecordPageController | null>(null);
 const actionsVersion = ref(0);
 
-// Which load is current. Navigating A -> B leaves A's fetch in flight, and without
-// this the slower response wins: `doc` would hold A while the URL says B, and `save()`
-// would then POST A's fields -- writing the record the user is not looking at.
+// The slower of two in-flight loads must not win: `save()` would then POST the wrong record.
 let generation = 0;
 
 const doctype = computed(() => addresses.doctypeOf(String(route.params.doctype)));
@@ -102,19 +89,8 @@ async function load() {
 	error.value = "";
 	const carriedActionError = actionError.value;
 
-	// Blank what is on screen before fetching the next record. `generation` already
-	// stops a slow response from repainting the record the reader left, but it says
-	// nothing about what is displayed MEANWHILE: the heading reads `route.params.name`,
-	// which changes synchronously, so without this the new record's name sits above the
-	// old record's field values. On a record page that is not a cosmetic flicker -- it
-	// is one record's data presented as another's.
-	//
-	// `saved` goes with `doc` so `isDirty` stays false across the gap rather than
-	// reading an empty draft against a populated baseline.
-	//
-	// The controller goes too, and that one is not cosmetic at all: its quick actions
-	// belong to the PREVIOUS doctype and close over the previous `page`. Left up, a
-	// reader could click one and run it against a record it was never contributed for.
+	// Blanked before the fetch: the heading changes synchronously, and the old controller's quick
+	// actions close over the previous page. `saved` goes with `doc` so `isDirty` stays false.
 	doc.value = {};
 	saved.value = {};
 	controller.value = null;
@@ -145,8 +121,7 @@ async function load() {
 		meta,
 		perms: () => ({}),
 		isDirty: () => JSON.stringify(doc.value) !== JSON.stringify(saved.value),
-		// No strip on this page, so the reader is never on a tab and activation is a
-		// no-op. The engine already refuses to activate a tab it cannot see.
+		// No tab strip on this page, so activation is a no-op.
 		activeTab: () => "",
 		activateTab: () => {},
 		save,
@@ -162,8 +137,7 @@ async function load() {
 }
 
 async function save() {
-	// Refuse rather than write the wrong record: if the route moved while an action was
-	// running, the draft in `doc` no longer belongs to what the URL addresses.
+	// Refuse to write the wrong record if the route moved while an action ran.
 	if (doc.value.name !== docname.value || doctype.value === null) {
 		throw new Error("The record changed while saving; nothing was written.");
 	}
@@ -185,10 +159,8 @@ async function save() {
 }
 
 async function runAction(action: { run: (page: unknown) => unknown }) {
-	// Awaited and caught. Neither, and a failing action leaves the draft mutated on
-	// screen with no error at all -- CRM's `markWon` sets status to Won *before*
-	// awaiting save(), so a user without write permission would watch the record flip
-	// to Won and nothing else happen. Reloading discards the rejected draft.
+	// Awaited and caught: a failing action would otherwise leave the draft mutated on screen
+	// with no error. Reloading discards the rejected draft.
 	actionError.value = "";
 	try {
 		await action.run(controller.value?.page);

--- a/frontend/src/public.ts
+++ b/frontend/src/public.ts
@@ -1,22 +1,5 @@
-// `@shell` -- the framework's public surface for CONTRIBUTED source.
-//
-// A contributed file lives in another app's repo but is compiled into this bundle by
-// the vite plugin, so it is in the same module graph and can import from here. What
-// it must not do is reach in through `@/…`, which is this app's private alias.
-//
-// It exists for one reason: after #42210 and #42211 a doctype URL has a shape a
-// contributed script cannot know -- it depends on the prefix the reader is standing
-// in, and whether that app declares `app_modular`. A script that spells one by hand
-// gets a 404 on ERPNext and a working link on CRM, which is the worst possible way to
-// find out. So the builder is published rather than the shape being documented.
-//
-// Deliberately small. This is not the record-page `page` surface (maps 1-4) and not a
-// second door into the shell: everything here is address arithmetic.
-//
-// `isModular` is here for the same reason as the builders. `routeForModule` only resolves
-// under a modular prefix, so a contributed navigation renderer that offers a module
-// destination has to be able to ASK before it builds one -- and the answer is a property
-// of the app serving the prefix, which the reader cannot see (#42211 §2).
+// `@shell`: what a contributed file may import from; `@/` is this app's private alias.
+// A doctype URL's shape depends on the prefix, so the builders are published, not the shape.
 
 export {
 	isModular,

--- a/frontend/src/router/contributed.ts
+++ b/frontend/src/router/contributed.ts
@@ -1,16 +1,11 @@
-// Contributed pages, from the synthesised virtual module.
-//
-// The file is short because the plugin did the work at build time. There is no hook
-// to read, no boot key to walk and no install order to respect -- the contributions
-// are already in this bundle.
+// Contributed pages, from the virtual module the vite plugin synthesised at build time.
 
 import { pages } from '@/contributions/registry'
 
 export function contributedRoutes(app: string | null) {
   if (!app) return []
 
-  // Only the declaring app's pages. A ten-app bench does not put ten apps' pages in
-  // one prefix's route table -- the same core-plus-declarer rule as boot (#42070).
+  // Only the declaring app's pages: the same core-plus-declarer rule as boot.
   return pages
     .filter((page) => page.app === app)
     .map((page) => ({

--- a/frontend/src/router/generated.ts
+++ b/frontend/src/router/generated.ts
@@ -1,10 +1,4 @@
-// The routes EVERY app gets with no declaration at all -- charter item 2's "default
-// first" made literal. An app that writes nothing in hooks.py gets all of this at
-// /apps/<its own name>.
-//
-// Note what is a path segment and what is a query param: path is identity, query is
-// context (#42068), as narrowed by #42210 -- context that must survive a paste earns
-// a path segment, which is how the prefix itself came to be one.
+// The routes every app gets with no declaration. Path is identity, query is context.
 
 const Home = () => import("@/pages/Home.vue");
 const List = () => import("@/pages/List.vue");
@@ -12,15 +6,8 @@ const Record = () => import("@/pages/Record.vue");
 const Module = () => import("@/pages/Module.vue");
 
 export function generatedRoutes(modular: boolean) {
-	// TWO tables, one set of NAMES. The modular table is the flat one shifted a segment
-	// deeper, and the route names are identical in both -- which is what lets
-	// `routeFor` build `{ name: 'record', params }` without branching on shape, and
-	// every consumer stay ignorant of which app it is running in.
-	//
-	// No in-app ambiguity, because the shape is fixed per app (#42211). It is precisely
-	// a shape that varied WITHIN an app that would be unparseable: frappe's `Workflow`
-	// module and `Workflow` doctype share a slug, so nothing could tell
-	// `/workflow/LEAVE-APPROVAL` from `/workflow/workflow`.
+	// Two tables, one set of names, so `routeFor` never branches on shape. The shape is
+	// fixed per app: one that varied within an app could not be parsed.
 	return modular ? modularRoutes() : flatRoutes();
 }
 
@@ -31,27 +18,20 @@ function flatRoutes() {
 		// /apps/crm/crm-deal
 		{ path: "/:doctype", name: "list", component: List },
 
-		// /apps/crm/crm-deal/view/open-deals -- a SAVED view, not a view type. v1's type
-		// names (report/kanban/calendar) become reserved saved-view ids.
+		// /apps/crm/crm-deal/view/open-deals, a saved view, not a view type.
 		{ path: "/:doctype/view/:viewName", name: "saved-view", component: List },
 
-		// /apps/crm/crm-deal/CRM-DEAL-01?view=open-deals&layout=Compact
-		// Neither of those two is a path segment, and that is a decision, not an omission.
+		// /apps/crm/crm-deal/CRM-DEAL-01?view=open-deals&layout=Compact; neither is a path segment.
 		{ path: "/:doctype/:name", name: "record", component: Record },
 	];
 }
 
 function modularRoutes() {
 	return [
-		// The app home lists MODULES rather than doctypes here. The address walks all the
-		// way up -- record, module, app, /apps -- because an addressable level that 404s
-		// is a navigation dead end, and a reader who deletes the tail of a URL expects to
-		// land somewhere (#42211 §6).
+		// The home lists modules here; every addressable level lands somewhere.
 		{ path: "/", name: "home", component: Home },
 
-		// /apps/erpnext/accounts -- framework-generated, permission-FILTERED. Addressability
-		// is permission-independent; navigation is filtered. Nobody pastes a module page as
-		// a record link, so filtering it changes no address's shape.
+		// /apps/erpnext/accounts, permission-filtered; addresses are not.
 		{ path: "/:module", name: "module", component: Module },
 
 		// /apps/erpnext/accounts/sales-invoice/SI-001
@@ -65,11 +45,5 @@ function modularRoutes() {
 	];
 }
 
-// NOT here, deliberately:
-//   - no per-doctype route. The doctype is a param, so a bench with 553 doctypes has
-//     4 routes, not 2,212. #42066 measured 143 microseconds per werkzeug rule for the
-//     server-side equivalent, and that measurement is the reason.
-//   - no opt-out. An app cannot hide its doctype from these routes (#42068).
-//   - no per-doctype module segment. Modularity is a property of the APP, never of
-//     the doctype: emitting a module "whenever the doctype has one" would stop a
-//     non-modular app being able to serve a foreign doctype at all (#42211 §2).
+// Deliberately absent: a per-doctype route (the doctype is a param), an opt-out, and a
+// per-doctype module segment (modularity belongs to the app, never the doctype).

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -60,8 +60,8 @@ export function createShellRouter(boot: Boot, addresses: Addresses) {
 }
 
 /**
-  * The flat form of an address this prefix spells with a module, `/sales-invoice` or
-  * `/sales-invoice/SI-001`. Returns the canonical location, or null.
+ * The flat form of an address this prefix spells with a module, `/sales-invoice` or
+ * `/sales-invoice/SI-001`. Returns the canonical location, or null.
  */
 function flatAddress(to: any, addresses: Addresses) {
 	const doctype = addresses.doctypeOf(String(to.params.module));

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,17 +1,5 @@
-// HOW ONE ROUTER SERVES N PREFIXES.
-//
-// The router's base is `boot.shell_base`, set at runtime, and every route path in the
-// system is prefix-relative. There is exactly one prefix live in a given page load --
-// the one the request came in at -- so the router never sees two.
-//
-// The rejected alternative was `base: '/'` with prefix-carrying route paths. Its only
-// advantage is cross-prefix `router.push`, and that is precisely what boot being
-// prefix-scoped already makes impossible without a re-fetch: arriving at `/apps/desk`
-// carrying `/apps/crm`'s boot gives you the wrong app's contributed keys with nothing
-// to notice it. So it pays a real cost -- the prefix leaves hooks.py and enters JS --
-// to enable something already known not to be free (#42072).
-//
-// The consequence that shapes main.ts: the router CANNOT be a module-scope singleton.
+// One router per document, based at `boot.shell_base`; every route path is prefix-relative.
+// It is created after boot, never at module scope: the base comes out of boot.
 
 import { createRouter, createWebHistory } from "vue-router";
 import type { Boot } from "@/boot";
@@ -24,19 +12,10 @@ export function createShellRouter(boot: Boot, addresses: Addresses) {
 	const modular = isModular(boot);
 
 	const router = createRouter({
-		// The prefix, asked for at runtime. The one line this file argues about.
 		history: createWebHistory(boot.shell_base),
 		routes: [
-			// Order matters and is not arbitrary: contributed pages match BEFORE generated
-			// doctype routes, because `/deals` must beat `/:doctype`. They share one flat
-			// namespace (#42068) -- and since #42211 that namespace holds MODULES too, both
-			// sitting at depth one.
-			//
-			// #42068 said an install-time check would guard it. It is NOT built -- neither
-			// `install.py` nor the manifest validates slugs -- so today a page file named
-			// `crm-deal.js` silently shadows the CRM Deal list, and under a modular prefix a
-			// page named `accounts.js` would shadow the Accounts module. Still fog on the
-			// map, now one item wider.
+			// Contributed pages match before generated routes: `/deals` must beat `/:doctype`.
+			// Nothing validates a page slug against a doctype or module slug; a clash shadows silently.
 			...contributedRoutes(boot.app),
 			...generatedRoutes(modular),
 			{
@@ -47,32 +26,13 @@ export function createShellRouter(boot: Boot, addresses: Addresses) {
 		],
 	});
 
-	// Canonicalise the doctype segment TO its slug -- never away from it. The slug is
-	// the address, so a pasted `/apps/crm/CRM Deal/CRM-DEAL-01` is redirected to
-	// `/apps/crm/crm-deal/CRM-DEAL-01` and not the other way about. Rewriting the
-	// param to the real doctype name would put `CRM Deal` in the URL bar, which is the
-	// opposite of "path is identity" (#42068).
-	//
-	// Synchronous, because the table came down with the address fetch before the router
-	// existed; CRM's frontend2 needs a server round-trip in `beforeResolve` today.
+	// Canonicalise the doctype segment to its slug, never away from it: the slug is the address.
 	router.beforeResolve((to) => {
-		// A modular prefix has to agree about the module too, and it is checked FIRST:
-		// `/apps/erpnext/nonsense/sales-invoice/SI-001` addresses nothing, and letting it
-		// through would render the record under a module it does not belong to -- the URL
-		// asserting something false, which is the whole reason the segment is the
-		// doctype's own module and never the app's (#42211 §1).
+		// The module is checked first: a record must not render under a module it does not belong to.
 		if (modular && typeof to.params.module === "string" && to.params.module) {
 			if (!addresses.hasModule(to.params.module)) {
-				// The segment is not a module. Before calling it a miss, ask whether it is a
-				// DOCTYPE -- which is what a flat two-segment address looks like once it has
-				// been parsed by a modular route table. `/apps/erpnext/sales-invoice/SI-001`
-				// is somebody's old link, or a reader who deleted the module out of the path.
-				// It gets what a wrong-cased doctype segment already gets: a redirect to the
-				// canonical address, because there is one record and one address for it.
-				//
-				// Only these two forms, and only when the first segment resolves to a
-				// doctype. Anything longer is genuinely ambiguous -- which is the whole
-				// reason the shape is fixed per app -- and stays a miss.
+				// Not a module: it may be a flat address read through a modular table, somebody's old
+				// link. Redirect it to the canonical address; anything longer is ambiguous and stays a miss.
 				const flat = flatAddress(to, addresses);
 				return flat ?? miss(to);
 			}
@@ -92,11 +52,7 @@ export function createShellRouter(boot: Boot, addresses: Addresses) {
 				replace: true,
 			};
 
-		// A segment that is neither a slug nor a doctype is a route miss, and the SHELL
-		// owns that state -- an app cannot brand its own 404 (#42072). Without this the
-		// `/:doctype` route swallows every unknown path and shows an empty list, which
-		// reads as "this doctype has no records" rather than "there is no such thing".
-		// The document was already served at 200; the miss is the router's to report.
+		// The shell owns the miss; otherwise `/:doctype` swallows every unknown path as an empty list.
 		return miss(to);
 	});
 
@@ -104,9 +60,8 @@ export function createShellRouter(boot: Boot, addresses: Addresses) {
 }
 
 /**
- * `/sales-invoice` or `/sales-invoice/SI-001` seen through a modular route table:
- * the flat form of an address this prefix spells with a module. Returns the canonical
- * location, or null if the first segment names no doctype.
+  * The flat form of an address this prefix spells with a module, `/sales-invoice` or
+  * `/sales-invoice/SI-001`. Returns the canonical location, or null.
  */
 function flatAddress(to: any, addresses: Addresses) {
 	const doctype = addresses.doctypeOf(String(to.params.module));
@@ -122,10 +77,8 @@ function flatAddress(to: any, addresses: Addresses) {
 	if (!to.params.doctype)
 		return { name: "list", params, query: to.query, replace: true };
 
-	// `/:module/:doctype` matched, so the second segment is really a docname. A third
-	// segment cannot be read this way: `/a/b/c` under a modular table is already a
-	// complete record address, and re-reading it as a flat one would need a rule for
-	// which of the two wins.
+	// `/:module/:doctype` matched, so the second segment is a docname. Three segments is
+	// already a complete record address and is not re-read.
 	if (!to.params.name) {
 		return {
 			name: "record",
@@ -146,15 +99,13 @@ function miss(to: { path: string }) {
 	};
 }
 
-/** Under a modular prefix the module segment must be the doctype's OWN module. */
+/** Under a modular prefix the module segment must be the doctype's own module. */
 function checkModule(to: any, addresses: Addresses) {
 	const doctype = addresses.doctypeOf(String(to.params.doctype));
 	const address = doctype ? addresses.addressOf(doctype) : null;
 	if (!address || address[1] === to.params.module) return true;
 
-	// Not a 404: the record exists and this is the wrong spelling of its address, which
-	// is exactly the case the slug canonicalisation above already redirects. Same
-	// treatment, same reason -- one record, one canonical address.
+	// Not a miss: the record exists and this is the wrong spelling of its address.
 	return { ...to, params: { ...to.params, module: address[1] }, replace: true };
 }
 

--- a/frontend/src/router/routeFor.ts
+++ b/frontend/src/router/routeFor.ts
@@ -40,7 +40,7 @@ export type RouteOptions = {
  *   routeFor('CRM Deal', 'CRM-DEAL-01')           -> /crm-deal/CRM-DEAL-01
  *   routeFor('CRM Deal', null, { view: 'open' })  -> /crm-deal/view/open
  *
-  * Under a modular prefix each is one segment deeper, with the doctype's own module.
+ * Under a modular prefix each is one segment deeper, with the doctype's own module.
  */
 export function routeFor(
 	doctype: string,
@@ -87,7 +87,7 @@ export function routeForModule(moduleSlug: string): RouteLocationRaw {
 }
 
 /**
-  * The same address as an href, for a `window.location` assignment or a plain `<a>`.
+ * The same address as an href, for a `window.location` assignment or a plain `<a>`.
  */
 export function urlFor(
 	doctype: string,

--- a/frontend/src/router/routeFor.ts
+++ b/frontend/src/router/routeFor.ts
@@ -1,22 +1,5 @@
-// THE ONE SANCTIONED WAY TO BUILD A DOCTYPE URL.
-//
-// Two things made this necessary, and neither was true when the shell was written.
-// The prefix became a lens, so a doctype is addressable under every prefix (#42210);
-// and an app may declare `app_modular`, so the address gained a module segment
-// (#42211). A hand-built `/${slug}/${name}` is now WRONG under a modular prefix, and
-// wrong in the worst way -- it resolves, to the module route, and shows a page that
-// is not the record. A 404, not a type error.
-//
-// So the shape must live in exactly one place. `routeFor` is that place, and the rule
-// is enforced rather than documented: `TestNoHandBuiltDoctypeUrls` in
-// `frappe/tests/test_shell.py` scans this repo's frontend source AND every installed
-// app's contributed files, and fails naming file and line. The allowlist there is
-// short, explicit and carries a reason each.
-//
-// What it does NOT do is cross a prefix. Following a link never leaves the prefix you
-// are standing in -- that is what the lens bought -- so every route this builds is
-// prefix-relative and the router's base supplies the rest. Crossing a prefix is a
-// full document load (#42102) and wants `urlFor`.
+// The one place a doctype URL's shape lives: a hand-built one is wrong under a modular
+// prefix, and `TestNoHandBuiltDoctypeUrls` fails it. Every route stays inside the prefix.
 
 import type { RouteLocationRaw, Router } from "vue-router";
 import type { Boot } from "@/boot";
@@ -24,10 +7,7 @@ import type { Addresses } from "@/addresses";
 
 export type Shell = { boot: Boot; addresses: Addresses; router: Router };
 
-// Module-scope, and worth being explicit about why that is allowed when #42072 forbids
-// a module-scope ROUTER: this is not one. It is a slot, empty until `main.ts` fills it
-// with the single shell this document owns, after boot has said what the base is. One
-// document, one prefix, one shell -- the invariant the whole map rests on.
+// A slot, not a module-scope router: empty until `main.ts` fills it after boot.
 let shell: Shell | null = null;
 
 export function registerShell(context: Shell) {
@@ -40,16 +20,16 @@ function current(): Shell {
 	return shell;
 }
 
-/** Does the app serving THIS prefix put the module in the address? */
+/** Does the app serving this prefix put the module in the address? */
 export function isModular(boot: Boot): boolean {
 	const prefix = boot.shell_base.split("/").filter(Boolean).pop();
 	return Boolean(prefix && boot.prefixes?.[prefix]?.modular);
 }
 
 export type RouteOptions = {
-	/** A saved view id -- `/<doctype>/view/<viewName>`. Never a view *type* (#42068). */
+	/** A saved view id, `/<doctype>/view/<viewName>`. Never a view type. */
 	view?: string;
-	/** Context, not identity. `?view=`, `?layout=` and friends live here (#42068). */
+	/** Context, not identity: `?view=`, `?layout=` and friends. */
 	query?: Record<string, string>;
 };
 
@@ -60,8 +40,7 @@ export type RouteOptions = {
  *   routeFor('CRM Deal', 'CRM-DEAL-01')           -> /crm-deal/CRM-DEAL-01
  *   routeFor('CRM Deal', null, { view: 'open' })  -> /crm-deal/view/open
  *
- * and under a modular prefix, each of those one segment deeper, with the doctype's
- * OWN module -- foreign doctypes included, because the shape is fixed per app.
+  * Under a modular prefix each is one segment deeper, with the doctype's own module.
  */
 export function routeFor(
 	doctype: string,
@@ -72,9 +51,7 @@ export function routeFor(
 	const address = addresses.addressOf(doctype);
 
 	if (!address) {
-		// A doctype the table has never heard of cannot be addressed, and guessing a slug
-		// would produce a URL that resolves to the shell's not-found anyway -- one hop
-		// later and with the reason lost. Say it here, where the caller is.
+		// A guessed slug would reach not-found one hop later, with the reason lost.
 		throw new Error(`routeFor: no address for doctype '${doctype}'`);
 	}
 
@@ -104,14 +81,13 @@ export function routeFor(
 	return { name: "list", params, query: options.query };
 }
 
-/** The route for a module's landing page. Modular prefixes only (#42211 §6). */
+/** The route for a module's landing page. Modular prefixes only. */
 export function routeForModule(moduleSlug: string): RouteLocationRaw {
 	return { name: "module", params: { module: moduleSlug } };
 }
 
 /**
- * The same address as an href, for the two cases a route object cannot serve: a
- * `window.location` assignment from a contributed script, and a plain `<a>`.
+  * The same address as an href, for a `window.location` assignment or a plain `<a>`.
  */
 export function urlFor(
 	doctype: string,

--- a/frontend/src/shell/AppRail.vue
+++ b/frontend/src/shell/AppRail.vue
@@ -1,45 +1,6 @@
 <!--
-  The rail. Shell-owned, and it never disappears.
-
-  It renders `boot.navigation.rail` — the app's own rows, the site's arrangement and
-  this person's, already merged by the server (#42232). The browser never restacks
-  those layers and holds no permission logic: an item that reached this list is one
-  this person may be offered.
-
-  Two data sources have gone before this one. It first derived from
-  `boot.doctype_slugs`, which was the ADDRESS space, so "permission, not declaration"
-  was false — it listed what was addressable, unfiltered. It then fetched the endpoint
-  now called `get_contents`, which was per-app and filtered, and made the claim true.
-  It is in boot for a reason neither of those had: a rail click must cost no request,
-  which a fetched rail cannot promise. What an app CONTAINS is still fetched, by the app home
-  and the module page that show it (`contents.ts`, #42357).
-
-  There is no "could not load" state left. Navigation arrives with boot, and a boot
-  that fails never mounts a shell for this to render in.
-
-  An app that ships no rail rows still gets a rail: its own doctypes, permission-
-  filtered, exactly the list this showed before. So the rail's appearance changes when
-  an app ships rows and not when this lands (#42356).
-
-  Some of these rows may belong to another app entirely — one that ships a `Rail`
-  record naming this app in `extends`. Nothing here can tell, and nothing here should:
-  the server merged them into the base before the layers went on, so they arrive as
-  ordinary items in one ordered list (#42364).
-
-  The renderers decide what every row does; this file never knows one kind from
-  another. It used to render `DocType` and drop the other seven, which was #42228's
-  skip-a-missing-renderer rule arrived at by accident: there were no renderers at all,
-  so there was nothing to miss. There are eight now, each shipped the way an app would
-  ship one — the type record plus `frontend/item.js` beside it — so the framework's own
-  kinds and a contributed ninth reach this list through the same door (DP2, #42420). One
-  of those kinds, `Sidebar`, is what makes a rail item LINKED; the panel it opens is the
-  shell's, not the rail's, because a rail that owned it would own a surface that outlives
-  any one of its rows (#42421).
-
-  The list arrives as a PROP rather than off `boot`, which is what lets it change without a
-  reload: a save returns the whole `{rail, sidebars}` and the shell swaps it in, so the rail
-  re-renders from the same server-resolved list it always renders from and never restacks a
-  layer of its own (#42232).
+  The rail, shell-owned and always present. It draws the server-merged list it is handed and
+  holds no permission logic; the renderers decide what every row does.
 -->
 <template>
 	<nav class="flex w-52 shrink-0 flex-col gap-1 border-r border-outline-gray-2 p-2">
@@ -100,17 +61,8 @@ import { useItemTree } from "@/navigation/useItemTree";
 import { useIconSlot } from "@/navigation/iconSlot";
 import type { ItemContext } from "@/navigation/types";
 
-// `arrangeable` is off on the index at `/apps`, which belongs to no app: there is no rail to
-// arrange there and no address to name one by, since `boot.app` is null and `boot.navigation`
-// is absent. The shell decides it, because the shell is what knows it is on the index.
-//
-// `context` and `current` arrive as props rather than being computed here, and that moved with
-// the panel (#42421). The context is composed once per list and the panel draws the same rows
-// off the same one; and exactly one row is current across the rail and the panel together, so
-// neither surface can work it out alone.
-//
-// `shareLink` is built by the shell, which is what knows whether the panel needs naming. The
-// button is here because the rail's footer is the only chrome present on every page.
+// The shell decides `arrangeable` (off on the index), `current` (one row across rail and panel)
+// and `shareLink` (it knows whether the panel needs naming); a context is composed once per list.
 const props = defineProps<{
 	items: NavigationItem[];
 	context: ItemContext;
@@ -133,8 +85,7 @@ async function copyLink() {
 	try {
 		await navigator.clipboard.writeText(props.shareLink);
 	} catch {
-		// Denied, or an insecure origin where `navigator.clipboard` is undefined. Nothing was
-		// copied, so claim nothing.
+		// Denied, or an insecure origin with no `navigator.clipboard`. Nothing was copied, so claim nothing.
 		return;
 	}
 
@@ -145,10 +96,7 @@ async function copyLink() {
 
 onBeforeUnmount(() => clearTimeout(clearCopied));
 
-// `parent_key` is the whole of hierarchy (#42227), and the server sends the tree flat. A
-// cycle in it is broken and reported by `useItemTree`: every row in one has a parent that is
-// present, so the server's orphan promotion passes it through, and rendering the tree would
-// then simply omit the rows — a silent drop of authored navigation.
+// A `parent_key` cycle passes the server's orphan check; `useItemTree` breaks and reports it.
 const tree = useItemTree(() => props.items, "the rail");
 
 const reserve = useIconSlot(

--- a/frontend/src/shell/AppShell.vue
+++ b/frontend/src/shell/AppShell.vue
@@ -1,28 +1,6 @@
 <!--
-  The shell's own surface.
-
-  The line the contribution contract draws: the shell owns everything that must look
-  the same in every app; an app contributes only INSIDE a routed view. There is no
-  contributeSidebarItem, no contributeCommand, no shell-level hook of any kind
-  (#42072).
-
-  Both halves go to the rail, and that is why they are one prop pair rather than two
-  components: a rail item of type `Sidebar` is what makes an item LINKED (#42227), and it
-  resolves its own destination out of the sidebar it opens — so the rail cannot draw the
-  rail without holding the sidebars too. The panel that shows one is this file's, not the
-  rail's: which sidebar is open is a fact about the ADDRESS, and the address outlives any
-  row on the rail (#42421).
-
-  Navigation lives here, one level above the rail, because it is not the rail's. A save
-  returns the WHOLE `{rail, sidebars}` for the prefix and the client swaps it in wholesale
-  (#42363) — so hiding a rail item of type `Sidebar` changes which sidebars are reachable, and
-  the one place that knows about both is this one. `boot.navigation` is kept in step for anything
-  that reads boot directly; the reactive copy is what renders.
-
-  The item context is composed here for the same reason. It is composed once per LIST, and
-  since the panel draws rows out of the same payload the rail does, two contexts would be two
-  answers to `renderingOf` for one row — and a `Sidebar` item resolves through the sidebars,
-  so the two would not even be equal.
+  The shell's own surface: rail, panel, routed view and the arrangement editor. Navigation lives
+  here because a save replaces the whole `{rail, sidebars}`, and the open sidebar is a fact about the address.
 -->
 <template>
 	<div class="flex h-screen w-screen bg-surface-white text-ink-gray-9">
@@ -85,16 +63,12 @@ const addresses = inject<Addresses>("addresses")!;
 const router = useRouter();
 const route = useRoute();
 
-// Which container is being arranged, or nothing. One editor rather than one per surface: the
-// three endpoints take the container as an argument, so a second component would only be the
-// same dialog with a different string baked in (#42363).
+// One editor for both containers; the endpoints take the container as an argument.
 const arranging = ref<{ container: Container; address: string; title: string } | null>(null);
 const navigation = ref<Navigation>(boot.navigation ?? { rail: [], sidebars: {} });
 
-// One context per container. The rail and each sidebar are separate LISTS, and a context is
-// composed once per list rather than once per row — `Module Contents` is what makes that more
-// than bookkeeping, since it measures "what is left of this module" against `context.items`.
-// A sidebar row handed the rail's context would answer that question about the rail.
+// One context per container: `Module Contents` measures against `context.items`, so a
+// sidebar row handed the rail's list would answer about the rail.
 const contexts = computed<NavigationContexts>(() => {
 	const compose = (items: NavigationItem[]) =>
 		itemContext(boot, addresses, router, items, navigation.value.sidebars);
@@ -110,8 +84,7 @@ const contexts = computed<NavigationContexts>(() => {
 	};
 });
 
-// A reader's own disclosures, one store per container and rebuilt when the payload is. A
-// container is named by what the shell knows: the rail by its app, a panel by its address.
+// A reader's own disclosures, one store per container: the rail by its app, a panel by its address.
 const sections = computed(() => ({
 	rail: boot.app
 		? sectionMemory(boot.user.name, `Rail:${boot.app}`, navigation.value.rail)
@@ -124,36 +97,31 @@ const sections = computed(() => ({
 	),
 }));
 
-// Every route navigation can be standing on. Off the PAYLOAD, so it survives a navigation:
-// building it costs a route resolution per row and the framework's own prefix carries 194 of
-// them (#42362), which is not a bill to pay on every click.
+// Off the payload, not per navigation: it costs a route resolution per row.
 const destinations = computed(() =>
 	navigationDestinations(navigation.value.rail, navigation.value.sidebars, contexts.value)
 );
 
-// A ref off a watcher, not a computed: the resolution feeds itself, since the panel open now
-// is the next address's first preference and recording the answer is a write.
+// A ref off a watcher, not a computed: the resolution feeds itself, since the open panel is
+// the next address's first preference and recording it is a write.
 const current = ref<CurrentNavigation>({});
 
 // The panel the address asked for, outranking the open one because a paste is deliberate.
 const asked = ref<string | undefined>(undefined);
 
-// Whether the navigation being resolved is a back or a forward: `listen` fires on pops
-// only, and reports the direction.
+// `listen` fires on pops only, so this marks a back or a forward.
 let popped = false;
 const stopListening = router.options.history.listen(() => {
 	popped = true;
 });
 onUnmounted(stopListening);
 
-// What the address alone says. Keeps the copy link honest: naming the panel a stranger lands
-// in anyway says nothing.
+// What the address alone says, so the copy link names the panel only where it adds something.
 const canonical = computed(() => currentFrom(destinations.value, route.path));
 
 function resolve() {
 	const path = route.path;
-	// Most wanted first, and each a tie-break only — which is how a `?sidebar=` that is stale,
-	// misspelled or filtered away by permissions loses and degrades silently.
+	// Most wanted first, each a tie-break only, so a stale or misspelled `?sidebar=` loses silently.
 	const prefer = [asked.value, stamped(), current.value.sidebar, recallSidebar(path)].filter(
 		(sidebar): sidebar is string => !!sidebar
 	);
@@ -161,8 +129,8 @@ function resolve() {
 	current.value = currentFrom(destinations.value, path, prefer);
 	const sidebar = current.value.sidebar;
 	if (sidebar) {
-		// Onto the ENTRY, so back and forward return to the sidebar a page was read in. The
-		// compare leaves a pop's own state alone, which is what its forward entries hang off.
+		// Onto the entry, so back and forward return to the sidebar a page was read in. The
+		// compare leaves a pop's own state alone, which its forward entries hang off.
 		if (stamped() !== sidebar) history.replaceState({ ...history.state, sidebar }, "");
 		if (!popped) rememberSidebar(path, sidebar);
 	}
@@ -175,13 +143,11 @@ function stamped(): string | undefined {
 	return typeof sidebar === "string" ? sidebar : undefined;
 }
 
-// The parameter seeds the same record browsing fills, then leaves the address by `replace`, so
-// the bar is clean without a second history entry for back to walk through.
+// The parameter seeds the record, then leaves the address by `replace` with no second history entry.
 watch(
 	[() => route.fullPath, destinations],
 	() => {
-		// Repeated in the address it arrives as an array, which must still be consumed or it
-		// sits in the bar for the rest of the session.
+		// Repeated in the address it arrives as an array, which must still be consumed.
 		const asking = route.query.sidebar;
 		const named = Array.isArray(asking) ? asking[0] : asking;
 		asked.value = typeof named === "string" ? named : undefined;
@@ -191,16 +157,14 @@ watch(
 		if (asking !== undefined) {
 			const { sidebar: _consumed, ...query } = route.query;
 			asked.value = undefined;
-			// `hash` addresses a place within the page, so it is not ours to drop. An aborted
-			// or redirected replace rejects, and the sidebar is recorded by then regardless.
+			// `hash` is not ours to drop. An aborted replace rejects, and the sidebar is recorded by then.
 			router.replace({ path: route.path, query, hash: route.hash }).catch(() => {});
 		}
 	},
 	{ immediate: true }
 );
 
-// The link to hand someone else. The parameter goes on only where it says something, matching
-// the rule `?from=` already follows on re-entering its own prefix.
+// The link to hand someone else; the parameter goes on only where it says something.
 const shareLink = computed(() => {
 	const sidebar = current.value.sidebar;
 	const query =
@@ -210,11 +174,7 @@ const shareLink = computed(() => {
 	return new URL(to.href, window.location.origin).href;
 });
 
-// The panel, or nothing. `current.sidebar` is only ever a key a rail item's renderer read out
-// of this same payload, so the rows are there — the row count is checked anyway because an
-// empty panel is the one state #42357 ruled out, and it is fenced twice before this: a sidebar
-// that resolved to nothing is absent from the payload rather than empty (#42356), and the
-// `Sidebar` renderer then draws no rail item to open it.
+// The panel, or nothing. An empty sidebar is absent from the payload; the count is the last fence.
 const panel = computed(() => {
 	const address = current.value.sidebar;
 	const items = address ? navigation.value.sidebars[address] : undefined;
@@ -226,10 +186,7 @@ const panel = computed(() => {
 		address,
 		items,
 		context: contexts.value.sidebars[address],
-		// The AUTHORED label and nothing else. `labelOf`'s fallbacks are all wrong for a
-		// `Sidebar` item: its renderer offers none, and the last resort is `link_to`, which
-		// here is the scrubbed address — a heading reading `module_def_accounts` is worse than
-		// no heading, and the rail item above it is highlighted either way.
+		// The authored label only: `labelOf`'s last resort is `link_to`, here the scrubbed address.
 		title: owner?.label,
 	};
 });

--- a/frontend/src/shell/AppSidebar.vue
+++ b/frontend/src/shell/AppSidebar.vue
@@ -1,29 +1,6 @@
 <!--
-  The panel a linked rail item opens.
-
-  The other half of charter point 1: a rail item is independent or LINKED, and this is
-  what linked means on screen. It draws `Navigation Item` rows — the same rows, the same
-  renderers and the same component as the rail, because they are two presentations of one
-  model and never two models (#42227).
-
-  NOTHING OPENS IT BY CLICKING. The address does. A rail item of type `Sidebar` resolves to
-  the first destination inside its sidebar and carries the sidebar's scrubbed key alongside
-  (`sidebar/frontend/item.js`), so following one is ordinary navigation and the panel that
-  appears is the shell reading the new address back (charter point 7,
-  `navigation/current.ts`). There is no selection stored anywhere, which is why pasting a
-  URL into a fresh tab lands on the same shell as clicking to it.
-
-  The empty panel does not exist. A sidebar that resolved to nothing is ABSENT from
-  `boot.navigation.sidebars` rather than empty (#42356), its rail item then renders as an
-  independent one, and with no rail item naming it there is no address that can open it
-  (#42357). The `v-if` in the shell is the last of three fences, not the first.
-
-  The title is the rail item's AUTHORED label, and an unlabelled item leaves the panel with
-  no heading at all. The payload allows nothing else: `sidebars` is keyed by scrubbed address
-  and carries rows rather than a record, so there is no `Sidebar` title to read — and
-  `labelOf`'s fallbacks all end at `link_to`, which for this kind is the scrubbed address. A
-  heading reading `module_def_accounts` is worse than none, and the rail item above the panel
-  is highlighted either way.
+  The panel a linked rail item opens. Nothing opens it by clicking: the address does, read back by
+  `navigation/current.ts`. An empty sidebar is absent from the payload, so no empty panel exists.
 -->
 <template>
 	<aside class="flex w-56 shrink-0 flex-col gap-1 border-r border-outline-gray-2 p-2">
@@ -61,10 +38,7 @@ import { useItemTree } from "@/navigation/useItemTree";
 import { useIconSlot } from "@/navigation/iconSlot";
 import type { ItemContext } from "@/navigation/types";
 
-// `address` is the scrubbed key, and it is a prop because it is also what the arrangement
-// endpoints take for a `Sidebar` — they read the `(link_doctype, link_to)` pair back off the
-// standard record, since unscrubbing is not a function (`arrangement.py`). So the panel is an
-// arrangeable container on the same terms as the rail, with the same three endpoints.
+// `address` is the scrubbed key, which is also what the arrangement endpoints take for a `Sidebar`.
 const props = defineProps<{
 	address: string;
 	items: NavigationItem[];

--- a/frontend/src/shell/ArrangementEditor.vue
+++ b/frontend/src/shell/ArrangementEditor.vue
@@ -1,25 +1,6 @@
 <!--
-  The arrangement editor: reorder, hide, rename, on either container.
-
-  ONE component for the rail and for a sidebar, because they are one model. It takes a container
-  and an address and nothing else about which surface it is editing — the moment it branched on
-  that, desk v2 would have desk v1's shape, where one base class and two subclasses spend about
-  1,800 lines saying the same thing twice.
-
-  It shows the list ONE SCOPE DEEP, hidden rows included, which is not what the rail shows. A
-  person cannot unhide what they cannot see, so an editor that rendered `boot.navigation` would
-  make hiding a one-way door.
-
-  A drag saves nothing on its own, and neither does an arrow or a rename. The write is the Save
-  button, and until then every edit is local — the same choice desk v1 made, and it is a choice
-  rather than a constraint: a save costs a request and a round trip that replaces the whole of
-  `boot.navigation`, which is not what anybody wants per keystroke.
-
-  There is no drag library. `sortablejs` and `vuedraggable` sit in the lockfile but are asked for
-  by neither `package.base.json` nor frappe-ui, so adopting one would be a new shared dependency
-  under #42069's singleton rule — a real cost, weighed here against about fifteen lines of the
-  platform's own drag events. The arrows are not a fallback for the drag; they are the half that
-  works from a keyboard.
+  The arrangement editor: reorder, hide, rename, one component for either container. It shows one
+  scope deep with hidden rows, writes only on Save, and uses the platform's own drag events plus arrows.
 -->
 <template>
 	<div class="flex w-80 shrink-0 flex-col border-l border-outline-gray-2 bg-surface-white">
@@ -104,9 +85,7 @@ const emit = defineEmits<{ close: []; saved: [Navigation] }>();
 const items = ref<ArrangedItem[]>([]);
 const dragging = ref<string | null>(null);
 const busy = ref(false);
-// A message rather than a boolean. An editor that failed to load its list is indistinguishable
-// from one whose navigation is empty, and "you have nothing to arrange" is a false statement to
-// put over a request that never landed.
+// A message, not a boolean: an editor that failed to load must not read as "nothing to arrange".
 const failed = ref<string | null>(null);
 
 onMounted(load);
@@ -120,8 +99,7 @@ async function load() {
 }
 
 function rename(key: string, label: string) {
-	// The whole row is replaced rather than mutated, so `items` is a list of values and a stale
-	// reference cannot leak an edit into a list this has already sent.
+	// Replaced, not mutated, so a stale reference cannot leak an edit into a list already sent.
 	items.value = items.value.map((item) => (item.key === key ? { ...item, label } : item));
 }
 

--- a/frontend/src/shell/tests/arrangement.test.ts
+++ b/frontend/src/shell/tests/arrangement.test.ts
@@ -1,9 +1,5 @@
-// The arrangement editor and the list operations under it (#42363).
-//
-// Mounted with Vue's own `createApp` into happy-dom rather than through `@vue/test-utils`,
-// which this package does not have. The editor is small enough that the difference is a
-// `nextTick` and a `querySelector`, and a new devDependency for one component is a cost the
-// shell's singleton rules make everyone else pay too.
+// The arrangement editor and the list operations under it. Mounted with Vue's own
+// `createApp`: this package has no `@vue/test-utils`.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createApp, h, nextTick } from "vue";
 import { createMemoryHistory, createRouter } from "vue-router";
@@ -203,8 +199,7 @@ describe("the editor", () => {
   });
 
   it("saves the whole list it is showing, not the difference", async () => {
-    // The reduction is the server's. A client that sent anchors would be computing identity
-    // against a base it may be holding stale, which is desk v1's mistake in reverse.
+    // The reduction is the server's; the client sends the whole list.
     const editing = await editor([item("a"), item("b")]);
     call.mockResolvedValue({ rail: [], sidebars: {} });
 

--- a/frontend/src/shell/tests/history.test.ts
+++ b/frontend/src/shell/tests/history.test.ts
@@ -1,7 +1,5 @@
-// Which sidebar a page is read in, as the reader walks back and forward (#42480).
-//
-// `createWebHistory`, not the memory history the other shell tests use: the sidebar is
-// stamped on the history entry, and only a real one carries state through a pop.
+// Which sidebar a page is read in, as the reader walks back and forward. `createWebHistory`,
+// not the memory history: only a real one carries state through a pop.
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createApp, nextTick, type App } from "vue";
 import { createRouter, createWebHistory, type Router } from "vue-router";
@@ -131,7 +129,7 @@ beforeEach(async () => {
 	vi.unstubAllGlobals();
 });
 
-/** Steps 1-5 of #42479's walk: `Item` read in Stock, then `Item` read in Buying. */
+/** `Item` read in Stock, then `Item` read in Buying. */
 async function walk() {
 	const { host, router, app } = await shell("/stock-entry?sidebar=module_def_stock");
 	const panel = () => host.querySelector("aside")!;
@@ -159,8 +157,7 @@ describe("the sidebar a page was read in", () => {
 
 		router.go(-1);
 		await settle();
-		// The same address, and the sidebar it was READ in rather than the one open a moment
-		// ago, which is the whole fix.
+		// The same address, and the sidebar it was read in, not the one open a moment ago.
 		expect(router.currentRoute.value.path).toBe("/item");
 		expect(open(host)).toBe("module_def_stock");
 

--- a/frontend/src/shell/tests/rail.test.ts
+++ b/frontend/src/shell/tests/rail.test.ts
@@ -149,8 +149,7 @@ describe("sections and nesting", () => {
 
 		const heading = row(host, "sales")!;
 		expect(heading.textContent).toContain("Sales");
-		// The child is INSIDE the section's own list item, which is what makes the tree the
-		// tree rather than an indent class on a flat list.
+		// The child is inside the section's own list item, not an indent class on a flat list.
 		expect(heading.closest("li")!.contains(row(host, "CRM Deal"))).toBe(true);
 	});
 
@@ -284,8 +283,8 @@ describe("Module Contents", () => {
 		(row(host, "more") as HTMLButtonElement).click();
 		await flush();
 
-		// Expanding is the one thing on the rail that costs a request, so it is the one
-		// thing that can fail from a dropped connection rather than from a bad row.
+		// Expanding is the one thing on the rail that costs a request, so the one that can fail
+		// from a dropped connection.
 		expect(row(host, "more")!.getAttribute("aria-expanded")).toBe("false");
 		expect(logged).toHaveBeenCalled();
 	});

--- a/frontend/src/shell/tests/rail.test.ts
+++ b/frontend/src/shell/tests/rail.test.ts
@@ -1,8 +1,4 @@
-// What the rail DRAWS, once every kind has a renderer (#42420).
-//
-// Mounted with Vue's own `createApp` into happy-dom, the way `arrangement.test.ts` does
-// and for the same reason: this package has no `@vue/test-utils`, and a new shared
-// devDependency for one component is a cost #42069's singleton rules make every app pay.
+// What the rail draws. Mounted with Vue's own `createApp`: this package has no `@vue/test-utils`.
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createApp, h, nextTick, ref, type Ref } from "vue";
 import { createMemoryHistory, createRouter } from "vue-router";
@@ -38,8 +34,7 @@ async function flush() {
 	await nextTick();
 }
 
-/** The mounted rail, plus the list it is rendering — so a test can replace it, which is
- *  what a save does (#42363). */
+/** The mounted rail plus the list it renders, so a test can replace it as a save does. */
 function mount(
 	initial: NavigationItem[],
 	sidebars: Record<string, NavigationItem[]> = {}
@@ -57,8 +52,7 @@ function mount(
 	});
 	registerShell({ boot, addresses, router });
 
-	// The shell composes the context now, because the panel draws out of the same one
-	// (#42421). The rail is mounted here alone, so this stands in for it.
+	// The shell composes the context; the rail is mounted alone here, so this stands in for it.
 	const app = createApp({
 		render: () =>
 			h(AppRail, {
@@ -117,9 +111,7 @@ beforeEach(() => {
 
 describe("the kinds the rail used to drop", () => {
 	it("draws all of them, not only DocType", () => {
-		// It filtered to `item_type === "DocType"` and silently dropped the other seven,
-		// which was #42228's skip-a-missing-renderer rule reached by accident: there were no
-		// renderers, so there was nothing to miss.
+		// It once drew only `DocType` rows and dropped the other seven.
 		const host = rail([
 			doctype("CRM Deal"),
 			{ key: "docs", item_type: "Link", url: "https://docs.frappe.io" },
@@ -133,8 +125,7 @@ describe("the kinds the rail used to drop", () => {
 	});
 
 	it("makes a Link a plain anchor, not a router link", () => {
-		// Following it leaves this prefix, which is a full document load; the router this
-		// document holds is scoped to one prefix and cannot resolve the other (#42364).
+		// Following it leaves this prefix: a full document load the router cannot resolve.
 		const host = rail([{ key: "docs", item_type: "Link", url: "https://docs.frappe.io" }]);
 		const anchor = row(host, "docs") as HTMLAnchorElement;
 		expect(anchor.tagName).toBe("A");
@@ -218,9 +209,8 @@ describe("sections and nesting", () => {
 
 describe("a linked item", () => {
 	it("carries the sidebar it opens, so the panel can mount off it", () => {
-		// A `Sidebar` item is what makes a rail item LINKED (#42227), and the panel that
-		// shows one is #42421's. The rail draws it as linked either way, or the two tickets
-		// deadlock on each other.
+		// A `Sidebar` item is what makes a rail item linked; the rail draws it so whether or not
+		// a panel exists.
 		const host = rail(
 			[
 				{
@@ -239,8 +229,7 @@ describe("a linked item", () => {
 
 		const link = row(host, "accounts") as HTMLAnchorElement;
 		expect(link.getAttribute("data-sidebar")).toBe("module_def_accounts");
-		// Real navigation, not shell state — charter point 7. The panel is named in the href,
-		// so middle-click and open-in-new-tab still work.
+		// Real navigation, not shell state: the panel is named in the href, so middle-click works.
 		expect(link.getAttribute("href")).toBe("/sales-invoice?sidebar=module_def_accounts");
 	});
 
@@ -320,10 +309,8 @@ describe("a row that cannot be drawn", () => {
 
 describe("an expanded overflow row when the list changes under it", () => {
 	it("collapses rather than keeping rows it worked out about the old list", async () => {
-		// A save returns the whole `{rail, sidebars}` and the shell swaps it in, while this
-		// component survives because `v-for` keys on the item's key. What it was showing was
-		// "what is left of the module" measured against the list the save replaced — so a
-		// doctype the save has just put on the rail by hand would be on screen twice.
+		// A save swaps in a new list while the component survives (`v-for` keys on the key), so
+		// what the expansion showed was measured against a list that no longer exists.
 		const contents = await import("@/contents");
 		vi.spyOn(contents, "fetchContents").mockResolvedValue([
 			{ doctype: "Sales Invoice", slug: "sales-invoice", module: "accounts" },
@@ -361,9 +348,8 @@ describe("a section's disclosure when the list changes under it", () => {
 	});
 
 	it("follows a reset that ships a different keep_closed", () => {
-		// A reset returns the app's own layer (#42363), so the same key comes back with a
-		// different shipped value while this component survives — `v-for` keys on the key.
-		// Without this the section sits open against what it now ships, until a reload.
+		// A reset returns the app's own layer while the component survives, so the same key
+		// comes back with a different shipped value.
 		const { host, items } = mount([section({ keep_closed: 1 }), doctype("CRM Deal", "sales")]);
 		expect(row(host, "CRM Deal")).toBeNull();
 
@@ -374,9 +360,8 @@ describe("a section's disclosure when the list changes under it", () => {
 	});
 
 	it("does not re-open what the reader just closed", async () => {
-		// The watch is on the shipped value, not on the row. A toggle changes `open` and
-		// never `keep_closed`, so a save that leaves the section alone leaves it closed —
-		// otherwise every save would undo the last thing somebody did to the rail.
+		// The watch is on the shipped value, not the row: a toggle changes `open` and never
+		// `keep_closed`, so a save that leaves the section alone leaves it closed.
 		const { host, items } = mount([section(), doctype("CRM Deal", "sales")]);
 
 		(row(host, "sales") as HTMLButtonElement).click();

--- a/frontend/src/shell/tests/sections.test.ts
+++ b/frontend/src/shell/tests/sections.test.ts
@@ -1,8 +1,5 @@
 // A section that ships shut, and the two things that open it: the address, and the reader.
-//
-// Driven off a real resolved payload rather than rows built here. `keep_closed` went months
-// exercised only where no route pointed inside a shut section, which is the defect this is
-// about, so the fixture is what an app actually ships.
+// Driven off a real resolved payload: the defect only shows where a route points inside one.
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createApp, nextTick } from "vue";
 import { createMemoryHistory, createRouter, type Router } from "vue-router";
@@ -128,9 +125,8 @@ describe("the fixture this is driven off", () => {
 });
 
 describe("the address opens the section it is standing in", () => {
-	// Asserted on the ROW, not on a named section: one fixture row sits behind a shut section
-	// in two panels, and which of them the address opens is a separate open question (#42465).
-	// A row only renders at all if the section holding it is open, so this covers both.
+	// Asserted on the row, not a named section: one fixture row sits behind a shut section in
+	// two panels. A row renders only if its section is open, so this covers both.
 	it.each(behindShutSections())(
 		"shows $item.key, shipped behind $section",
 		async ({ item }) => {

--- a/frontend/src/shell/tests/sidebar.test.ts
+++ b/frontend/src/shell/tests/sidebar.test.ts
@@ -1,8 +1,5 @@
-// The panel a linked rail item opens (#42421).
-//
-// Mounted through `AppShell`, not through `AppSidebar`, and that is the point: which sidebar
-// is open is a fact about the address, so a test that handed the panel its own rows would be
-// testing a list renderer and calling it navigation.
+// The panel a linked rail item opens. Mounted through `AppShell`: which sidebar is open is
+// a fact about the address, so handing the panel its own rows would test a list renderer.
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createApp, nextTick } from "vue";
 import { createMemoryHistory, createRouter, type Router } from "vue-router";
@@ -120,15 +117,13 @@ describe("what opens the panel", () => {
 	it("opens it because of where you are, not because of a click", async () => {
 		const { host } = await shell([accounts], sidebars, "/crm-lead");
 
-		// Nothing was clicked. `/crm-lead` is a row inside the Accounts sidebar, and that is
-		// the whole of it — which is what makes a pasted URL land on the same shell.
+		// Nothing was clicked: `/crm-lead` is a row inside the Accounts sidebar, and that is all.
 		expect(panel(host)?.textContent).toContain("Sales Invoice");
 		expect(panel(host)?.textContent).toContain("CRM Lead");
 	});
 
 	it("heads it with the rail item's own label", async () => {
-		// `sidebars` is keyed by scrubbed address and carries rows, not a record, so there is
-		// no other title available — and the rail item is the words a reader clicked anyway.
+		// `sidebars` carries rows, not a record, so the rail item's label is the only title there is.
 		const { host } = await shell([accounts], sidebars, "/sales-invoice");
 		expect(panel(host)?.textContent).toContain("Accounts");
 	});
@@ -154,9 +149,8 @@ describe("what opens the panel", () => {
 
 describe("the empty case", () => {
 	it("draws no panel and no rail item when the sidebar has no rows", async () => {
-		// #42357: a linked rail item whose sidebar has nothing in it renders as an independent
-		// one — and a `Sidebar` item's whole content IS the sidebar, so it is simply not drawn.
-		// There is no empty panel anywhere in this design.
+		// A linked rail item whose sidebar is empty renders as independent, and a `Sidebar` item's
+		// whole content is the sidebar, so it is not drawn at all.
 		const { host } = await shell([accounts], { module_def_accounts: [] }, "/sales-invoice");
 		expect(panel(host)).toBeNull();
 		expect(host.querySelector("[data-key='accounts']")).toBeNull();
@@ -204,8 +198,7 @@ describe("what is marked current", () => {
 
 describe("two containers, one key", () => {
 	it("does not confuse a rail row with a sidebar row of the same name", async () => {
-		// A key identifies a row within ONE container — the same thing `registry.ts`'s depth
-		// guard exists for. Here it is the highlight: the rail's `lead` must not light up
+		// A key identifies a row within one container: the rail's `lead` must not light up
 		// because the panel's `lead` is current.
 		const { host } = await shell(
 			[accounts, { ...lead, link_to: "CRM Deal" }],
@@ -220,9 +213,8 @@ describe("two containers, one key", () => {
 
 describe("the panel is a container, not a view of the rail", () => {
 	it("offers its own Arrange, addressed at the sidebar", async () => {
-		// The three arrangement endpoints take the container as an argument and read the
-		// `(link_doctype, link_to)` pair back off the scrubbed address (`arrangement.py`), so
-		// the panel arranges on exactly the terms the rail does (#42363).
+		// The arrangement endpoints take the container as an argument, so the panel arranges on
+		// the rail's terms.
 		const { host } = await shell([accounts], sidebars, "/sales-invoice");
 		expect(panel(host)?.textContent).toContain("Arrange");
 	});
@@ -237,8 +229,7 @@ describe("what the panel draws", () => {
 
 		const heading = panel(host)?.querySelector("[data-key='billing']");
 		expect(heading?.textContent?.trim()).toBe("Billing");
-		// The row is inside the section's list, not beside it. `parent_key` is the whole of
-		// hierarchy and the server sends the tree flat (#42227).
+		// The row is inside the section's list, not beside it.
 		expect(heading?.parentElement?.querySelector("[data-key='invoice']")).not.toBeNull();
 	});
 
@@ -250,9 +241,8 @@ describe("what the panel draws", () => {
 	});
 
 	it("reports a cycle in each container it happens in", async () => {
-		// A key identifies a row within one container, so one shared "reported once" set would
-		// swallow the panel's report as a repeat of the rail's and leave a sidebar silently
-		// missing rows.
+		// A key is unique within one container, so a shared "reported once" set would swallow
+		// the panel's report as a repeat of the rail's.
 		const errors: string[] = [];
 		const original = console.error;
 		console.error = (...args: unknown[]) => errors.push(String(args[0]));
@@ -281,9 +271,8 @@ describe("what the panel draws", () => {
 
 describe("the panel's own context", () => {
 	it("measures what is left of a module against the sidebar, not against the rail", async () => {
-		// A context is composed once per LIST, and there are two lists here. `Module Contents`
-		// expands into "what this module holds that the list does not already show" — so a row
-		// handed the rail's context would hide the doctypes the RAIL shows and repeat its own.
+		// A context is composed once per list: a row handed the rail's context would hide the
+		// doctypes the rail shows and repeat its own.
 		fetchContents.mockResolvedValue([
 			{ doctype: "CRM Lead", slug: "crm-lead", module: "FCRM" },
 			{ doctype: "Sales Invoice", slug: "sales-invoice", module: "Accounts" },
@@ -319,8 +308,7 @@ describe("the panel's heading", () => {
 	});
 
 	it("is absent rather than a scrubbed address when nobody labelled the item", async () => {
-		// `labelOf` would fall through to `link_to`, which for this kind is the key boot files
-		// the sidebar under. A heading reading `module_def_accounts` is worse than none.
+		// `labelOf` would fall through to `link_to`, here the scrubbed address; no heading beats that.
 		const { host } = await shell([{ ...accounts, label: undefined }], sidebars, "/sales-invoice");
 
 		expect(panel(host)).not.toBeNull();
@@ -330,8 +318,7 @@ describe("the panel's heading", () => {
 
 
 describe("icons in the panel", () => {
-	// One model, two presentations, so the icon question is answered once for both. Only
-	// four sidebar rows on the bench carry one, all of them CRM's.
+	// One model, two presentations, so the icon question is answered once for both.
 	function withSprite() {
 		vi.stubGlobal(
 			"fetch",

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,14 +1,5 @@
-// ONE framework-owned Tailwind config. Apps contribute `theme` and `plugins` only.
-//
-// The shape came from the tooling, not from taste: `theme` and `plugins` merge from a
-// preset; `content` and `safelist` do NOT -- `content` never, at any depth (frappe-ui
-// documents this), and `safelist` last-non-empty-wins silently. So the framework owns
-// exactly the two keys that cannot compose (#42123).
-//
-// And nobody gets a safelist, including the framework. CRM's `!(text|bg)-` pattern is
-// 88% of its CSS gzip bytes; it serves CRM v1's runtime class composition and arrived
-// in frontend2 by copy-paste. The one genuinely unscannable case, Page Script icons,
-// is already solved without one.
+// The one Tailwind config. Apps contribute `theme` and `plugins` through a preset; `content`
+// and `safelist` never merge from one, and nobody gets a safelist.
 
 import { createRequire } from "node:module";
 import { existsSync, readFileSync } from "node:fs";
@@ -20,13 +11,8 @@ const require = createRequire(import.meta.url);
 const here = dirname(fileURLToPath(import.meta.url));
 const manifest = JSON.parse(readFileSync(join(here, "manifest.json"), "utf-8")).apps;
 
-// Contribution is a colocated file, found the way every other contribution is -- NOT
-// a scalar hook. The `app_prefix`/`app_boot`/`app_permission` family exists because
-// those values are needed before JS is read, or per-site at runtime. A preset is
-// neither.
-//
-// Loaded synchronously: tailwind 3 reads this config through jiti, which has no
-// top-level await.
+// A colocated file, found like every other contribution. Loaded synchronously: tailwind 3
+// reads this config through jiti, which has no top-level await.
 const appPresets = [];
 for (const { source_dir } of manifest) {
 	const preset = join(source_dir, "frontend", "tailwind.preset.js");
@@ -37,8 +23,6 @@ for (const { source_dir } of manifest) {
 
 export default {
 	presets: [frappeUIPreset, ...appPresets],
-	// Derived from the manifest's `source_dir`, which loses nothing: the only
-	// hand-written globs on this bench point at packages the framework now owns.
 	content: [
 		join(here, "index.html"),
 		join(here, "src/**/*.{vue,js,ts,jsx,tsx}"),

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,10 +1,4 @@
-// The framework's ONE vite config. There is no other in any app.
-//
-// It is worth reading beside `crm/frontend2/vite.config.js`, because everything that
-// file works around exists only because it was one of N hosts: the __SOCKETIO_PORT__
-// define reading common_site_config.json, the '@framework/ui' alias into a sibling
-// repo, the optimizeDeps include/exclude fixing dual-instance prosemirror. In one
-// module graph none of them has a cause.
+// The framework's one vite config; no app has another.
 
 import { fileURLToPath, URL } from "node:url";
 import { defineConfig } from "vite";
@@ -14,32 +8,17 @@ import contributions from "./plugin/contributions.js";
 import oneTree from "./plugin/oneTree.js";
 import { readManifest, readAllSourceDirs } from "./plugin/manifest.js";
 
-// Assembled by Python, because `app_prefix` is Python-only truth and a prefix cannot
-// be globbed for. Singleton enforcement happens there too, at assembly, so a version
-// conflict fails before vite is even spawned (#42069).
+// Assembled by Python, which also enforces singletons before vite is spawned.
 const manifest = readManifest();
 const allSourceDirs = readAllSourceDirs();
 
 export default defineConfig(({ command }) => ({
-	// ONE asset root for the whole bench. `/assets/frappe/` is a symlink to
-	// `frappe/public/`, so the built tree at `frappe/public/frontend/` is served from
-	// here. Per-app asset URLs are lost and app identity rides in the chunk name
-	// instead (#42069).
-	//
-	// Build only: in dev the framework's vite server serves the document itself, and a
-	// prefixed base would make it ask for its own modules under a path it does not own.
+	// One asset root for the bench: `/assets/frappe/` is a symlink to `frappe/public/`.
+	// Build only; in dev the vite server serves the document itself.
 	base: command === "build" ? "/assets/frappe/frontend/" : "/",
 
 	plugins: [
-		// frappe-ui's plugin, and WHICH options are off is the interesting part:
-		//   - jinjaBootData: false -- the document carries no boot island. Boot is
-		//     fetched in both environments, so an injected one would be a second producer
-		//     that only ever ran in prod (#42070).
-		//   - buildConfig: false -- it writes an app's outDir and index.html into a
-		//     sibling app's `www/`. The framework owns its output now (#42069).
-		//   - no frontendRoute -- `__FRONTEND_ROUTE__` is removed, not deprecated. One
-		//     bundle, one router, and the prefix asked for at runtime (#42065).
-		// What survives is icons, and the dev proxy.
+		// `jinjaBootData`, `buildConfig` and `frontendRoute` stay off; see CLAUDE.md.
 		...frappeui({
 			lucideIcons: true,
 			frappeProxy: true,
@@ -53,43 +32,23 @@ export default defineConfig(({ command }) => ({
 	resolve: {
 		alias: {
 			"@": fileURLToPath(new URL("./src", import.meta.url)),
-			// The public surface for CONTRIBUTED files, which live in other apps' repos
-			// and cannot use `@/…`. One module, `src/public.ts`, publishing the address
-			// builders and nothing else -- see the header there for why a builder had to
-			// be published at all.
+			// The surface a contributed file imports from; another app's repo cannot use `@/`.
 			"@shell": fileURLToPath(new URL("./src/public.ts", import.meta.url)),
 		},
-		// The framework's tree is the ONE tree, so a package reached through a symlink
-		// must resolve its imports here rather than beside its own source. `@framework/ui`
-		// is raw source with no build step of its own, linked in and compiled in the same
-		// module graph as the shell -- so "no build step" stops being a property of the
-		// package and becomes a property of the bundle (#42071).
-		//
-		// Deliberately NOT `resolve.dedupe`, and not a per-package alias either. Dedupe
-		// silently picks a winner, and aliasing a package to a directory bypasses its
-		// `exports` map, which breaks every subpath import (`frappe-ui/code-editor`).
-		// By the time vite runs, `enforce_singletons` has already established there is
-		// one version of each shared library; this is what makes everything find it.
+		// The framework's tree is the one tree: a symlinked package resolves its imports here.
+		// Not `resolve.dedupe` and not an alias; see CLAUDE.md.
 		preserveSymlinks: true,
 	},
 	build: {
-		// ONE root, /assets/frappe/frontend/. Per-app asset URLs are lost; app identity
-		// rides in the chunk name instead (#42069).
+		// One root for the bench; app identity rides in the chunk name.
 		outDir: fileURLToPath(new URL("../frappe/public/frontend", import.meta.url)),
-		// `bench build` overrides both of these: it points --outDir at a staging
-		// directory and passes --emptyOutDir, then swaps the result in only on success.
-		// That is what gets BOTH properties at once -- a failed build leaves the served
-		// assets untouched (crm/frontend2 does exactly the wrong thing here today), and a
-		// successful one leaves no orphaned chunks behind, which plain `emptyOutDir: false`
-		// does not: content hashes change every build and nothing ever removes the old
-		// ones. These values are the safe answer for a bare `yarn build` run by hand.
+		// `bench build` overrides both, building to a staging directory and swapping it in;
+		// these are the safe answer for a bare `yarn build`.
 		emptyOutDir: false,
 		sourcemap: true,
 	},
 	server: {
-		// Every app's source is outside this root, so all of them must be readable. This
-		// generalises the single escape hatch crm/frontend2 already needs for one
-		// sibling repo.
+		// Every app's source is outside this root.
 		fs: {
 			allow: [
 				fileURLToPath(new URL("..", import.meta.url)),

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -1,35 +1,20 @@
-// The runner for the record-page engine's unit tests.
-//
-// Deliberately NOT `vite.config.js`. That config reads `manifest.json`, which Python
-// generates during `bench build` and .gitignore excludes -- so on a fresh clone, and on
-// CI, it does not exist. This config takes only what the tests need, and states the
-// manifest inline rather than reading one.
-//
-// The engine's tests used to run through `crm/frontend2`'s vitest, because that was the
-// only place `frappe-ui` was installed. Now that the engine lives here, the runner and
-// the tests are in the same package and the suite finally runs against the frappe-ui
-// version the shell actually ships.
+// The test runner. Separate from `vite.config.js`, which reads the `manifest.json` that
+// `bench build` generates and a clean clone lacks.
 import { fileURLToPath, URL } from "node:url";
 import { defineConfig } from "vitest/config";
 import vue from "@vitejs/plugin-vue";
 import frappeui from "frappe-ui/vite";
 import contributions from "./plugin/contributions.js";
 
-// The contributions plugin IS wanted here, and it is not the reason this config is
-// separate. What it must not do is read `manifest.json`, which `bench build` generates and
-// .gitignore excludes -- so the manifest is written out here instead, with the one app the
-// tests need: frappe's own eight navigation item renderers are contributions like any
-// other (#42420), and a test that mocked the virtual module would exercise the mock rather
-// than the door the whole design rests on.
+// The manifest is stated inline: frappe's own item renderers are contributions, and a
+// test that mocked the virtual module would exercise the mock.
 const manifest = [
 	{ app: "frappe", source_dir: fileURLToPath(new URL("../frappe", import.meta.url)) },
 ];
 
 export default defineConfig({
 	plugins: [
-		// Only for `~icons/*`: frappe-ui's own components import the lucide virtual
-		// modules, so without this any test that reaches a real field component fails
-		// to resolve them. Every other option this plugin has belongs to the build.
+		// Only for `~icons/*`; frappe-ui's own components import the lucide virtual modules.
 		...frappeui({ lucideIcons: true }),
 		vue(),
 		contributions(
@@ -40,22 +25,14 @@ export default defineConfig({
 	resolve: {
 		alias: {
 			"@": fileURLToPath(new URL("./src", import.meta.url)),
-			// The surface a CONTRIBUTED file imports from, and the framework's own renderers
-			// are contributed files. Aliased in `vite.config.js` since #42068 and never here,
-			// because until now nothing under test reached one.
+			// The surface a contributed file imports from; the framework's renderers are contributed files.
 			"@shell": fileURLToPath(new URL("./src/public.ts", import.meta.url)),
 		},
-		// Same reason as the build: `@framework/ui` is linked in as raw source and must
-		// resolve its imports in this tree rather than beside its own.
+		// `@framework/ui` is linked in as raw source and must resolve its imports in this tree.
 		preserveSymlinks: true,
 	},
-	// No postcss, which means no Tailwind. `postcss.config.js` loads
-	// `tailwind.config.js`, which reads `manifest.json` at module scope -- the very file
-	// this config exists to avoid needing, reached by a second route: a frappe-ui component
-	// with a `<style>` block sends the transform through `vite:css`, and the run dies on a
-	// clean clone with a postcss error naming a `.vue` file nobody wrote a test about. An
-	// empty object here overrides the project config rather than merging with it, and these
-	// tests assert on DOM structure and never on a class taking effect.
+	// No postcss: `tailwind.config.js` reads `manifest.json` at module scope, and a frappe-ui
+	// `<style>` block would reach it through `vite:css`. An empty object overrides, not merges.
 	css: { postcss: {} },
 	test: {
 		globals: true,
@@ -63,11 +40,8 @@ export default defineConfig({
 		include: ["src/**/tests/*.test.ts"],
 		server: {
 			deps: {
-				// frappe-ui's sources import extensionless (`from './resources'`). Vitest
-				// externalizes node_modules by default and loads them as native Node ESM,
-				// which requires exact extensions, so the import fails even though the
-				// file is right there. Inlining hands it to vite's resolver, which does
-				// extension resolution.
+				// frappe-ui imports extensionless; externalised as native Node ESM that fails, and
+				// inlining hands it to vite's resolver.
 				inline: ["frappe-ui"],
 			},
 		},


### PR DESCRIPTION
Brings the rest of `frontend/` under the comment rule in the root `AGENTS.md`: the shell, the router, the contribution seam, the navigation model, the pages, the icons, the build plumbing and their tests. Comment-only: `.github/helper/comment_equivalence.py upstream/desk-v2 HEAD` reports every changed source file comment-only; `frontend`'s vitest run is green (26 files, 442 tests); `bench build` produces a working shell at `/apps/crm`, with a clean console; prettier 2.7.1 passes on the changed `.js`/`.vue`.

Wayfinder ticket: #42416, on map #42413.

**Numbers.** The ticket counted 29 files and 611 comment lines on 2026-09-02; `navigation/`, `icons/` and the shell tests landed since, so the folder re-measured at 51 files with comments, 1,604 comment lines in 6,052 → 679 in 5,127 (27% → 13%). Every ticket citation and every "rather than" argument in a comment is gone. Densest files:

| File | Before | After |
| --- | --- | --- |
| `navigation/NavigationRow.vue` | 72 / 140 (34%) | 26 / 140 (16%) |
| `navigation/current.ts` | 69 / 79 (47%) | 29 / 79 (27%) |
| `router/index.ts` | 68 / 82 (45%) | 19 / 82 (19%) |
| `navigation/types.ts` | 64 / 23 (74%) | 26 / 23 (53%) |
| `shell/AppShell.vue` | 63 / 166 (28%) | 24 / 166 (13%) |
| `boot.ts` | 63 / 57 (52%) | 29 / 57 (34%) |
| `arrangement.ts` | 62 / 91 (41%) | 26 / 91 (22%) |
| `plugin/contributions.js` | 61 / 172 (26%) | 22 / 172 (11%) |
| `shell/AppRail.vue` | 55 / 82 (40%) | 10 / 82 (11%) |
| `vite.config.js` | 53 / 43 (55%) | 12 / 43 (22%) |

**What survives** is the one-line file note and the constraints a reader would otherwise undo: the `Object.hasOwn` guard on `/apps/crm/constructor`, 401 read as unauthorized, the route-order note (`/deals` must beat `/:doctype`) and that nothing validates a page slug against a doctype slug, canonicalise to the slug never away from it, the depth guard in the navigation registry being a depth and not a key set, the walk over the index rather than the list in `tree.ts`, the explicit `aria-current` that suppresses `RouterLink`'s own, the generation guards, the `<!-- lucide- prefixed -->` note in the editor, and the vitest `postcss: {}` and `inline: ["frappe-ui"]` traps. Where a constraint is already argued in `frontend/CLAUDE.md` (the frappe-ui options that stay off, the no-alias rule, `preserveSymlinks`), the code keeps one line and points there.

**Two things the check itself needed.** `comment_equivalence.py` never stripped `<!-- -->`, so a Vue template comment counted as code and every `.vue` file here would have failed it; and an apostrophe in template text (`app's home`) opened a "string" that swallowed the next comment. Both are fixed, and Greptile then found three edges of the apostrophe rule in turn (a single-quoted attribute, whitespace around its `=`, and `=` in text outside a tag), each fixed with a self-test case (15/15); the record-page sweep still passes under the stricter stripper. That is the one non-comment change in this PR, in its own commits.

**Docs.** `frontend/PHILOSOPHY.md`'s DP2 said the registry's own comment argued its size; it now states the claim itself. `frontend/CLAUDE.md` likewise, and its two `vite.config.js:NN-NN` line references now name the file only, since the lines moved.

**Judgement calls.** `routeFor`'s docstring keeps its three worked examples; they are the API's contract, not rationale. `contributions/types.ts` keeps a two-line "not contributable" list, because adding a hook there is exactly what a reader would do without it.
