### PR TITLE
chore(desk-v2): field descriptions that fit under the field

### DIFF
--- a/frappe/desk/doctype/navigation_item/navigation_item.json
+++ b/frappe/desk/doctype/navigation_item/navigation_item.json
@@ -2,7 +2,7 @@
  "actions": [],
  "allow_bulk_edit": 1,
  "creation": "2026-09-01 10:00:00.000000",
- "description": "One row of desk v2 navigation. The same row serves the rail and the sidebar, which is why it is named for what it does rather than for where it sits. A row points at exactly one destination and carries no query of its own.",
+ "description": "One row of desk v2 navigation, serving both the rail and the sidebar.",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
@@ -40,14 +40,14 @@
    "label": "Identity"
   },
   {
-   "description": "This row's address, authored once and then frozen. Every site and user edit is filed against it, so changing or dropping a key is a breaking change in the same sense that renaming a `fieldname` is: the deltas that named the old key go inert and the site silently loses its arrangement. Minted from a slug of the destination when the row is first exported, and never recomputed after that — identity is not derived from the destination columns, because an app retargeting an item is an ordinary product change and would otherwise orphan every customization of it.",
+   "description": "Frozen address every site and user edit is filed against. Never changed once shipped.",
    "fieldname": "key",
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Key"
   },
   {
-   "description": "The `key` of the row this one sits under. Blank means top level. This is the whole of hierarchy: there is no `child`, no `indent` and no depth cap, because a renderer that draws two levels says so itself rather than the framework deciding an app's navigation shape. A `parent_key` naming a row that is gone promotes this one to top level rather than dropping it, so an app removing a section never silently deletes navigation.",
+   "description": "Key of the row this one sits under. Blank, or naming a missing row, means top level.",
    "fieldname": "parent_key",
    "fieldtype": "Data",
    "label": "Parent Key"
@@ -57,7 +57,7 @@
    "fieldtype": "Column Break"
   },
   {
-   "description": "What kind of thing this row opens. A Link to the code-owned type registry rather than a Select, because a Select's options live in one DocType JSON owned by one app, so a second app could only extend it with a Property Setter. Link rows are additive across apps with no shared field to fight over. Required on a row that IS an item — one an app ships, or one a layer added — and blank on a delta, which is an opinion about an item the layer below it holds and says nothing about what that item opens.",
+   "description": "What this row opens. Required on an item, blank on a delta over a lower layer's item.",
    "fieldname": "item_type",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -70,7 +70,7 @@
    "label": "Destination"
   },
   {
-   "description": "The doctype `link_to` names. Fetched from the type's `Target DocType`, and only when the row leaves it blank -- which is what lets `Record`, the one type that hands the choice to the item, carry its own. Fetched rather than filled in `validate`, because a Dynamic Link is checked before any document hook runs on insert, and the framework resolves Link fields before Dynamic Links in the same pass. A Link rather than Data so that renaming a doctype repairs the pointer through ordinary link renaming.",
+   "description": "Fetched from the type's Target DocType when blank; only a Record row sets its own.",
    "fetch_from": "item_type.target_doctype",
    "fetch_if_empty": 1,
    "fieldname": "link_doctype",
@@ -79,7 +79,7 @@
    "options": "DocType"
   },
   {
-   "description": "The record this row opens. A real Dynamic Link, which is what keeps `rename_dynamic_links` repairing every pointer on the site in one statement — base rows and layer rows alike. That matters most for the `Record` type, which has the highest rename traffic of all.",
+   "description": "The record this row opens.",
    "fieldname": "link_to",
    "fieldtype": "Dynamic Link",
    "in_list_view": 1,
@@ -87,7 +87,7 @@
    "options": "link_doctype"
   },
   {
-   "description": "Where a `Link` row goes. The one type with no document behind it, and so the one row with nothing for the Dynamic Link to hold.",
+   "description": "Where a Link row goes.",
    "fieldname": "url",
    "fieldtype": "Data",
    "label": "URL"
@@ -97,7 +97,7 @@
    "fieldtype": "Column Break"
   },
   {
-   "description": "The type-specific tail: whatever a type needs that no other type has, such as a `Link` row's open-in-new-tab choice or a `Page`'s query. Inside the row's identity, because a payload is by definition part of where the row goes. Never a filter or a saved query — what a list shows belongs to the document a `View` row points at, so that an authored item never carries a query it could be reformatted out of.",
+   "description": "Type-specific JSON, such as a Link row's open-in-new-tab. Never a filter or a saved query.",
    "fieldname": "payload",
    "fieldtype": "Code",
    "label": "Payload",
@@ -109,14 +109,13 @@
    "label": "Presentation"
   },
   {
-   "description": "What this row reads as. Outside identity, so re-labelling an item never detaches the customizations filed against it. A label a person authored — one named in `overrides` — renders verbatim and is never translated; a shipped one translates as usual.",
+   "description": "Shown as typed, never translated. Blank falls back to the type's label, then the destination.",
    "fieldname": "label",
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Label"
   },
   {
-   "description": "What this row draws with. Outside identity, for the same reason as `label`.",
    "fieldname": "icon",
    "fieldtype": "Icon",
    "label": "Icon",
@@ -128,7 +127,6 @@
   },
   {
    "default": "0",
-   "description": "Whether this row's children can be folded away. Generic to any node that has children, which is why it survived the columns that used to describe the tree instead of storing it.",
    "fieldname": "collapsible",
    "fieldtype": "Check",
    "label": "Collapsible"
@@ -142,27 +140,27 @@
   },
   {
    "collapsible": 1,
-   "description": "Only meaningful on a site or user layer, where a row is either a delta against a row the app ships or an item the layer added outright.",
+   "description": "Site and user layers only: a delta against a shipped row, or an item this layer added.",
    "fieldname": "customization_section",
    "fieldtype": "Section Break",
    "label": "Customization"
   },
   {
    "default": "0",
-   "description": "Hide this item. Explicit rather than implied by the row's absence, which is what lets a user's `hidden: 0` un-hide something the site hid. Hiding is a preference and stays in the payload with this flag set; a permission check is a different thing and removes the row before any layer merges.",
+   "description": "Hides the item. Explicit, so a user's unticked Hidden can un-hide what the site hid.",
    "fieldname": "hidden",
    "fieldtype": "Check",
    "label": "Hidden"
   },
   {
    "default": "0",
-   "description": "0 means this row is a delta against a base row with the same `key`. 1 means a whole item this layer added, rendered as it stands.",
+   "description": "0: a delta against the base row with this key. 1: an item this layer added outright.",
    "fieldname": "added",
    "fieldtype": "Check",
    "label": "Added"
   },
   {
-   "description": "On a delta row, the JSON list of fieldnames this layer actually has an opinion about. Naming them explicitly is what lets a site clear a value the app shipped — remove an icon, blank a label — which an empty-means-inherit encoding cannot express, and what makes \"did a human author this label\" answerable at render time.",
+   "description": "JSON list of fieldnames this delta has an opinion about, so a blank can clear a shipped value.",
    "fieldname": "overrides",
    "fieldtype": "Code",
    "label": "Overrides",
@@ -170,13 +168,13 @@
   },
   {
    "collapsible": 1,
-   "description": "Only meaningful on a row one app contributes to another app's rail — a `Rail` layer with `extends` set. An app's own rows are already where their author put them. A site or user layer says where a row goes with an anchor too, but stores it on the row it is moving rather than here, because that row is a delta over somebody else's item.",
+   "description": "Where a contributed row lands. A site or user layer's moves are stored as anchors too.",
    "fieldname": "contribution_section",
    "fieldtype": "Section Break",
    "label": "Contribution"
   },
   {
-   "description": "Where this row wants to land in the host's list, as an ordered JSON list of attempts. Each attempt is an object naming at most one of `after` and `before`, a sibling to sit next to, and optionally `parent_key`, a row to nest under; every key it names has to be in the merged list for the attempt to resolve. The first that resolves wins and the rest are ignored, which is how an app says \"beside Customers, or failing that beside Contacts, or failing that anywhere\" without knowing which version of the host is installed. None resolving means the row is appended at the top level and never dropped, because a contributed item that lands in the wrong place is a cosmetic problem and one that vanishes is a bug report. Keys are written as the host wrote them, unprefixed; the merge namespaces contributed keys but never the anchors that name them. A layer row uses the same list for the same reason one phase later: a person's move is stored as what it landed beside, not as a position, so an item an app ships afterwards lands where the app put it instead of after everything that person has arranged. There the fallback is the row's own shipped position rather than the end, because unlike a contributed row it has one.",
+   "description": "Ordered JSON list of placements naming after, before or parent_key. First to resolve wins.",
    "fieldname": "anchors",
    "fieldtype": "Code",
    "label": "Anchors",
@@ -188,7 +186,7 @@
   },
   {
    "default": "0",
-   "description": "Whether following this row leaves the host app for the app that contributed it. Off by default, and that default needs no code: a contributed row is an ordinary prefix-relative link, so clicking it keeps you where you are — addresses are bench-wide, so a foreign doctype opens under the host's prefix. On, the server sends the finished absolute URL, because the client resolves routes through the router it is standing in and cannot build one into another prefix. A column rather than a corner of `payload`, so that `overrides` can name it: a site that wants a contributed item to stay put, or to leave, is stating an opinion about a field, and `payload` sits inside the row's identity.",
+   "description": "Following this row leaves the host app for the app that contributed it.",
    "fieldname": "switches_app",
    "fieldtype": "Check",
    "label": "Switches App"
@@ -198,7 +196,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-09-02 12:00:00.000000",
+ "modified": "2026-09-03 18:03:47.000000",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Navigation Item",

--- a/frappe/desk/doctype/navigation_item/navigation_item.py
+++ b/frappe/desk/doctype/navigation_item/navigation_item.py
@@ -7,13 +7,7 @@ from frappe.model.document import Document
 
 
 class NavigationItem(Document):
-	"""One row of desk v2 navigation, on the rail or in a sidebar.
-
-	The row holds no behaviour. Everything it does is decided by its `item_type`: the framework
-	resolves a row to a destination and a permission bucket by reading the type, so the client
-	renders an item without branching on what kind it is, and a type the client has never heard
-	of is not a case it has to handle.
-	"""
+	"""One row of desk v2 navigation, on the rail or in a sidebar; its `item_type` decides everything it does."""
 
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
@@ -48,18 +42,7 @@ class NavigationItem(Document):
 		self.validate_type_on_an_item()
 
 	def validate_type_on_an_item(self):
-		"""A row that *is* an item names its type; a delta does not have one to name.
-
-		`item_type` is not `reqd` on the field, because two different kinds of row live in this
-		table. An **added** row brings an item nothing below it holds, and a row an app ships is
-		an item by definition -- both open something, so both must say what. A **delta** states an
-		opinion about an item a lower layer already holds, and what that item opens is not its
-		business: a person renaming a row would otherwise have to restate a type they have no view
-		on, and the copy would go stale the day the app changed it.
-
-		The shipped case is checked by the container instead, in `validate_item_keys`, because a
-		row cannot see whether its parent is standard without loading it.
-		"""
+		"""An added row is the item and names its type; `item_type` is not `reqd` because a delta row has none."""
 		if self.added and not self.item_type:
 			frappe.throw(
 				_("Row {0} adds an item but does not say what kind. An added row is the item.").format(
@@ -70,23 +53,11 @@ class NavigationItem(Document):
 
 
 def validate_item_keys(items):
-	"""Refuse a shipped list whose rows are not addressable or not typed, one by one.
-
-	A `key` is what every site and user edit is filed against, so a missing or duplicated one
-	is not a cosmetic slip: the deltas naming it go inert and the site quietly loses its
-	arrangement while the navigation still renders correctly. Navigation that breaks quietly
-	gets misdiagnosed as a permission problem, so this fails at write time instead.
-
-	Both containers call it, because both hold these rows and the resolver reads them by key
-	from either. Only the app layer is ever checked: a layer's rows are addressed by the base
-	key they name, and a row a layer *added* is minted a key when it is written.
-	"""
+	"""Refuse a shipped list with an untyped, keyless or duplicate-keyed row; both containers call this."""
 	seen = set()
 
 	for item in items:
 		if not item.item_type:
-			# Checked here rather than on the field, which cannot be `reqd` because a delta row
-			# in a site or user layer has no type to give -- see `validate_type_on_an_item`.
 			frappe.throw(
 				_("Row {0} does not say what kind of item it is.").format(item.idx),
 				title=_("Missing Type"),

--- a/frappe/desk/doctype/navigation_item_type/navigation_item_type.json
+++ b/frappe/desk/doctype/navigation_item_type/navigation_item_type.json
@@ -3,7 +3,7 @@
  "allow_rename": 0,
  "autoname": "field:type_name",
  "creation": "2026-09-01 10:00:00.000000",
- "description": "The kinds of thing a `Navigation Item` can be. Code-owned: a row is shipped as a file in an app and arrives on a site by migrate, never by someone filling in this form. An app adds a kind by shipping one of these rows and a renderer beside it, which is the same mechanism the framework's own kinds use. The framework ships eight: `DocType`, `Record`, `Module`, `Module Contents`, `Page`, `Link`, `Section` and `Sidebar`.",
+ "description": "The kinds of thing a Navigation Item can be. Code-owned: an app ships a row as a file, with a renderer beside it.",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
@@ -18,7 +18,7 @@
  ],
  "fields": [
   {
-   "description": "What this kind is called, on screen and as its record name. Named for its destination, which is the rule the whole set follows: a `DocType` row opens a doctype, a `Sidebar` row opens a sidebar, a `Module` row opens a module's page. The two exceptions are named for what they hold rather than for where they go, because they go nowhere themselves: `Section`, a heading with rows under it, and `Module Contents`, the overflow row that expands into whatever of a module is left.",
+   "description": "Named for what an item of this kind opens: DocType, Sidebar, Module.",
    "fieldname": "type_name",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -27,14 +27,14 @@
    "unique": 1
   },
   {
-   "description": "How this kind reads when an item of it needs describing and has no label of its own.",
+   "description": "Fallback label for an item of this kind that has none of its own.",
    "fieldname": "label",
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Label"
   },
   {
-   "description": "The icon an item of this kind falls back to.",
+   "description": "Fallback icon for an item of this kind.",
    "fieldname": "icon",
    "fieldtype": "Icon",
    "label": "Icon",
@@ -45,7 +45,7 @@
    "fieldtype": "Column Break"
   },
   {
-   "description": "The module whose folder ships this row, which is also where it is exported to and where the import walk finds it again.",
+   "description": "The module whose folder this row is exported to and imported from.",
    "fieldname": "module",
    "fieldtype": "Link",
    "label": "Module",
@@ -53,7 +53,7 @@
    "reqd": 1
   },
   {
-   "description": "The doctype an item of this kind points into, copied onto the item's `link_doctype` so a row of this kind cannot name a destination in the wrong table. Left blank by the one kind that lets the item choose -- `Record`, where the user picks the doctype as well as the document -- and by the kinds that point nowhere at all. Two kinds may share a target and still be two kinds: `Module` and `Module Contents` both name a `Module Def`, and what tells them apart is what they do with it, which is their renderer's business and not a column here.",
+   "description": "Copied onto an item's blank Link DocType. Blank for Record, whose items choose, and for kinds that open nothing.",
    "fieldname": "target_doctype",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -61,7 +61,7 @@
    "options": "DocType"
   },
   {
-   "description": "Which rule decides whether a user sees an item of this kind. Filtering navigation is a courtesy and never a control \u2014 hiding the way to a document is not hiding the document \u2014 so a rule may skip an expensive case and be wrong in the safe direction. Declaring a bucket is what keeps a new kind to two files and no framework change; `Custom` is the door for a kind that genuinely needs its own answer, and almost none should.\n\n`Readable DocType`: visible when the user can read the doctype it points at, whether by role or by a share.\n`Module Contents`: visible when any doctype in the module is readable, less an administrator's block. Named for the question it asks and not for the kind of the same name, which does not use it.\n`Derived From Children`: visible when anything under it survives, and dropped when nothing does.\n`Permitted Page`: visible when the page is in the user's page set.\n`Always Visible`: never filtered; for a kind that points outside the site.\n`Custom`: answered by the type's own batched `can_see`, contributed alongside its renderer.",
+   "description": "Which rule decides whether a user sees an item of this kind. Custom defers to the type's own can_see.",
    "fieldname": "permission_rule",
    "fieldtype": "Select",
    "label": "Permission Rule",
@@ -72,7 +72,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-09-01 18:00:00.000000",
+ "modified": "2026-09-03 18:03:47.000000",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Navigation Item Type",

--- a/frappe/desk/doctype/navigation_item_type/navigation_item_type.py
+++ b/frappe/desk/doctype/navigation_item_type/navigation_item_type.py
@@ -5,27 +5,12 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
-# The writes that are an app's content arriving on a site rather than a person editing it: an
-# install, an app update, a migrate, or a fixture import. Each is a real route by which a type
-# ships, and without them installing an app that contributes a kind would fail on every site.
+# The routes by which a shipped type reaches a site without a person editing it.
 SYSTEM_WRITE_FLAGS = ("in_install", "in_patch", "in_migrate", "in_import", "in_setup_wizard")
 
 
 class NavigationItemType(Document):
-	"""A kind of navigation item, contributed by an app as a file.
-
-	Two things make a kind, and neither of them is a row of code. The kind's *declaration* is this
-	record, shipped at `<app>/<module>/navigation_item_type/<name>/<name>.json` and re-imported by
-	the ordinary migrate sync. What an item of the kind *does* on click is a JS module shipped
-	beside it. Server code is optional, and arrives through a hook keyed by type name rather than
-	through a dotted path stored here: a path in a database row is code-in-data, and since a type
-	row and its handler are always edited in the same commit, storing the path would buy nothing
-	and cost a way to change behaviour by editing a record.
-
-	Rows are therefore code-owned. Nobody has create or write permission on this doctype — a
-	non-developer minting a row would be minting behaviour — and the guard below stops the two
-	remaining routes, developer-mode authoring aside.
-	"""
+	"""A kind of navigation item, shipped by an app as a file beside its renderer; rows are code-owned."""
 
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
@@ -54,15 +39,7 @@ class NavigationItemType(Document):
 		self.validate_app_content()
 
 	def validate_app_content(self):
-		"""Refuse a write that is not an app shipping its own content.
-
-		The permission rows already withhold create and write from every role, so this only has to
-		catch what permissions cannot see: a write made with `ignore_permissions`, and Administrator,
-		who is exempt from permission checks entirely. `Rail`'s equivalent guard is conditional
-		because its three layers share one table and two of them must stay writable at runtime.
-		This one is unconditional, because every row here is app content and there is no second
-		layer to protect.
-		"""
+		"""Refuse writes outside developer mode or a system write; permissions miss Administrator."""
 		if frappe.conf.developer_mode:
 			return
 
@@ -81,12 +58,7 @@ class NavigationItemType(Document):
 		self.export_type()
 
 	def export_type(self):
-		"""Write this type to its file, so authoring it and shipping it are one step.
-
-		The path is the usual per-record folder inside the module — the same walk that imports
-		`Sidebar` and `Workspace` — which is what lets the row arrive at migrate and its renderer
-		at build on two independent channels, with no manifest to disagree with a seeder.
-		"""
+		"""Write this type to its module folder, the same walk that imports `Sidebar` and `Workspace`."""
 		from frappe.modules.export_file import export_to_files
 
 		if frappe.flags.in_import or not frappe.conf.developer_mode:

--- a/frappe/desk/doctype/rail/rail.json
+++ b/frappe/desk/doctype/rail/rail.json
@@ -2,7 +2,7 @@
  "actions": [],
  "autoname": "hash",
  "creation": "2026-09-01 10:00:00.000000",
- "description": "One layer of one app's rail. Four kinds of row share this table, told apart by `app`, `extends`, `user` and `standard`: the app's own rail, which it ships as an exported document and a developer authors; the site's arrangement of it, curated by a System Manager and applying to everyone; and one person's own, applied last and winning. The order is strict -- app, then site, then user -- and there is no role layer, because a user with three roles would get three competing arrangements and a precedence rule the framework has nowhere else. A rail belongs to an app, so arranging ERPNext's does not touch CRM's. The fourth kind is another app's contribution to this one's rail, which names its host in `extends` and is merged into the base before any of those three are laid over it. The container is named for where it is and its rows for what they do, which is the only arrangement in which one row type can honestly serve both this and a sidebar.",
+ "description": "One layer of one app's rail: the app's own, the site's arrangement, one user's own, or another app's contribution.",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
@@ -15,7 +15,7 @@
  ],
  "fields": [
   {
-   "description": "The app whose rail this layer arranges. Required: a rail belongs to an app, and a layer that named none would be one arrangement spanning every rail. An `Autocomplete` over installed apps rather than a Link, because there is no `App` doctype -- the house spelling, shared with `Sidebar.app` and `Dock.app`.",
+   "description": "The app whose rail this layer arranges.",
    "fieldname": "app",
    "fieldtype": "Autocomplete",
    "in_list_view": 1,
@@ -26,7 +26,7 @@
   },
   {
    "depends_on": "eval:doc.standard == 1",
-   "description": "The app whose rail this layer joins, for an app that adds entries to somebody else's. Blank on an app's own rail, which is what nearly every row is. This replaces `mount_on`, which was desk v1's arrangement and a different claim: there, a companion app surrendered its own rail and its apps-screen tile to live inside a host, and one column could only ever name one host. An app that extends ERPNext *or* CRM *or* Helpdesk ships one row per host and keeps its own, which is why this belongs to the address rather than to the app. An **app name** rather than a Link to a `Rail`, because a pin aimed at a record would be a pin aimed at one of that app's three layers, which means nothing. Not nullable, for the reason `user` is not: one spelling of \"extends nobody\" has to reach the unique index. App-layer only -- `depends_on` hides it elsewhere and `validate` blanks it, because hiding a field does not stop an API write, and a site or user layer naming a host would be one person's arrangement of a rail they do not own.",
+   "description": "The host app whose rail this layer joins. App layer only; blank on an app's own rail.",
    "fieldname": "extends",
    "fieldtype": "Autocomplete",
    "in_standard_filter": 1,
@@ -35,7 +35,7 @@
    "options": "Installed Applications"
   },
   {
-   "description": "The person whose own arrangement this is. Blank means the app's own rail or the site's arrangement of it, told apart by `standard`. Not nullable, so that one spelling of \"not a user's own layer\" reaches the index: a blank column stored as `NULL` is distinct from every other `NULL`, and an app could then hold two site layers that both look like one address.",
+   "description": "Whose own arrangement this is. Blank means the app's or the site's layer, told apart by Standard.",
    "fieldname": "user",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -46,7 +46,7 @@
   },
   {
    "default": "0",
-   "description": "Owned by the app: exported to `<app>/rail/<app>/<app>.json` and re-imported by migrate. This is the app layer, the one the other two are laid over, and the only one an app ever writes. Writable in developer mode alone, because a standard rail with no exported file is an orphan and gets deleted on the next migrate.",
+   "description": "Owned by the app and exported to its rail folder by name. Authored in developer mode only.",
    "fieldname": "standard",
    "fieldtype": "Check",
    "in_list_view": 1,
@@ -60,7 +60,7 @@
    "label": "Items"
   },
   {
-   "description": "The entries this layer has an opinion about. Order is per parent, so dragging inside one section cannot renumber another, and it is a sparse move-list: an entry this layer never names keeps its shipped position and follows the ones it does. That is what lets an app add an item between two others and have it land there even for someone who has already rearranged the list.",
+   "description": "Rows this layer has an opinion about. Order is sparse and per parent: unnamed rows keep their place.",
    "fieldname": "items",
    "fieldtype": "Table",
    "label": "Items",
@@ -70,7 +70,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-09-02 12:00:00.000000",
+ "modified": "2026-09-03 18:03:47.000000",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Rail",

--- a/frappe/desk/doctype/rail/rail.py
+++ b/frappe/desk/doctype/rail/rail.py
@@ -7,29 +7,19 @@ from frappe.database.utils import drop_index_if_exists
 from frappe.desk.doctype.navigation_item.navigation_item import validate_item_keys
 from frappe.model.document import Document
 
-# Blank, not `None`: the column is not nullable so that one spelling of "not a user's own layer"
-# reaches the index. Every `NULL` is distinct to an index, so a nullable column would let one app
-# hold two site layers that both look like one address.
+# Blank, not `None`: every `NULL` is distinct to the unique index, so a nullable column
+# would let one app hold two site layers at one address.
 SITE_LAYER = ""
 
-# Blank, for the same reason and read the same way: "this layer extends nobody, it is the app's
-# own rail". A nullable column would not reach the unique index below.
+# Blank for the same reason: "extends nobody" has to reach the unique index.
 NO_HOST = ""
 
-# The writes that are an app's content arriving on a site rather than a person editing it. Each is
-# a real route by which a shipped rail reaches a site, and without them, installing or updating an
-# app that ships one would fail on every customer site.
+# The routes by which a shipped rail reaches a site without a person editing it.
 SYSTEM_WRITE_FLAGS = ("in_install", "in_patch", "in_migrate", "in_import", "in_setup_wizard")
 
 
 class Rail(Document):
-	"""One layer of one app's rail.
-
-	The document holds the layer; how they resolve into the list a person sees is not
-	here. That resolution is one engine shared with the sidebar -- the rail and the sidebar are two
-	presentations of one model, not two models -- and it runs at read time, against the whole of a
-	prefix, on the way into boot.
-	"""
+	"""One layer of one app's rail; the layers are resolved into a list at read time, not here."""
 
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
@@ -48,20 +38,7 @@ class Rail(Document):
 	# end: auto-generated types
 
 	def autoname(self):
-		"""Name a shipped rail after what it arranges; everything else gets a hash.
-
-		The export path requires it, because the record name is the file path. A hash-named
-		standard record would write `<app>/rail/6a1f9c2e/6a1f9c2e.json`, and a re-export from a
-		fresh bench would create a second file, leaving the first as a permanent orphan.
-
-		An app ships more than one of these once it extends somebody: its own rail, plus a record
-		per host. So the name is the address and not the app alone — `telephony` for its own,
-		`telephony-erpnext` for what it adds to ERPNext's. A hyphen separates them because an app
-		name is a Python module name and can never contain one.
-
-		An opaque name costs the other two layers nothing, because a layer is looked up by filter
-		and never by name.
-		"""
+		"""Name a shipped rail `<app>` or `<app>-<host>`, since the name is its export path; the rest get a hash."""
 		if not self.standard:
 			return
 
@@ -77,23 +54,12 @@ class Rail(Document):
 		self.validate_item_keys()
 
 	def blank_the_host(self):
-		"""Clear `extends` outside the app layer, because extending is an app-layer claim.
-
-		`depends_on` hides the field on the two writable layers but does not stop an API write, and
-		a site or user row naming a host would be one person's arrangement of a rail they do not
-		own — which is also the row that already exists, since a person arranges a host rail
-		through the host's own address and gets every contributed item in the same list.
-		"""
+		"""Clear `extends` outside the app layer: `depends_on` hides the field but does not stop an API write."""
 		if not self.standard:
 			self.extends = NO_HOST
 
 	def refuse_extending_itself(self):
-		"""An app extending itself is its own rail written twice, and the two would both merge.
-
-		Cheap to state and impossible to mean: the second record would be appended to the first
-		with its keys namespaced `<app>:<key>`, so every item would appear once addressable and
-		once not.
-		"""
+		"""An app extending itself is its own rail written twice."""
 		if self.extends and self.extends == self.app:
 			frappe.throw(
 				_("{0} cannot extend its own rail. Ship the items on its own rail instead.").format(
@@ -103,21 +69,8 @@ class Rail(Document):
 			)
 
 	def refuse_a_second_record_at_this_address(self):
-		"""Say plainly that a shipped rail is already there, rather than letting the insert fail.
-
-		The unique index below is the guarantee and stays the guarantee — it holds against a bulk
-		write and against anything that skips the document. This is about the message. A shipped
-		rail's name *is* its address, while the doctype autonames by `hash` for the sake of the
-		other two layers, so `db_insert` reads the primary-key collision as a hash collision and
-		retries. `autoname` puts the same name back each time, so it retries five times and then
-		re-raises the driver's own `IntegrityError`, which names a column and no cause.
-
-		Only shipped rows have a deterministic name, so only they can reach that path. Everything
-		else keeps its hash and meets the index, which reports itself properly.
-
-		In `validate` rather than `before_insert`, which runs before the name exists: `insert`
-		calls `before_insert`, then `set_new_name`, then the before-save methods.
-		"""
+		"""Refuse a second shipped rail by name: `db_insert` would read the collision as a hash retry."""
+		# Needs the name, which `before_insert` runs too early to see.
 		if not self.is_new() or not self.standard or not frappe.db.exists("Rail", self.name):
 			return
 
@@ -129,17 +82,8 @@ class Rail(Document):
 		)
 
 	def validate_app_content(self):
-		"""Allow only developer mode to set or clear the standard flag, because it is app content.
-
-		Conditional rather than blanket: all three layers live in one table, and the site's and
-		each person's rows have to stay writable at runtime. With no guard at all, a Workspace
-		Manager could take an app's row, clear the flag, and turn git-versioned app content into a
-		site row they own.
-
-		The `is_new()` check matters: on an unsaved document `has_value_changed` returns True for
-		every field, so without it every site- and user-layer row would be refused outside
-		developer mode.
-		"""
+		"""Only developer mode or a system write may set or clear `standard`, which is app content."""
+		# On an unsaved document `has_value_changed` is True for every field, hence `is_new()`.
 		if not (self.standard or (not self.is_new() and self.has_value_changed("standard"))):
 			return
 
@@ -158,11 +102,7 @@ class Rail(Document):
 		)
 
 	def validate_item_keys(self):
-		"""The shared rule, in `navigation_item.py`: an app's rows must each carry a unique key.
-
-		Only the app layer is checked. A layer's rows are addressed by the base key they name,
-		and a row the layer *added* is minted a key on export alongside the rest.
-		"""
+		"""Every row an app ships carries a unique key; only the app layer is checked."""
 		if not self.standard:
 			return
 
@@ -172,14 +112,7 @@ class Rail(Document):
 		self.export_rail()
 
 	def export_rail(self):
-		"""Write this rail to its file, so authoring it and shipping it are one step.
-
-		The path is `<app>/rail/<name>/<name>.json`: the usual per-record folder, rooted at the app
-		instead of a module, because no module owns a rail. The import walk and the orphan sweep
-		both work on that shape unchanged, because the filename and the record name agree — which
-		is why `autoname` makes the name the address, so an app that extends two hosts writes three
-		files rather than overwriting one.
-		"""
+		"""Write this rail to `<app>/rail/<name>/<name>.json`, rooted at the app since no module owns a rail."""
 		from frappe.modules.export_file import export_to_files
 
 		if not self.standard or frappe.flags.in_import or not frappe.conf.developer_mode:
@@ -189,23 +122,9 @@ class Rail(Document):
 
 
 def on_doctype_update():
-	"""Enforce one layer per address in the schema rather than in a `validate` hook.
-
-	A hook is bypassed by `db_insert`, a bulk write, or anything that skips the document, and two
-	documents at one address would give the merge two answers for the same layer.
-
-	The index is composite because an address is four columns. `user` alone would let one person
-	arrange only one app's rail. `standard` is in it because an app's own rail and the site's
-	arrangement of it are two documents at the same `(app, user)`: one shipped, one curated, and
-	resetting the site's must not touch the app's. `extends` is in it because an app ships one
-	record per rail it joins and one for its own, and the three-column form made extending
-	unstorable rather than merely unresolvable: `telephony` already owns `(telephony, "", 1)`, so
-	its second record collided with its first.
-
-	The old three-column index is dropped by name. `add_unique` is keyed on the constraint name
-	and does nothing when one already exists, so widening the columns under the same name would
-	have been a silent no-op on every bench that has already migrated this branch.
-	"""
+	"""One layer per address, held by the schema so a bulk write cannot bypass it."""
+	# `add_unique` is keyed on the constraint name and skips an existing one, so the old
+	# three-column index has to be dropped by name before the wider one can land.
 	drop_index_if_exists("tabRail", "unique_layer_address")
 	frappe.db.add_unique(
 		"Rail", ("app", "extends", "user", "standard"), constraint_name="unique_rail_address"
@@ -213,19 +132,7 @@ def on_doctype_update():
 
 
 def has_permission(doc, ptype="read", user=None, debug=False):
-	"""Allow a System Manager to curate the site and the apps; everyone else gets only their own.
-
-	This is the document-level half of the gate the endpoints hold. A `Desk User` has `read` and
-	nothing more: rearranging a rail goes through an endpoint that writes one person's own layer
-	with `ignore_permissions`, so no write permission is needed or granted. This stops the read
-	they do have from being a read of everyone else's layers.
-
-	`System Manager`, not `Workspace Manager`: this table is not about workspaces, and `Sidebar`,
-	the other container desk v2 uses, has always granted `System Manager` and has never had a
-	`Workspace Manager` row. Reaching for the narrower role here made the branch disagree with
-	itself about who may curate. The cost is real and accepted: curating the site layer can no
-	longer be delegated without full site administration.
-	"""
+	"""A System Manager may read every layer; everyone else only their own."""
 	user = user or frappe.session.user
 	if user == "Administrator" or "System Manager" in frappe.get_roles(user):
 		return True
@@ -234,17 +141,7 @@ def has_permission(doc, ptype="read", user=None, debug=False):
 
 
 def get_permission_query_conditions(user=None):
-	"""Restrict list queries so everyone but a System Manager sees only their own layer.
-
-	This pairs with `has_permission` and is not redundant: reports, the API and the desk's export
-	go through this rather than through the document-level check.
-
-	Returns a query-builder term rather than a SQL string. The hook accepts either -- `query.py`
-	wraps a string in a `RawCriterion` and lets a term through as it is -- and the term keeps the
-	identifier quoting out of this file, which a hand-written `` `tabRail` `` spells the way only
-	MySQL accepts. The sidebar's two older hooks still build strings; they are desk v1's and are
-	left alone.
-	"""
+	"""The list-query half of `has_permission`: reports, the API and export go through this."""
 	user = user or frappe.session.user
 	if user == "Administrator" or "System Manager" in frappe.get_roles(user):
 		return None

--- a/frappe/desk/doctype/rail/test_rail.py
+++ b/frappe/desk/doctype/rail/test_rail.py
@@ -9,25 +9,17 @@ from frappe.desk.doctype.rail.rail import Rail
 from frappe.tests import IntegrationTestCase
 from frappe.tests.classes.context_managers import set_user
 
-# An app that is certainly installed on any site running these tests. Which app it is does not
-# matter: these tests are about the layers and the rows, not about anyone's actual navigation.
+# Any app certainly installed on a site running these tests.
 APP = "frappe"
 
-# Hosts an extension names. Neither has to be installed: `Rail.app` and `Rail.extends` are
-# `Autocomplete` columns over installed apps rather than Links, so nothing on the document
-# resolves them. Resolution is where an uninstalled app stops counting, and that is tested
-# against the resolver in `frappe/tests/test_shell_navigation.py`.
+# Hosts need not be installed: `Rail.app` and `Rail.extends` are `Autocomplete`, not Links.
 HOST = "erpnext"
 OTHER_HOST = "helpdesk"
 
 
 @contextlib.contextmanager
 def authoring():
-	"""Author app content the way a developer does, without writing a file into the working tree.
-
-	`export_rail` is what makes authoring and shipping one step, and in a test that is a fixture
-	leaking into the repo: the database is rolled back afterwards and the file is not.
-	"""
+	"""Author app content as a developer, with `export_rail` patched so no file lands in the working tree."""
 	with developer_mode(True), patch.object(Rail, "export_rail"):
 		yield
 
@@ -54,12 +46,7 @@ def item(**kwargs):
 
 class TestRail(IntegrationTestCase):
 	def test_the_eight_shipped_types_are_present(self):
-		"""The framework's own kinds arrive by migrate, as records rather than through a seeder.
-
-		`Sidebar` joined them once desk v2 had a sidebar container for it to point at. `View` is
-		still deliberately absent: the doctype it points at is a separate effort, and a type row
-		with a wrong target is worse than a missing one.
-		"""
+		"""The framework's own kinds arrive by migrate; `View` is deliberately absent until its doctype exists."""
 		shipped = set(frappe.get_all("Navigation Item Type", pluck="name"))
 		self.assertTrue(
 			{"DocType", "Record", "Module", "Module Contents", "Page", "Link", "Section", "Sidebar"}
@@ -78,11 +65,7 @@ class TestRail(IntegrationTestCase):
 		self.assertEqual(buckets["Link"], "Always Visible")
 
 	def test_module_and_module_contents_are_two_kinds(self):
-		"""They share a target doctype and are told apart by what they do with it. `Module` opens a
-		module's page and is visible when anything in the module is readable; `Module Contents` is
-		the overflow row that expands into what is left, so it drops when nothing survives under
-		it, exactly as a `Section` does.
-		"""
+		"""They share a target doctype and are told apart by their permission rule."""
 		buckets = dict(
 			frappe.get_all("Navigation Item Type", fields=["name", "permission_rule"], as_list=True)
 		)
@@ -150,12 +133,7 @@ class TestRail(IntegrationTestCase):
 		self.assertEqual(rail.items[0].link_doctype, "User")
 
 	def test_a_site_layer_cannot_claim_another_apps_rail(self):
-		"""`extends` is an app-layer claim, and hiding the field does not stop an API write.
-
-		A site or user row naming a host would be one person's arrangement filed onto a rail
-		they do not own — and it is unnecessary besides, since arranging a host rail is one row
-		at the host's own address covering every contributed item in the list.
-		"""
+		"""`extends` is an app-layer claim, and hiding the field does not stop an API write."""
 		rail = make_rail(extends=HOST)
 		rail.insert()
 		self.addCleanup(rail.delete)
@@ -168,11 +146,7 @@ class TestRail(IntegrationTestCase):
 			self.assertRaises(frappe.ValidationError, rail.insert)
 
 	def test_an_extension_is_named_after_the_address_and_not_the_app(self):
-		"""An app ships its own rail and one record per host, so the app name is not enough.
-
-		The record name is the export path, so two records sharing a name would overwrite one
-		file — which is exactly what `mount_on`'s single column made unavoidable.
-		"""
+		"""An app ships its own rail and one record per host, so the app name alone is not enough."""
 		own = make_rail(standard=1, items=[item(key="users", link_to="User")])
 		extension = make_rail(standard=1, extends=HOST, items=[item(key="users", link_to="User")])
 		with authoring():
@@ -185,12 +159,7 @@ class TestRail(IntegrationTestCase):
 		self.assertEqual(extension.name, f"{APP}-{HOST}")
 
 	def test_one_app_may_extend_two_hosts_and_keep_its_own_rail(self):
-		"""The whole reason `mount_on` came off: a scalar could name one host, and Payments and
-		Telephony each extend ERPNext *or* CRM *or* Helpdesk, choosing per site.
-
-		This is also what the old three-column index made unstorable rather than merely
-		unresolvable — every one of these rows is `(app, "", 1)` under it.
-		"""
+		"""One app extends several hosts, each as its own record beside its own rail."""
 		with authoring():
 			for extends in ("", HOST, OTHER_HOST):
 				rail = make_rail(standard=1, extends=extends, items=[item(key="users", link_to="User")])
@@ -203,13 +172,7 @@ class TestRail(IntegrationTestCase):
 		)
 
 	def test_two_extensions_of_one_host_by_one_app_are_still_refused(self):
-		"""The index widened; it did not stop enforcing one layer per address.
-
-		A shipped row is refused by name rather than by the index, and says so: its name is its
-		address, so the second one collides on the primary key — which `db_insert` reads as a
-		hash collision, retries five times against an `autoname` that keeps returning the same
-		string, and then re-raises the driver's own error naming a column and no cause.
-		"""
+		"""A second shipped row at one address is refused by name, with a message and not a driver error."""
 		with authoring():
 			first = make_rail(standard=1, extends=HOST, items=[item(key="users", link_to="User")])
 			first.insert()
@@ -239,10 +202,7 @@ class TestRail(IntegrationTestCase):
 			self.assertRaises(frappe.ValidationError, make_rail(standard=1).insert)
 
 	def test_two_layers_cannot_share_one_address(self):
-		"""The database holds this, not a hook, because a bulk write skips the document entirely.
-
-		Two rows at one `(app, user, standard)` would give the merge two answers for one layer.
-		"""
+		"""The database holds this, not a hook, because a bulk write skips the document entirely."""
 		first = make_rail()
 		first.insert()
 		self.addCleanup(first.delete)
@@ -251,12 +211,7 @@ class TestRail(IntegrationTestCase):
 			make_rail().insert()
 
 	def test_a_person_lists_only_their_own_layer(self):
-		"""The list query is the half `has_permission` does not cover.
-
-		Reports, the API and the desk's own export go through the query condition rather than
-		through the document check, so without it a `Desk User`'s read would be a read of
-		everyone else's arrangements.
-		"""
+		"""The list query is the half `has_permission` does not cover."""
 		site = make_rail()
 		site.insert()
 		self.addCleanup(site.delete)
@@ -275,8 +230,7 @@ class TestRail(IntegrationTestCase):
 		mine.insert()
 		self.addCleanup(mine.delete)
 
-		# `get_list`, not `get_all`: the latter bypasses permissions by design, so it would pass
-		# whether or not the condition exists.
+		# `get_list`, not `get_all`, which bypasses permissions and would pass either way.
 		with set_user(person.name):
 			visible = frappe.get_list("Rail", pluck="name")
 

--- a/frappe/desk/doctype/sidebar/sidebar.json
+++ b/frappe/desk/doctype/sidebar/sidebar.json
@@ -24,7 +24,7 @@
  ],
  "fields": [
   {
-   "description": "What this sidebar is called, on screen and -- on desk v1's sidebars -- as its record name (`autoname: field:title`). Defaults to the module's name there, and the default is stored, so a module's own sidebar keeps the name it has always had and a second sidebar under that module is told apart by being called something else. On a desk v2 sidebar the name comes from the address instead and this is only the label, which is why uniqueness is enforced in the controller for v1's rows rather than by an index over both.",
+   "description": "Desk v1 names a sidebar after this, unique among them; on desk v2 it is only the label.",
    "fieldname": "title",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -32,7 +32,7 @@
    "reqd": 1
   },
   {
-   "description": "The module this sidebar belongs to. Neither required nor unique: one module may own several sidebars, and which of them answers for the module itself is decided by the name -- the one called after the module -- rather than by a column here. May also be blank, which means the sidebar belongs to its app rather than to any one of the app's modules; such a sidebar is exported to the app's own folder and says which app in `app`.",
+   "description": "Optional. A module may own several sidebars; the one named after the module answers for it.",
    "fieldname": "module",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -50,28 +50,28 @@
    "fieldtype": "Column Break"
   },
   {
-   "description": "The app this sidebar is placed in. Derived from the module when there is one -- a module sits in exactly one app. Author-set when there is not: an app-rooted sidebar has no module to derive it from, and this is then the only thing that says which app ships the file.",
+   "description": "Derived from the module when there is one; set by hand on a sidebar with no module.",
    "fieldname": "app",
    "fieldtype": "Autocomplete",
    "label": "App",
    "options": "Installed Applications"
   },
   {
-   "description": "Desk v2 only. The doctype half of the address this sidebar hangs on -- `Module Def` for a module's sidebar, a doctype for a doctype's. Blank on desk v1's sidebars, which are addressed by `module` and named by `title` instead. A Link rather than Data so that renaming a doctype repairs the pointer through ordinary link renaming, matching `Navigation Item.link_doctype`.",
+   "description": "Desk v2 only: Module Def for a module's sidebar, a doctype for a doctype's. Blank on desk v1 sidebars.",
    "fieldname": "link_doctype",
    "fieldtype": "Link",
    "label": "Link DocType",
    "options": "DocType"
   },
   {
-   "description": "The record this sidebar belongs to. With `link_doctype` this is the whole address, and it is what a rail item of type `Sidebar` points at: a linked rail item names the sidebar the address produced. A real Dynamic Link, so `rename_dynamic_links` repairs every pointer on the site in one statement.",
+   "description": "The module or doctype this sidebar hangs on. With Link DocType, this is its address.",
    "fieldname": "link_to",
    "fieldtype": "Dynamic Link",
    "label": "Link To",
    "options": "link_doctype"
   },
   {
-   "description": "The person whose own arrangement this is. Blank means the app's own sidebar or the site's arrangement of it, told apart by `standard` -- the same three layers, in the same strict order, that `Rail` holds for the rail. Not nullable, so that one spelling of \"not a user's own layer\" reaches the index: every `NULL` is distinct to an index, so a nullable column would let one address hold two site layers that both look like one address.",
+   "description": "Whose own arrangement this is. Blank means the app's or the site's layer, told apart by Standard.",
    "fieldname": "user",
    "fieldtype": "Link",
    "label": "User",
@@ -90,7 +90,7 @@
    "options": "Sidebar Item"
   },
   {
-   "description": "Desk v2's rows, in the same table type the rail holds -- one row model serving both surfaces. Beside v1's `items` rather than replacing them: v1's sidebars keep rendering from `Sidebar Item` untouched, and a row can only be read by the desk that understands its columns. Order is per parent and sparse, so an item this layer never names keeps its shipped position.",
+   "description": "Desk v2's rows, the same row type the rail holds. Desk v1 sidebars keep rendering from Items.",
    "fieldname": "navigation_items",
    "fieldtype": "Table",
    "label": "Navigation Items",
@@ -103,7 +103,7 @@
   },
   {
    "default": "0",
-   "description": "Owned by an app: exported to its module's folder -- or to the app's own folder when it has no module -- and re-imported by migrate. Set via the Mark as Standard action, not by hand -- a standard sidebar with no exported file is an orphan and gets deleted on the next migrate. Everything else belongs to this site, however it got here.",
+   "description": "Owned by an app and exported to its module or app folder. Set via Mark as Standard, not by hand.",
    "fieldname": "standard",
    "fieldtype": "Check",
    "label": "Standard",
@@ -124,7 +124,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-09-01 18:45:00.000000",
+ "modified": "2026-09-03 17:55:12.000000",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Sidebar",


### PR DESCRIPTION
Part of the desk v2 comment cleanup, [Desk v2: the code reads as code](https://github.com/frappe/frappe/issues/42413). Resolves [The four DocTypes: field descriptions that fit under the field](https://github.com/frappe/frappe/issues/42418).

A field's `description` renders as a paragraph under the input, so it is user-facing text. On `Rail`, `Navigation Item`, `Navigation Item Type` and `Sidebar`, 35 of the 38 descriptions ran past 80 characters, the longest to 1,058, and most of that was the reasoning behind the field's design. That reasoning lives in the wayfinder ticket that decided each field; the form now says what the field holds and any constraint on its value.

| DocType | Longest before | Longest after |
| --- | --- | --- |
| Navigation Item | 1,219 | 101 |
| Navigation Item Type | 1,058 | 108 |
| Rail | 1,021 | 100 |
| Sidebar | 516 | 102 |

`Navigation Item.icon` lost its description entirely, since the label says it. The three DocType-level descriptions are cut the same way. Every `modified` stamp is bumped so migrate re-imports the JSON.

The controllers in the same folders follow the rule in the root `AGENTS.md`: one summary line per docstring, and a comment only where it records a constraint a reader would otherwise undo. 287 lines out, 80 in, no behaviour change.

Checked on a real site: `bench migrate` clean, the four forms opened and read (one description had used `<app>/rail/<name>` and the browser ate the angle brackets as tags; reworded), `test_rail` 19 green, `test_sidebar` 98 green.

>no-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
