### PR TITLE
fix: surface progress and errors when generating report PDF

### DIFF
--- a/cypress/integration/render_pdf.js
+++ b/cypress/integration/render_pdf.js
@@ -1,0 +1,73 @@
+context("Render PDF", () => {
+	const pdf_route = "/api/method/frappe.utils.print_format.report_to_pdf";
+
+	const render_pdf = () =>
+		cy
+			.window()
+			.its("frappe")
+			.then((frappe) =>
+				frappe.render_pdf("<h1>Stock Balance</h1>", { report_name: "stock_balance.pdf" })
+			);
+
+	before(() => {
+		cy.login();
+	});
+
+	beforeEach(() => {
+		cy.visit("/app/todo");
+	});
+
+	it("freezes the page while the PDF is generated", () => {
+		cy.intercept("POST", pdf_route, { statusCode: 504, body: "", delay: 1000 }).as("pdf");
+
+		render_pdf();
+
+		cy.get("#freeze .freeze-message").should("contain", "Generating PDF...");
+		cy.wait("@pdf");
+		cy.get("#freeze").should("not.exist");
+	});
+
+	it("reports a gateway timeout as a size problem", () => {
+		cy.intercept("POST", pdf_route, { statusCode: 504, body: "" }).as("pdf");
+
+		render_pdf();
+		cy.wait("@pdf");
+
+		cy.get(".msgprint-dialog .modal-title").should("contain", "Could not generate PDF");
+		cy.get(".msgprint").should("contain", "may be too large");
+	});
+
+	it("points at the Error Log when the server fails for another reason", () => {
+		cy.intercept("POST", pdf_route, { statusCode: 500, body: "" }).as("pdf");
+
+		render_pdf();
+		cy.wait("@pdf");
+
+		cy.get(".msgprint").should("contain", "Check the Error Log for details.");
+	});
+
+	it("shows the server message when the response carries one", () => {
+		cy.intercept("POST", pdf_route, {
+			statusCode: 417,
+			body: {
+				_server_messages: JSON.stringify([
+					JSON.stringify({ message: "Report is too large to render" }),
+				]),
+			},
+		}).as("pdf");
+
+		render_pdf();
+		cy.wait("@pdf");
+
+		cy.get(".msgprint").should("contain", "Report is too large to render");
+	});
+
+	it("does not blame report size when the connection drops", () => {
+		cy.intercept("POST", pdf_route, { forceNetworkError: true }).as("pdf");
+
+		render_pdf();
+
+		cy.get(".msgprint").should("contain", "Check your connection");
+		cy.get("#freeze").should("not.exist");
+	});
+});

--- a/frappe/public/js/frappe/microtemplate.js
+++ b/frappe/public/js/frappe/microtemplate.js
@@ -196,6 +196,36 @@ frappe.render_template = function (name, data) {
 		w.document.close();
 	});
 
+function parse_server_messages(response) {
+	try {
+		const body = JSON.parse(new TextDecoder().decode(response));
+		return body._server_messages ? JSON.parse(body._server_messages) : null;
+	} catch {
+		return null;
+	}
+}
+
+function pdf_size_message() {
+	return __(
+		"The report may be too large to render in a single request. Narrow the filters and try again, or use Print and save as PDF from your browser."
+	);
+}
+
+function show_pdf_error(message, response) {
+	const server_messages = parse_server_messages(response);
+
+	if (server_messages) {
+		frappe.msgprint(server_messages);
+		return;
+	}
+
+	frappe.msgprint({
+		title: __("Could not generate PDF"),
+		message: message,
+		indicator: "red",
+	});
+}
+
 frappe.render_pdf = function (html, opts = {}) {
 	//Create a form to place the HTML content
 	var formData = new FormData();
@@ -212,24 +242,50 @@ frappe.render_pdf = function (html, opts = {}) {
 	xhr.open("POST", "/api/method/frappe.utils.print_format.report_to_pdf");
 	xhr.setRequestHeader("X-Frappe-CSRF-Token", frappe.csrf_token);
 	xhr.responseType = "arraybuffer";
+	xhr.timeout = 10 * 60 * 1000;
+
+	frappe.dom?.freeze(__("Generating PDF..."));
 
 	xhr.onload = function (success) {
-		if (this.status === 200) {
-			var blob = new Blob([success.currentTarget.response], { type: "application/pdf" });
-			var objectUrl = URL.createObjectURL(blob);
+		frappe.dom?.unfreeze();
 
-			// Create a hidden a tag to force set report name
-			// https://stackoverflow.com/questions/19327749/javascript-blob-filename-without-link
-			let hidden_a_tag = document.createElement("a");
-			document.body.appendChild(hidden_a_tag);
-			hidden_a_tag.style = "display: none";
-			hidden_a_tag.href = objectUrl;
-			hidden_a_tag.download = opts.report_name || "report.pdf";
+		if (this.status !== 200) {
+			const timed_out = [408, 502, 503, 504].includes(this.status);
 
-			// Open report in a new window
-			hidden_a_tag.click();
-			window.URL.revokeObjectURL(objectUrl);
+			show_pdf_error(
+				timed_out ? pdf_size_message() : __("Check the Error Log for details."),
+				success.currentTarget.response
+			);
+			return;
 		}
+
+		var blob = new Blob([success.currentTarget.response], { type: "application/pdf" });
+		var objectUrl = URL.createObjectURL(blob);
+
+		// Create a hidden a tag to force set report name
+		// https://stackoverflow.com/questions/19327749/javascript-blob-filename-without-link
+		let hidden_a_tag = document.createElement("a");
+		document.body.appendChild(hidden_a_tag);
+		hidden_a_tag.style = "display: none";
+		hidden_a_tag.href = objectUrl;
+		hidden_a_tag.download = opts.report_name || "report.pdf";
+
+		// Open report in a new window
+		hidden_a_tag.click();
+		window.URL.revokeObjectURL(objectUrl);
 	};
+
+	xhr.ontimeout = function () {
+		frappe.dom?.unfreeze();
+		show_pdf_error(pdf_size_message());
+	};
+
+	xhr.onerror = function () {
+		frappe.dom?.unfreeze();
+		show_pdf_error(
+			__("The request could not be completed. Check your connection and try again.")
+		);
+	};
+
 	xhr.send(formData);
 };


### PR DESCRIPTION
## Problem

Report PDFs are generated synchronously inside the web request. Large reports can take tens of seconds or even a few minutes to finish.

Previously, `frappe.render_pdf` gave no indication that the PDF was being generated, and `onload` only handled `status === 200`. This meant slow requests, timeouts, server errors, and network errors all looked the same to the user:

> Click PDF → nothing happens.

This made it difficult to know whether the report was still generating or had failed. The actual error was also being discarded by the client.

## Changes

- Show a `Generating PDF...` freeze message while the PDF is being generated.
- Unfreeze the page when the request succeeds or fails.
- Handle non-200 responses and show the server's error message when available.
- Show a "report may be too large" message for timeout-related statuses: `408`, `502`, `503`, and `504`.
- Handle network errors with a useful error message.
- Fall back to the Error Log for other server errors instead of incorrectly treating them as a report-size issue.
- Added handling for `onerror`, which was previously missing.

## Note

This change does **not** make large reports render faster. PDF generation is still synchronous. Moving PDF generation out of the web request is separate work.

## Behaviour 


https://github.com/user-attachments/assets/4e2d430d-e00a-4e68-89f6-9717d439bf69

