### PR TITLE
fix: sync standard user timezone with system settings

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -266,7 +266,7 @@ def add_home_page(bootinfo, docs):
 
 
 def add_timezone_info(bootinfo):
-	system = bootinfo.sysdefaults.get("time_zone")
+	system = get_system_timezone()
 	import frappe.utils.momentjs
 
 	bootinfo.timezone_info = {"zones": {}, "rules": {}, "links": {}}

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -109,7 +109,10 @@ frappe.ui.form.on("User", {
 		});
 
 		if (frm.is_new()) {
-			frm.set_value("time_zone", frappe.sys_defaults.time_zone);
+			frm.set_value(
+				"time_zone",
+				frappe.boot.time_zone?.system || frappe.sys_defaults.time_zone
+			);
 		}
 
 		if (

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -5,6 +5,7 @@ import json
 from typing import Any
 
 import frappe
+import frappe.defaults
 from frappe import _
 from frappe.core.doctype.installed_applications.installed_applications import get_setup_wizard_completed_apps
 from frappe.geo.country_info import get_country_info
@@ -185,7 +186,7 @@ def update_global_settings(args):  # nosemgrep
 
 	update_system_settings(args)
 	create_or_update_user(args)
-	frappe.enqueue(set_timezone, timezone=args.get("timezone"))
+	frappe.enqueue(set_timezone, timezone=args.get("timezone"), enqueue_after_commit=True)
 
 
 def apply_telemetry_preference(telemetry_enabled):
@@ -349,7 +350,11 @@ def create_or_update_user(args):  # nosemgrep
 def set_timezone(timezone=None):
 	if not timezone:
 		return
+
 	frappe.db.set_value("User", {"name": ("in", frappe.STANDARD_USERS)}, "time_zone", timezone)
+	# db.set_value bypasses User.on_update, so sync the per-user default explicitly.
+	for user in frappe.STANDARD_USERS:
+		frappe.defaults.set_default("time_zone", timezone, user)
 
 
 def parse_args(args):  # nosemgrep

--- a/frappe/desk/page/setup_wizard/test_setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/test_setup_wizard.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026, Frappe Technologies and Contributors
+# License: MIT. See LICENSE
+
+import frappe
+import frappe.defaults
+from frappe.tests import IntegrationTestCase
+
+from .setup_wizard import set_timezone
+
+
+class TestSetupWizard(IntegrationTestCase):
+	def setUp(self):
+		super().setUp()
+		self.original_user_timezones = {
+			user: frappe.db.get_value("User", user, "time_zone") for user in frappe.STANDARD_USERS
+		}
+		self.original_defaults = {
+			user: frappe.db.get_value(
+				"DefaultValue", {"parent": user, "defkey": "time_zone"}, "defvalue"
+			)
+			for user in frappe.STANDARD_USERS
+		}
+		self.addCleanup(self.restore_standard_user_timezones)
+
+	def restore_standard_user_timezones(self):
+		for user in frappe.STANDARD_USERS:
+			frappe.db.set_value(
+				"User", user, "time_zone", self.original_user_timezones[user], update_modified=False
+			)
+			if self.original_defaults[user] is None:
+				frappe.defaults.clear_default("time_zone", parent=user)
+			else:
+				frappe.defaults.set_default("time_zone", self.original_defaults[user], user)
+
+	def test_set_timezone_updates_standard_user_defaults(self):
+		old_timezone = "Asia/Kolkata"
+		new_timezone = "Africa/Nairobi"
+
+		for user in frappe.STANDARD_USERS:
+			frappe.db.set_value("User", user, "time_zone", old_timezone, update_modified=False)
+			frappe.defaults.set_default("time_zone", old_timezone, user)
+
+		set_timezone(new_timezone)
+
+		for user in frappe.STANDARD_USERS:
+			self.assertEqual(frappe.db.get_value("User", user, "time_zone"), new_timezone)
+			self.assertEqual(frappe.defaults.get_user_default("time_zone", user), new_timezone)

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -268,3 +268,4 @@ frappe.patches.v16_0.backfill_notification_email_type_preferences
 frappe.patches.v16_0.backfill_notification_log_app
 execute:frappe.db.set_single_value("Contact Us Settings", "send_acknowledgement_email", 1)
 frappe.patches.v16_0.seed_sms_settings_allowed_roles
+frappe.patches.v16_0.sync_standard_user_timezones

--- a/frappe/patches/v16_0/sync_standard_user_timezones.py
+++ b/frappe/patches/v16_0/sync_standard_user_timezones.py
@@ -1,0 +1,6 @@
+import frappe
+from frappe.desk.page.setup_wizard.setup_wizard import set_timezone
+
+
+def execute():
+	set_timezone(frappe.db.get_single_value("System Settings", "time_zone"))

--- a/frappe/tests/test_boot.py
+++ b/frappe/tests/test_boot.py
@@ -1,10 +1,22 @@
+from unittest.mock import patch
+
 import frappe
+from frappe.boot import add_timezone_info
 from frappe.desk.desk_views import DeskViews
 from frappe.desk.doctype.note.note import _get_unseen_notes, get_unseen_notes, mark_as_seen
 from frappe.tests import IntegrationTestCase
 
 
 class TestBootData(IntegrationTestCase):
+	def test_timezone_info_uses_system_timezone(self):
+		bootinfo = frappe._dict(sysdefaults={"time_zone": "Asia/Kolkata"})
+
+		with patch("frappe.boot.get_system_timezone", return_value="Africa/Nairobi"):
+			with patch("frappe.utils.momentjs.update") as update:
+				add_timezone_info(bootinfo)
+
+		update.assert_called_once_with("Africa/Nairobi", bootinfo.timezone_info)
+
 	def test_get_unseen_notes(self):
 		frappe.db.delete("Note")
 		frappe.db.delete("Note Seen By")


### PR DESCRIPTION
closes #41320

## Problem

On v16, the setup wizard updates the User.time_zone field for Administrator and Guest with a direct database update. This bypasses User.on_update, which normally persists the matching per-user DefaultValue. As a result, a user's boot data and the new User form can continue using a stale Asia/Kolkata timezone after the site timezone is configured.

## Changes

- Queue the standard-user timezone sync after the setup transaction and update both User.time_zone and the per-user DefaultValue.
- Use the authoritative system timezone for boot timezone data and new User form defaults.
- Add a v16 migration to repair existing standard-user records and defaults.
- Add regression tests for default synchronization and boot timezone data.

## Testing

- bench --site test_site migrate (passed)
- bench --site test_site run-tests --module frappe.desk.page.setup_wizard.test_setup_wizard (1 passed)
- bench --site test_site run-tests --module frappe.tests.test_boot (5 passed)
- bench --site test_site run-tests --module frappe.tests.test_patches (10 passed)
- node --check frappe/core/doctype/user/user.js (passed)
- node_modules/.bin/prettier --check frappe/core/doctype/user/user.js (passed)
- git diff --check (passed)

The full Frappe suite was attempted but is not green in this local environment because of unrelated setup failures, including a missing wkhtmltopdf executable and an unavailable HTTP test service.

## Screenshots/GIFs

Not applicable; this changes default and boot timezone data and does not change the UI layout.