### PR TITLE
fix(oauth): re-validate provider identity on every social login

### DIFF
--- a/frappe/integrations/doctype/social_login_key/test_social_login_key.py
+++ b/frappe/integrations/doctype/social_login_key/test_social_login_key.py
@@ -60,6 +60,42 @@ class TestSocialLoginKey(IntegrationTestCase):
 			login_via_oauth2("github", "iwriu", create_oauth_state(None))
 		self.assertEqual(frappe.session.user, TEST_GITHUB_USER)
 
+	def test_repeat_login_with_same_provider_identity_succeeds(self):
+		"""logging in again with the SAME provider subject must keep working."""
+		github_social_login_setup()
+
+		mock_session = MagicMock()
+		mock_session.get.side_effect = github_response_for_login
+
+		with patch.object(OAuth2Service, "get_auth_session", return_value=mock_session):
+			login_via_oauth2("github", "iwriu", create_oauth_state(None))
+		self.assertEqual(frappe.session.user, TEST_GITHUB_USER)
+
+		frappe.set_user("Guest")
+		with patch.object(OAuth2Service, "get_auth_session", return_value=mock_session):
+			login_via_oauth2("github", "iwriu", create_oauth_state(None))
+		self.assertEqual(frappe.session.user, TEST_GITHUB_USER)
+
+	def test_login_with_different_provider_identity_for_linked_account_is_rejected(self):
+		"""A different GitHub account presenting the SAME email but a DIFFERENT subject must
+		not be able to log in as the account already linked to the original identity."""
+		github_social_login_setup()
+
+		legit_session = MagicMock()
+		legit_session.get.side_effect = github_response_for_login
+		with patch.object(OAuth2Service, "get_auth_session", return_value=legit_session):
+			login_via_oauth2("github", "iwriu", create_oauth_state(None))
+		self.assertEqual(frappe.session.user, TEST_GITHUB_USER)
+
+		frappe.set_user("Guest")
+
+		attacker_session = MagicMock()
+		attacker_session.get.side_effect = github_response_for_login_different_identity
+		with patch.object(OAuth2Service, "get_auth_session", return_value=attacker_session):
+			login_via_oauth2("github", "iwriu", create_oauth_state(None))
+
+		self.assertEqual(frappe.session.user, "Guest")
+
 	def test_oauth_state_helpers_reject_unknown_and_reused_tokens(self):
 		"""consume_oauth_state must only resolve tokens it minted itself, and only once."""
 		self.assertIsNone(consume_oauth_state("attacker-forged-token"))
@@ -176,7 +212,7 @@ def github_response_for_private_email(url, *args, **kwargs):
 	if url == "user":
 		return_value = {
 			"login": "dummy_username",
-			"id": "223342",
+			"id": 223342,
 			"email": None,
 			"first_name": "Github Private",
 		}
@@ -190,7 +226,7 @@ def github_response_for_public_email(url, *args, **kwargs):
 	if url == "user":
 		return_value = {
 			"login": "dummy_username",
-			"id": "223343",
+			"id": 223343,
 			"email": "github_public@example.com",
 			"first_name": "Github Public",
 		}
@@ -202,9 +238,23 @@ def github_response_for_login(url, *args, **kwargs):
 	if url == "user":
 		return_value = {
 			"login": "dummy_username",
-			"id": "223346",
+			"id": 223346,
 			"email": None,
 			"first_name": "Github Login",
+		}
+	else:
+		return_value = [{"email": TEST_GITHUB_USER, "primary": True, "verified": True}]
+
+	return MagicMock(status_code=200, json=MagicMock(return_value=return_value))
+
+
+def github_response_for_login_different_identity(url, *args, **kwargs):
+	if url == "user":
+		return_value = {
+			"login": "attacker_username",
+			"id": 999999,
+			"email": None,
+			"first_name": "Attacker",
 		}
 	else:
 		return_value = [{"email": TEST_GITHUB_USER, "primary": True, "verified": True}]

--- a/frappe/utils/oauth.py
+++ b/frappe/utils/oauth.py
@@ -309,6 +309,21 @@ def get_user_record(user: str, data: dict, provider: str) -> "User":
 	return user
 
 
+def get_oauth_userid(data: dict, provider: str) -> str:
+	"""Return the provider's subject/id claim that identifies this user at `provider`."""
+	match provider:
+		case "facebook" | "google" | "github":
+			userid = data["id"]
+		case "frappe" | "office_365":
+			userid = data["sub"]
+		case "salesforce":
+			userid = "/".join(data["sub"].split("/")[-2:])
+		case _:
+			user_id_property = frappe.db.get_value("Social Login Key", provider, "user_id_property") or "sub"
+			userid = data[user_id_property]
+	return str(userid)
+
+
 def update_oauth_user(user: str, data: dict, provider: str):
 	if isinstance(data.get("location"), dict):
 		data["location"] = data["location"].get("name")
@@ -320,25 +335,28 @@ def update_oauth_user(user: str, data: dict, provider: str):
 		frappe.respond_as_web_page(_("Not Allowed"), _("User {0} is disabled").format(user.email))
 		return False
 
-	if not user.get_social_login_userid(provider):
+	incoming_userid = get_oauth_userid(data, provider)
+	stored_userid = user.get_social_login_userid(provider)
+
+	if stored_userid:
+		# the presented identity must match the one linked previously,
+		# regardless of how convincingly this login's email claim checks out.
+		if stored_userid != incoming_userid:
+			frappe.respond_as_web_page(
+				_("Not Allowed"),
+				_("This account is already linked to a different {0} account.").format(provider.title()),
+			)
+			return False
+	else:
 		update_user_record = True
 		match provider:
 			case "facebook":
-				user.set_social_login_userid(provider, userid=data["id"], username=data.get("username"))
 				user.update({"user_image": f"https://graph.facebook.com/{data['id']}/picture"})
-			case "google":
-				user.set_social_login_userid(provider, userid=data["id"])
+				user.set_social_login_userid(provider, userid=incoming_userid, username=data.get("username"))
 			case "github":
-				user.set_social_login_userid(provider, userid=data["id"], username=data.get("login"))
-			case "frappe" | "office_365":
-				user.set_social_login_userid(provider, userid=data["sub"])
-			case "salesforce":
-				user.set_social_login_userid(provider, userid="/".join(data["sub"].split("/")[-2:]))
+				user.set_social_login_userid(provider, userid=incoming_userid, username=data.get("login"))
 			case _:
-				user_id_property = (
-					frappe.db.get_value("Social Login Key", provider, "user_id_property") or "sub"
-				)
-				user.set_social_login_userid(provider, userid=data[user_id_property])
+				user.set_social_login_userid(provider, userid=incoming_userid)
 
 	if update_user_record:
 		user.flags.ignore_permissions = True


### PR DESCRIPTION
Re-validate provider identity on every social login, instead of just doing so once.

related to closing Ticket 77534