### PR TITLE
refactor(contacts): use query builder for address and contact queries

### DIFF
--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -11,6 +11,7 @@ from frappe.contacts.address_and_contact import set_link_title
 from frappe.core.doctype.dynamic_link.dynamic_link import deduplicate_dynamic_links
 from frappe.model.document import Document
 from frappe.model.naming import make_autoname
+from frappe.query_builder.functions import Coalesce
 from frappe.utils import cstr
 
 
@@ -122,22 +123,25 @@ class Address(Document):
 
 def get_preferred_address(doctype, name, preferred_key="is_primary_address"):
 	if preferred_key in ["is_shipping_address", "is_primary_address"]:
-		address = frappe.db.sql(
-			""" SELECT
-				addr.name
-			FROM
-				`tabAddress` addr, `tabDynamic Link` dl
-			WHERE
-				dl.parent = addr.name and dl.link_doctype = {} and
-				dl.link_name = {} and ifnull(addr.disabled, 0) = 0 and
-				{} = {}
-			""".format("%s", "%s", preferred_key, "%s"),
-			(doctype, name, 1),
-			as_dict=1,
+		Address = frappe.qb.DocType("Address")
+		DynamicLink = frappe.qb.DocType("Dynamic Link")
+
+		address = (
+			frappe.qb.from_(Address)
+			.inner_join(DynamicLink)
+			.on(DynamicLink.parent == Address.name)
+			.select(Address.name)
+			.where(
+				(DynamicLink.link_doctype == doctype)
+				& (DynamicLink.link_name == name)
+				& (Coalesce(Address.disabled, 0) == 0)
+				& (Address[preferred_key] == 1)
+			)
+			.run(pluck=True)
 		)
 
 		if address:
-			return address[0].name
+			return address[0]
 
 	return
 

--- a/frappe/contacts/doctype/address/test_address.py
+++ b/frappe/contacts/doctype/address/test_address.py
@@ -9,6 +9,7 @@ from frappe.contacts.doctype.address.address import (
 	get_address_display,
 	get_address_list,
 	get_list_context,
+	get_preferred_address,
 )
 from frappe.tests import IntegrationTestCase
 
@@ -111,3 +112,13 @@ class TestAddress(IntegrationTestCase):
 
 		self.assertGreaterEqual(len(query(txt="Admin")), 1)
 		self.assertEqual(len(query(txt="what_zyx")), 0)
+
+	def test_get_preferred_address(self):
+		addr_name = self.create_test_address(address_title="_Test Preferred Address")
+		addr_doc = frappe.get_doc("Address", addr_name)
+		addr_doc.append("links", {"link_doctype": "User", "link_name": "Administrator"})
+		addr_doc.is_primary_address = 1
+		addr_doc.save()
+
+		preferred = get_preferred_address("User", "Administrator", "is_primary_address")
+		self.assertEqual(preferred, addr_name)

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -442,29 +442,29 @@ def address_query(links: str | list):
 	]
 	result = []
 
+	Address = frappe.qb.DocType("Address")
+	DynamicLink = frappe.qb.DocType("Dynamic Link")
+
 	for link in links:
 		if not frappe.has_permission(
 			doctype=link.get("link_doctype"), ptype="read", doc=link.get("link_name")
 		):
 			continue
 
-		res = frappe.db.sql(
-			"""
-			SELECT `tabAddress`.name
-			FROM `tabAddress`, `tabDynamic Link`
-			WHERE `tabDynamic Link`.parenttype='Address'
-				AND `tabDynamic Link`.parent=`tabAddress`.name
-				AND `tabDynamic Link`.link_doctype = %(link_doctype)s
-				AND `tabDynamic Link`.link_name = %(link_name)s
-		""",
-			{
-				"link_doctype": link.get("link_doctype"),
-				"link_name": link.get("link_name"),
-			},
-			as_dict=True,
+		res = (
+			frappe.qb.from_(Address)
+			.inner_join(DynamicLink)
+			.on(DynamicLink.parent == Address.name)
+			.select(Address.name)
+			.where(
+				(DynamicLink.parenttype == "Address")
+				& (DynamicLink.link_doctype == link.get("link_doctype"))
+				& (DynamicLink.link_name == link.get("link_name"))
+			)
+			.run(pluck=True)
 		)
 
-		result.extend([l.name for l in res])
+		result.extend(res)
 
 	return result
 

--- a/frappe/contacts/doctype/contact/test_contact.py
+++ b/frappe/contacts/doctype/contact/test_contact.py
@@ -52,6 +52,24 @@ class TestContact(IntegrationTestCase):
 		result = address_query(links=[{"link_doctype": "User", "link_name": "Administrator"}])
 		self.assertIsInstance(result, list)
 
+	def test_address_query_returns_linked_address(self):
+		from frappe.contacts.doctype.contact.contact import address_query
+
+		addr = frappe.get_doc(
+			{
+				"doctype": "Address",
+				"address_title": "Contact Address Link Test",
+				"address_type": "Billing",
+				"address_line1": "Link Street",
+				"city": "Link City",
+				"country": "India",
+				"links": [{"link_doctype": "User", "link_name": "Administrator"}],
+			}
+		).insert()
+
+		result = address_query(links=[{"link_doctype": "User", "link_name": "Administrator"}])
+		self.assertIn(addr.name, result)
+
 	def test_contact_query_for_linked_contact(self):
 		contact = create_contact("Contact Query Match", "Mr", save=False)
 		contact.append("links", {"link_doctype": "User", "link_name": "Administrator"})


### PR DESCRIPTION
### Summary
Refactor raw SQL queries in Address and Contact core models to use Frappe Query Builder (`frappe.qb`) for improved database compatibility across MariaDB and PostgreSQL.

### Changes
- Refactor `get_preferred_address` in `frappe/contacts/doctype/address/address.py` to use `frappe.qb`
- Refactor `address_query` in `frappe/contacts/doctype/contact/contact.py` to use `frappe.qb`
- Add unit test in `test_address.py` for `get_preferred_address`
- Add unit test in `test_contact.py` for `address_query`

Fixes #42336