### PR TITLE
fix(shell): paint the page background with bg-surface-base

### DIFF
--- a/frontend/src/shell/AppShell.vue
+++ b/frontend/src/shell/AppShell.vue
@@ -3,7 +3,7 @@
   here because a save replaces the whole `{rail, sidebars}`, and the open sidebar is a fact about the address.
 -->
 <template>
-	<div class="flex h-screen w-screen bg-surface-white text-ink-gray-9">
+	<div class="flex h-screen w-screen bg-surface-base text-ink-gray-9">
 		<AppRail
 			:items="navigation.rail"
 			:context="contexts.rail"

--- a/frontend/src/shell/ArrangementEditor.vue
+++ b/frontend/src/shell/ArrangementEditor.vue
@@ -3,7 +3,7 @@
   scope deep with hidden rows, writes only on Save, and uses the platform's own drag events plus arrows.
 -->
 <template>
-	<div class="flex w-80 shrink-0 flex-col border-l border-outline-gray-2 bg-surface-white">
+	<div class="flex w-80 shrink-0 flex-col border-l border-outline-gray-2 bg-surface-base">
 		<header class="flex items-center justify-between border-b border-outline-gray-2 p-3">
 			<h2 class="text-base font-medium text-ink-gray-8">{{ title }}</h2>
 			<Button variant="ghost" label="Close" @click="emit('close')" />

--- a/ui/src/components/ConditionBuilder/ConditionGroup.vue
+++ b/ui/src/components/ConditionBuilder/ConditionGroup.vue
@@ -15,7 +15,7 @@
 		:aria-describedby="describedBy || undefined"
 		:aria-invalid="invalid || undefined"
 		class="flex w-full min-w-0 flex-col gap-4"
-		:class="hasCard && 'rounded-lg border border-outline-gray-2 bg-surface-white p-3'"
+		:class="hasCard && 'rounded-lg border border-outline-gray-2 bg-surface-base p-3'"
 	>
 		<legend v-if="rootTag === 'fieldset'" :id="legendId" class="sr-only">
 			{{ groupName }}


### PR DESCRIPTION
## Problem

On a machine that prefers dark mode the desk v2 shell renders near-white text and dark-grey borders on a white page (seen on a fresh Frappe Cloud bench at `/apps/erpnext`, and reproducible on any local bench).

The shell's root element in `AppShell.vue` paints its background with `bg-surface-white`. frappe-ui defines no `--surface-white` token, so Tailwind generates no rule for the class and the built CSS contains no `surface-white` at all. The background is transparent and falls through to the browser's white. In light mode that is the right colour by accident. Under `data-theme="dark"` the ink tokens resolve to near-white and land on that unpainted page.

## Fix

`bg-surface-white` becomes `bg-surface-base`, the token frappe-ui uses for the page background in both themes. Three usages, in two commits by layer:

- `frontend/src/shell/AppShell.vue` (the page) and `frontend/src/shell/ArrangementEditor.vue` (the side panel)
- `ui/src/components/ConditionBuilder/ConditionGroup.vue` (the card)

Verified by rebuilding the shell: the CSS now carries a `.bg-surface-base` rule and no `surface-white`. Setting `data-theme="light"` on the broken page rendered it correctly, which is what isolated the fault to the background.

Worth a follow-up: any other class naming a token frappe-ui no longer defines fails the same silent way, so a grep of `frontend/` and `ui/` against frappe-ui's token list would catch the rest.

>no-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)