### PR TITLE
fix(shell): publish the boot CSRF token where frappe-ui reads it

### DIFF
--- a/frontend/src/boot.ts
+++ b/frontend/src/boot.ts
@@ -95,5 +95,8 @@ export async function fetchBoot(): Promise<Boot> {
 		throw new BootUnauthorized("Not permitted");
 	if (!res.ok) throw new Error(`Boot failed with ${res.status}`);
 
-	return (await res.json()).message;
+	const boot: Boot = (await res.json()).message;
+	// frappe-ui's request layer reads the token from this global; the shell has no Jinja to set it.
+	window.csrf_token = boot.csrf_token;
+	return boot;
 }

--- a/frontend/src/shell/tests/boot.test.ts
+++ b/frontend/src/shell/tests/boot.test.ts
@@ -1,0 +1,35 @@
+// Boot's one side effect: the CSRF token lands where frappe-ui's request layer reads it.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { BootUnauthorized, fetchBoot } from "@/boot";
+
+function respond(status: number, message?: object) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: status < 400,
+      status,
+      json: async () => ({ message }),
+    }))
+  );
+}
+
+describe("fetchBoot", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete (window as { csrf_token?: string }).csrf_token;
+  });
+
+  it("publishes the session's CSRF token on window for frappe-ui's requests", async () => {
+    respond(200, { csrf_token: "tok-123", app_order: ["frappe"] });
+    const boot = await fetchBoot();
+    expect(boot.csrf_token).toBe("tok-123");
+    expect(window.csrf_token).toBe("tok-123");
+  });
+
+  it("leaves no token behind when boot is refused", async () => {
+    respond(403);
+    await expect(fetchBoot()).rejects.toBeInstanceOf(BootUnauthorized);
+    expect(window.csrf_token).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

Clicking **Arrange** in the desk v2 shell on a Frappe Cloud bench and saving fails with a CSRF token error.

The arrangement editor writes through frappe-ui's `call` helper. frappe-ui adds the `X-Frappe-CSRF-Token` header only when it finds a token at `window.csrf_token`. The shell receives the token in the boot response as `boot.csrf_token` but never put it on `window`, so every write through frappe-ui left without the header. Only the record save in `Record.vue`, which sets the header by hand from `boot.csrf_token`, worked.

A local bench never shows this because its site config has `ignore_csrf: 1`, which makes the server skip the check. Frappe Cloud enforces it.

Affected: arrangement save and reset, record creation and page-script calls on the record page, the error-report channel, and the `ui/` file upload, which reads the same global.

## Fix

`fetchBoot` sets `window.csrf_token` from the boot response before anything renders. frappe-ui already declares the property on `Window`.

## Test

`shell/tests/boot.test.ts`: a successful boot publishes the token on `window`; a refused boot leaves none behind.

>no-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)