### PR TITLE
fix(ui): constrain captured image size in camera preview

### DIFF
--- a/frappe/public/js/frappe/ui/capture.js
+++ b/frappe/public/js/frappe/ui/capture.js
@@ -193,8 +193,8 @@ frappe.ui.Capture = class {
 		this.images.forEach((image, idx) => {
 			images += `
 				<div class="mt-1 p-1 rounded col-md-3 col-sm-4 col-xs-4" data-idx="${idx}">
-					<span class="capture-remove-btn" data-idx="${idx}">
-						${frappe.utils.icon("x", "lg")}
+					<span class="capture-remove-btn" data-idx="${idx}" title="${__("Remove")}">
+						${frappe.utils.icon("x", "sm")}
 					</span>
 					<img class="rounded img-fluid" src="${image}" data-idx="${idx}">
 				</div>

--- a/frappe/public/js/frappe/ui/capture.js
+++ b/frappe/public/js/frappe/ui/capture.js
@@ -193,9 +193,16 @@ frappe.ui.Capture = class {
 		this.images.forEach((image, idx) => {
 			images += `
 				<div class="mt-1 p-1 rounded col-md-3 col-sm-4 col-xs-4" data-idx="${idx}">
-					<span class="capture-remove-btn" data-idx="${idx}" title="${__("Remove")}">
+					<button
+						class="es-button capture-remove-btn"
+						data-size="xs"
+						data-variant="outline"
+						data-icon-button="true"
+						data-idx="${idx}"
+						title="${__("Remove")}"
+					>
 						${frappe.utils.icon("x", "sm")}
-					</span>
+					</button>
 					<img class="rounded img-fluid" src="${image}" data-idx="${idx}">
 				</div>
 			`;

--- a/frappe/public/js/frappe/ui/capture.js
+++ b/frappe/public/js/frappe/ui/capture.js
@@ -196,7 +196,7 @@ frappe.ui.Capture = class {
 					<span class="capture-remove-btn" data-idx="${idx}">
 						${frappe.utils.icon("x", "lg")}
 					</span>
-					<img class="rounded" src="${image}" data-idx="${idx}">
+					<img class="rounded img-fluid" src="${image}" data-idx="${idx}">
 				</div>
 			`;
 		});

--- a/frappe/public/scss/common/controls.scss
+++ b/frappe/public/scss/common/controls.scss
@@ -619,9 +619,17 @@ button.data-pill {
 
 .capture-remove-btn {
 	position: absolute;
-	top: 0;
-	right: 0;
+	top: var(--margin-xs);
+	right: var(--margin-xs);
+	display: flex;
+	padding: 2px;
+	border: 1px solid var(--border-color);
+	border-radius: var(--radius-full);
+	background-color: var(--fg-color);
+	box-shadow: var(--shadow-sm);
 	cursor: pointer;
+
+	--icon-stroke: var(--text-color);
 }
 
 //switch

--- a/frappe/public/scss/common/controls.scss
+++ b/frappe/public/scss/common/controls.scss
@@ -621,15 +621,6 @@ button.data-pill {
 	position: absolute;
 	top: var(--margin-xs);
 	right: var(--margin-xs);
-	display: flex;
-	padding: 2px;
-	border: 1px solid var(--border-color);
-	border-radius: var(--radius-full);
-	background-color: var(--fg-color);
-	box-shadow: var(--shadow-sm);
-	cursor: pointer;
-
-	--icon-stroke: var(--text-color);
 }
 
 //switch


### PR DESCRIPTION
Preview images in the camera upload dialog render at full webcam resolution, so with more than one capture they overflow their grid column and stack across the modal. `img-fluid` bounds them to the column and keeps the aspect ratio.

### Before/After

<img width="1144" height="797" alt="Screenshot 2026-09-04 at 9 40 19 PM" src="https://github.com/user-attachments/assets/059b790b-e515-4ca5-92e8-4078f202a87a" />

<img width="667" height="455" alt="Screenshot 2026-09-04 at 9 53 06 PM" src="https://github.com/user-attachments/assets/c4e94d40-640d-4585-baf8-718842df8899" />

---

Ref: https://support.frappe.io/helpdesk/tickets/77701?view=VIEW-HD+Ticket-1252
