### PR TITLE
refactor: drop unused `user` field from Notification Settings

### DIFF
--- a/frappe/desk/doctype/notification_settings/notification_settings.json
+++ b/frappe/desk/doctype/notification_settings/notification_settings.json
@@ -17,7 +17,6 @@
   "enable_email_mention",
   "enable_email_assignment",
   "enable_email_share",
-  "user",
   "seen"
  ],
  "fields": [
@@ -84,15 +83,6 @@
    "label": "Document Share"
   },
   {
-   "default": "__user",
-   "fieldname": "user",
-   "fieldtype": "Link",
-   "hidden": 1,
-   "label": "User",
-   "options": "User",
-   "read_only": 1
-  },
-  {
    "default": "0",
    "fieldname": "seen",
    "fieldtype": "Check",
@@ -118,7 +108,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-02-24 11:06:24.112935",
+ "modified": "2026-09-04 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Notification Settings",

--- a/frappe/desk/doctype/notification_settings/notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/notification_settings.py
@@ -32,7 +32,6 @@ class NotificationSettings(Document):
 		enabled: DF.Check
 		seen: DF.Check
 		subscribed_documents: DF.TableMultiSelect[NotificationSubscribedDocument]
-		user: DF.Link | None
 	# end: auto-generated types
 
 	def on_update(self):


### PR DESCRIPTION
- doctype is named after the user, so `name` was always the source of truth
- nothing read the field
- its `__user` default recorded whoever created the record (usually Administrator during user creation), not the settings owner — so the value was wrong on nearly every row