### PR TITLE
fix(dashboard): keep chart data when last_synced_on write conflicts

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/test_dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/test_dashboard_chart.py
@@ -324,6 +324,36 @@ class TestDashboardChart(IntegrationTestCase):
 			result = get(chart_name="Test Dashboard Chart Date Label")
 			self.assertEqual(sorted(result.get("labels")), sorted(["01-19-2019", "01-05-2019", "01-12-2019"]))
 
+	def test_chart_returns_data_when_last_synced_on_write_deadlocks(self):
+		chart_name = "Test Dashboard Chart Sync Conflict"
+		if frappe.db.exists("Dashboard Chart", chart_name):
+			frappe.delete_doc("Dashboard Chart", chart_name)
+
+		frappe.get_doc(
+			doctype="Dashboard Chart",
+			chart_name=chart_name,
+			chart_type="Count",
+			document_type="DocType",
+			based_on="creation",
+			timespan="Last Year",
+			time_interval="Monthly",
+			filters_json="{}",
+			timeseries=1,
+		).insert()
+
+		set_value = frappe.db.set_value
+
+		def deadlock_on_chart_write(doctype, *args, **kwargs):
+			if doctype == "Dashboard Chart":
+				raise frappe.QueryDeadlockError
+			return set_value(doctype, *args, **kwargs)
+
+		with patch.object(frappe.db, "set_value", side_effect=deadlock_on_chart_write):
+			result = get(chart_name=chart_name, refresh=1)
+
+		self.assertTrue(result.get("labels"))
+		self.assertIsNone(frappe.db.get_value("Dashboard Chart", chart_name, "last_synced_on"))
+
 
 def insert_test_records(doctype_name):
 	create_new_record(doctype_name, "Title 1", datetime(2018, 12, 30), 50)

--- a/frappe/utils/dashboard.py
+++ b/frappe/utils/dashboard.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 import os
+from contextlib import suppress
 from functools import wraps
 from os.path import join
 
@@ -65,9 +66,14 @@ def generate_and_cache_results(args, function, cache_key, chart):
 			raise
 
 	if not frappe.flags.read_only:
-		frappe.db.set_value(
-			"Dashboard Chart", args.chart_name, "last_synced_on", frappe.utils.now(), update_modified=False
-		)
+		with suppress(frappe.QueryDeadlockError):
+			frappe.db.set_value(
+				"Dashboard Chart",
+				args.chart_name,
+				"last_synced_on",
+				frappe.utils.now(),
+				update_modified=False,
+			)
 	return results
 
 


### PR DESCRIPTION
Opening a dashboard fails with "Server failed to process this request because of a concurrent conflicting request" when more than one user loads the same chart at once:

```
frappe.exceptions.QueryDeadlockError: (1020, "Record has changed since last read in table 'tabDashboard Chart'")
```

## Why it happens

`generate_and_cache_results` in `frappe/utils/dashboard.py` stamps `last_synced_on` on the chart row at the end of every chart request. That row is already in the request transaction's snapshot, so when a concurrent request has updated it in the meantime, MariaDB aborts the statement with 1020, which `is_deadlocked` reports as a deadlock. The chart data is already built and correct at that point; the bookkeeping write is the only thing that fails, and it takes the whole response with it.

## Fix

Wrap the write in `suppress(frappe.QueryDeadlockError)`. Nothing reads `last_synced_on` back, so a dropped update costs nothing and the next chart load writes it again. `update_last_known_versions` in `frappe/utils/change_log.py` already treats its `User` write the same way.

---

Ref: https://support.frappe.io/helpdesk/tickets/76669?view=VIEW-HD+Ticket-1252