### PR TITLE
fix: clear include filters and hide column picker when a print format is set

### DIFF
--- a/frappe/public/js/frappe/form/print_utils.js
+++ b/frappe/public/js/frappe/form/print_utils.js
@@ -73,6 +73,11 @@ frappe.ui.get_print_settings = function (
 					disabled: 0,
 				},
 			}),
+			onchange: function () {
+				dialog.set_value("include_filters", this.get_value() ? 0 : 1);
+				dialog.set_value("pick_columns", 0);
+				dialog.fields_dict.columns?.select_all(true);
+			},
 		});
 	}
 
@@ -98,7 +103,7 @@ frappe.ui.get_print_settings = function (
 				label: __("Select Columns"),
 				fieldtype: "MultiCheck",
 				fieldname: "columns",
-				depends_on: "pick_columns",
+				depends_on: "eval: doc.pick_columns && !doc.print_format",
 				columns: 2,
 				select_all: true,
 				options: pick_columns.map((df) => ({
@@ -109,7 +114,7 @@ frappe.ui.get_print_settings = function (
 		);
 	}
 
-	return frappe.prompt(
+	const dialog = frappe.prompt(
 		columns,
 		function (settings) {
 			settings = $.extend(print_settings, settings);
@@ -130,6 +135,10 @@ frappe.ui.get_print_settings = function (
 
 			if (settings.print_format) {
 				settings.pick_columns = 0;
+				settings.include_filters = 0;
+			}
+
+			if (!settings.pick_columns) {
 				settings.columns = null;
 			}
 
@@ -141,6 +150,8 @@ frappe.ui.get_print_settings = function (
 		},
 		title ? __(title) : __("Print Settings")
 	);
+
+	return dialog;
 };
 
 // qz tray connection wrapper


### PR DESCRIPTION
`depends_on` only hides a field, so `include_filters` stayed set behind a selected print format and leaked into the template as a subtitle, and the column picker stayed visible.