### PR TITLE
fix(ui): make capture preview remove control readable over photos

### DIFF
--- a/frappe/public/js/frappe/ui/capture.js
+++ b/frappe/public/js/frappe/ui/capture.js
@@ -193,9 +193,14 @@ frappe.ui.Capture = class {
 		this.images.forEach((image, idx) => {
 			images += `
 				<div class="mt-1 p-1 rounded col-md-3 col-sm-4 col-xs-4" data-idx="${idx}">
-					<span class="capture-remove-btn" data-idx="${idx}">
-						${frappe.utils.icon("close", "lg")}
-					</span>
+					<button
+						type="button"
+						class="btn btn-default icon-btn capture-remove-btn"
+						data-idx="${idx}"
+						title="${__("Remove")}"
+					>
+						${frappe.utils.icon("x", "sm")}
+					</button>
 					<img class="rounded img-fluid" src="${image}" data-idx="${idx}">
 				</div>
 			`;

--- a/frappe/public/scss/common/controls.scss
+++ b/frappe/public/scss/common/controls.scss
@@ -571,9 +571,9 @@ button.data-pill {
 
 .capture-remove-btn {
 	position: absolute;
-	top: 0;
-	right: 0;
-	cursor: pointer;
+	top: var(--margin-xs);
+	right: var(--margin-xs);
+	z-index: 1;
 }
 
 .frappe-control[data-fieldtype="Attachment Gallery"] {


### PR DESCRIPTION
Follow up to https://github.com/frappe/frappe/pull/42524 for version-16-hotfix. The remove control paints `#icon-close` onto the photo with no ground of its own, so it disappears over dark frames, and it sits flush in the tile corner.

develop fixed this with the espresso button component, which the v16 desk bundle does not carry; this uses `btn icon-btn`, the same control as the sidebar card close button.