### PR TITLE
fix: translate only backtick-delimited identifiers for postgres and sqlite

### DIFF
--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -31,7 +31,7 @@ from psycopg2.extensions import ISOLATION_LEVEL_REPEATABLE_READ
 import frappe
 from frappe.database.database import CREATE_OR_DROP, Database
 from frappe.database.postgres.schema import PostgresTable
-from frappe.database.utils import EmptyQueryValues, LazyDecode
+from frappe.database.utils import EmptyQueryValues, LazyDecode, convert_backtick_identifiers
 from frappe.utils import cstr, get_table_name
 
 # cast decimals as floats
@@ -879,8 +879,8 @@ def _copy_flush(cursor, copy_sql, buffer):
 
 def modify_query(query):
 	""" "Modifies query according to the requirements of postgres"""
-	# replace ` with " for definitions
-	query = str(query).replace("`", '"')
+	# replace ` with " only where a backtick delimits an identifier
+	query = convert_backtick_identifiers(str(query))
 	query = replace_locate_with_strpos(query)
 	# MySQL REGEXP operator -> postgres case-insensitive regex match
 	query = REGEXP_PATTERN.sub(_replace_regexp_operator, query)

--- a/frappe/database/sqlite/database.py
+++ b/frappe/database/sqlite/database.py
@@ -11,6 +11,7 @@ from frappe.database.database import (
 	ImplicitCommitError,
 )
 from frappe.database.sqlite.schema import SQLiteTable
+from frappe.database.utils import convert_backtick_identifiers
 from frappe.utils import get_table_name
 
 _PARAM_COMP = re.compile(r"%\([\w]*\)s")
@@ -608,9 +609,9 @@ def modify_query(query):
 	"""
 	Modifies query according to the requirements of SQLite
 	"""
-	# Replace ` with " for definitions
+	# Replace ` with " only where a backtick delimits an identifier
 	query = str(query)
-	query = query.replace("`", '"')
+	query = convert_backtick_identifiers(query)
 	query = replace_locate_with_instr(query)
 
 	# Select from requires ""

--- a/frappe/database/utils.py
+++ b/frappe/database/utils.py
@@ -28,6 +28,41 @@ NestedSetHierarchy = (
 # split when non-alphabetical character is found
 QUERY_TYPE_PATTERN = re.compile(r"\s*([A-Za-z]*)")
 
+# Spans whose contents are data, not code. Only the backtick span is rewritten; the rest are
+# matched to be stepped over -- both so a backtick inside one survives, and so an apostrophe inside
+# one cannot pair with the next quote and swallow the identifiers between. Scanned left to right,
+# so a quote only opens a span when it is not already inside one. postgres' own literal forms
+# (E'...', $tag$...$tag$) need no branch: what reaches here is MySQL-dialect SQL.
+SKIPPED_SPAN_PATTERN = re.compile(
+	r"""
+	  '(?:[^']|'')*'                     # string literal (only '' escapes a quote)
+	| "(?:[^"]|"")*"                     # quoted identifier
+	| --[^\n]*                           # line comment
+	| /\*.*?\*/                          # block comment
+	| `(?:[^`]|``)*`                     # backtick identifier: the one span we rewrite
+	""",
+	re.DOTALL | re.VERBOSE,
+)
+
+
+def convert_backtick_identifiers(query: str) -> str:
+	"""Rewrite MySQL-style ```identifier``` quoting as ANSI ``"identifier"``.
+
+	Only backticks that open or close an identifier are translated; one inside any span
+	``SKIPPED_SPAN_PATTERN`` matches is content, and survives.
+	"""
+	if "`" not in query:
+		return query
+
+	def translate(match: re.Match) -> str:
+		span = match.group()
+		if not span.startswith("`"):
+			return span  # a literal, an already-ANSI identifier or a comment
+		name = span[1:-1].replace("``", "`")  # unescape MySQL's doubled backtick
+		return '"{}"'.format(name.replace('"', '""'))  # re-escape for ANSI
+
+	return SKIPPED_SPAN_PATTERN.sub(translate, query)
+
 
 def convert_to_value(o: FilterValue):
 	if isinstance(o, bool):

--- a/frappe/query_builder/custom.py
+++ b/frappe/query_builder/custom.py
@@ -29,19 +29,27 @@ class GROUP_CONCAT(DistinctOptionFunction):
 		self._separator = separator
 
 	def get_sql(self, **kwargs):
+		# SEPARATOR goes inside the closing paren, so render without the alias and re-attach it
+		# below rather than let Function.get_sql place it before the clause exists.
 		query_alias = self.alias
 		self.alias = None
-		sql = super().get_sql(**kwargs)
+		try:
+			sql = super().get_sql(**kwargs)
+		finally:
+			self.alias = query_alias
 		# an explicit "" is a real request for no delimiter, not "use the default": dropping the
 		# clause would silently fall back to MariaDB's comma while STRING_AGG concatenates bare.
 		if self._separator is not None:
 			assert sql.endswith(")"), "GROUP_CONCAT SQL must end with ')' before injecting SEPARATOR"
 			sql = f"{sql[:-1]} SEPARATOR {frappe.db.escape(self._separator)})"
 
-		self.alias = query_alias
-		if self.alias:
-			quote = kwargs.get("quote_char", "`")
-			sql += f" {quote}{self.alias}{quote}"
+		# Re-attach through format_alias_sql, the same path every other term uses: it escapes the
+		# quote char in the alias, and honours `with_alias` so the alias is emitted in the SELECT
+		# clause only. Hand-rolling it quoted the alias raw -- disagreeing with the escaped alias
+		# pypika renders for the same term in GROUP BY / ORDER BY -- and appended it in operand
+		# position too, where `GROUP_CONCAT(...) `a` LIKE ...` is a syntax error.
+		if kwargs.get("with_alias"):
+			return format_alias_sql(sql, query_alias, **kwargs)
 		return sql
 
 

--- a/frappe/query_builder/utils.py
+++ b/frappe/query_builder/utils.py
@@ -19,7 +19,11 @@ class PseudoColumnMapper(PseudoColumn):
 
 	def get_sql(self, **kwargs):
 		if frappe.db.db_type == "postgres":
-			self.name = self.name.replace("`", '"')
+			# Returned, not assigned to `self.name`: rendering must not mutate the term, or a
+			# pseudo-column rendered once on postgres renders wrongly everywhere after.
+			from frappe.database.utils import convert_backtick_identifiers
+
+			return convert_backtick_identifiers(self.name)
 		return self.name
 
 

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -12,10 +12,10 @@ from frappe.core.utils import find
 from frappe.custom.doctype.custom_field.custom_field import create_custom_field
 from frappe.database import get_db, savepoint
 from frappe.database.database import get_query_execution_timeout
-from frappe.database.utils import FallBackDateTimeStr
+from frappe.database.utils import FallBackDateTimeStr, convert_backtick_identifiers
 from frappe.query_builder import Field
 from frappe.query_builder.functions import Concat_ws
-from frappe.tests import IntegrationTestCase, timeout
+from frappe.tests import IntegrationTestCase, UnitTestCase, timeout
 from frappe.tests.test_query_builder import db_type_is, run_only_if, unimplemented_for
 from frappe.utils import add_days, now, random_string, set_request
 from frappe.utils.data import now_datetime
@@ -2022,3 +2022,81 @@ class TestBulkInsertCopy(IntegrationTestCase):
 		got = dict(frappe.db.sql('SELECT "name", "flag" FROM "tabBulkFlagTest"'))
 		self.assertEqual(got["a"], 1)
 		self.assertEqual(got["b"], 0)
+
+
+class TestBacktickIdentifierConversion(UnitTestCase):
+	"""The postgres and sqlite drivers translate MySQL-style raw SQL into ANSI quoting.
+
+	Only backticks that delimit an identifier may be rewritten: one inside a string literal or a
+	``"..."`` identifier is content, and promoting it into a quote char ends the identifier early.
+	"""
+
+	def test_identifiers_are_translated(self):
+		for src, want in (
+			("select `name` from `tabUser`", 'select "name" from "tabUser"'),
+			("select `tabA`.`b` from `tabA`", 'select "tabA"."b" from "tabA"'),
+			("select `Note Seen By`.`user`", 'select "Note Seen By"."user"'),
+			("select `na``me` from t", 'select "na`me" from t'),
+			('select `na"me` from t', 'select "na""me" from t'),
+		):
+			with self.subTest(src=src):
+				self.assertEqual(want, convert_backtick_identifiers(src))
+
+	def test_query_without_backticks_is_untouched(self):
+		self.assertEqual("select 1", convert_backtick_identifiers("select 1"))
+
+	def test_string_literals_are_not_rewritten(self):
+		for src in (
+			"select * from t where c = 'a`b'",
+			"select * from t where c = 'it''s `x`'",
+			"select * from t where c = 'SELECT `x` FROM `y`'",
+		):
+			with self.subTest(src=src):
+				self.assertEqual(src, convert_backtick_identifiers(src))
+
+	def test_existing_ansi_identifiers_are_not_rewritten(self):
+		for src in (
+			'select "na`me" from t',
+			'select "a""b" from t',
+			'select "name` FROM `tabUser` -- " from "tabUser"',
+		):
+			with self.subTest(src=src):
+				self.assertEqual(src, convert_backtick_identifiers(src))
+
+	def test_comments_are_not_rewritten(self):
+		# a comment is data on both backends, so the shared pattern already steps over one
+		for src, want in (
+			("select `a` -- `b`", 'select "a" -- `b`'),
+			("select /* `b` */ `a`", 'select /* `b` */ "a"'),
+		):
+			with self.subTest(src=src):
+				self.assertEqual(want, convert_backtick_identifiers(src))
+
+	def test_apostrophe_in_a_comment_does_not_swallow_identifiers(self):
+		# An apostrophe inside a comment is not a string delimiter, so it must not pair with the
+		# next quote: everything between them -- real identifiers included -- would then read as
+		# one literal and go out untranslated.
+		for src in (
+			"/* it's */ select `tabUser`.`name` from `tabUser` where c = 'a'",
+			"-- it's\nselect `tabUser`.`name` from `tabUser` where c = 'a'",
+		):
+			with self.subTest(src=src):
+				out = convert_backtick_identifiers(src)
+				self.assertIn('"tabUser"."name"', out)
+				self.assertNotIn("`", out)
+
+	def test_injected_column_name_stays_one_identifier(self):
+		# as pypika renders `table[payload]` when the quote char is "
+		for payload in (
+			"name` FROM `tabUser` WHERE `name`='Administrator' -- ",
+			"name`=1 UNION SELECT `name` FROM `tabUser` -- ",
+			"` blah`",
+			'a`b"c',
+		):
+			with self.subTest(payload=payload):
+				rendered = '"{}"'.format(payload.replace('"', '""'))
+				out = convert_backtick_identifiers(f'SELECT {rendered} FROM "tabUser"')
+				body = out[len("SELECT ") : out.index(' FROM "tabUser"')]
+				self.assertTrue(body.startswith('"') and body.endswith('"'), body)
+				for run in body[1:-1].split('""'):  # every quote char must be in an escaped pair
+					self.assertNotIn('"', run, f"identifier closed early: {body}")

--- a/frappe/tests/test_query_builder.py
+++ b/frappe/tests/test_query_builder.py
@@ -53,6 +53,27 @@ class TestCustomFunctionsMariaDB(IntegrationTestCase):
 		self.assertIn("SEPARATOR ' | '", sql)
 		self.assertIn("`user_list`", sql)
 
+	def test_concat_alias_escapes_the_quote_char(self):
+		# The alias goes through format_alias_sql like every other term, so the quote char inside
+		# it is doubled. Rendering it raw would close the identifier early, and would disagree
+		# with the escaped alias pypika emits for the same term in GROUP BY / ORDER BY.
+		user = frappe.qb.DocType("User")
+		gc = GroupConcat(user.email).as_("a`b")
+		sql = frappe.qb.from_(user).select(gc).groupby(gc).get_sql()
+		self.assertIn("`a``b`", sql)
+		self.assertNotIn("`a`b`", sql)
+		# the alias SELECT declares is the one GROUP BY refers to
+		self.assertEqual(2, sql.count("`a``b`"))
+
+	def test_concat_alias_only_in_select_position(self):
+		# an alias is part of the select clause, not of the expression: appending it in operand
+		# position produces `GROUP_CONCAT(...) `x` LIKE ...`, which is a syntax error
+		user = frappe.qb.DocType("User")
+		gc = GroupConcat(user.email).as_("user_list")
+		sql = frappe.qb.from_(user).select(user.name).where(gc.like("%admin%")).get_sql()
+		self.assertNotIn("`user_list`", sql)
+		self.assertIn("GROUP_CONCAT(`email` SEPARATOR ',') LIKE", sql)
+
 	def test_concat_with_explicit_empty_separator(self):
 		# "" means "no delimiter", not "use the default" -- dropping the clause would silently
 		# fall back to MariaDB's comma while postgres STRING_AGG concatenates bare.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     # do NOT add loose requirements on PyMySQL versions.
     "PyMySQL==1.1.2",
     "pypdf==6.16.1",
-    "PyPika @ git+https://github.com/frappe/pypika@2c50e6142b2d61d2d243e466fdd5dc03b3d918f2",
+    "PyPika @ git+https://github.com/frappe/pypika@7ef6e40215d46cd531e8c4e58650b84c11abbd04",
     "mysqlclient==2.2.8",
     "PyQRCode~=1.2.1",
     "PyYAML~=6.0.3",


### PR DESCRIPTION
On postgres and sqlite the driver translates frappe's MySQL-dialect SQL into ANSI quoting. This was a blanket `query.replace("`", '"')`, which also rewrites a backtick that is *content* — one inside a caller-supplied identifier or a string literal — instead of only the backticks that delimit an identifier.

`convert_backtick_identifiers` replaces it with a left-to-right scanner (`SKIPPED_SPAN_PATTERN`) that steps over whole spans — string literals, `"…"` identifiers, and `--` / `/* */` comments — and translates a backtick only where it opens or closes an identifier. Comments are in the set because an apostrophe inside one is not a delimiter: unmodelled, it pairs with the next real quote and swallows every identifier in between, which then reaches the backend untranslated. postgres' own literal forms (`E'…'`, `$tag$…$tag$`) need no branch — what arrives here is MySQL-dialect SQL, and hand-written postgres SQL carries no backticks for the early-out to let through.

`PseudoColumnMapper.get_sql` is updated to return the converted name rather than mutate the term in place.

`GROUP_CONCAT.get_sql` is moved onto the same alias path as every other term. It rendered its alias by hand, because SEPARATOR has to be injected inside the closing paren before the alias is attached — quoting the alias raw, disagreeing with what pypika renders for the same term in GROUP BY / ORDER BY, and running unconditionally, so the alias was also emitted in operand position where it is a syntax error. It now goes through `format_alias_sql` and honours `with_alias`. `STRING_AGG`, the postgres counterpart, never overrode `get_sql` and was already correct.

The PyPika pin moves to frappe/pypika#8 (0.48.9 → 0.51.1). The change this depends on is `format_quotes`, which now doubles the quote char inside the value, so an identifier the query builder renders escapes itself instead of trusting what the caller handed it.

Covered by `TestBacktickIdentifierConversion` in `test_db.py` and `test_concat_alias_*` in `test_query_builder.py`.
