### PR TITLE
fix(web_form): inherit allow_read_on_all_link_options for child-table Link fields

### DIFF
--- a/frappe/website/doctype/web_form/test_web_form.py
+++ b/frappe/website/doctype/web_form/test_web_form.py
@@ -1218,6 +1218,37 @@ class TestWebForm(IntegrationTestCase):
 		link_field = next(f for f in result.web_form.web_form_fields if f.fieldname == "reference_doctype")
 		self.assertEqual(link_field.fieldtype, "Autocomplete")
 
+	def test_get_form_data_child_table_link_inherits_allow_read_on_all_link_options(self):
+		"""A Link inside a child Table has no Web Form Field row of its own, so it
+		inherits `allow_read_on_all_link_options` from the parent Table's Web Form
+		Field. Without this, the owner-scoping guard in `get_link_options` fires
+		unconditionally for every child-table Link even when the form designer opted
+		out at the parent Table level (regression against #42341)."""
+		self.set_web_form_settings(login_required=1)
+		self.add_web_form_child_table_field(allow_read_on_all_link_options=1)
+
+		result = get_form_data(doctype="Event", web_form_name="manage-events")
+
+		table_field = next(f for f in result.web_form.web_form_fields if f.fieldname == "event_participants")
+		self.assertEqual(table_field.fieldtype, "Table")
+
+		child_link = next(f for f in table_field.fields if f["fieldname"] == "reference_doctype")
+		self.assertEqual(child_link["fieldtype"], "Autocomplete")
+		self.assertEqual(child_link.get("allow_read_on_all_link_options"), 1)
+
+	def test_get_form_data_child_table_link_defaults_to_owner_filter(self):
+		"""When the parent Table's `allow_read_on_all_link_options` is 0 (the
+		default), child-table Links stay owner-scoped so existing Web Forms that
+		never touched the flag see no behaviour change."""
+		self.set_web_form_settings(login_required=1)
+		self.add_web_form_child_table_field(allow_read_on_all_link_options=0)
+
+		result = get_form_data(doctype="Event", web_form_name="manage-events")
+
+		table_field = next(f for f in result.web_form.web_form_fields if f.fieldname == "event_participants")
+		child_link = next(f for f in table_field.fields if f["fieldname"] == "reference_doctype")
+		self.assertFalse(child_link.get("allow_read_on_all_link_options"))
+
 	def test_guest_key_web_form_rejects_unauthorized_link_field_on_save(self):
 		self.set_web_form_settings(key_required=1, login_required=0)
 		web_form = frappe.get_doc("Web Form", "manage-events")
@@ -1299,6 +1330,33 @@ class TestWebForm(IntegrationTestCase):
 				"User",
 				web_form_request_key=web_form_request.key,
 			)
+
+	def add_web_form_child_table_field(self, allow_read_on_all_link_options=0):
+		web_form = frappe.get_doc("Web Form", "manage-events")
+		original_fields = [field.as_dict() for field in web_form.web_form_fields]
+
+		def restore_fields():
+			restore_form = frappe.get_doc("Web Form", "manage-events")
+			restore_form.web_form_fields = []
+			for field in original_fields:
+				restore_form.append("web_form_fields", field)
+			restore_form.save(ignore_permissions=True)
+			frappe.clear_document_cache("Web Form", "manage-events")
+
+		self.addCleanup(restore_fields)
+
+		web_form.append(
+			"web_form_fields",
+			{
+				"fieldname": "event_participants",
+				"fieldtype": "Table",
+				"label": "Participants",
+				"options": "Event Participants",
+				"allow_read_on_all_link_options": allow_read_on_all_link_options,
+			},
+		)
+		web_form.save(ignore_permissions=True)
+		frappe.clear_document_cache("Web Form", "manage-events")
 
 	def add_web_form_link_field(self):
 		link_doctype = "Salutation"

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -562,7 +562,11 @@ def get_context(context):
 		for field in context.web_form_doc.web_form_fields:
 			if field.fieldtype == "Table":
 				field.fields = get_in_list_view_fields(
-					field.options, self.name, web_form_request_key, docname
+					field.options,
+					self.name,
+					web_form_request_key,
+					docname,
+					parent_field=field,
 				)
 
 			if field.fieldtype == "Link":
@@ -1137,7 +1141,11 @@ def get_form_data(
 	for field in out.web_form.web_form_fields:
 		if field.fieldtype == "Table":
 			field.fields = get_in_list_view_fields(
-				field.options, web_form_name, web_form_request_key, docname
+				field.options,
+				web_form_name,
+				web_form_request_key,
+				docname,
+				parent_field=field,
 			)
 			out.update({field.fieldname: field.fields})
 
@@ -1162,7 +1170,13 @@ def get_web_form_list_fields(web_form_doc: "WebForm", web_form_request_key: str 
 	return fields
 
 
-def get_in_list_view_fields(doctype, web_form_name=None, web_form_request_key=None, docname=None):
+def get_in_list_view_fields(
+	doctype,
+	web_form_name=None,
+	web_form_request_key=None,
+	docname=None,
+	parent_field=None,
+):
 	meta = frappe.get_meta(doctype)
 	fields = []
 
@@ -1182,6 +1196,15 @@ def get_in_list_view_fields(doctype, web_form_name=None, web_form_request_key=No
 
 		df = meta.get_field(fieldname).as_dict()
 		if df.get("options") and df.get("fieldtype") == "Link":
+			# A Link inside a child Table has no Web Form Field row of its own,
+			# so inherit `allow_read_on_all_link_options` from the parent Table's
+			# Web Form Field. Without this, `get_link_options` always applies the
+			# owner filter on child-table Links even when the form designer has
+			# opted out of it at the parent Table level.
+			if parent_field is not None:
+				df["allow_read_on_all_link_options"] = getattr(
+					parent_field, "allow_read_on_all_link_options", 0
+				)
 			process_link_field(df, web_form_name, web_form_request_key, docname)
 		return df
 

--- a/frappe/website/doctype/web_form_field/web_form_field.json
+++ b/frappe/website/doctype/web_form_field/web_form_field.json
@@ -51,7 +51,8 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:doc.fieldtype === 'Link' && parent.login_required",
+   "depends_on": "eval:(doc.fieldtype === 'Link' || doc.fieldtype === 'Table') && parent.login_required",
+   "description": "For a Table field, this flag also applies to every Link inside the child DocType.",
    "fieldname": "allow_read_on_all_link_options",
    "fieldtype": "Check",
    "label": "Allow Read On All Link Options"


### PR DESCRIPTION
Closes #42341.

The bug

On a Web Form with login_required=1, a Link field that lives inside a child Table always has its options filtered by owner = frappe.session.user, so users only see records they personally created. Any picker for admin-owned master data comes back empty.

Root cause

get_link_options (frappe/website/doctype/web_form/web_form.py:1224) applies the owner filter at line 1252 when web_form.login_required and not allow_read_on_all_link_options. The allow_read_on_all_link_options value flows in via process_link_field (line 802), which reads it off the passed-in field with getattr(field, "allow_read_on_all_link_options", False).

For top-level Link fields on a Web Form, field is a Web Form Field row — which carries allow_read_on_all_link_options as a proper attribute. The gate works.

For child-table Link fields, get_in_list_view_fields (line 1165) walks the child DocType's meta and hands process_link_field a plain schema DocField (frappe.get_meta(child_doctype).get_field(fieldname).as_dict()). DocField never carries allow_read_on_all_link_options — that flag is a WebFormField-only attribute — so getattr(..., False) always resolves to False and the owner filter fires unconditionally.

The web_form_fields list has one entry per parent field only; when the parent has a Table, there's a single Web Form Field row for the Table itself but not for each Link inside the child. So the fix has to teach the child-table walk to look up one level for the flag.

What this PR changes

Server (web_form.py) — get_in_list_view_fields gains a parent_field=None kwarg. When set, each child Link inherits allow_read_on_all_link_options from the parent Table's Web Form Field row before process_link_field reads it. Both call sites (WebForm.get_context at line 562 and get_form_data at line 1141) now pass parent_field=field. The old parameter-less contract is preserved (parent_field defaults to None), so no behaviour change for callers that don't have a parent field to hand down (e.g. get_web_form_list_fields).

Schema (web_form_field.json) — the checkbox depends_on is widened so it's now settable on Table rows too, and a description documents the new semantic. Without this, admins couldn't actually opt in to the new behaviour from the UI even though the server would honour it.

Compat / behaviour

- No behaviour change for existing Web Forms. The flag defaults to 0, so any form whose admin never touched it keeps the owner-scoped behaviour it has today.
- No JS change. Web Form Link options are rendered server-side into an Autocomplete field at page load (process_link_field at line 803); there is no follow-up AJAX to update.
- No Table MultiSelect support — that fieldtype isn't handled by get_in_list_view_fields in the first place, so it's out of scope here.

Tests

Two new tests in test_web_form.py, following the add_web_form_link_field / set_web_form_settings pattern:

- test_get_form_data_child_table_link_inherits_allow_read_on_all_link_options — with allow_read_on_all_link_options=1 on the parent Table Web Form Field, the child Link's returned dict carries the flag through to process_link_field.
- test_get_form_data_child_table_link_defaults_to_owner_filter — with the flag unset (default 0), the child Link does not inherit any override — pinning the "no behaviour change for existing forms" guarantee.

Tests use the existing manage-events fixture plus a new add_web_form_child_table_field helper that appends event_participants to the Web Form and restores the fixture on cleanup, so no new DocTypes / no new fixtures are introduced.

Adjacent smells flagged during recon (not touched in this PR)

- get_link_options:1252 guards the owner filter with web_form.login_required; a key_required && !login_required guest-key form falls through with no owner filter and no permission filter. Guest read on the DocType is enforced upstream (ensure_guest_key_link_doctype_allowed), but there's no per-user scoping. Probably intentional; flagged only.
- has_link_option(fields, doctype) at line 1206 only checks that some field on the Web Form points at the requested doctype; it doesn't confirm the requested doctype matches the specific field the picker is for. A form with two child tables each pointing at different DocTypes leaks the union. Pre-existing; out of scope.

Happy to split the schema depends_on change into a separate commit if reviewers prefer that shape.

---