### PR TITLE
fix(model): allow list values for JSON fieldtypes in get_valid_dict

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -587,7 +587,7 @@ class BaseDocument:
 					value = self.get_virtual_field_value(df)
 
 				fieldtype = df.fieldtype
-				if isinstance(value, list) and fieldtype not in table_fields:
+				if isinstance(value, list) and fieldtype not in table_fields and fieldtype != "JSON":
 					frappe.throw(_("Value for {0} cannot be a list").format(_(df.label, context=df.parent)))
 
 				if fieldtype == "Check":
@@ -596,7 +596,7 @@ class BaseDocument:
 				elif fieldtype == "Int" and not isinstance(value, int):
 					value = cint(value)
 
-				elif fieldtype == "JSON" and isinstance(value, dict):
+				elif fieldtype == "JSON" and isinstance(value, (dict, list)):
 					value = json.dumps(value, separators=(",", ":"))
 
 				elif fieldtype in float_like_fields and not isinstance(value, float):

--- a/frappe/tests/test_base_document.py
+++ b/frappe/tests/test_base_document.py
@@ -230,6 +230,30 @@ class TestBaseDocument(IntegrationTestCase):
 			self.assertTrue(hasattr(unpickled_instance, "on_update"))
 			self.assertTrue(hasattr(unpickled_instance, "validate"))
 
+	def test_get_valid_dict_json_field_with_list(self):
+		"""Test that get_valid_dict properly handles and serializes JSON fields with list values."""
+		from frappe._dict import _dict
+
+		doc = BaseDocument({"doctype": "DocField", "fieldname": "test_json_field", "link_filters": [{"key": "val"}]})
+		meta = _dict(
+			_fields={"link_filters": _dict(fieldname="link_filters", fieldtype="JSON", label="Link Filters")},
+			get_valid_fields=lambda: ["link_filters"],
+			get_table_fields=lambda **kwargs: (),
+		)
+		doc.meta = meta
+		valid_dict = doc.get_valid_dict()
+		self.assertEqual(valid_dict["link_filters"], '[{"key":"val"}]')
+
+		# Non-JSON non-table fields should still reject list values
+		doc_invalid = BaseDocument({"doctype": "DocField", "label": "Invalid List", "description": ["item1", "item2"]})
+		doc_invalid.meta = _dict(
+			_fields={"description": _dict(fieldname="description", fieldtype="Small Text", label="Description")},
+			get_valid_fields=lambda: ["description"],
+			get_table_fields=lambda **kwargs: (),
+		)
+		with self.assertRaises(frappe.ValidationError):
+			doc_invalid.get_valid_dict()
+
 
 def clear_todo_controller_cache():
 	"""Helper method to clear controller cache for ToDo"""


### PR DESCRIPTION
### Problem
Closes #42462.

When serializing a document via `as_dict()` / `get_valid_dict()`, `base_document.py` checked:
```python
if isinstance(value, list) and fieldtype not in table_fields:
    frappe.throw(_("Value for {0} cannot be a list").format(_(df.label, context=df.parent)))
```
This mistakenly threw a `ValidationError` when a valid `JSON` field type contained a Python `list` (e.g., `link_filters` in `DocField` containing `[{"key": "val"}]`), breaking serialization and operations like `remove_orphan_doctypes()` / `add_to_deleted_document()`. Furthermore, the JSON serialization branch only handled `isinstance(value, dict)` and missed lists.

### Solution
1. Excluded `fieldtype != "JSON"` from the list rejection guard in `get_valid_dict()`.
2. Updated the `JSON` dump serialization branch to handle `isinstance(value, (dict, list))`.
3. Added a unit test in `frappe/tests/test_base_document.py` (`test_get_valid_dict_json_field_with_list`) verifying that JSON list values are properly serialized to JSON strings without error, while non-JSON non-table fields continue to reject list values.
