### PR TITLE
feat(desk-v2): home COMPATIBILITY.md and port the dialog layout files

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -38,7 +38,7 @@ yarn --cwd frontend test:run
 That is exactly what CI does (`.github/workflows/frontend-tests.yml`). The **base** file
 is the correct input, not a `bench build`-generated one: `yarn.lock` was resolved from
 `package.base.json` alone, and no test needs anything an app contributes. Baseline is
-**28 files / 471 tests**, under `recordPage/tests/`, `shell/tests/` and
+**28 files / 473 tests**, under `recordPage/tests/`, `shell/tests/` and
 `navigation/tests/`.
 
 **`vitest.config.js` runs with `css: { postcss: {} }`, and that is not cosmetic.**

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -38,7 +38,7 @@ yarn --cwd frontend test:run
 That is exactly what CI does (`.github/workflows/frontend-tests.yml`). The **base** file
 is the correct input, not a `bench build`-generated one: `yarn.lock` was resolved from
 `package.base.json` alone, and no test needs anything an app contributes. Baseline is
-**25 files / 428 tests**, under `recordPage/tests/`, `shell/tests/` and
+**28 files / 471 tests**, under `recordPage/tests/`, `shell/tests/` and
 `navigation/tests/`.
 
 **`vitest.config.js` runs with `css: { postcss: {} }`, and that is not cosmetic.**

--- a/frontend/COMPATIBILITY.md
+++ b/frontend/COMPATIBILITY.md
@@ -1,0 +1,365 @@
+# What `page` promises
+
+The compatibility policy for the Record page customization API — the `page` object
+every handler receives. Two audiences program against it, and they carry very
+different risk:
+
+- **File scripts** are contributions compiled into the shell's own bundle. They are
+  rebuilt with the host, so a break is caught at build time by the person who caused
+  it. Cheapest to break.
+- **Client Scripts** are text stored in a site's database, as `Client Script` rows with
+  `view = Record`. Nobody rebuilds them. They survive every upgrade, on sites with no
+  developer watching. The audience that pays for a break.
+
+## Start with the version reality
+
+The engine lives in `frontend/src/recordPage/` on the `desk-v2` branch, which is not yet
+released. Two of the four shared dependencies a script may reach — `frappe-ui` and
+`@framework/ui`, at version `0.0.0` — carry no stability guarantee at all.
+
+So this document does not make a guarantee. It states an **intent**: which parts of
+`page` are designed to outlive the implementation underneath them, which parts are
+explicitly not, and how you find out when one moves. Everything below should be read
+in that voice.
+
+## The stable idea: verbs and events
+
+What `page` is _for_ is a small, closed vocabulary:
+
+- **Four surfaces** — `quickActions`, `headerActions`, `tabs`, `panelSections` — each
+  speaking the same **seven verbs**: `add`, `hide`, `show`, `update`, `move`, `has`,
+  `order`.
+- **Two more, `fields` and `formTabs`**, speaking a strict subset of them — `hide`,
+  `show`, `update`, `has`, `get`. The subset is the point: the other four arrange items
+  a script may also create, while these are authored elsewhere and a script only
+  overrides their properties, so there is no `add`, `move` or `order` to mean anything.
+  For `fields` the author is the DocType; for `formTabs` — the **Form Layout tabs**, the
+  strip inside the record's details tab — it is the administrator editing the layout, and
+  a tab there is a container of *fields*, so an `add` would have to invent fields. That is
+  `page.dialog`'s job. On both surfaces a script **beats `depends_on` in both directions**:
+  `hide()` closes a tab the condition opened, `show()` opens one it closed. On `formTabs`,
+  `update` takes a **`label` and nothing else**: rewriting the administrator's `depends_on`
+  expression is not a script's to do, and a script wanting conditional visibility already
+  has a real `if` in `onRefresh`. `formTabs` additionally carries two members `fields` has
+  no use for — `active` and `activate` — for the plain reason that a strip has a reader
+  standing on it and a field list does not. What the subset excludes is **arrangement**,
+  not reading or navigation.
+- **Two tab surfaces, and they are not interchangeable.** `page.tabs` means the **record**
+  strip — activity, emails, files, details — and always will; `page.formTabs` means the
+  Form Layout strip *inside* details. `page.tabs.active` returns a tab's **name**, because
+  those tabs are named by whoever wrote them; `page.formTabs.active` returns an
+  **identity** — a resolved address — or `''` when the reader is not in the form. The
+  asymmetry is real; do not assume one from the other. An identity is **safe to store in a
+  script**: a Form Layout is named when it is *saved*, once and for good, so renaming a
+  tab's label or dragging an unlabelled one leaves its address alone. It reads as an
+  identity rather than a name because `FormLayout` resolves it itself — it renders in
+  dialogs too, where nothing has named the tabs — not because an administrator's tab might
+  be nameless. It no longer can be.
+- **`activate(name)` moves the reader; it is the only verb that does.** Both tab surfaces
+  carry it, each addressing its own strip and no other — `page.tabs.activate('emails')`,
+  `page.formTabs.activate('shipping')`. It is a **verb and not a writable `active`** on
+  purpose: `active` is *derived* from what the strip can currently show, so a script that
+  assigned a hidden or unknown name would read back something it never wrote. A verb can
+  say so instead. Naming a tab that is hidden, unknown, or on the other strip **warns in a
+  development build and does nothing** — activation does not reveal a hidden tab, because
+  `show()` is already the verb for that, and one act should not quietly perform two. The
+  name resolves against the strip as it stands at the moment of the call: an activation
+  fired before the tab exists misses, and is not queued. Called from `onRefresh`, it
+  resolves against the strip that replay is building — a tab the same handler just
+  added is a tab it can move to — and the reader arrives once the replay has settled,
+  because until then the strip on screen is still the last one. A tab that leaves the
+  strip before it settles is a miss, and warns like one.
+
+  Two things follow from *moving the reader* that reading `active` never had to worry
+  about. A **hit is not synchronous**: the move goes through the host's own navigation,
+  so `active` on the next line still reads the tab you left — read it in the next
+  handler. And a move **fires the strip's change event**, since `onTabChange` and
+  `onFormTabChange` fire on any cause; `activate` is the first verb that lets a handler
+  cause the event it is handling, so activating from inside one is yours to make
+  terminate.
+- **The header's renderings come from one flat list.** A `headerActions` item carries
+  `display`: `'button'` gives it a top-level button of its own, `'dropdown'` gives it a
+  top-level dropdown button of its own, `'section'` gives it a titled band, and omitting it
+  — the default — leaves it an ordinary entry in the shared `⋯`.
+
+  A `dropdown` and a `section` are **containers**: ordinary, addressable items that carry
+  the label and the icon, differing only in when their members are visible — a dropdown
+  hides them behind a trigger, a section shows them under a grey title. So
+  `hide('telephony')` removes the whole control, members and all, however deep they sit,
+  and a container is placed by **its own** position, never by its first member's.
+
+  **`group` has one meaning: _put me inside the item named this._** If an item of that name
+  is declared, you get what it declares; if nothing of that name exists, the engine
+  synthesises an **anonymous, untitled container** — the adjacency band inside `⋯` that an
+  omitted `group` (meaning `actions`) has always given. So **a band shows a heading iff its
+  container is declared**, and a script that never declared one never grows headings.
+
+  ```js
+  page.headerActions.add({ name: 'refresh_quote', label: 'Refresh Quote', display: 'button' })
+  page.headerActions.add([
+    { name: 'telephony', label: 'Telephony', display: 'dropdown' },
+    { name: 'call', label: 'Call customer', group: 'telephony' },
+    { name: 'danger', label: 'Danger', display: 'section', group: 'telephony' },
+    { name: 'wipe', label: 'Wipe call log', group: 'danger' },
+  ])
+  ```
+
+  **The list you write stays flat; only the rendering nests.** A container that points at
+  another container renders inside it — a dropdown as a submenu, a section as a titled band
+  — so every item keeps one name and `hide`, `move` and `order` still reach all of them.
+  Nesting stops at **two containers**: deeper, and a `group` cycle, are clamped to the
+  deepest level they can reach and warned about in a development build. A container never
+  runs — its `run` warns and does nothing; the items inside it run.
+
+  A section's `icon` is part of the item — it is what makes the section
+  addressable, and `update('danger', { icon })` works like any other — but the
+  heading it renders as has no room for one, so **an icon on a section is not
+  drawn**. Nothing else about it is different.
+
+  **`add` also takes an array**, which splices as a unit at the anchor, in list order. It
+  is the same flat list either way: you still repeat `group` on each member, because
+  indentation is not scope and names are one namespace per surface.
+
+  **Position orders items only within one rendering.** An anchor naming an item that
+  renders somewhere else still splices exactly where it always did — and warns in a
+  development build, because the author asked for "after Refresh Quote" and the reader got
+  "below Delete".
+- **How many top-level controls fit is the host's business, and a script cannot observe
+  it.** An item that does not fit is **demoted into `⋯`**, keeping its own band ahead of
+  the built-ins and in the order it asked for; a dropdown collapses whole, under its label.
+  A submenu inside it survives the collapse and a **section inside it loses its title**,
+  which is one more thing demotion is lossy about and nothing to branch on.
+  That is `add`'s promise — that the item is *reachable* — being kept, so there is no
+  signal and nothing to branch on: `visible()` means *not hidden*, never *on screen where
+  you asked*. A dropdown whose members are all hidden is a button that opens nothing, so it
+  neither renders nor takes up room, while staying addressable. Which item loses is stated
+  over the one flat order — the last one loses first — so `order()` and `move()` are the
+  priority knob and there is no `priority` key. A promoted built-in
+  (`update('delete', { display: 'button' })` is allowed, like any other update) is ordered
+  and demoted by that same rule, with no exception for where it came from.
+- **`Save` is not on this surface and never will be.** It is not an item on
+  `headerActions`, so it cannot be hidden, relabelled, reordered or demoted, and
+  `hide('save')` reaches nothing. It is the one control the reader must always find.
+- **A closed event list** — `onRefresh`, `beforeSave`, `afterSave`, `onTabChange`,
+  `onFormTabChange`, `<fieldname>`, and a child table's own family, written **nested under
+  the table's fieldname**: a handler per child field, plus `onAdd` and `onRemove`.
+
+  ```js
+  export default {
+    onRefresh(page) {},
+    status(page) {},
+    products: {
+      onAdd(page, row) {},
+      onRemove(page) {},
+      qty(page, row) {},
+    },
+  }
+  ```
+
+  Internally these are one flat keyspace — `products.qty`, `products.onAdd` — joined
+  on the one character a Frappe fieldname structurally cannot contain, so a child
+  field can never collide with a parent one. **Every event name in that keyspace is
+  `on`-prefixed or camelCased for one reason**: the alternative is a legal fieldname.
+  `products.add` would be the same string as the commit event of a child field called
+  `add`, and `refresh`, `before_save` and `after_save` are all spellings a real field
+  can carry — which is why the top-level keys read `onRefresh`, `beforeSave`,
+  `afterSave`, `onTabChange`. Those four were respelled from snake_case as a **hard
+  break**: the old spellings are now unknown keys, warned about once and never fired.
+  Dual-accepting both would have put the collision back permanently.
+
+  The `on` prefix is a convention rather than a guarantee — no fieldname *has* to be
+  lowercase — so a child doctype carrying `onAdd` or `onRemove` is warned about by name
+  at load, **in a development build**. Where it collides, editing that field on a row
+  fires the table's lifecycle handler: the hole is announced, but it is a misfire, not
+  an inert gap.
+- **Both tab events fire on a change, never on arrival.** A tab event means the active tab
+  *changed* — by a click, by a script hiding the tab the reader was on, or by a `depends_on`
+  condition taking it away. It does not fire on first paint, and a strip that is torn down
+  and rebuilt is a first paint again: returning to the details tab restores where the reader
+  was without announcing it, because that move is the *record* strip's and `onTabChange`
+  has already reported it. A script that wants the tab on load reads `page.formTabs.active`
+  in `onRefresh` — which is what "state lives on `page`" is for.
+- **One rule for a handler's arguments: its key decides them.** A top-level key gets
+  `(page)`; one nested under a table gets `(page, row)`, except `onRemove`, whose
+  row is gone. The row is an address, not a payload — `page.rows('products')`
+  hands you the same handles in any handler at all.
+- **A handful of contracts**: every `page.dialog` verb resolves `null` when the reader
+  dismissed the dialog, so `if (!result) return` is always the idiom; a throw in
+  `beforeSave` blocks the save; a handler that throws is isolated, half-applied, and
+  does not take other scripts down with it.
+
+These are deliberately small, closed, and shaped like frappe rather than like the
+component library beneath them. They are what we would fight hardest to preserve.
+
+## The line: `page` never passes your options through
+
+The important half of this policy is not the verb list. It is the boundary between
+`page` and the unstable things reachable _through_ it.
+
+**The rule: no `page` verb forwards an options object, a nested option shape, or a
+callback argument straight to a dependency.** Everything a script hands `page` is
+picked apart by the engine and forwarded key by key; everything the engine hands a
+script's callback is the engine's own object.
+
+This costs something real, and the cost is deliberate. It means a new option that
+frappe-ui adds does **not** reach your script for free — somebody has to add it to
+`page` and release it. "frappe-ui got better" and "scripts got better" are unrelated
+events, on purpose.
+
+What we bought for that cost is the thing a script author cannot otherwise see: an
+option whose _meaning_ a dependency changes cannot silently change what a stored Page
+Script does on an upgrade nobody reviewed. If `page` accepted the object and passed it
+on, every such change would arrive invisibly, and the author holding the script would
+have no way to tell which of their options were safe and which were borrowed.
+
+A key `page` does not forward is **dropped, with a dev-mode warning naming it**. It
+does not silently do nothing.
+
+### What that means for the header's menus
+
+The header renders through frappe-ui's `Menu`, which offers a good deal more than
+`display` and `group` do. The question is never *which of its keys do we pass on* —
+none, by the rule above — but **which of its capabilities the engine adopts into its
+own vocabulary**, and there the answer follows from what the engine already owns.
+
+Sections and submenus are **arrangement**: the shape of a list the engine builds
+itself, which it can therefore say in its own words, with no frappe-ui key ever
+reaching a script. That is why they are in.
+
+The rest is out for the same reason, read the other way. A switch is **state**, which
+the engine neither holds nor has a verb for. A custom row component is options
+forwarding at its purest — and is deprecated upstream, so adopting it would mean
+inheriting somebody else's exit. A route duplicates what `run` already does and drags
+in navigation policy that is `page.router`'s argument, not this one. Trigger width,
+side, alignment and portal target are **host layout**, which no script has ever been
+able to set anywhere else on the page.
+
+Expect that line to hold as `Menu` grows: a new frappe-ui option is not a new script
+capability, and the fact that it renders in a menu we happen to use is not an argument
+for it. There is no compiler help here either — a menu option type carries an index
+signature, so a key we do not adopt type-checks and vanishes.
+
+### The same line, outbound
+
+The rule above governs what goes _in_ to `page`. The symmetric one governs what comes
+back out:
+
+**Every object `page` hands back is read-only.** A script may not mutate `page`'s
+return values into shared state; a write throws, names the member, and points at the
+supported verb. `page.doc` is the one exception, and it is one by design — mutating the
+document is the API. A **row handle** from `page.rows()` inherits that exemption for
+the same reason: it addresses a row *inside* `page.doc`, so `row.amount = …` is a
+document write spelled shorter. The array holding the handles is read-only as usual.
+
+This is a rule about `page`, not a list of members, and it binds every member added
+after it without anyone re-deriving the argument. The reason it has to be a rule is
+that almost nothing `page` returns belongs to your record: `page.roles` is the
+session's roles array, shared by the entire application; `page.perms` is a view shared
+by every source on the page; `page.meta` is a cached document that outlives navigating
+to another record — and to another doctype. A script that sorted `page.roles` in place
+was corrupting all three for everyone, permanently, with no error and no way to trace
+it.
+
+Only writes are refused. **Reads, `find`, `filter`, `map`, `includes` and spreads all
+keep working**, and a script that legitimately wants to reorder or edit copies first:
+
+```js
+const sorted = [...page.roles].sort();
+const visible = page.meta.fields.filter((field) => !field.hidden);
+```
+
+Both allocate something new, and what you do to it afterwards is your business.
+
+### The one hand-through: `page.router`
+
+Both rules above have exactly one standing exception. It is written down here because
+the engine claimed for a long time that it *was* written down here, and it was not.
+
+`page.router` is `host.router`, handed straight through. The outbound rule does not
+wrap it because it is vue-router's object rather than ours, and the inbound rule never
+catches it because nothing is being picked apart key by key — the whole dependency is
+the member.
+
+The cost is precisely the cost those rules exist to prevent, so it is worth saying
+plainly. A script calling `page.router.replace({ query: { … } })` is coupled to two
+things it does not own: vue-router's API, and **this host's URL scheme**. A stored
+script that names a query parameter goes on naming it after the host renames it, and
+nothing warns, because from `page`'s side nothing happened.
+
+It stays because withdrawing a shipped member is a break we have no reason to inflict,
+not because it earns its keep. Two rules bound it:
+
+- **No `page` capability may _require_ it.** Where reaching the router is the only way
+  to do something, that is a missing verb and the verb gets built. Moving the reader
+  between tabs was the case that established this: `activate()` exists on both tab
+  surfaces so that the capability is never spelled as a URL edit.
+- **It is not a precedent.** No second member is handed through on the strength of this
+  one.
+
+## Asking what a host has
+
+`page` carries **no version number**, and will not get one. A version number invites
+`if (page.version >= 3)` branches inside stored scripts that nobody will ever prune,
+and it implies a contract this document has just declined to make.
+
+Ask with plain JavaScript instead:
+
+```js
+if (typeof page.dialog.form === "function") {
+  // …
+}
+```
+
+Feature detection is the supported way, and it is the only tool a Client Script has — it
+cannot pin a host version the way a file script or an extension can.
+
+## When something is removed
+
+A removed verb is **tombstoned for one major version**: the name stays, as a function
+that throws a message naming the removal and what replaces it, and is deleted a major
+later. So a script that breaks tells you _why_ it broke rather than only that it did.
+
+Names that were removed but never tombstoned are caught by a second net: reading one
+off `page` warns in the console, by name. Reading a name that never existed stays
+quiet — probing with `typeof` is legitimate and must not be punished.
+
+Where you hear about it:
+
+- **Tombstone hit** — console error, an **Error Log** row through the customization
+  error reporter, and a toast shown once per script per session to users who can edit
+  Client Scripts. A removal that fires on a live site is an upgrade breaking a
+  customer's customization; it is not a developer-console matter, and it is not gated
+  to dev builds.
+- **Unknown-member warning** — console only, always on. Advisory, and too frequent to
+  put in the Error Log.
+
+## Forward compatibility is not a goal
+
+A script written against a newer host, run on an older one, is not supported. A
+handler key this host has never heard of warns once and never fires; a verb it does
+not have simply is not there. Target the host you run on. A file script is rebuilt
+against a host, and a Client Script is authored in an editor connected to the very site
+it runs on, so there is no path we are closing off here — only one we are declining to
+invent.
+
+## What is not promised, in exactly those words
+
+- **No version, no negotiation.** `page` carries no version number and never will. Ask
+  with `typeof`, not with a number.
+- **Nothing reachable _through_ `page` is stable.** frappe-ui components you pass to
+  `add()` or `open()`, and anything you import from the four shared deps, move on
+  their own cadence. `page` being unchanged does not mean your script still works.
+- **New frappe-ui features do not reach your script for free.** Every `page` verb is
+  an allowlist.
+- **No forward compatibility.** A script using an event this host has never heard of
+  warns once and never fires.
+- **A removed verb will break your script.** We tombstone it for one major so the
+  error names the removal, and we tell you in the Error Log. We do not keep it
+  working.
+- **You may not write to what `page` hands you.** Every return value is read-only
+  except `page.doc`; a write throws and names the verb to use instead. Copy it if you
+  need to change it.
+- **No migration tooling for stored scripts.** A Client Script is text in a table.
+  Nothing rewrites it for you.
+- **None of this is a security boundary.** Error isolation is not sandboxing, and
+  anything a script hides is hidden from the eye, not from the server.

--- a/frontend/COMPATIBILITY.md
+++ b/frontend/COMPATIBILITY.md
@@ -207,7 +207,7 @@ frappe-ui adds does **not** reach your script for free — somebody has to add i
 events, on purpose.
 
 What we bought for that cost is the thing a script author cannot otherwise see: an
-option whose _meaning_ a dependency changes cannot silently change what a stored Page
+option whose _meaning_ a dependency changes cannot silently change what a stored Client
 Script does on an upgrade nobody reviewed. If `page` accepted the object and passed it
 on, every such change would arrive invisibly, and the author holding the script would
 have no way to tell which of their options were safe and which were borrowed.
@@ -311,7 +311,7 @@ if (typeof page.dialog.form === "function") {
 ```
 
 Feature detection is the supported way, and it is the only tool a Client Script has — it
-cannot pin a host version the way a file script or an extension can.
+cannot pin a host version the way a file script can.
 
 ## When something is removed
 

--- a/frontend/CONTEXT.md
+++ b/frontend/CONTEXT.md
@@ -209,8 +209,8 @@ reads only the `Form` and `List` rows of the same table, so neither side sees th
 _Avoid_: Page Script (the tier's old name), Form Script (CRM v1's).
 
 **Tier**:
-The Client Script tier is the **last** in run order, after the host's file scripts and app
-extensions, because it runs at page mount. A script that fails to load is skipped whole
+The Client Script tier is the **last** in run order, after the file scripts every app
+contributes, because it runs at page mount. A script that fails to load is skipped whole
 and the rest of the tier still runs; a tier that could not be fetched is distinct from an
 empty one.
 

--- a/frontend/PHILOSOPHY.md
+++ b/frontend/PHILOSOPHY.md
@@ -38,6 +38,9 @@ exist to prevent. This doc adds only the `DP*` principles specific to the desk l
 - **`CONTEXT.md`** is the *vocabulary* — what a **Record page**, a **contribution**, a
   **surface**, a **Client Script** mean. PHILOSOPHY is the *rules* that use the vocabulary.
   Not yet written.
+- **`COMPATIBILITY.md`** is the *promise* — what a script author can rely on across an
+  upgrade of the host: which `page` verbs and events are meant to outlive the
+  implementation, which are not, and how a removal announces itself.
 - **`docs/adr/`** are *decisions* — specific applications of a principle to a specific
   question. **ADRs cite principles; principles never cite ADRs.** That direction is what
   stops this file growing a paragraph every time something is settled. Not yet written.

--- a/frontend/src/recordPage/dialog.ts
+++ b/frontend/src/recordPage/dialog.ts
@@ -122,7 +122,7 @@ export function createPageDialogs(host: PageDialogHost): PageDialogs {
       else
         warn(
           verb,
-          `with '${key}'${where}, which it does not forward — dropped. See COMPATIBILITY.md.`,
+          `with '${key}'${where}, which it does not forward — dropped. See frontend/COMPATIBILITY.md.`,
         );
     }
     return kept;

--- a/frontend/src/recordPage/formDialogLayout.ts
+++ b/frontend/src/recordPage/formDialogLayout.ts
@@ -32,7 +32,7 @@ export function layoutMode(options: PageDialogFormOptions): LayoutMode {
   return LAYOUT_MODES.find((mode) => options[mode] != null) ?? "none";
 }
 
-/** Warns, once per open, about the two layout requests that render nothing. */
+/** Warns about the two layout requests that render nothing. */
 export function warnAmbiguousLayout(options: PageDialogFormOptions): void {
   if (!import.meta.env.DEV) return;
   const given = LAYOUT_MODES.filter((mode) => options[mode] != null);

--- a/frontend/src/recordPage/formDialogLayout.ts
+++ b/frontend/src/recordPage/formDialogLayout.ts
@@ -1,0 +1,193 @@
+// Turns `page.dialog.form()` options into a `FormLayoutSchema` and reports which
+// mandatory fields are still empty. Pure: the `doctype` mode's fetch is the dialog's.
+import { mapField } from "@framework/ui/components/FormLayout/buildLayoutFromMeta";
+import { fieldsToLayout } from "@framework/ui/components/FormLayout/fieldsToLayout";
+import { resolveLayout } from "@framework/ui/components/FormLayout/resolveLayout";
+import type {
+  FieldNode,
+  FormLayoutSchema,
+  RawMetaField,
+  Section,
+  Tab,
+} from "@framework/ui/components/FormLayout/types";
+import type { FieldAccess } from "@framework/ui/composables/useDocPermissions";
+// The meta path's permlevel gate and section constructor, so a dialog and a
+// stored layout agree on what a reader may write and which sections open.
+import { withAccess } from "./formLayoutSource/fieldAccess";
+import { buildColumn, buildSection } from "./formLayoutSource/section";
+import type {
+  PageDialogField,
+  PageDialogFormOptions,
+  PageDialogSection,
+  PageDialogTab,
+} from "./types";
+
+/** The layout modes, in the order the dev warning names them. */
+export const LAYOUT_MODES = ["fields", "tabs", "doctype"] as const;
+
+export type LayoutMode = (typeof LAYOUT_MODES)[number] | "none";
+
+/** The layout mode the options ask for; the modes are exclusive and the first listed wins. */
+export function layoutMode(options: PageDialogFormOptions): LayoutMode {
+  return LAYOUT_MODES.find((mode) => options[mode] != null) ?? "none";
+}
+
+/** Warns, once per open, about the two layout requests that render nothing. */
+export function warnAmbiguousLayout(options: PageDialogFormOptions): void {
+  if (!import.meta.env.DEV) return;
+  const given = LAYOUT_MODES.filter((mode) => options[mode] != null);
+  if (given.length > 1)
+    console.warn(
+      `[record-page] page.dialog.form was given ${given.join(" and ")} — the layout modes are mutually exclusive, using ${given[0]}`,
+    );
+  // `fieldnames` names fields *of* a doctype; alone it silently renders nothing.
+  if (!given.length && options.fieldnames)
+    console.warn(
+      "[record-page] page.dialog.form was given fieldnames without a doctype — nothing will render",
+    );
+}
+
+/** A flat field list, wrapped in one unlabelled, borderless section. */
+export function layoutFromFields(fields: PageDialogField[]): FormLayoutSchema {
+  return fieldsToLayout(fields.map(toFieldNode));
+}
+
+/** A hand-written `tabs > sections > columns > fields` tree. */
+export function layoutFromTabs(tabs: PageDialogTab[]): FormLayoutSchema {
+  return tabs.map((tab): Tab => ({
+    name: tab.name,
+    label: tab.label,
+    dependsOn: tab.depends_on,
+    sections: (tab.sections ?? []).map(toSection),
+  }));
+}
+
+/** The `doctype` + `fieldnames` mode: the named fields, in order, flat, from the meta. */
+// Not the `Quick Entry` layout: that is a curated subset and would drop fields silently.
+export function pickMetaFields(
+  fields: RawMetaField[] | undefined,
+  fieldnames: string[],
+  fieldAccess?: (field: RawMetaField) => FieldAccess,
+): FormLayoutSchema {
+  const byName = new Map(
+    (fields ?? []).map((field) => [field.fieldname, field]),
+  );
+  return fieldsToLayout(
+    fieldnames
+      .map((name) => byName.get(name))
+      .filter(isRawField)
+      .map((field) => mapField(withAccess(field, fieldAccess), {})),
+  );
+}
+
+/** Force `required` fieldnames mandatory, whatever the layout said. */
+export function applyRequired(
+  layout: FormLayoutSchema,
+  required: string[] | undefined,
+): FormLayoutSchema {
+  if (!required?.length) return layout;
+  const forced = new Set(required);
+  return mapFields(layout, (field) =>
+    forced.has(field.fieldname)
+      ? { ...field, reqd: true, mandatoryDependsOn: undefined }
+      : field,
+  );
+}
+
+/** Seed the dialog's doc: `defaults` over every field's empty value. */
+export function initialDoc(
+  layout: FormLayoutSchema,
+  defaults: Record<string, any> | undefined,
+): Record<string, any> {
+  const doc: Record<string, any> = {};
+  for (const field of flatFields(layout)) doc[field.fieldname] = null;
+  return { ...doc, ...(defaults ?? {}) };
+}
+
+/** The labels a submit refuses over: mandatory, visible after `depends_on`, still empty. */
+export function missingRequired(
+  layout: FormLayoutSchema,
+  doc: Record<string, any>,
+): string[] {
+  const missing: string[] = [];
+  for (const tab of resolveLayout(layout, doc, doc)) {
+    if (tab.hidden) continue;
+    for (const section of tab.sections) {
+      if (section.hidden) continue;
+      for (const column of section.columns)
+        for (const field of column.fields)
+          if (field.reqd && !field.hidden && isEmpty(doc[field.fieldname]))
+            missing.push(field.label || field.fieldname);
+    }
+  }
+  return missing;
+}
+
+/** The values a submit resolves with: every field the layout rendered. */
+export function formData(
+  layout: FormLayoutSchema,
+  doc: Record<string, any>,
+): Record<string, any> {
+  const data: Record<string, any> = {};
+  for (const field of flatFields(layout))
+    data[field.fieldname] = doc[field.fieldname];
+  return data;
+}
+
+function toSection(section: PageDialogSection): Section {
+  // Listed key by key: a spread is not excess-checked, so a renamed key would
+  // silently stop reaching `buildSection`.
+  return buildSection(
+    {
+      name: section.name,
+      label: section.label,
+      hideLabel: section.hideLabel,
+      hideBorder: section.hideBorder,
+      collapsible: section.collapsible,
+      opened: section.opened,
+      dependsOn: section.depends_on,
+    },
+    (section.columns ?? []).map((column) =>
+      buildColumn(column, (column.fields ?? []).map(toFieldNode)),
+    ),
+  );
+}
+
+// `mapField` is the meta path's reading of DocField vocabulary, so both tiers agree
+// on what a field means. No child metas: a dialog field list cannot describe a grid.
+function toFieldNode(field: PageDialogField): FieldNode {
+  return mapField(field, {});
+}
+
+function mapFields(
+  layout: FormLayoutSchema,
+  transform: (field: FieldNode) => FieldNode,
+): FormLayoutSchema {
+  return layout.map((tab) => ({
+    ...tab,
+    sections: tab.sections.map((section) => ({
+      ...section,
+      columns: section.columns.map((column) => ({
+        ...column,
+        fields: column.fields.map(transform),
+      })),
+    })),
+  }));
+}
+
+function flatFields(layout: FormLayoutSchema): FieldNode[] {
+  return layout.flatMap((tab) =>
+    tab.sections.flatMap((section) =>
+      section.columns.flatMap((column) => column.fields),
+    ),
+  );
+}
+
+function isRawField(field: RawMetaField | undefined): field is RawMetaField {
+  return field != null;
+}
+
+function isEmpty(value: any): boolean {
+  if (Array.isArray(value)) return value.length === 0;
+  return value == null || value === "";
+}

--- a/frontend/src/recordPage/formLayoutSource/section.ts
+++ b/frontend/src/recordPage/formLayoutSource/section.ts
@@ -1,0 +1,44 @@
+import type {
+  Column,
+  Section,
+} from "@framework/ui/components/FormLayout/types";
+
+/** The section keys a Form Layout row and a dialog both carry, so neither grows its own default. */
+export interface SectionSpec {
+  name?: string;
+  label?: string;
+  hideLabel?: boolean;
+  hideBorder?: boolean;
+  collapsible?: boolean;
+  /** Explicit initial state; open when unset (see `buildSection`). */
+  opened?: boolean;
+  dependsOn?: string;
+}
+
+/** The one `Section` constructor for the stored-layout paths. */
+// Open unless `opened: false` is explicit, matching `buildLayoutFromMeta`'s `newSection`.
+export function buildSection(spec: SectionSpec, columns: Column[]): Section {
+  return {
+    name: spec.name,
+    label: spec.label,
+    hideLabel: Boolean(spec.hideLabel),
+    hideBorder: Boolean(spec.hideBorder),
+    collapsible: Boolean(spec.collapsible),
+    opened: spec.opened !== false,
+    dependsOn: spec.dependsOn,
+    columns,
+  };
+}
+
+/** The matching `Column` constructor; `hideLabel` is carried, not dropped. */
+export function buildColumn(
+  spec: { name?: string; label?: string; hideLabel?: boolean },
+  fields: Column["fields"],
+): Column {
+  return {
+    name: spec.name,
+    label: spec.label,
+    hideLabel: Boolean(spec.hideLabel),
+    fields,
+  };
+}

--- a/frontend/src/recordPage/formLayoutSource/section.ts
+++ b/frontend/src/recordPage/formLayoutSource/section.ts
@@ -15,8 +15,7 @@ export interface SectionSpec {
   dependsOn?: string;
 }
 
-/** The one `Section` constructor for the stored-layout paths. */
-// Open unless `opened: false` is explicit, matching `buildLayoutFromMeta`'s `newSection`.
+/** The one `Section` constructor for the stored-layout paths; open unless `opened: false`. */
 export function buildSection(spec: SectionSpec, columns: Column[]): Section {
   return {
     name: spec.name,

--- a/frontend/src/recordPage/tests/dialog.test.ts
+++ b/frontend/src/recordPage/tests/dialog.test.ts
@@ -1,0 +1,416 @@
+// `page.dialog` as executable claims: the close contract, the page binding,
+// attribution, and the layout modes `form` accepts.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+
+const confirmSpy = vi.fn();
+const dangerSpy = vi.fn();
+
+// The page only borrows `call`, `toast` and the imperative `dialog` namespace;
+// the real barrel drags icon plugins in.
+vi.mock("frappe-ui", () => ({
+  call: vi.fn(),
+  toast: { success: vi.fn(), error: vi.fn() },
+  dialog: {
+    confirm: (args: any) => confirmSpy(args),
+    danger: (args: any) => dangerSpy(args),
+  },
+  createResource: () => ({
+    data: null,
+    loading: false,
+    fetch() {},
+    reload() {},
+  }),
+  frappeRequest: vi.fn(),
+}));
+
+import { createRecordPage, type RecordPageHost } from "../createRecordPage";
+import { registerRecordPage, resetRegistry } from "../registry";
+import {
+  applyRequired,
+  layoutFromFields,
+  layoutMode,
+  missingRequired,
+  pickMetaFields,
+  warnAmbiguousLayout,
+} from "../formDialogLayout";
+import type { FormLayoutSchema } from "@framework/ui/components/FormLayout/types";
+
+function makeHost(overrides: Partial<RecordPageHost> = {}): RecordPageHost {
+  return {
+    doctype: "CRM Deal",
+    docname: "CRM-DEAL-1",
+    doc: ref({ status: "Open" }),
+    saved: ref({ status: "Open" }),
+    meta: ref(null),
+    perms: () => ({}),
+    isDirty: () => false,
+    activeTab: () => "activity",
+    activateTab: () => {},
+    save: async () => {},
+    reload: async () => {},
+    router: {} as any,
+    ...overrides,
+  };
+}
+
+describe("page.dialog.form and open", () => {
+  beforeEach(() => {
+    resetRegistry();
+    confirmSpy.mockReset();
+    dangerSpy.mockReset();
+  });
+
+  it("resolves with the data the dialog closes with", async () => {
+    const { page, dialogs } = createRecordPage(makeHost());
+    const promise = page.dialog.form({
+      fields: [{ fieldname: "summary", fieldtype: "Small Text" }],
+    });
+
+    expect(dialogs.value).toHaveLength(1);
+    dialogs.value[0].settle({ summary: "Called back" });
+
+    expect(await promise).toEqual({ summary: "Called back" });
+    // The answer settles now; the entry leaves the stack when the host's leave
+    // transition ends, so an unmount in that window cannot rewrite the answer.
+    expect(dialogs.value).toHaveLength(1);
+    dialogs.value[0].dismiss();
+    expect(dialogs.value).toHaveLength(0);
+  });
+
+  it("keeps a settled answer when the page goes away mid-transition", async () => {
+    const controller = createRecordPage(makeHost());
+    const promise = controller.page.dialog.form({ fields: [] });
+
+    controller.dialogs.value[0].settle({ summary: "submitted" });
+    controller.closeDialogs();
+
+    expect(await promise).toEqual({ summary: "submitted" });
+  });
+
+  it("refuses to open once the page has gone away", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const controller = createRecordPage(makeHost());
+    controller.closeDialogs();
+
+    expect(await controller.page.dialog.form({ fields: [] })).toBeNull();
+    expect(controller.dialogs.value).toHaveLength(0);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("after leaving the record"),
+    );
+    warn.mockRestore();
+  });
+
+  it("resolves null when the dialog is dismissed", async () => {
+    const { page, dialogs } = createRecordPage(makeHost());
+    const promise = page.dialog.form({ fields: [] });
+    dialogs.value[0].settle();
+    expect(await promise).toBeNull();
+  });
+
+  it("tags the open with the source that ran", async () => {
+    registerRecordPage("CRM Deal", {
+      onRefresh: (page) => {
+        page.dialog.form({ fields: [] });
+      },
+    });
+    const controller = createRecordPage(makeHost());
+    await controller.refresh();
+
+    expect(controller.dialogs.value[0].source).toBe("host");
+  });
+
+  it("hands `open` the component and its props, and answers with close(result)", async () => {
+    const component = { name: "LogCall" };
+    const { page, dialogs } = createRecordPage(makeHost());
+    const promise = page.dialog.open(component as any, { deal: "D-1" });
+
+    const entry = dialogs.value[0];
+    expect(entry.kind).toBe("component");
+    expect(entry.component).toBe(component);
+    expect(entry.props).toEqual({ deal: "D-1" });
+
+    entry.settle("logged");
+    expect(await promise).toBe("logged");
+  });
+
+  it("closes the stack newest-first when the page goes away", async () => {
+    const controller = createRecordPage(makeHost());
+    const closed: string[] = [];
+    const first = controller.page.dialog.form({ title: "first", fields: [] });
+    const second = controller.page.dialog.form({ title: "second", fields: [] });
+    const titles = controller.dialogs.value.map((entry) => entry.form?.title);
+    void first.then(() => closed.push("first"));
+    void second.then(() => closed.push("second"));
+
+    controller.closeDialogs();
+
+    expect(await first).toBeNull();
+    expect(await second).toBeNull();
+    expect(titles).toEqual(["first", "second"]);
+    expect(closed).toEqual(["second", "first"]);
+    expect(controller.dialogs.value).toHaveLength(0);
+  });
+
+  it("warns, naming the source, when a verb fires during a replay", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    registerRecordPage("CRM Deal", {
+      onRefresh: (page) => {
+        page.dialog.form({ fields: [] });
+      },
+    });
+    await createRecordPage(makeHost()).refresh();
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("host called page.dialog.form during a replay"),
+    );
+    warn.mockRestore();
+  });
+
+  it("does not warn when a verb fires outside a replay", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { page } = createRecordPage(makeHost());
+    page.dialog.form({ fields: [] });
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+describe("page.dialog.confirm and danger", () => {
+  beforeEach(() => {
+    confirmSpy.mockReset();
+    dangerSpy.mockReset();
+  });
+
+  it("resolves true when confirmed and null when cancelled", async () => {
+    confirmSpy.mockImplementation(() => {
+      close: vi.fn();
+    });
+    const { page } = createRecordPage(makeHost());
+
+    const confirmed = page.dialog.confirm({ title: "Sure?" });
+    await confirmSpy.mock.calls[0][0].onConfirm({});
+    expect(await confirmed).toBe(true);
+
+    const cancelled = page.dialog.confirm({ title: "Sure?" });
+    confirmSpy.mock.calls[1][0].onCancel();
+    expect(await cancelled).toBeNull();
+  });
+
+  it("routes danger through frappe-ui's danger, forwarding the keys it names", async () => {
+    dangerSpy.mockImplementation(() => ({ close: vi.fn() }));
+    const { page } = createRecordPage(makeHost());
+    page.dialog.danger({ title: "Delete?", message: "Gone for good" });
+
+    expect(dangerSpy.mock.calls[0][0]).toMatchObject({
+      title: "Delete?",
+      message: "Gone for good",
+    });
+  });
+
+  it("drops an option frappe-ui's schema does not name, saying which", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    confirmSpy.mockImplementation(() => ({ close: vi.fn() }));
+    const { page } = createRecordPage(makeHost());
+    page.dialog.confirm({ title: "Sure?", position: "top" } as any);
+
+    expect(confirmSpy.mock.calls[0][0]).not.toHaveProperty("position");
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("with 'position', which it does not forward"),
+    );
+    warn.mockRestore();
+  });
+
+  it("drops theme and icon on danger, which frappe-ui forces for itself", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    dangerSpy.mockImplementation(() => ({ close: vi.fn() }));
+    const { page } = createRecordPage(makeHost());
+    page.dialog.danger({ theme: "blue", icon: "lucide-flag" } as any);
+
+    expect(dangerSpy.mock.calls[0][0]).not.toHaveProperty("theme");
+    expect(dangerSpy.mock.calls[0][0]).not.toHaveProperty("icon");
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("with 'theme'"));
+    warn.mockRestore();
+  });
+
+  it("narrows an action to the props page names, not the whole Button surface", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    confirmSpy.mockImplementation(() => ({ close: vi.fn() }));
+    const { page } = createRecordPage(makeHost());
+    page.dialog.confirm({
+      actions: [{ label: "Flag", variant: "solid", size: "sm" }],
+    } as any);
+
+    const action = confirmSpy.mock.calls[0][0].actions[0];
+    expect(action).toMatchObject({ label: "Flag", variant: "solid" });
+    expect(action).not.toHaveProperty("size");
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("with 'size' on action 'Flag'"),
+    );
+    warn.mockRestore();
+  });
+
+  it("hands a callback the engine's own object, not frappe-ui's control", async () => {
+    confirmSpy.mockImplementation(() => ({ close: vi.fn() }));
+    const close = vi.fn();
+    const setError = vi.fn();
+    const seen: any[] = [];
+    const { page } = createRecordPage(makeHost());
+    page.dialog.confirm({ onConfirm: (control) => seen.push(control) });
+
+    await confirmSpy.mock.calls[0][0].onConfirm({
+      close,
+      setError,
+      internal: "frappe-ui's own",
+    });
+
+    expect(Object.keys(seen[0])).toEqual(["close", "setError"]);
+    seen[0].close();
+    seen[0].setError("nope");
+    expect(close).toHaveBeenCalled();
+    expect(setError).toHaveBeenCalledWith("nope");
+  });
+
+  it("resolves null for a custom action that only dismisses", async () => {
+    confirmSpy.mockImplementation(() => ({ close: vi.fn() }));
+    const { page } = createRecordPage(makeHost());
+    const promise = page.dialog.confirm({ actions: [{ label: "Cancel" }] });
+
+    await confirmSpy.mock.calls[0][0].actions[0].onClick({});
+
+    expect(await promise).toBeNull();
+  });
+
+  it("resolves true for a custom action that acted", async () => {
+    confirmSpy.mockImplementation(() => ({ close: vi.fn() }));
+    const onClick = vi.fn();
+    const { page } = createRecordPage(makeHost());
+    const promise = page.dialog.confirm({
+      actions: [{ label: "Flag", onClick }],
+    });
+
+    await confirmSpy.mock.calls[0][0].actions[0].onClick({});
+
+    expect(onClick).toHaveBeenCalled();
+    expect(await promise).toBe(true);
+  });
+
+  it("dismisses a native dialog and resolves null when the page goes away", async () => {
+    const handle = { close: vi.fn() };
+    confirmSpy.mockImplementation(() => handle);
+    const controller = createRecordPage(makeHost());
+    const promise = controller.page.dialog.confirm({ title: "Sure?" });
+
+    controller.closeDialogs();
+
+    expect(handle.close).toHaveBeenCalled();
+    expect(await promise).toBeNull();
+  });
+});
+
+describe("form layout modes", () => {
+  it("takes the first when two modes are given, and warns separately", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(layoutMode({ fields: [], doctype: "Contact" })).toBe("fields");
+    expect(warn).not.toHaveBeenCalled();
+
+    warnAmbiguousLayout({ fields: [], doctype: "Contact" });
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("mutually exclusive"),
+    );
+    warn.mockRestore();
+  });
+
+  it("warns when fieldnames arrives without a doctype to read them from", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    warnAmbiguousLayout({ fieldnames: ["email"] });
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("fieldnames without a doctype"),
+    );
+    warn.mockRestore();
+  });
+
+  it("reads DocField vocabulary, not FieldMeta's", () => {
+    const layout = layoutFromFields([
+      {
+        fieldname: "reason",
+        fieldtype: "Small Text",
+        label: "Reason",
+        reqd: 1,
+        depends_on: "eval:doc.status",
+      },
+    ]);
+    const field = layout[0].sections[0].columns[0].fields[0];
+
+    expect(field.reqd).toBe(true);
+    expect(field.dependsOn).toBe("eval:doc.status");
+  });
+
+  it("picks meta fields in the order asked for, dropping unknown ones", () => {
+    const picked = pickMetaFields(
+      [
+        { fieldname: "a", fieldtype: "Data" },
+        { fieldname: "b", fieldtype: "Data" },
+        { fieldname: "c", fieldtype: "Data" },
+      ],
+      ["c", "a", "nope"],
+    );
+
+    expect(
+      picked[0].sections[0].columns[0].fields.map((f) => f.fieldname),
+    ).toEqual(["c", "a"]);
+  });
+
+  it("demotes a field the reader may only read, and hides one they may not", () => {
+    const picked = pickMetaFields(
+      [
+        { fieldname: "a", fieldtype: "Data" },
+        { fieldname: "b", fieldtype: "Data" },
+      ],
+      ["a", "b"],
+      (field) => (field.fieldname === "a" ? "read" : "none"),
+    );
+    const fields = picked[0].sections[0].columns[0].fields;
+
+    expect(fields[0].readOnly).toBe(true);
+    expect(fields[1].hidden).toBe(true);
+  });
+
+  it("forces `required` fieldnames mandatory", () => {
+    const layout = applyRequired(
+      layoutFromFields([{ fieldname: "email", fieldtype: "Data" }]),
+      ["email"],
+    );
+    expect(layout[0].sections[0].columns[0].fields[0].reqd).toBe(true);
+  });
+});
+
+describe("mandatory checking", () => {
+  const layout: FormLayoutSchema = layoutFromFields([
+    {
+      fieldname: "summary",
+      fieldtype: "Small Text",
+      label: "Summary",
+      reqd: 1,
+    },
+    {
+      fieldname: "reason",
+      fieldtype: "Small Text",
+      label: "Reason",
+      reqd: 1,
+      depends_on: "eval:doc.summary == 'lost'",
+    },
+  ]);
+
+  it("names the empty mandatory fields by label", () => {
+    expect(missingRequired(layout, {})).toEqual(["Summary"]);
+  });
+
+  it("does not demand a field its depends_on has hidden", () => {
+    expect(missingRequired(layout, { summary: "won" })).toEqual([]);
+  });
+
+  it("demands a conditional field once it is on screen", () => {
+    expect(missingRequired(layout, { summary: "lost" })).toEqual(["Reason"]);
+  });
+});

--- a/frontend/src/recordPage/tests/dialog.test.ts
+++ b/frontend/src/recordPage/tests/dialog.test.ts
@@ -28,7 +28,10 @@ import { createRecordPage, type RecordPageHost } from "../createRecordPage";
 import { registerRecordPage, resetRegistry } from "../registry";
 import {
   applyRequired,
+  formData,
+  initialDoc,
   layoutFromFields,
+  layoutFromTabs,
   layoutMode,
   missingRequired,
   pickMetaFields,
@@ -183,9 +186,7 @@ describe("page.dialog.confirm and danger", () => {
   });
 
   it("resolves true when confirmed and null when cancelled", async () => {
-    confirmSpy.mockImplementation(() => {
-      close: vi.fn();
-    });
+    confirmSpy.mockImplementation(() => ({ close: vi.fn() }));
     const { page } = createRecordPage(makeHost());
 
     const confirmed = page.dialog.confirm({ title: "Sure?" });
@@ -328,6 +329,35 @@ describe("form layout modes", () => {
       expect.stringContaining("fieldnames without a doctype"),
     );
     warn.mockRestore();
+  });
+
+  it("builds a tabs tree with sections open unless told otherwise", () => {
+    const layout = layoutFromTabs([
+      {
+        name: "main",
+        depends_on: "eval:doc.kind",
+        sections: [
+          {
+            name: "open",
+            columns: [{ fields: [{ fieldname: "a", fieldtype: "Data" }] }],
+          },
+          { name: "shut", opened: false, columns: [] },
+        ],
+      },
+    ]);
+    expect(layout[0].dependsOn).toBe("eval:doc.kind");
+    const [open, shut] = layout[0].sections;
+    expect(open.opened).toBe(true);
+    expect(open.columns[0].fields[0].fieldname).toBe("a");
+    expect(shut.opened).toBe(false);
+  });
+
+  it("seeds every rendered field and returns only rendered fields", () => {
+    const layout = layoutFromFields([
+      { fieldname: "email", fieldtype: "Data" },
+    ]);
+    expect(initialDoc(layout, { email: "a@b" })).toEqual({ email: "a@b" });
+    expect(formData(layout, { email: "x", stray: 1 })).toEqual({ email: "x" });
   });
 
   it("reads DocField vocabulary, not FieldMeta's", () => {

--- a/frontend/src/recordPage/types.ts
+++ b/frontend/src/recordPage/types.ts
@@ -240,7 +240,7 @@ export interface PageDialogFormOptions {
   fields?: PageDialogField[];
   /** Full `tabs > sections > columns > fields` layout. */
   tabs?: PageDialogTab[];
-  /** Renders the doctype's `Quick Entry` Form Layout, meta-derived if none. */
+  /** With `fieldnames`: those fields, in that order, straight from the doctype's meta. */
   doctype?: string;
   /** With `doctype`: only these fields, in this order. */
   fieldnames?: string[];


### PR DESCRIPTION
Lands what the leftover-triage research ticket called "port now", so the header ticket edits a file that exists. Part of the record-page map (#42271); resolves #42555.

## What changes

- **`frontend/COMPATIBILITY.md`** — the promise made to script authors, moved from `ui/src/experimental/RecordPage/` on the pre-split branch. Listed in `PHILOSOPHY.md`'s doc set. Its opening is rewritten for the new location: the engine is under `frontend/src/recordPage/`, the "Extensions" audience is gone with `loader.ts`, and the tier is named **Client Script** throughout. `CONTEXT.md`'s tier definition drops the same stale "app extensions" phrase. The Save note is left alone; the header ticket deletes it.
- **`formDialogLayout.ts`** resolves the `fields`, `tabs` and `doctype` modes that `PageDialogFormOptions` already promised, with **`formLayoutSource/section.ts`** as its section constructor. Pre-split comment blocks are cut to the `AGENTS.md` rule. Its renderer, `PageFormDialog.vue`, follows when `Record.vue` renders fields; until then the module is reached by its tests only, on purpose.
- **`tests/dialog.test.ts`** carries the claims for `page.dialog`, plus new tests for the tabs, `initialDoc` and `formData` paths.
- `dialog.ts` names the doc's real path. `CLAUDE.md`'s test baseline is corrected to 28 files / 473 tests.

## Checks

- `yarn --cwd frontend test:run`: 28 files / 473 tests green.
- `/quality-code-review` run; its findings (a docstring on `types.ts` that contradicted the code, two leftover phrases in the doc, a block-body arrow in a test, missing tests for three paths) are in the second commit.
- Comment rule read against the diff: no block over two lines, no ticket numbers, no "rather than" in code comments.

>no-docs
