### PR TITLE
fix: detect web tier concurrency without /proc

### DIFF
--- a/frappe/concurrency_limiter.py
+++ b/frappe/concurrency_limiter.py
@@ -17,44 +17,45 @@ Usage::
 
 """
 
+import os
+import sys
 from collections.abc import Callable
-from functools import wraps
+from functools import cache, wraps
 
 import frappe
 from frappe.exceptions import ServiceUnavailableError
 from frappe.utils import cint
-from frappe.utils.caching import redis_cache
 from frappe.utils.redis_semaphore import RedisSemaphore
 
 # Default wait timeout (seconds) before returning 503 to the caller.
 _DEFAULT_WAIT_TIMEOUT = 10
 
 
-@redis_cache(shared=True)
-def _default_limit() -> int:
-	"""Derive a sensible default concurrency limit from gunicorn's max concurrency."""
-	return max(1, gunicorn_max_concurrency() // 2)
+@cache
+def web_tier_concurrency() -> int | None:
+	"""Number of requests this process' web tier serves at once.
+
+	Returns ``None`` when there is no fixed pool to exhaust: the development
+	server starts a thread per request, and CLI commands and background jobs
+	are not a web tier at all.
+
+	Gunicorn sets ``SERVER_SOFTWARE``, and its workers are forked from the master,
+	so ``sys.argv`` in a worker is the master's own command line. Both hold on
+	every platform. Reading the parent's ``/proc/<pid>/cmdline`` instead reports
+	nothing on macOS, where every process then looks like a small gunicorn.
+	"""
+	if not os.environ.get("SERVER_SOFTWARE", "").startswith("gunicorn"):
+		return None
+
+	workers = _extract_cli_int(sys.argv, "-w", "--workers") or 1
+	threads = _extract_cli_int(sys.argv, "--threads") or 1
+	return workers * threads
 
 
-def gunicorn_max_concurrency() -> int:
-	"""Detect max concurrent requests from the running gunicorn master's cmdline."""
-	import os
-
-	fallback = 4
-
-	try:
-		ppid = os.getppid()
-		with open(f"/proc/{ppid}/cmdline", "rb") as f:
-			args = f.read().rstrip(b"\0").decode().split("\0")
-
-		if not any("gunicorn" in a for a in args):
-			return fallback
-
-		workers = _extract_cli_int(args, "-w", "--workers") or fallback
-		threads = _extract_cli_int(args, "--threads") or 1
-		return workers * threads
-	except OSError:
-		return fallback
+def _default_limit() -> int | None:
+	"""Half of the web tier's capacity, or ``None`` when nothing needs protecting."""
+	capacity = web_tier_concurrency()
+	return max(1, capacity // 2) if capacity else None
 
 
 def _extract_cli_int(args: list[str], *flags: str) -> int | None:
@@ -64,10 +65,17 @@ def _extract_cli_int(args: list[str], *flags: str) -> int | None:
 	"""
 	for i, arg in enumerate(args):
 		for flag in flags:
+			value = None
 			if arg == flag and i + 1 < len(args):
-				return int(args[i + 1])
-			if arg.startswith(f"{flag}="):
-				return int(arg.split("=", 1)[1])
+				value = args[i + 1]
+			elif arg.startswith(f"{flag}="):
+				value = arg.split("=", 1)[1]
+
+			if value is not None:
+				try:
+					return int(value)
+				except ValueError:
+					return None
 	return None
 
 
@@ -75,7 +83,8 @@ def concurrent_limit(limit: int | None = None, wait_timeout: int = _DEFAULT_WAIT
 	"""Decorator that limits simultaneous in-flight executions of the wrapped function.
 
 	:param limit: Maximum number of concurrent executions. Defaults to half of ``workers x threads``
-	    as detected from the gunicorn master process.
+	    as detected from the gunicorn command line, and to no limit when the process serves
+	    requests without a fixed worker pool.
 	:param wait_timeout: Seconds to wait for a free slot before returning 503.
 	    Defaults to 10 s.
 
@@ -92,6 +101,9 @@ def concurrent_limit(limit: int | None = None, wait_timeout: int = _DEFAULT_WAIT
 				return fn(*args, **kwargs)
 
 			_limit = cint(limit) if limit is not None else _default_limit()
+			if _limit is None:
+				return fn(*args, **kwargs)
+
 			key = f"concurrency:{fn.__module__}.{fn.__qualname__}"
 
 			sem = RedisSemaphore(key, _limit, wait_timeout, shared=True)
@@ -117,9 +129,7 @@ def concurrent_limit(limit: int | None = None, wait_timeout: int = _DEFAULT_WAIT
 @frappe.whitelist()
 def get_stats() -> dict:
 	frappe.only_for("System Manager")
-	cached_limit = _default_limit()
-	gunicorn_limit = gunicorn_max_concurrency()
 	return {
-		"cached_limit": cached_limit,
-		"gunicorn_limit": gunicorn_limit,
+		"default_limit": _default_limit(),
+		"web_tier_concurrency": web_tier_concurrency(),
 	}

--- a/frappe/tests/test_concurrency_limiter.py
+++ b/frappe/tests/test_concurrency_limiter.py
@@ -1,12 +1,15 @@
 # Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
+import contextlib
 import contextvars
+import os
+import sys
 import threading
 from unittest.mock import MagicMock, patch
 
 import frappe
-from frappe.concurrency_limiter import concurrent_limit
+from frappe.concurrency_limiter import _default_limit, concurrent_limit, web_tier_concurrency
 from frappe.exceptions import ServiceUnavailableError
 from frappe.tests import IntegrationTestCase
 
@@ -159,5 +162,67 @@ class TestConcurrentLimit(IntegrationTestCase):
 		finally:
 			del frappe.local.request
 			_cleanup(fn)
+
+		self.assertEqual(calls, [True])
+
+
+class TestWebTierConcurrency(IntegrationTestCase):
+	@contextlib.contextmanager
+	def _server(self, argv, server_software="gunicorn/23.0.0"):
+		"""Run the body as if this process were a gunicorn worker started with *argv*."""
+		env = {"SERVER_SOFTWARE": server_software} if server_software else {}
+		web_tier_concurrency.cache_clear()
+		try:
+			with patch.object(sys, "argv", argv), patch.dict(os.environ, env, clear=False):
+				if not server_software:
+					os.environ.pop("SERVER_SOFTWARE", None)
+				yield
+		finally:
+			web_tier_concurrency.cache_clear()
+
+	def test_no_limit_without_a_worker_pool(self):
+		"""The development server starts a thread per request, so there is no pool to protect."""
+		with self._server(["bench", "serve"], server_software=None):
+			self.assertIsNone(web_tier_concurrency())
+			self.assertIsNone(_default_limit())
+
+	def test_reads_workers_and_threads_from_the_gunicorn_command_line(self):
+		"""Workers are forked, so sys.argv in a worker is the master's command line."""
+		with self._server(["gunicorn", "-w", "3", "--threads", "4", "frappe.app:application"]):
+			self.assertEqual(web_tier_concurrency(), 12)
+			self.assertEqual(_default_limit(), 6)
+
+	def test_reads_the_flag_equals_value_form(self):
+		with self._server(["gunicorn", "--workers=2", "--threads=2", "frappe.app:application"]):
+			self.assertEqual(web_tier_concurrency(), 4)
+
+	def test_threads_default_to_one(self):
+		with self._server(["gunicorn", "-w", "5", "frappe.app:application"]):
+			self.assertEqual(web_tier_concurrency(), 5)
+			self.assertEqual(_default_limit(), 2)
+
+	def test_limit_is_at_least_one(self):
+		with self._server(["gunicorn", "-w", "1", "frappe.app:application"]):
+			self.assertEqual(_default_limit(), 1)
+
+	def test_unparseable_flag_falls_back_to_one(self):
+		with self._server(["gunicorn", "-w", "auto", "frappe.app:application"]):
+			self.assertEqual(web_tier_concurrency(), 1)
+
+	def test_pool_is_skipped_when_there_is_no_limit(self):
+		"""A request on the development server must not touch the semaphore."""
+		calls = []
+
+		@concurrent_limit()
+		def fn():
+			calls.append(True)
+
+		try:
+			frappe.local.request = frappe._dict()
+			with self._server(["bench", "serve"], server_software=None):
+				with patch.object(frappe.cache, "lpop", side_effect=AssertionError("semaphore used")):
+					fn()
+		finally:
+			del frappe.local.request
 
 		self.assertEqual(calls, [True])


### PR DESCRIPTION
`_default_limit()` reads `/proc/<ppid>/cmdline` to find gunicorn's `-w` and `--threads`. macOS has no `/proc`, so the read always fails and the fallback applies. Every developer machine limits each `@concurrent_limit` method to 2, and so does any bench running `bench serve` — a threaded server with no fixed pool to exhaust.

The fallback conflates "under gunicorn with 4 slots" with "I cannot tell what server I am". Those need different answers.

Detect gunicorn by `SERVER_SOFTWARE`, which its arbiter sets, and read the counts from `sys.argv`, which a forked worker inherits from the master. Neither depends on the OS. With no gunicorn there is no pool, so the decorator skips the semaphore.

Measured on macOS, same server, `gunicorn -w 3`:

| | `web_tier_concurrency` | limit |
|---|---|---|
| develop | 4 | 2 |
| this branch | 3 | 1 |

`develop` reports the fallback. This branch reports the server.

Two notes for review:

- `--threads` set in a gunicorn config file rather than on the command line is not seen. The count then comes out low, so the limit is stricter than needed. bench passes both flags on the command line.
- `_default_limit` was `@redis_cache(shared=True)`, cached across sites for an hour. Whichever process computed it first won, so a `bench execute` could set the value that every gunicorn worker then read. The input is process-constant, so `functools.cache` covers it.