### PR TITLE
fix(oauth): expire authorization codes and bind them to their redirect_uri

### DIFF
--- a/frappe/oauth.py
+++ b/frappe/oauth.py
@@ -11,7 +11,10 @@ import frappe
 from frappe.auth import LoginManager
 from frappe.integrations.doctype.oauth_bearer_token.oauth_bearer_token import get_oauth_token_hash
 from frappe.integrations.doctype.oauth_client.oauth_client import OAuthClient
-from frappe.utils.data import cstr, get_system_timezone, now_datetime
+from frappe.utils.data import add_to_date, cstr, get_system_timezone, now_datetime
+
+# RFC 6749 §4.1.2 recommends a maximum authorization code lifetime of 10 minutes.
+AUTHORIZATION_CODE_EXPIRY_SECONDS = 600
 
 
 class OAuthWebRequestValidator(RequestValidator):
@@ -83,6 +86,9 @@ class OAuthWebRequestValidator(RequestValidator):
 		oac.client = client_id
 		oac.user = frappe.session.user
 		oac.authorization_code = code["code"]
+		oac.expiration_time = add_to_date(
+			now_datetime(), seconds=AUTHORIZATION_CODE_EXPIRY_SECONDS, as_datetime=True
+		)
 
 		if request.nonce:
 			oac.nonce = request.nonce
@@ -139,11 +145,16 @@ class OAuthWebRequestValidator(RequestValidator):
 		code_details = frappe.db.get_value(
 			"OAuth Authorization Code",
 			{"name": code, "client": client_id, "validity": "Valid"},
-			("scopes", "user", "code_challenge_method", "code_challenge"),
+			("scopes", "user", "code_challenge_method", "code_challenge", "expiration_time"),
 			as_dict=True,
 		)
 
 		if code_details:
+			if code_details.expiration_time and now_datetime() > code_details.expiration_time:
+				frappe.db.set_value("OAuth Authorization Code", code, "validity", "Invalid")
+				frappe.db.commit()
+				return False
+
 			request.scopes = code_details.scopes.split(get_url_delimiter())
 			request.user = code_details.user
 			code_challenge_method = code_details.code_challenge_method
@@ -171,17 +182,13 @@ class OAuthWebRequestValidator(RequestValidator):
 		return False
 
 	def confirm_redirect_uri(self, client_id, code, redirect_uri, client, *args, **kwargs):
-		client_redirects = frappe.get_cached_value(
-			"OAuth Client", client_id, ("default_redirect_uri", "redirect_uris"), as_dict=True
+		# The redirect_uri presented at the token endpoint must match the exact
+		# redirect_uri the authorization code was issued for (RFC 6749 §4.1.3),
+		# not merely be one of the client's registered redirect_uris.
+		bound_redirect_uri = frappe.db.get_value(
+			"OAuth Authorization Code", code, "redirect_uri_bound_to_authorization_code"
 		)
-		saved_redirect_uri = client_redirects.default_redirect_uri
-		redirect_uris = client_redirects.redirect_uris
-
-		if redirect_uris:
-			redirect_uris = redirect_uris.split(get_url_delimiter())
-			return redirect_uri in redirect_uris
-
-		return saved_redirect_uri == redirect_uri
+		return bool(bound_redirect_uri) and bound_redirect_uri == redirect_uri
 
 	def validate_grant_type(self, client_id, grant_type, client, request, *args, **kwargs):
 		# Clients should only be allowed to use one type of grant.
@@ -562,6 +569,9 @@ def calculate_at_hash(access_token, hash_alg):
 
 def delete_oauth2_data():
 	frappe.db.delete("OAuth Authorization Code", {"validity": "Invalid"})
+	frappe.db.delete(
+		"OAuth Authorization Code", {"validity": "Valid", "expiration_time": ("<", now_datetime())}
+	)
 	frappe.db.delete("OAuth Bearer Token", {"status": "Revoked"})
 
 

--- a/frappe/oauth.py
+++ b/frappe/oauth.py
@@ -150,9 +150,8 @@ class OAuthWebRequestValidator(RequestValidator):
 		)
 
 		if code_details:
-			if code_details.expiration_time and now_datetime() > code_details.expiration_time:
+			if not code_details.expiration_time or now_datetime() > code_details.expiration_time:
 				frappe.db.set_value("OAuth Authorization Code", code, "validity", "Invalid")
-				frappe.db.commit()
 				return False
 
 			request.scopes = code_details.scopes.split(get_url_delimiter())

--- a/frappe/tests/test_oauth20.py
+++ b/frappe/tests/test_oauth20.py
@@ -9,11 +9,12 @@ from werkzeug.test import TestResponse
 
 import frappe
 from frappe.integrations.oauth2 import encode_params
-from frappe.oauth import OAuthWebRequestValidator
+from frappe.oauth import AUTHORIZATION_CODE_EXPIRY_SECONDS, OAuthWebRequestValidator, get_url_delimiter
 from frappe.tests import IntegrationTestCase
 from frappe.tests.test_api import get_test_client, make_request, suppress_stdout
 from frappe.tests.utils import make_test_records
 from frappe.tests.utils.test_capabilities import TestService, requires_test_service
+from frappe.utils.data import add_to_date, get_datetime
 from frappe.utils.oauth import build_oauth_url
 
 if TYPE_CHECKING:
@@ -279,6 +280,114 @@ class TestOAuth20(FrappeRequestTestCase):
 
 		decoded_token = self.decode_id_token(bearer_token.get("id_token"))
 		self.assertEqual(decoded_token["email"], "test@example.com")
+
+	def test_expired_authorization_code_is_rejected(self):
+		update_client_for_auth_code_grant(self.client_id)
+		self.TEST_CLIENT.set_cookie(key="sid", value=self.sid)
+
+		issued_at = get_datetime("2026-01-01 00:00:00")
+		with self.freeze_time(issued_at):
+			resp = self.get(
+				"/api/method/frappe.integrations.oauth2.authorize",
+				{
+					"client_id": self.client_id,
+					"scope": self.scope,
+					"response_type": "code",
+					"redirect_uri": self.redirect_uri,
+				},
+				follow_redirects=True,
+			)
+		query = parse_qs(resp.request.environ["QUERY_STRING"])
+		auth_code = query.get("code")[0]
+
+		frappe.db.commit()  # nosemgrep
+
+		self.assertEqual(
+			frappe.db.get_value("OAuth Authorization Code", auth_code, "expiration_time"),
+			add_to_date(issued_at, seconds=AUTHORIZATION_CODE_EXPIRY_SECONDS, as_datetime=True),
+		)
+
+		# 20 minutes later: past the 10-minute expiry window.
+		with self.freeze_time(add_to_date(issued_at, minutes=20)):
+			token_response = self.post(
+				"/api/method/frappe.integrations.oauth2.get_token",
+				headers=self.form_header,
+				data={
+					"grant_type": "authorization_code",
+					"code": auth_code,
+					"redirect_uri": self.redirect_uri,
+					"client_id": self.client_id,
+					"client_secret": self.client_secret,
+					"scope": self.scope,
+				},
+			)
+
+		self.assertEqual(token_response.status_code, 400)
+		self.assertEqual(token_response.json.get("error"), "invalid_grant")
+		self.assertIsNone(token_response.json.get("access_token"))
+
+		# Refresh this thread's transaction snapshot again: the get_token request
+		# above ran (and committed the validity flip) on its own thread/connection.
+		frappe.db.commit()  # nosemgrep
+
+		# The expired code must also now be marked Invalid, so it can't be
+		# redeemed later even if a client retries after obtaining a fresh clock.
+		self.assertEqual(frappe.db.get_value("OAuth Authorization Code", auth_code, "validity"), "Invalid")
+
+	def test_authorization_code_rejects_mismatched_redirect_uri(self):
+		client = update_client_for_auth_code_grant(self.client_id)
+		other_redirect_uri = "http://localhost:8001"
+		# Register a second redirect_uri on the same client so both are valid
+		# for the client in general, but the code is only bound to one.
+		client.redirect_uris = get_url_delimiter().join([self.redirect_uri, other_redirect_uri])
+		client.save()
+		frappe.db.commit()  # nosemgrep
+
+		self.TEST_CLIENT.set_cookie(key="sid", value=self.sid)
+		resp = self.get(
+			"/api/method/frappe.integrations.oauth2.authorize",
+			{
+				"client_id": self.client_id,
+				"scope": self.scope,
+				"response_type": "code",
+				"redirect_uri": self.redirect_uri,
+			},
+			follow_redirects=True,
+		)
+		query = parse_qs(resp.request.environ["QUERY_STRING"])
+		auth_code = query.get("code")[0]
+
+		# Redeeming with a *different but still client-registered* redirect_uri
+		# must fail: the code is bound to the exact URI it was issued for.
+		mismatched_response = self.post(
+			"/api/method/frappe.integrations.oauth2.get_token",
+			headers=self.form_header,
+			data={
+				"grant_type": "authorization_code",
+				"code": auth_code,
+				"redirect_uri": other_redirect_uri,
+				"client_id": self.client_id,
+				"client_secret": self.client_secret,
+				"scope": self.scope,
+			},
+		)
+		self.assertEqual(mismatched_response.status_code, 400)
+		self.assertIsNone(mismatched_response.json.get("access_token"))
+
+		# Redeeming with the exact issuing redirect_uri still works.
+		correct_response = self.post(
+			"/api/method/frappe.integrations.oauth2.get_token",
+			headers=self.form_header,
+			data={
+				"grant_type": "authorization_code",
+				"code": auth_code,
+				"redirect_uri": self.redirect_uri,
+				"client_id": self.client_id,
+				"client_secret": self.client_secret,
+				"scope": self.scope,
+			},
+		)
+		self.assertTrue(correct_response.json.get("access_token"))
 
 	def test_revoke_token(self):
 		client = frappe.get_doc("OAuth Client", self.client_id)


### PR DESCRIPTION
Expire authorization codes and bind them to their redirect_uri.

> Authorization codes MUST be short lived and single-use.

Ref:
1. https://www.rfc-editor.org/info/rfc6749/#section-4.1.2
2. https://www.rfc-editor.org/info/rfc6749/#section-4.1.3
3. https://www.rfc-editor.org/info/rfc6749/#section-10.5

closes Ticket 77534