### PR TITLE
feat(desk-v2): draw the record page's header row from page.header

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,8 +56,11 @@ field's design belongs in its ticket.
 
 ## Before you close a ticket
 
-Run `/quality-code-review`, and read your diff against the comment rule above. For a
-change that is comments only, `.github/helper/comment_equivalence.py` proves it: it strips
+Run `/quality-code-review` **in a fresh subagent**, never in the session that wrote the
+diff. Give it only the diff range, the checklist, this file, the layer's `CLAUDE.md`, and
+the ticket's question with the rulings it must not re-open; not the session's reasoning.
+Answer every finding, and close one that contradicts a ruling with the ruling. Then read
+your diff against the comment rule above. For a change that is comments only, `.github/helper/comment_equivalence.py` proves it: it strips
 comments from both revisions and asserts the remaining code is identical.
 
 ```bash

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -38,7 +38,7 @@ yarn --cwd frontend test:run
 That is exactly what CI does (`.github/workflows/frontend-tests.yml`). The **base** file
 is the correct input, not a `bench build`-generated one: `yarn.lock` was resolved from
 `package.base.json` alone, and no test needs anything an app contributes. Baseline is
-**28 files / 481 tests**, under `recordPage/tests/`, `shell/tests/` and
+**29 files / 487 tests**, under `recordPage/tests/`, `shell/tests/` and
 `navigation/tests/`.
 
 **`vitest.config.js` runs with `css: { postcss: {} }`, and that is not cosmetic.**

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -38,7 +38,7 @@ yarn --cwd frontend test:run
 That is exactly what CI does (`.github/workflows/frontend-tests.yml`). The **base** file
 is the correct input, not a `bench build`-generated one: `yarn.lock` was resolved from
 `package.base.json` alone, and no test needs anything an app contributes. Baseline is
-**28 files / 473 tests**, under `recordPage/tests/`, `shell/tests/` and
+**28 files / 481 tests**, under `recordPage/tests/`, `shell/tests/` and
 `navigation/tests/`.
 
 **`vitest.config.js` runs with `css: { postcss: {} }`, and that is not cosmetic.**

--- a/frontend/COMPATIBILITY.md
+++ b/frontend/COMPATIBILITY.md
@@ -11,6 +11,9 @@ different risk:
   `view = Record`. Nobody rebuilds them. They survive every upgrade, on sites with no
   developer watching. The audience that pays for a break.
 
+What `page` offers, verb by verb and region by region, is in [`SCRIPTING.md`](./SCRIPTING.md);
+this document says what of it survives an upgrade.
+
 ## Start with the version reality
 
 The engine lives in `frontend/src/recordPage/` on the `desk-v2` branch, which is not yet
@@ -26,7 +29,7 @@ in that voice.
 
 What `page` is _for_ is a small, closed vocabulary:
 
-- **Four surfaces** — `quickActions`, `headerActions`, `tabs`, `panelSections` — each
+- **Four surfaces** — `quickActions`, `header`, `tabs`, `panelSections` — each
   speaking the same **seven verbs**: `add`, `hide`, `show`, `update`, `move`, `has`,
   `order`.
 - **Two more, `fields` and `formTabs`**, speaking a strict subset of them — `hide`,
@@ -77,10 +80,20 @@ What `page` is _for_ is a small, closed vocabulary:
   `onFormTabChange` fire on any cause; `activate` is the first verb that lets a handler
   cause the event it is handling, so activating from inside one is yours to make
   terminate.
-- **The header's renderings come from one flat list.** A `headerActions` item carries
-  `display`: `'button'` gives it a top-level button of its own, `'dropdown'` gives it a
-  top-level dropdown button of its own, `'section'` gives it a titled band, and omitting it
-  — the default — leaves it an ordinary entry in the shared `⋯`.
+- **The whole header row is one flat list.** A `header` item carries `zone`: `'left'`
+  puts it among the crumbs, and omitting it — the default — puts it on the right, with
+  the controls and `⋯`. The crumbs and `Save` are ordinary built-in items on that list,
+  named `doctype`, `record` and `save`, so `update('record', { label })` renames the
+  title crumb and `hide('save')` removes the button, as desk v1's `disable_save` does.
+  An item's place within its zone is its place in the one list; `zone` is a patchable
+  key like any other, so `update('favourite', { zone: 'right' })` relocates an item.
+
+  A `header` item also carries `display`. On the right, `'button'` gives it a top-level
+  button of its own, `'dropdown'` gives it a top-level dropdown button of its own,
+  `'section'` gives it a titled band, and omitting it leaves it an ordinary entry in the
+  shared `⋯`. On the left, `'crumb'` draws it as a breadcrumb — linking to `href` when
+  one is given, running `run` when that is — and omitting it gives a button, since the
+  left has no menu to default into. `zone` and `display` are orthogonal.
 
   A `dropdown` and a `section` are **containers**: ordinary, addressable items that carry
   the label and the icon, differing only in when their members are visible — a dropdown
@@ -95,8 +108,8 @@ What `page` is _for_ is a small, closed vocabulary:
   container is declared**, and a script that never declared one never grows headings.
 
   ```js
-  page.headerActions.add({ name: 'refresh_quote', label: 'Refresh Quote', display: 'button' })
-  page.headerActions.add([
+  page.header.add({ name: 'refresh_quote', label: 'Refresh Quote', display: 'button' })
+  page.header.add([
     { name: 'telephony', label: 'Telephony', display: 'dropdown' },
     { name: 'call', label: 'Call customer', group: 'telephony' },
     { name: 'danger', label: 'Danger', display: 'section', group: 'telephony' },
@@ -123,7 +136,8 @@ What `page` is _for_ is a small, closed vocabulary:
   **Position orders items only within one rendering.** An anchor naming an item that
   renders somewhere else still splices exactly where it always did — and warns in a
   development build, because the author asked for "after Refresh Quote" and the reader got
-  "below Delete".
+  "below Delete". The left zone is a rendering of its own, so an anchor across the two
+  zones warns the same way.
 - **How many top-level controls fit is the host's business, and a script cannot observe
   it.** An item that does not fit is **demoted into `⋯`**, keeping its own band ahead of
   the built-ins and in the order it asked for; a dropdown collapses whole, under its label.
@@ -137,9 +151,10 @@ What `page` is _for_ is a small, closed vocabulary:
   priority knob and there is no `priority` key. A promoted built-in
   (`update('delete', { display: 'button' })` is allowed, like any other update) is ordered
   and demoted by that same rule, with no exception for where it came from.
-- **`Save` is not on this surface and never will be.** It is not an item on
-  `headerActions`, so it cannot be hidden, relabelled, reordered or demoted, and
-  `hide('save')` reaches nothing. It is the one control the reader must always find.
+- **`Save` is an item like any other, and the last built-in on the list.** A new item
+  with no anchor appends after it; `add(item, { before: 'save' })` is how a button sits
+  to its left. It is ordered and demoted by the fitting rule with no exception, and the
+  host alone decides that it is disabled while nothing has changed.
 - **A closed event list** — `onRefresh`, `beforeSave`, `afterSave`, `onTabChange`,
   `onFormTabChange`, `<fieldname>`, and a child table's own family, written **nested under
   the table's fieldname**: a handler per child field, plus `onAdd` and `onRemove`.

--- a/frontend/CONTEXT.md
+++ b/frontend/CONTEXT.md
@@ -167,7 +167,7 @@ _Avoid_: form, frm, context.
 **Surface**:
 One customizable **region** of a Record page, whose verbs *record ops*; the rendered list
 is those ops replayed over the host's built-ins. Four are true surfaces —
-`quickActions`, `headerActions`, `tabs`, `panelSections` — sharing the verb set `add`,
+`quickActions`, `header`, `tabs`, `panelSections` — sharing the verb set `add`,
 `hide`, `show`, `update`, `move`, `has`, `order`. Two more, `fields` and `formTabs`, are
 counted as surfaces and stage with them but are **not** `Surface`s: they override
 properties rather than arrange items, and speak a strict subset with no `add`, `move` or
@@ -278,11 +278,10 @@ reach for the unambiguous alternative.
 - **`prefix`** and **`claim`** — a URL prefix an app claims, versus a dotted-path prefix in
   the compatibility guard, versus a header item's recorded anchor claim.
 
-**One live inconsistency, not a collision:** the header surface is `page.headerActions` in
-code, while "header" unqualified names the *rendered* region (`HeaderControl`, `HeaderBand`,
-`HeaderProjection`). A decision to rename the surface to **`page.header`** and its item type
-to `HeaderItem`, adding a `zone: 'left' | 'right'` key, is settled but **not implemented**
-— see frappe/frappe#42271. Until it lands, write `headerActions` for the surface.
+**Header**: both the surface, `page.header`, and the rendered row it projects to
+(`HeaderControl`, `HeaderBand`, `HeaderProjection`). One flat list of `HeaderItem`s in two
+**zones**, `left` and `right`; the crumbs, `Save` and every control are items on it.
+_Avoid_: headerActions (the surface's old name), toolbar.
 
 ## Example dialogue
 

--- a/frontend/PHILOSOPHY.md
+++ b/frontend/PHILOSOPHY.md
@@ -38,6 +38,8 @@ exist to prevent. This doc adds only the `DP*` principles specific to the desk l
 - **`CONTEXT.md`** is the *vocabulary* — what a **Record page**, a **contribution**, a
   **surface**, a **Client Script** mean. PHILOSOPHY is the *rules* that use the vocabulary.
   Not yet written.
+- **`SCRIPTING.md`** is the *reference* — what `page` offers a Client Script, region by
+  region, with the script each region's design was judged by as its worked example.
 - **`COMPATIBILITY.md`** is the *promise* — what a script author can rely on across an
   upgrade of the host: which `page` verbs and events are meant to outlive the
   implementation, which are not, and how a removal announces itself.

--- a/frontend/SCRIPTING.md
+++ b/frontend/SCRIPTING.md
@@ -92,14 +92,20 @@ And a fuller one, touching both zones:
 ```js
 export default {
   onRefresh(page) {
-    // A parent crumb before the record's, linking to the organization
+    // A crumb before the record's, linking to the deals of the same organization.
+    // Resolve paths through the router: a hand-built one is wrong under a modular prefix.
+    const { name, params } = page.router.currentRoute.value
     page.header.add(
       {
         name: 'organization',
         label: page.doc.organization,
         zone: 'left',
         display: 'crumb',
-        href: `/crm-organization/${page.doc.organization}`,
+        href: page.router.resolve({
+          name: 'list',
+          params,
+          query: { organization: page.doc.organization },
+        }).path,
       },
       { before: 'record' },
     )

--- a/frontend/SCRIPTING.md
+++ b/frontend/SCRIPTING.md
@@ -1,0 +1,117 @@
+# Writing a Client Script for the record page
+
+What `page` offers a script, region by region, with the script each region's design was
+judged by as its worked example. [`COMPATIBILITY.md`](./COMPATIBILITY.md) says which of
+this survives an upgrade; this document says what there is.
+
+One section per region of the page. A region's section lands with the region, so a
+region not listed here is not yet addressable.
+
+## Where a script runs
+
+A record-page script is a `Client Script` row with `view = Record` and `dt` set to the
+doctype. Its body is an ES module whose default export is an object of handlers, keyed by
+event (`onRefresh`, `beforeSave`, `afterSave`, `onTabChange`, `onFormTabChange`) or by a
+fieldname. Every handler receives `page`.
+
+`onRefresh` is a **replay**: the surfaces are cleared and rebuilt from the host's
+built-ins on every pass, so a conditional customization is a plain `if` over `page.doc`,
+with no `else` to undo it. Scripts run in `run_order`, and on one name the last to write
+wins.
+
+```js
+export default {
+  onRefresh(page) {
+    if (page.doc.status === 'Won') page.header.hide('save')
+  },
+}
+```
+
+## The header row: `page.header`
+
+The row is **one flat list** of items, drawn in **two zones**. Every crumb, button, menu
+entry and `Save` is an item on it, so every one of them has a name a script can reach.
+
+The surface speaks the seven verbs: `add`, `hide`, `show`, `update`, `move`, `has`,
+`order`. `add` takes one item or an array, and a `position` of `{ before }` or
+`{ after }` naming another item; an anchor that names nothing appends.
+
+### An item
+
+| Key | What it does |
+| --- | --- |
+| `name` | The address every verb uses. One namespace for the whole row. |
+| `label` | The text drawn. |
+| `zone` | `'left'` or `'right'`. Omitted means `'right'`. |
+| `display` | On the right: `'button'`, `'dropdown'`, `'section'`, or omitted for an entry in `⋯`. On the left: `'crumb'`, `'dropdown'`, or omitted for a button. |
+| `href` | A path inside this app's prefix; a crumb with one is a link. |
+| `run` | `(page) => any`. A crumb or button with one runs it; `run` wins over `href`. |
+| `group` | The container this sits in. A member sits in its container's zone. |
+| `icon` | A lucide name. |
+
+`zone` and `display` are orthogonal: a favourite star is `{ zone: 'left', display: 'button' }`.
+A `section` on the left has no menu to title a band in, so its members render in its
+place. A `crumb` on the right draws nowhere, so it lands in `⋯`. Both warn in a
+development build.
+
+### The built-ins
+
+The generated page seeds three items, in this order:
+
+| Name | Zone | What it is |
+| --- | --- | --- |
+| `doctype` | left | The doctype's crumb; links to the list. |
+| `record` | left | The record's crumb: its title field, or its name. |
+| `save` | right | The Save button. Disabled by the host while nothing has changed. |
+
+`Save` is an ordinary item. `hide('save')` removes it, as desk v1's `frm.disable_save()`
+does. A new item with no anchor lands **after** `Save`; to sit to its left, anchor it:
+`page.header.add(item, { before: 'save' })`.
+
+### Fitting
+
+The host decides how many top-level controls the right zone keeps, and a script cannot
+observe it. The generated page keeps three. Beyond that, the last control in list order
+demotes into `⋯` first, so `order()` and `move()` are the priority knob. The left zone
+has no menu and nothing in it is demoted.
+
+### The script this design was judged by
+
+The first act of the map's proof walk: rename the record crumb on a real record.
+
+```js
+export default {
+  onRefresh(page) {
+    page.header.update('record', { label: `${page.doc.name} (reviewed)` })
+  },
+}
+```
+
+And a fuller one, touching both zones:
+
+```js
+export default {
+  onRefresh(page) {
+    // A parent crumb before the record's, linking to the organization
+    page.header.add(
+      {
+        name: 'organization',
+        label: page.doc.organization,
+        zone: 'left',
+        display: 'crumb',
+        href: `/crm-organization/${page.doc.organization}`,
+      },
+      { before: 'record' },
+    )
+
+    // A button to the left of Save, and an entry in ⋯
+    page.header.add(
+      { name: 'snapshot', label: 'Snapshot', display: 'button', run: (p) => p.toast.success('Saved a snapshot') },
+      { before: 'save' },
+    )
+    page.header.add({ name: 'copy_ref', label: 'Copy reference', run: (p) => p.toast.success(p.docname) })
+
+    if (page.doc.status === 'Won') page.header.hide('save')
+  },
+}
+```

--- a/frontend/src/pages/Record.vue
+++ b/frontend/src/pages/Record.vue
@@ -196,13 +196,13 @@ async function load() {
 // One request at a time: a `page.save()` that lands mid-flight awaits the one in flight.
 let inFlight: Promise<void> | null = null;
 
-function save() {
+async function save() {
 	// Refuse to write the wrong record if the route moved while an action ran.
 	if (doc.value.name !== docname.value || doctype.value === null) {
 		throw new Error("The record changed while saving; nothing was written.");
 	}
 	if (!inFlight) inFlight = write().finally(() => (inFlight = null));
-	return inFlight;
+	await inFlight;
 }
 
 async function write() {

--- a/frontend/src/pages/Record.vue
+++ b/frontend/src/pages/Record.vue
@@ -1,6 +1,6 @@
 <!--
-  The generated record page every app gets at /apps/<prefix>/<slug>/<name>: a minimal host for
-  the record-page engine, with no form layout, tabs or panel.
+  The generated record page every app gets at /apps/<prefix>/<slug>/<name>: a host for the
+  record-page engine with a real header row, and no form layout, tabs or panel yet.
 -->
 <template>
 	<div class="overflow-y-auto p-8">
@@ -9,20 +9,27 @@
 		</p>
 
 		<template v-else>
-			<header class="flex items-center gap-3">
+			<RecordHeader
+				v-if="controller"
+				:projection="header"
+				:dirty="dirty"
+				:saving="saving"
+				@run="runAction"
+			/>
+			<header v-else class="flex items-center gap-3">
 				<h1 class="text-lg font-semibold">{{ route.params.name }}</h1>
 				<span class="text-sm text-ink-gray-5">{{ doctype }}</span>
-
-				<!-- Contributed quick actions, in the run order the registry decided. -->
-				<div class="ml-auto flex gap-2">
-					<Button
-						v-for="action in quickActions"
-						:key="action.name"
-						:label="action.label"
-						@click="runAction(action)"
-					/>
-				</div>
 			</header>
+
+			<!-- Contributed quick actions, in the run order the registry decided. -->
+			<div v-if="quickActions.length" class="mt-4 flex gap-2">
+				<Button
+					v-for="action in quickActions"
+					:key="action.name"
+					:label="action.label"
+					@click="runAction(action)"
+				/>
+			</div>
 
 			<p v-if="actionError" class="mt-4 text-sm text-ink-red-4">{{ actionError }}</p>
 			<p v-if="error" class="mt-4 text-sm text-ink-red-4">{{ error }}</p>
@@ -41,7 +48,15 @@
 import { computed, inject, ref, shallowRef, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { Button } from "frappe-ui";
-import { createRecordPage, type RecordPageController } from "@/recordPage";
+import {
+	createRecordPage,
+	loadClientScripts,
+	projectHeader,
+	type HeaderItem,
+	type RecordPageController,
+} from "@/recordPage";
+import { routeFor } from "@/router/routeFor";
+import RecordHeader from "./record/RecordHeader.vue";
 import type { Boot } from "@/boot";
 import type { Addresses } from "@/addresses";
 
@@ -58,6 +73,10 @@ const error = ref("");
 const actionError = ref("");
 const controller = shallowRef<RecordPageController | null>(null);
 const actionsVersion = ref(0);
+const saving = ref(false);
+
+// The right zone keeps this many top-level controls; the rest demote into `⋯`.
+const HEADER_BUDGET = 3;
 
 // The slower of two in-flight loads must not win: `save()` would then POST the wrong record.
 let generation = 0;
@@ -75,6 +94,40 @@ const quickActions = computed(() => {
 	actionsVersion.value; // re-read after each replay
 	return controller.value?.quickActions.visible() ?? [];
 });
+
+const dirty = computed(() => JSON.stringify(doc.value) !== JSON.stringify(saved.value));
+
+const header = computed(() => {
+	actionsVersion.value;
+	const resolved = controller.value?.header.resolve() ?? [];
+	return projectHeader(resolved, HEADER_BUDGET);
+});
+
+// The row's built-ins, re-read on every resolve so the title crumb tracks the draft.
+function headerBuiltins(): HeaderItem[] {
+	const title = doc.value[meta.value?.title_field] || docname.value;
+	return [
+		{
+			name: "doctype",
+			label: doctype.value ?? "",
+			zone: "left",
+			display: "crumb",
+			href: router.resolve(routeFor(doctype.value!)).path,
+		},
+		{ name: "record", label: String(title), zone: "left", display: "crumb" },
+		{ name: "save", label: "Save", display: "button", run: saveFromHeader },
+	];
+}
+
+// Not through `runAction`: a failed save must keep the draft on screen, not reload over it.
+async function saveFromHeader() {
+	actionError.value = "";
+	try {
+		await save();
+	} catch (e) {
+		actionError.value = String((e as Error)?.message ?? e);
+	}
+}
 
 async function call(method: string, params: Record<string, string>) {
 	const res = await fetch(`/api/method/${method}?${new URLSearchParams(params)}`);
@@ -113,23 +166,26 @@ async function load() {
 		return;
 	}
 
-	controller.value = createRecordPage({
+	const created = createRecordPage({
 		doctype: target.doctype,
 		docname: target.name,
 		doc,
 		saved,
 		meta,
 		perms: () => ({}),
-		isDirty: () => JSON.stringify(doc.value) !== JSON.stringify(saved.value),
+		isDirty: () => dirty.value,
 		// No tab strip on this page, so activation is a no-op.
 		activeTab: () => "",
 		activateTab: () => {},
 		save,
 		reload: load,
 		router,
+		sourcesReady: () => loadClientScripts(target.doctype),
 	});
+	created.header.provideBuiltins(headerBuiltins);
+	controller.value = created;
 
-	await controller.value.refresh();
+	await created.refresh();
 	if (mine !== generation) return;
 	// A reload triggered by a failed action must not wipe the message explaining it.
 	actionError.value = carriedActionError;
@@ -143,27 +199,35 @@ async function save() {
 	}
 
 	const mine = generation;
-	const res = await fetch("/api/method/frappe.client.save", {
-		method: "POST",
-		headers: { "Content-Type": "application/json", "X-Frappe-CSRF-Token": boot.csrf_token },
-		body: JSON.stringify({ doc: { ...doc.value, doctype: doctype.value } }),
-	});
-	if (!res.ok) throw new Error(`Save failed with ${res.status}`);
+	saving.value = true;
+	try {
+		const res = await fetch("/api/method/frappe.client.save", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"X-Frappe-CSRF-Token": boot.csrf_token,
+			},
+			body: JSON.stringify({ doc: { ...doc.value, doctype: doctype.value } }),
+		});
+		if (!res.ok) throw new Error(`Save failed with ${res.status}`);
 
-	const document = (await res.json()).message;
-	if (mine !== generation) return;
-	saved.value = { ...document };
-	doc.value = JSON.parse(JSON.stringify(document));
+		const document = (await res.json()).message;
+		if (mine !== generation) return;
+		saved.value = { ...document };
+		doc.value = JSON.parse(JSON.stringify(document));
+	} finally {
+		saving.value = false;
+	}
 	await controller.value?.refresh();
 	actionsVersion.value++;
 }
 
-async function runAction(action: { run: (page: unknown) => unknown }) {
+async function runAction(action: { run?: (page: unknown) => unknown }) {
 	// Awaited and caught: a failing action would otherwise leave the draft mutated on screen
 	// with no error. Reloading discards the rejected draft.
 	actionError.value = "";
 	try {
-		await action.run(controller.value?.page);
+		await action.run?.(controller.value?.page);
 	} catch (e) {
 		actionError.value = String((e as Error)?.message ?? e);
 		await load();

--- a/frontend/src/pages/Record.vue
+++ b/frontend/src/pages/Record.vue
@@ -121,6 +121,7 @@ function headerBuiltins(): HeaderItem[] {
 
 // Not through `runAction`: a failed save must keep the draft on screen, not reload over it.
 async function saveFromHeader() {
+	if (!dirty.value) return;
 	actionError.value = "";
 	try {
 		await save();
@@ -198,6 +199,8 @@ async function save() {
 		throw new Error("The record changed while saving; nothing was written.");
 	}
 
+	// One request at a time: a script's `page.save()` can land while the button's is in flight.
+	if (saving.value) return;
 	const mine = generation;
 	saving.value = true;
 	try {

--- a/frontend/src/pages/Record.vue
+++ b/frontend/src/pages/Record.vue
@@ -193,14 +193,19 @@ async function load() {
 	actionsVersion.value++;
 }
 
-async function save() {
+// One request at a time: a `page.save()` that lands mid-flight awaits the one in flight.
+let inFlight: Promise<void> | null = null;
+
+function save() {
 	// Refuse to write the wrong record if the route moved while an action ran.
 	if (doc.value.name !== docname.value || doctype.value === null) {
 		throw new Error("The record changed while saving; nothing was written.");
 	}
+	if (!inFlight) inFlight = write().finally(() => (inFlight = null));
+	return inFlight;
+}
 
-	// One request at a time: a script's `page.save()` can land while the button's is in flight.
-	if (saving.value) return;
+async function write() {
 	const mine = generation;
 	saving.value = true;
 	try {

--- a/frontend/src/pages/record/RecordHeader.vue
+++ b/frontend/src/pages/record/RecordHeader.vue
@@ -1,0 +1,144 @@
+<!-- The record's header row, drawn from `page.header`: crumbs and buttons on the left, controls, `⋯` and Save on the right. -->
+<template>
+	<header class="flex items-center justify-between gap-3">
+		<nav class="flex min-w-0 items-center gap-1 text-base">
+			<template v-for="(control, index) in projection.left" :key="control.item.name">
+				<span
+					v-if="isCrumb(control) && isCrumb(projection.left[index - 1])"
+					class="text-ink-gray-4"
+				>
+					/
+				</span>
+
+				<RouterLink
+					v-if="isCrumb(control) && control.item.href && !control.item.run"
+					:to="control.item.href"
+					class="truncate text-ink-gray-5 hover:text-ink-gray-8"
+				>
+					{{ control.item.label }}
+				</RouterLink>
+				<button
+					v-else-if="isCrumb(control) && control.item.run"
+					type="button"
+					class="truncate text-ink-gray-5 hover:text-ink-gray-8"
+					@click="run(control.item)"
+				>
+					{{ control.item.label }}
+				</button>
+				<span v-else-if="isCrumb(control)" class="truncate font-medium text-ink-gray-9">
+					{{ control.item.label }}
+				</span>
+
+				<Dropdown
+					v-else-if="control.kind === 'dropdown'"
+					:options="menuContent(control.members, run)"
+					side="bottom"
+					align="start"
+				>
+					<div class="flex shrink-0">
+						<Button
+							:label="control.item.label"
+							:icon-left="control.item.icon"
+							icon-right="lucide-chevron-down"
+							variant="ghost"
+						/>
+					</div>
+				</Dropdown>
+
+				<Button
+					v-else
+					:label="control.item.label"
+					:icon-left="control.item.icon"
+					variant="ghost"
+					@click="run(control.item)"
+				/>
+			</template>
+		</nav>
+
+		<div class="flex shrink-0 items-center gap-2">
+			<template v-for="control in projection.controls" :key="control.item.name">
+				<Dropdown
+					v-if="control.kind === 'dropdown'"
+					:options="menuContent(control.members, run)"
+					side="bottom"
+					align="end"
+				>
+					<!-- The trigger must own a box: a display:contents wrapper anchors the menu at 0,0. -->
+					<div class="flex shrink-0">
+						<Button
+							:label="control.item.label"
+							:icon-left="control.item.icon"
+							icon-right="lucide-chevron-down"
+							variant="subtle"
+						/>
+					</div>
+				</Dropdown>
+
+				<Tooltip
+					v-else-if="control.item.name === 'save'"
+					text="No changes to save"
+					:disabled="dirty"
+				>
+					<!-- A disabled button fires no pointer events, so the wrapper owns the box the tooltip hovers on. -->
+					<div class="flex shrink-0">
+						<Button
+							:label="control.item.label"
+							:icon-left="control.item.icon"
+							variant="solid"
+							:disabled="!dirty"
+							:loading="saving"
+							@click="run(control.item)"
+						/>
+					</div>
+				</Tooltip>
+
+				<Button
+					v-else
+					:label="control.item.label"
+					:icon-left="control.item.icon"
+					variant="subtle"
+					@click="run(control.item)"
+				/>
+			</template>
+
+			<Dropdown v-if="projection.bands.length" :options="bands" side="bottom" align="end">
+				<div class="flex shrink-0">
+					<Button icon="lucide-more-horizontal" variant="subtle" label="More actions" />
+				</div>
+			</Dropdown>
+		</div>
+	</header>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { RouterLink } from "vue-router";
+import { Button, Dropdown, Tooltip } from "frappe-ui";
+import type { HeaderControl, HeaderItem, HeaderProjection } from "@/recordPage";
+import { bandRows, menuContent } from "./headerMenuOptions";
+
+const props = defineProps<{
+	projection: HeaderProjection;
+	dirty: boolean;
+	saving: boolean;
+}>();
+
+const emit = defineEmits<{ run: [item: HeaderItem] }>();
+
+// Bands are `MenuGroupOption`s, and a band shows a heading only when its container was declared.
+const bands = computed(() =>
+	props.projection.bands.map((band) => ({
+		group: band.label ?? band.group,
+		hideLabel: !band.label,
+		options: bandRows(band.items, run),
+	}))
+);
+
+function isCrumb(control?: HeaderControl) {
+	return control?.kind === "crumb";
+}
+
+function run(item: HeaderItem) {
+	emit("run", item);
+}
+</script>

--- a/frontend/src/pages/record/RecordHeader.vue
+++ b/frontend/src/pages/record/RecordHeader.vue
@@ -1,4 +1,4 @@
-<!-- The record's header row, drawn from `page.header`: crumbs and buttons on the left, controls, `⋯` and Save on the right. -->
+<!-- The record's header row, drawn from `page.header`: crumbs left; controls, `⋯` and Save right. -->
 <template>
 	<header class="flex items-center justify-between gap-3">
 		<nav class="flex min-w-0 items-center gap-1 text-base">
@@ -112,7 +112,7 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import { RouterLink } from "vue-router";
+import { RouterLink, useRouter } from "vue-router";
 import { Button, Dropdown, Tooltip } from "frappe-ui";
 import type { HeaderControl, HeaderItem, HeaderProjection } from "@/recordPage";
 import { bandRows, menuContent } from "./headerMenuOptions";
@@ -124,6 +124,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{ run: [item: HeaderItem] }>();
+const router = useRouter();
 
 // Bands are `MenuGroupOption`s, and a band shows a heading only when its container was declared.
 const bands = computed(() =>
@@ -138,7 +139,12 @@ function isCrumb(control?: HeaderControl) {
 	return control?.kind === "crumb";
 }
 
+// `run` wins over `href`; an item with only an `href` is a link wherever it renders.
 function run(item: HeaderItem) {
+	if (!item.run && item.href) {
+		router.push(item.href);
+		return;
+	}
 	emit("run", item);
 }
 </script>

--- a/frontend/src/pages/record/headerMenuOptions.ts
+++ b/frontend/src/pages/record/headerMenuOptions.ts
@@ -26,6 +26,9 @@ function row(node: HeaderNode, run: Run) {
       icon: node.item.icon,
       submenu: menuContent(node.members, run),
     };
+  // `run` wins over `href`, as the item type promises.
+  if (!node.item.run && node.item.href)
+    return { label: node.item.label, icon: node.item.icon, route: node.item.href };
   return {
     label: node.item.label,
     icon: node.item.icon,

--- a/frontend/src/pages/record/headerMenuOptions.ts
+++ b/frontend/src/pages/record/headerMenuOptions.ts
@@ -1,0 +1,34 @@
+// The header's projected rows, spelled in frappe-ui's `Menu` vocabulary.
+import type { HeaderItem, HeaderNode } from "@/recordPage";
+
+type Run = (item: HeaderItem) => void;
+
+/** Rows for a list that may hold groups: a dropdown's content, or the `⋯` menu's bands. */
+export function menuContent(nodes: HeaderNode[], run: Run): any[] {
+  return nodes.map((node) => {
+    // `MenuGroupOption` has no icon slot, so a section's icon renders nowhere.
+    if (node.container === "section")
+      return { group: node.item.label, options: bandRows(node.members, run) };
+    return row(node, run);
+  });
+}
+
+/** Rows for the inside of a band, which may not hold groups; the engine flattened them. */
+export function bandRows(nodes: HeaderNode[], run: Run): any[] {
+  return nodes.map((node) => row(node, run));
+}
+
+function row(node: HeaderNode, run: Run) {
+  // A submenu trigger can never also be an action, which is why a container's `run` warns.
+  if (node.container === "dropdown")
+    return {
+      label: node.item.label,
+      icon: node.item.icon,
+      submenu: menuContent(node.members, run),
+    };
+  return {
+    label: node.item.label,
+    icon: node.item.icon,
+    onClick: () => run(node.item),
+  };
+}

--- a/frontend/src/pages/record/tests/headerMenuOptions.test.ts
+++ b/frontend/src/pages/record/tests/headerMenuOptions.test.ts
@@ -1,0 +1,49 @@
+// The projected rows in frappe-ui's Menu vocabulary: what runs, what links, what nests.
+import { describe, expect, it, vi } from "vitest";
+import type { HeaderItem, HeaderNode } from "@/recordPage";
+import { bandRows, menuContent } from "../headerMenuOptions";
+
+function node(item: Partial<HeaderItem> & { name: string }, members: HeaderNode[] = []): HeaderNode {
+  const container = item.display === "dropdown" || item.display === "section" ? item.display : undefined;
+  return { item: { label: item.name, ...item }, container, members };
+}
+
+describe("menuContent", () => {
+  it("gives a plain item an onClick that runs it", () => {
+    const run = vi.fn();
+    const item = node({ name: "copy_ref", run: () => {} });
+    const [row] = menuContent([item], run);
+    row.onClick();
+    expect(run).toHaveBeenCalledWith(item.item);
+    expect(row.route).toBeUndefined();
+  });
+
+  it("gives an item with only an href a route, and no onClick", () => {
+    const [row] = menuContent([node({ name: "parent", href: "/crm-organization" })], vi.fn());
+    expect(row).toEqual({ label: "parent", icon: undefined, route: "/crm-organization" });
+  });
+
+  it("lets run win over href", () => {
+    const [row] = menuContent([node({ name: "both", href: "/x", run: () => {} })], vi.fn());
+    expect(row.route).toBeUndefined();
+    expect(row.onClick).toBeTypeOf("function");
+  });
+
+  it("renders a section as a group and a dropdown as a submenu", () => {
+    const rows = menuContent(
+      [
+        node({ name: "danger", label: "Danger", display: "section" }, [node({ name: "wipe" })]),
+        node({ name: "tools", label: "Tools", display: "dropdown" }, [node({ name: "audit" })]),
+      ],
+      vi.fn()
+    );
+    expect(rows[0]).toMatchObject({ group: "Danger", options: [{ label: "wipe" }] });
+    expect(rows[1]).toMatchObject({ label: "Tools", submenu: [{ label: "audit" }] });
+  });
+
+  it("bandRows never nests a group", () => {
+    const rows = bandRows([node({ name: "one" }), node({ name: "two", href: "/two" })], vi.fn());
+    expect(rows.map((row) => row.group)).toEqual([undefined, undefined]);
+    expect(rows[1].route).toBe("/two");
+  });
+});

--- a/frontend/src/recordPage/createRecordPage.ts
+++ b/frontend/src/recordPage/createRecordPage.ts
@@ -14,7 +14,7 @@ import { holdsChildRows } from "@framework/ui/components/Fields/rowIdentity";
 import type { RowAddress } from "@framework/ui/components/Fields/types";
 import { FieldsSurface, LAYOUT_BREAKS } from "./fields";
 import { FormTabsSurface } from "./formTabs";
-import { HeaderActionsSurface } from "./headerRenderings";
+import { HeaderSurface } from "./headerRenderings";
 import { ROW_EVENTS } from "./flattenHandlers";
 import { withRemovals } from "./pageCompatibility";
 import { createPagePermissions } from "./pagePermissions";
@@ -106,7 +106,7 @@ export interface RecordPageHost {
 export interface RecordPageController {
   page: RecordPageApi;
   quickActions: Surface<QuickAction>;
-  headerActions: HeaderActionsSurface;
+  header: HeaderSurface;
   tabs: Surface<TabItem>;
   panelSections: Surface<PanelSectionItem>;
   /** Field property overrides; the host feeds `resolve()` to its layout source. */
@@ -129,7 +129,7 @@ export interface RecordPageController {
 
 export function createRecordPage(host: RecordPageHost): RecordPageController {
   const quickActions = new Surface<QuickAction>();
-  const headerActions = new HeaderActionsSurface();
+  const header = new HeaderSurface();
   const tabs = new Surface<TabItem>();
   const panelSections = new Surface<PanelSectionItem>();
   const permissions = createPagePermissions(host);
@@ -152,7 +152,7 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
   // Every overlay a replay stages; `fields` and `formTabs` are not `Surface`s but stage here.
   const surfaces: { beginReplay: () => void; commitReplay: () => void }[] = [
     quickActions,
-    headerActions,
+    header,
     tabs,
     panelSections,
     fields,
@@ -208,7 +208,7 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
       return host.isDirty();
     },
     quickActions,
-    headerActions,
+    header,
     tabs: tabs as unknown as TabsApi,
     panelSections,
     fields,
@@ -415,7 +415,7 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
   return {
     page,
     quickActions,
-    headerActions,
+    header,
     tabs,
     panelSections,
     fields,

--- a/frontend/src/recordPage/headerRenderings.ts
+++ b/frontend/src/recordPage/headerRenderings.ts
@@ -1,7 +1,7 @@
-// How the header's one flat list becomes its renderings, and what happens when
-// it asks for more top-level controls than fit.
+// How the header's one flat list becomes its two zones, and what happens when the
+// right zone asks for more top-level controls than fit.
 import { Surface, type ResolvedItem } from "./surface";
-import type { HeaderAction, Position } from "./types";
+import type { HeaderItem, HeaderZone, Position } from "./types";
 
 /** The displays that hold other items, as against `button` and the default. */
 export type ContainerDisplay = "dropdown" | "section";
@@ -14,7 +14,7 @@ export const MAX_CONTAINER_DEPTH = 2;
 
 /** One row of a rendered list: an action, or a container holding more rows. */
 export interface HeaderNode {
-  item: HeaderAction;
+  item: HeaderItem;
   /** Set when this row holds others; absent on a plain action row. */
   container?: ContainerDisplay;
   /** Set when this container could not render where declared; it is then a band of `⋯`, never a control. */
@@ -22,10 +22,11 @@ export interface HeaderNode {
   members: HeaderNode[];
 }
 
-/** A control the host draws in the header itself, left of `⋯ │ Save`. */
+/** A control the host draws in the row itself: a crumb, a button, or a dropdown. */
 export type HeaderControl =
-  | { kind: "button"; item: HeaderAction }
-  | { kind: "dropdown"; item: HeaderAction; members: HeaderNode[] };
+  | { kind: "crumb"; item: HeaderItem }
+  | { kind: "button"; item: HeaderItem }
+  | { kind: "dropdown"; item: HeaderItem; members: HeaderNode[] };
 
 /** One band of the `⋯` menu; it shows a heading iff its container was declared. */
 export interface HeaderBand {
@@ -35,54 +36,71 @@ export interface HeaderBand {
 }
 
 export interface HeaderProjection {
+  /** The left zone in order; it has no menu, so nothing in it is demoted. */
+  left: HeaderControl[];
   controls: HeaderControl[];
   bands: HeaderBand[];
 }
 
-/**
- * Projects the resolved items into the header's controls and the `⋯` menu's bands.
- * Takes the resolved list, not the visible one: a hidden container takes its members with it.
- */
-export function projectHeaderActions(
-  resolved: ResolvedItem<HeaderAction>[],
+/** An item's zone, with the default applied; a member sits wherever its container does. */
+export function zoneOf(item: HeaderItem): HeaderZone {
+  return item.zone === "left" ? "left" : "right";
+}
+
+/** Both zones from the resolved list, not the visible one: a hidden container takes its members with it. */
+export function projectHeader(
+  resolved: ResolvedItem<HeaderItem>[],
   budget: number
 ): HeaderProjection {
   if (import.meta.env.DEV) for (const entry of resolved) warnItem(entry.item);
   const items = surviving(resolved);
   const containers = containersOf(items);
   const tree = prune(build(items, containers));
+  const right = tree.filter((node) => zoneOf(node.item) === "right");
   // An empty dropdown is a button that opens nothing, so it is dropped before the budget applies.
-  const controls = tree
+  const controls = right
     .filter(isControl)
     .map(asControl)
     .filter((control) => control.kind === "button" || control.members.length);
   const kept = Math.max(budget, 0);
   return {
+    left: leftControls(tree.filter((node) => zoneOf(node.item) === "left")),
     controls: controls.slice(0, kept),
-    bands: [...demotedBands(controls.slice(kept)), ...menuBands(tree)],
+    bands: [...demotedBands(controls.slice(kept)), ...menuBands(right)],
   };
 }
 
-function containerDisplay(item: HeaderAction): ContainerDisplay | undefined {
+// A section has no band to title on the left, so its members render in its place.
+function leftControls(nodes: HeaderNode[]): HeaderControl[] {
+  return nodes.flatMap((node): HeaderControl[] => {
+    if (node.container === "section") return leftControls(node.members);
+    if (node.container === "dropdown")
+      return [{ kind: "dropdown", item: node.item, members: node.members }];
+    if (node.item.display === "crumb") return [{ kind: "crumb", item: node.item }];
+    return [{ kind: "button", item: node.item }];
+  });
+}
+
+function containerDisplay(item: HeaderItem): ContainerDisplay | undefined {
   if (item.display === "dropdown" || item.display === "section")
     return item.display;
   return undefined;
 }
 
-function containersOf(items: HeaderAction[]) {
-  const containers = new Map<string, HeaderAction>();
+function containersOf(items: HeaderItem[]) {
+  const containers = new Map<string, HeaderItem>();
   for (const item of items)
     if (containerDisplay(item)) containers.set(item.name, item);
   return containers;
 }
 
 /** The items a hidden container has not taken with it; a `group` naming a plain item is no floor. */
-function surviving(resolved: ResolvedItem<HeaderAction>[]): HeaderAction[] {
+function surviving(resolved: ResolvedItem<HeaderItem>[]): HeaderItem[] {
   const containers = containersOf(resolved.map((entry) => entry.item));
   const hidden = new Set(
     resolved.filter((entry) => entry.hidden).map((entry) => entry.item.name)
   );
-  const buried = (item: HeaderAction) => {
+  const buried = (item: HeaderItem) => {
     const seen = new Set<string>();
     let group = item.group;
     while (group && containers.has(group) && !seen.has(group)) {
@@ -101,7 +119,7 @@ function surviving(resolved: ResolvedItem<HeaderAction>[]): HeaderAction[] {
  * How many containers deep a container sits, counting itself. `Infinity` when
  * its `group` chain cycles, which has no depth at all.
  */
-function depthOf(name: string, containers: Map<string, HeaderAction>): number {
+function depthOf(name: string, containers: Map<string, HeaderItem>): number {
   const seen = new Set<string>([name]);
   let depth = 1;
   let group = containers.get(name)!.group;
@@ -119,8 +137,8 @@ function depthOf(name: string, containers: Map<string, HeaderAction>): number {
  * it can reach, never promoted to a control; a cycle lands in `⋯` as a band of its own.
  */
 function placeContainer(
-  item: HeaderAction,
-  containers: Map<string, HeaderAction>
+  item: HeaderItem,
+  containers: Map<string, HeaderItem>
 ) {
   const depth = depthOf(item.name, containers);
   if (depth <= MAX_CONTAINER_DEPTH) {
@@ -129,7 +147,7 @@ function placeContainer(
     if (group && containerDisplay(item) === "section")
       if (containers.get(group)!.display === "section")
         warnOnce(
-          `headerActions: the section '${item.name}' is inside the section ` +
+          `header: the section '${item.name}' is inside the section ` +
             `'${group}', which cannot hold a titled band — its members render ` +
             `under '${group}' and its own title is dropped.`
         );
@@ -145,14 +163,14 @@ function placeContainer(
 
 /** The container an item's `group` names, if one was declared. */
 function declaredGroup(
-  item: HeaderAction,
-  containers: Map<string, HeaderAction>
+  item: HeaderItem,
+  containers: Map<string, HeaderItem>
 ) {
   return item.group && containers.has(item.group) ? item.group : undefined;
 }
 
 /** `group: 'x'` puts an item inside the item named `x`; an undeclared `x` synthesises an anonymous container. */
-function build(items: HeaderAction[], containers: Map<string, HeaderAction>) {
+function build(items: HeaderItem[], containers: Map<string, HeaderItem>) {
   const nodes = new Map<string, HeaderNode>();
   const top: HeaderNode[] = [];
   const parents: (string | undefined)[] = [];
@@ -220,7 +238,7 @@ function demotedBands(controls: HeaderControl[]): HeaderBand[] {
   );
 }
 
-function row(item: HeaderAction): HeaderNode {
+function row(item: HeaderItem): HeaderNode {
   return { item, members: [] };
 }
 
@@ -259,10 +277,11 @@ function menuBands(top: HeaderNode[]): HeaderBand[] {
  * Which list an item is ordered within. Read off the declared `display`, never
  * the effective one, so nothing computed from it can become width-dependent.
  */
-export function renderingOf(item: HeaderAction, items: HeaderAction[]): string {
+export function renderingOf(item: HeaderItem, items: HeaderItem[]): string {
   const containers = containersOf(items);
   const group = declaredGroup(item, containers);
   if (group) return `container:${group}`;
+  if (zoneOf(item) === "left") return "left";
   if (item.display === "button" || item.display === "dropdown") return "row";
   return "menu";
 }
@@ -273,12 +292,12 @@ type AnchorClaim = { verb: string; name: string; anchor: string };
  * An ordinary `Surface` plus one warning: an anchor naming an item in a different
  * rendering. Checked over the resolved list, since a member can be added before its container.
  */
-export class HeaderActionsSurface extends Surface<HeaderAction> {
+export class HeaderSurface extends Surface<HeaderItem> {
   private claims: AnchorClaim[] = [];
   private said = new Set<string>();
 
   // One claim per block: a block splices as a unit, so only its head is anchored.
-  add(item: HeaderAction | HeaderAction[], position?: Position) {
+  add(item: HeaderItem | HeaderItem[], position?: Position) {
     const block = Array.isArray(item) ? item : [item];
     if (block.length) this.claim("add", block[0].name, position);
     super.add(item, position);
@@ -307,7 +326,7 @@ export class HeaderActionsSurface extends Surface<HeaderAction> {
     if (anchor) this.claims.push({ verb, name, anchor });
   }
 
-  private warnCrossRendering(items: HeaderAction[]) {
+  private warnCrossRendering(items: HeaderItem[]) {
     for (const claim of this.claims) {
       const item = items.find((one) => one.name === claim.name);
       const anchor = items.find((one) => one.name === claim.anchor);
@@ -317,7 +336,7 @@ export class HeaderActionsSurface extends Surface<HeaderAction> {
       if (renderingOf(item, items) === `container:${claim.anchor}`) continue;
       if (renderingOf(anchor, items) === `container:${claim.name}`) continue;
       const message =
-        `[record-page] headerActions.${claim.verb}('${claim.name}'): anchor ` +
+        `[record-page] header.${claim.verb}('${claim.name}'): anchor ` +
         `'${claim.anchor}' renders as ${describe(anchor, items)}, but ` +
         `'${claim.name}' renders as ${describe(
           item,
@@ -331,7 +350,7 @@ export class HeaderActionsSurface extends Surface<HeaderAction> {
   }
 }
 
-function describe(item: HeaderAction, items: HeaderAction[]) {
+function describe(item: HeaderItem, items: HeaderItem[]) {
   const containers = containersOf(items);
   const group = declaredGroup(item, containers);
   if (group) {
@@ -339,6 +358,7 @@ function describe(item: HeaderAction, items: HeaderAction[]) {
     const kind = container.display === "section" ? "section" : "dropdown";
     return `an entry in the “${container.label}” ${kind}`;
   }
+  if (zoneOf(item) === "left") return "an item in the left zone";
   if (item.display === "button") return "a top-level button";
   if (item.display === "dropdown") return `the “${item.label}” dropdown button`;
   return "an entry in the ⋯ menu";
@@ -358,35 +378,52 @@ export function resetHeaderWarnings(): void {
   warned.clear();
 }
 
-function warnClamp(item: HeaderAction, depth: number) {
+function warnClamp(item: HeaderItem, depth: number) {
   const where =
     depth === Infinity
       ? "sits in a `group` cycle, which reaches no level at all"
       : `nests ${depth} containers deep, and only ${MAX_CONTAINER_DEPTH} render`;
   warnOnce(
-    `headerActions: '${item.name}' ${where} — ` +
+    `header: '${item.name}' ${where} — ` +
       `rendered at the deepest level it can reach.`
   );
 }
 
 // Checked before anything is placed, hidden items included. `display` type-checks
 // anything (`SurfaceItem` has an index signature), so an unknown value is silently the default.
-function warnItem(item: HeaderAction) {
+function warnItem(item: HeaderItem) {
   const display = item.display;
-  if (display && !containerDisplay(item) && display !== "button")
+  // Read as a string: the index signature lets any value through the type.
+  const zone = item.zone as string | undefined;
+  if (display && !containerDisplay(item) && display !== "button" && display !== "crumb")
     warnOnce(
-      `headerActions: '${item.name}' has display: '${display}' — expected ` +
-        `'button', 'dropdown' or 'section'; rendered as an entry in the ⋯ menu.`
+      `header: '${item.name}' has display: '${display}' — expected 'button', ` +
+        `'dropdown', 'section' or 'crumb'; rendered as the zone's default.`
+    );
+  if (zone && zone !== "left" && zone !== "right")
+    warnOnce(
+      `header: '${item.name}' has zone: '${zone}' — expected 'left' or 'right'; ` +
+        `rendered on the right.`
+    );
+  if (display === "crumb" && zoneOf(item) === "right")
+    warnOnce(
+      `header: '${item.name}' is a crumb on the right, which draws no crumbs — ` +
+        `add zone: 'left'; rendered as an entry in the ⋯ menu.`
+    );
+  if (display === "section" && zoneOf(item) === "left")
+    warnOnce(
+      `header: '${item.name}' is a section on the left, which has no menu to ` +
+        `title a band in — its members render in its place.`
     );
   if (item.run && containerDisplay(item))
     warnOnce(
-      `headerActions: '${item.name}' is a ${display}, a container, so its ` +
+      `header: '${item.name}' is a ${display}, a container, so its ` +
         `\`run\` never fires; the items inside it run.`
     );
   // `group` decides where an item goes; `display` only what it looks like once there.
   if (display === "button" && item.group)
     warnOnce(
-      `headerActions: '${item.name}' is a button inside '${item.group}', and a ` +
+      `header: '${item.name}' is a button inside '${item.group}', and a ` +
         `container holds rows, not buttons — if it should stand on its own, drop its \`group\`.`
     );
 }

--- a/frontend/src/recordPage/index.ts
+++ b/frontend/src/recordPage/index.ts
@@ -17,6 +17,16 @@ export {
 } from "./context";
 
 export { createRecordPage } from "./createRecordPage";
+export { loadClientScripts, reloadClientScripts } from "./clientScripts";
 export type { RecordPageController } from "./createRecordPage";
 
 export type { AuthoredHandlers, Handler, RecordPageHandlers } from "./types";
+
+export { projectHeader, zoneOf } from "./headerRenderings";
+export type {
+  HeaderBand,
+  HeaderControl,
+  HeaderNode,
+  HeaderProjection,
+} from "./headerRenderings";
+export type { HeaderItem, RecordPageApi } from "./types";

--- a/frontend/src/recordPage/tests/headerRenderings.test.ts
+++ b/frontend/src/recordPage/tests/headerRenderings.test.ts
@@ -1,13 +1,14 @@
 // The three header renderings and the fitting rule as executable claims.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  HeaderActionsSurface,
-  projectHeaderActions,
+  HeaderSurface,
+  projectHeader,
   renderingOf,
   resetHeaderWarnings,
+  zoneOf,
   type HeaderNode,
 } from "../headerRenderings";
-import type { HeaderAction } from "../types";
+import type { HeaderItem } from "../types";
 
 const BUDGET = 2;
 
@@ -23,18 +24,18 @@ beforeEach(() => {
   resetHeaderWarnings();
 });
 
-function action(name: string, extra: Partial<HeaderAction> = {}): HeaderAction {
+function action(name: string, extra: Partial<HeaderItem> = {}): HeaderItem {
   return { name, label: name, ...extra };
 }
 
-const button = (name: string, extra: Partial<HeaderAction> = {}) =>
+const button = (name: string, extra: Partial<HeaderItem> = {}) =>
   action(name, { display: "button", ...extra });
 
-const dropdown = (name: string, extra: Partial<HeaderAction> = {}) =>
+const dropdown = (name: string, extra: Partial<HeaderItem> = {}) =>
   action(name, { display: "dropdown", ...extra });
 
 /** The surface's own shape: what `resolve()` hands the host. */
-function resolved(items: HeaderAction[], ...hidden: string[]) {
+function resolved(items: HeaderItem[], ...hidden: string[]) {
   return items.map((item) => ({
     item,
     source: "test",
@@ -42,17 +43,17 @@ function resolved(items: HeaderAction[], ...hidden: string[]) {
   }));
 }
 
-function project(items: HeaderAction[], budget = BUDGET) {
-  return projectHeaderActions(resolved(items), budget);
+function project(items: HeaderItem[], budget = BUDGET) {
+  return projectHeader(resolved(items), budget);
 }
 
-function controlNames(items: HeaderAction[], budget = BUDGET) {
+function controlNames(items: HeaderItem[], budget = BUDGET) {
   return project(items, budget).controls.map(
     (control) => `${control.kind}:${control.item.name}`
   );
 }
 
-function bandNames(items: HeaderAction[], budget = BUDGET) {
+function bandNames(items: HeaderItem[], budget = BUDGET) {
   return project(items, budget).bands.map(
     (band) => `${band.group}[${band.items.map(rendered).join(",")}]`
   );
@@ -220,7 +221,7 @@ describe("the fitting rule", () => {
       action("sms", { group: "telephony" }),
       action("copy_url"),
     ];
-    const projection = projectHeaderActions(
+    const projection = projectHeader(
       resolved(items, "telephony"),
       BUDGET
     );
@@ -245,7 +246,7 @@ describe("the fitting rule", () => {
 // A section is a container spelled the way a dropdown is, and a submenu is a
 // container inside a container; both fall out of one rule.
 describe("sections and submenus", () => {
-  const section = (name: string, extra: Partial<HeaderAction> = {}) =>
+  const section = (name: string, extra: Partial<HeaderItem> = {}) =>
     action(name, { display: "section", ...extra });
 
   it("titles a band with a top-level section, and charges it no budget", () => {
@@ -329,7 +330,7 @@ describe("sections and submenus", () => {
       action("delete", { group: "danger" }),
       action("copy_url"),
     ];
-    const projection = projectHeaderActions(resolved(items, "tools"), BUDGET);
+    const projection = projectHeader(resolved(items, "tools"), BUDGET);
     expect(projection.controls).toEqual([]);
     expect(projection.bands.map((band) => band.group)).toEqual(["actions"]);
   });
@@ -362,7 +363,7 @@ describe("sections and submenus", () => {
 
 // Clamped, never ignored: ignoring `group` would promote the container to a top-level control.
 describe("the depth cap", () => {
-  const section = (name: string, extra: Partial<HeaderAction> = {}) =>
+  const section = (name: string, extra: Partial<HeaderItem> = {}) =>
     action(name, { display: "section", ...extra });
 
   it("moves a third-level container up to the deepest level it can reach", () => {
@@ -439,7 +440,7 @@ describe("the depth cap", () => {
 // A block splices as a unit, the same shape `order(names[])` set.
 describe("add takes a block", () => {
   it("splices the block as a unit at the anchor, in list order", () => {
-    const built = new HeaderActionsSurface();
+    const built = new HeaderSurface();
     built.provideBuiltins(() => [action("copy_url"), action("delete")]);
     built.add(
       [
@@ -459,7 +460,7 @@ describe("add takes a block", () => {
   });
 
   it("appends the block when the anchor names nothing", () => {
-    const built = new HeaderActionsSurface();
+    const built = new HeaderSurface();
     built.provideBuiltins(() => [action("copy_url")]);
     built.add([action("a"), action("b")], { after: "nowhere" });
     expect(built.visible().map((item) => item.name)).toEqual([
@@ -472,7 +473,7 @@ describe("add takes a block", () => {
   // The block is spliced one item at a time, so an anchor naming an item the
   // same block adds must still leave the block contiguous and in order.
   it("stays contiguous when the anchor is inside the block", () => {
-    const built = new HeaderActionsSurface();
+    const built = new HeaderSurface();
     built.provideBuiltins(() => [action("copy_url"), action("delete")]);
     built.add([action("a"), action("b"), action("c")], { before: "b" });
     expect(built.visible().map((item) => item.name)).toEqual([
@@ -486,7 +487,7 @@ describe("add takes a block", () => {
 
   // The icon bridge and the raw-component guard run per item, or only the head of a block gets them.
   it("bridges every item's icon, not just the head's", () => {
-    const built = new HeaderActionsSurface();
+    const built = new HeaderSurface();
     built.provideBuiltins(() => []);
     built.add([
       action("a", { icon: "lucide-circle" }),
@@ -499,7 +500,7 @@ describe("add takes a block", () => {
   });
 
   it("does nothing with an empty block", () => {
-    const built = new HeaderActionsSurface();
+    const built = new HeaderSurface();
     built.provideBuiltins(() => [action("copy_url")]);
     built.add([]);
     expect(built.visible().map((item) => item.name)).toEqual(["copy_url"]);
@@ -509,7 +510,7 @@ describe("add takes a block", () => {
   // every item would report an anchor the tail was never given.
   it("warns about the block's anchor once, for its head", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const built = new HeaderActionsSurface();
+    const built = new HeaderSurface();
     built.provideBuiltins(() => [button("refresh_quote"), action("delete")]);
     built.add(
       [
@@ -521,13 +522,13 @@ describe("add takes a block", () => {
     );
     built.visible();
     expect(warn.mock.calls.map((call) => call[0])).toEqual([
-      expect.stringContaining("headerActions.add('tools')"),
+      expect.stringContaining("header.add('tools')"),
     ]);
     warn.mockRestore();
   });
 
   it("stages a block in a replay and swaps it in whole", () => {
-    const built = new HeaderActionsSurface();
+    const built = new HeaderSurface();
     built.provideBuiltins(() => [action("copy_url")]);
     built.beginReplay();
     built.add([action("a"), action("b")]);
@@ -575,15 +576,15 @@ describe("group beats display", () => {
       action("leaf", { group: "middle" }),
       action("copy_url"),
     ];
-    const projection = projectHeaderActions(resolved(items, "outer"), BUDGET);
+    const projection = projectHeader(resolved(items, "outer"), BUDGET);
     expect(projection.controls).toEqual([]);
     expect(projection.bands.map((band) => band.group)).toEqual(["actions"]);
   });
 });
 
 describe("the cross-rendering anchor warning", () => {
-  function surface(items: HeaderAction[]) {
-    const built = new HeaderActionsSurface();
+  function surface(items: HeaderItem[]) {
+    const built = new HeaderSurface();
     built.provideBuiltins(() => items);
     return built;
   }
@@ -731,5 +732,127 @@ describe("renderingOf", () => {
   it("leaves a group that names no dropdown in the menu", () => {
     const items = [action("call", { group: "elsewhere" })];
     expect(renderingOf(items[0], items)).toBe("menu");
+  });
+});
+
+describe("the two zones", () => {
+  const crumb = (name: string, extra: Partial<HeaderItem> = {}) =>
+    action(name, { zone: "left", display: "crumb", ...extra });
+
+  function leftNames(items: HeaderItem[]) {
+    return project(items).left.map(
+      (control) => `${control.kind}:${control.item.name}`
+    );
+  }
+
+  it("defaults an item to the right, and a member to its container's zone", () => {
+    expect(zoneOf(action("delete"))).toBe("right");
+    expect(zoneOf(action("favourite", { zone: "left" }))).toBe("left");
+    const items = [
+      dropdown("tools", { zone: "left" }),
+      action("audit", { group: "tools", zone: "right" }),
+    ];
+    expect(leftNames(items)).toEqual(["dropdown:tools"]);
+    expect(project(items).left[0]).toMatchObject({
+      members: [expect.objectContaining({ item: items[1] })],
+    });
+    expect(bandNames(items)).toEqual([]);
+  });
+
+  it("keeps the left zone out of the controls, the bands and the budget", () => {
+    const items = [
+      crumb("doctype"),
+      crumb("record"),
+      action("favourite", { zone: "left" }),
+      button("refresh_quote"),
+      button("escalate"),
+      button("archive"),
+      action("delete"),
+    ];
+    expect(leftNames(items)).toEqual([
+      "crumb:doctype",
+      "crumb:record",
+      "button:favourite",
+    ]);
+    expect(controlNames(items)).toEqual([
+      "button:refresh_quote",
+      "button:escalate",
+    ]);
+    expect(bandNames(items)).toEqual(["archive[archive]", "actions[delete]"]);
+  });
+
+  it("relocates an item by patching its zone, and by nothing else", () => {
+    const built = new HeaderSurface();
+    built.provideBuiltins(() => [
+      crumb("record"),
+      action("favourite", { zone: "left" }),
+      button("save"),
+    ]);
+    built.update("favourite", { zone: "right", display: "button" });
+    const projected = projectHeader(built.resolve(), BUDGET);
+    expect(projected.left.map((control) => control.item.name)).toEqual(["record"]);
+    expect(projected.controls.map((control) => control.item.name)).toEqual([
+      "favourite",
+      "save",
+    ]);
+  });
+
+  it("takes a hidden left container's members with it, wherever they sit", () => {
+    const items = [
+      dropdown("tools", { zone: "left" }),
+      action("audit", { group: "tools" }),
+      action("delete"),
+    ];
+    const projected = projectHeader(resolved(items, "tools"), BUDGET);
+    expect(projected.left).toEqual([]);
+    expect(projected.bands.map((band) => band.items.map(rendered))).toEqual([
+      ["delete"],
+    ]);
+  });
+
+  it("flattens a section on the left into its place, and says so", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const items = [
+      crumb("record"),
+      action("more", { zone: "left", display: "section" }),
+      action("star", { group: "more" }),
+      action("watch", { group: "more" }),
+    ];
+    expect(leftNames(items)).toEqual([
+      "crumb:record",
+      "button:star",
+      "button:watch",
+    ]);
+    expect(warn.mock.calls[0][0]).toContain("has no menu");
+  });
+
+  it("warns about a crumb on the right and leaves it in the menu", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const items = [action("parent", { display: "crumb" })];
+    expect(leftNames(items)).toEqual([]);
+    expect(bandNames(items)).toEqual(["actions[parent]"]);
+    expect(warn.mock.calls[0][0]).toContain("add zone: 'left'");
+  });
+
+  it("warns about an unknown zone and renders on the right", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const items = [button("escalate", { zone: "middle" as any })];
+    expect(leftNames(items)).toEqual([]);
+    expect(controlNames(items)).toEqual(["button:escalate"]);
+    expect(warn.mock.calls[0][0]).toContain("expected 'left' or 'right'");
+  });
+
+  it("is a rendering of its own, so a cross-zone anchor warns and appends", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const built = new HeaderSurface();
+    built.provideBuiltins(() => [crumb("record"), button("save")]);
+    built.add(action("watch", { zone: "left" }), { before: "save" });
+    expect(renderingOf(built.visible()[1], built.visible())).toBe("left");
+    expect(built.visible().map((item) => item.name)).toEqual([
+      "record",
+      "watch",
+      "save",
+    ]);
+    expect(warn.mock.calls[0][0]).toContain("an item in the left zone");
   });
 });

--- a/frontend/src/recordPage/tests/headerRenderings.test.ts
+++ b/frontend/src/recordPage/tests/headerRenderings.test.ts
@@ -781,7 +781,7 @@ describe("the two zones", () => {
     expect(bandNames(items)).toEqual(["archive[archive]", "actions[delete]"]);
   });
 
-  it("relocates an item by patching its zone, and by nothing else", () => {
+  it("relocates an item by patching its zone", () => {
     const built = new HeaderSurface();
     built.provideBuiltins(() => [
       crumb("record"),
@@ -794,6 +794,21 @@ describe("the two zones", () => {
     expect(projected.controls.map((control) => control.item.name)).toEqual([
       "favourite",
       "save",
+    ]);
+  });
+
+  it("keeps a crumb's href, and at budget 0 keeps the left zone and demotes the right", () => {
+    const items = [
+      crumb("doctype", { href: "/crm-deal" }),
+      crumb("record"),
+      button("save"),
+    ];
+    const projected = projectHeader(resolved(items), 0);
+    expect(projected.left[0].item.href).toBe("/crm-deal");
+    expect(leftNames(items)).toEqual(["crumb:doctype", "crumb:record"]);
+    expect(projected.controls).toEqual([]);
+    expect(projected.bands.map((band) => band.items.map(rendered))).toEqual([
+      ["save"],
     ]);
   });
 

--- a/frontend/src/recordPage/types.ts
+++ b/frontend/src/recordPage/types.ts
@@ -20,15 +20,22 @@ export interface QuickAction extends SurfaceItem {
   run?: (page: RecordPageApi) => any;
 }
 
+/** Which half of the header row an item sits in; omitted means `right`. */
+export type HeaderZone = "left" | "right";
+
 /**
- * An action in the record's header. A `dropdown` or a `section` is a container:
- * its members point at it with `group`, and containers nest two deep.
+ * One item of the header row: a crumb, a button, a menu entry or `Save`. A `dropdown`
+ * or a `section` is a container: its members point at it with `group`, two deep.
  */
-export interface HeaderAction extends SurfaceItem {
+export interface HeaderItem extends SurfaceItem {
   label: string;
-  display?: "button" | "dropdown" | "section";
+  zone?: HeaderZone;
+  /** Omitted: an entry in `⋯` on the right, a button on the left. */
+  display?: "button" | "dropdown" | "section" | "crumb";
   /** The container this sits in; an undeclared name gets an anonymous one inside `⋯`. */
   group?: string;
+  /** A path this item links to; `run` wins when both are given. */
+  href?: string;
   run?: (page: RecordPageApi) => any;
 }
 
@@ -337,7 +344,7 @@ export interface RecordPageApi {
   fieldAccess(fieldname: string): FieldAccess;
   isDirty: boolean;
   quickActions: SurfaceVerbs<QuickAction>;
-  headerActions: SurfaceVerbs<HeaderAction>;
+  header: SurfaceVerbs<HeaderItem>;
   tabs: TabsApi;
   panelSections: SurfaceVerbs<PanelSectionItem>;
   fields: PageFields;


### PR DESCRIPTION
Builds the record page's header row as the record-page map decided it (frappe/frappe#42271, ticket #42551): one flat list at `page.header`, two zones, every element an item a Client Script can name.

## What changes

- **Engine.** `page.headerActions` is renamed `page.header` and `HeaderAction` becomes `HeaderItem`, a straight rename with no alias. An item gains `zone: 'left' | 'right'` (default right), `display: 'crumb'` and `href`. `projectHeader` returns `{ left, controls, bands }` from one pass. The left zone has no menu and no budget; a section there flattens into its members. Cross-zone anchors warn through the existing net.
- **Host.** `Record.vue` seeds three built-ins, `doctype` (links to the list), `record` and `save`, and renders the projection through a new `pages/record/RecordHeader.vue`. It loads the doctype's Client Scripts before the first replay, so stored scripts now reach the generated page.
- **Docs.** `frontend/SCRIPTING.md` starts with the header section and the proof script the design was judged by. `COMPATIBILITY.md` links to it and drops the promise that Save is never on the surface. `CONTEXT.md` defines the header; `PHILOSOPHY.md` lists the guide in the doc set.

## Verified

- `frontend/` vitest: 28 files, 481 tests (eight new, on the zones).
- Walked on `crm.localhost` with a `Client Script` row (view Record) that renames the record crumb: the row reads `CRM Deal / CRM-DEAL-2026-00037 (reviewed)`, the doctype crumb links to the list, and a second script's entries fill the overflow menu.
- The 28-script coverage battery is renamed to `page.header` and re-seeded.

>no-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)