### PR TITLE
refactor: Filter versions based on user's permitted fields

### DIFF
--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -266,28 +266,60 @@ def get_versions(doc: "Document") -> list[dict]:
 
 	has_read_permission = doc.get_permlevel_access(permission_type="read")
 
-	if frappe.session.user == "Administrator" or not has_read_permission:
+	if 0 not in has_read_permission and frappe.share.get_shared(
+		doc.doctype,
+		frappe.session.user,
+		rights=["read"],
+		filters=[["share_name", "=", str(doc.name)]],
+		limit=1,
+	):
+		has_read_permission = [*has_read_permission, 0]
+
+	if frappe.session.user == "Administrator":
 		return mask_version_data(versions, doc.doctype)
 
-	allowed_fields = []
-
-	for field in doc.meta.fields:
-		if field.permlevel in has_read_permission:
-			allowed_fields.append(field.fieldname)
-
+	allowed_parent_fields = {df.fieldname for df in doc.meta.fields if df.permlevel in has_read_permission}
+	allowed_child_fields = {}
 	for table_field in doc.meta.get_table_fields():
-		nested_fields = frappe.get_meta(table_field.options).fields or []
-		for field in nested_fields:
-			if field.permlevel in has_read_permission:
-				allowed_fields.append(field.fieldname)
+		allowed_child_fields[table_field.fieldname] = {
+			df.fieldname
+			for df in (frappe.get_meta(table_field.options).fields or [])
+			if df.permlevel in has_read_permission
+		}
+
+	def filter_changed(logs):
+		return [log for log in logs or [] if log and log[0] in allowed_parent_fields]
+
+	def filter_row_changed(logs):
+		out = []
+		for log in logs or []:
+			if len(log) < 4:
+				continue
+			allowed = allowed_child_fields.get(log[0])
+			if allowed is None:
+				continue
+			nested = [entry for entry in (log[3] or []) if entry and entry[0] in allowed]
+			if nested:
+				out.append([log[0], log[1], log[2], nested])
+		return out
+
+	def filter_rows(logs):
+		out = []
+		for log in logs or []:
+			if len(log) < 2:
+				continue
+			allowed = allowed_child_fields.get(log[0])
+			if allowed is None or not isinstance(log[1], dict):
+				continue
+			out.append([log[0], {k: v for k, v in log[1].items() if k in allowed}])
+		return out
 
 	for version in versions:
 		data = frappe.parse_json(version.data)
-		# Iterate over logs and remove any fields that the user does not have permission to
-		data["changed"] = filter_logs(data.get("changed", []), allowed_fields)
-		data["added"] = filter_logs(data.get("added", []), allowed_fields)
-		data["removed"] = filter_logs(data.get("removed", []), allowed_fields)
-		data["row_changed"] = filter_logs(data.get("row_changed", []), allowed_fields)
+		data["changed"] = filter_changed(data.get("changed"))
+		data["added"] = filter_rows(data.get("added"))
+		data["removed"] = filter_rows(data.get("removed"))
+		data["row_changed"] = filter_row_changed(data.get("row_changed"))
 		version.data = frappe.utils.orjson_dumps(data)
 
 	return mask_version_data(versions, doc.doctype)

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -247,6 +247,15 @@ def get_versions(doc: "Document") -> list[dict]:
 
 	from frappe.model.utils.mask import mask_version_data
 
+	def filter_logs(logs, allowed_fields: list[str]):
+		if not logs:
+			return []
+		filtered_logs = []
+		for log in logs:
+			if log[0] in allowed_fields:
+				filtered_logs.append(log)
+		return filtered_logs
+
 	versions = frappe.get_all(
 		"Version",
 		filters=dict(ref_doctype=doc.doctype, docname=str(doc.name)),
@@ -254,6 +263,33 @@ def get_versions(doc: "Document") -> list[dict]:
 		limit=10,
 		order_by="creation desc",
 	)
+
+	has_read_permission = doc.get_permlevel_access(permission_type="read")
+
+	if frappe.session.user == "Administrator" or not has_read_permission:
+		return mask_version_data(versions, doc.doctype)
+
+	allowed_fields = []
+
+	for field in doc.meta.fields:
+		if field.permlevel in has_read_permission:
+			allowed_fields.append(field.fieldname)
+
+	for table_field in doc.meta.get_table_fields():
+		nested_fields = frappe.get_meta(table_field.options).fields or []
+		for field in nested_fields:
+			if field.permlevel in has_read_permission:
+				allowed_fields.append(field.fieldname)
+
+	for version in versions:
+		data = frappe.parse_json(version.data)
+		# Iterate over logs and remove any fields that the user does not have permission to
+		data["changed"] = filter_logs(data.get("changed", []), allowed_fields)
+		data["added"] = filter_logs(data.get("added", []), allowed_fields)
+		data["removed"] = filter_logs(data.get("removed", []), allowed_fields)
+		data["row_changed"] = filter_logs(data.get("row_changed", []), allowed_fields)
+		version.data = frappe.utils.orjson_dumps(data)
+
 	return mask_version_data(versions, doc.doctype)
 
 

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -281,6 +281,9 @@ def get_versions(doc: "Document") -> list[dict]:
 	allowed_parent_fields = {df.fieldname for df in doc.meta.fields if df.permlevel in has_read_permission}
 	allowed_child_fields = {}
 	for table_field in doc.meta.get_table_fields():
+		# The table field's own permlevel gates the whole table, same as apply_fieldlevel_read_permissions
+		if table_field.fieldname not in allowed_parent_fields:
+			continue
 		allowed_child_fields[table_field.fieldname] = {
 			df.fieldname
 			for df in (frappe.get_meta(table_field.options).fields or [])

--- a/frappe/tests/test_form_load.py
+++ b/frappe/tests/test_form_load.py
@@ -3,7 +3,8 @@
 import frappe
 from frappe.core.page.permission_manager.permission_manager import add, reset, update
 from frappe.custom.doctype.property_setter.property_setter import make_property_setter
-from frappe.desk.form.load import get_docinfo, getdoc, getdoctype
+from frappe.desk.form.load import get_docinfo, get_versions, getdoc, getdoctype
+from frappe.share import add as add_share
 from frappe.tests import IntegrationTestCase
 from frappe.tests.test_helpers import setup_for_tests
 from frappe.utils.file_manager import save_file
@@ -192,6 +193,180 @@ class TestFormLoad(IntegrationTestCase):
 		self.assertEqual(len(docinfo.communications), 1)
 		self.assertIn("email", docinfo.communications[0].content)
 		note.delete()
+
+
+class TestVersionPermlevelFiltering(IntegrationTestCase):
+	"""get_versions() must honour permlevels the same way the live document does.
+
+	Set up on Contact via property setters:
+	- `phone_nos` is a Table field pushed to permlevel 1, so the whole table is restricted
+	  (apply_fieldlevel_read_permissions deletes the attribute outright),
+	- `email_ids` stays readable, but `is_primary` inside it is pushed to permlevel 1,
+	- Contact's "All" role permission is dropped so access comes only from an explicit
+	  role or an explicit DocShare, never ambiently.
+	"""
+
+	RESTRICTED_USER = "test@example.com"
+	SHARED_USER = "test1@example.com"
+
+	def setUp(self):
+		# Contact does not track changes out of the box, and versions are what we filter
+		make_property_setter("Contact", None, "track_changes", 1, "Check", for_doctype=True)
+		# the whole phone_nos table sits above permlevel 0 ...
+		make_property_setter("Contact", "phone_nos", "permlevel", 1, "Int")
+		# ... while email_ids stays readable with one restricted field inside it
+		make_property_setter("Contact Email", "is_primary", "permlevel", 1, "Int")
+
+		reset("Contact")
+		# "All" grants every user read at permlevel 0 on Contact, which would mask what
+		# the role and the DocShare are actually contributing
+		update("Contact", "All", 0, "read", 0)
+
+		self._set_roles(self.RESTRICTED_USER, ["Sales User"])
+		self._set_roles(self.SHARED_USER, [])
+
+	def _set_roles(self, email, roles):
+		user = frappe.get_doc("User", email)
+		user.remove_roles(*frappe.get_roles(email))
+		if roles:
+			user.add_roles(*roles)
+
+	def _make_contact(self):
+		"""Create a Contact, then edit it so the version records changed/added/row_changed."""
+		contact = frappe.new_doc("Contact")
+		contact.first_name = f"_Test Version Contact {frappe.generate_hash(length=8)}"
+		contact.append("phone_nos", {"phone": "1111111111"})
+		contact.append("email_ids", {"email_id": "before@example.com", "is_primary": 0})
+		contact.insert()
+
+		contact.designation = "Head of Testing"
+		contact.phone_nos[0].phone = "9999999999"
+		contact.append("phone_nos", {"phone": "2222222222"})
+		contact.email_ids[0].email_id = "after@example.com"
+		contact.email_ids[0].is_primary = 1
+		contact.append("email_ids", {"email_id": "extra@example.com"})
+		contact.save(ignore_version=False)
+
+		return contact
+
+	def _collect(self, versions):
+		"""Flatten versions into (tables touched, parent fields changed, table-section payload).
+
+		Only the table sections are serialised: Contact keeps read-only permlevel 0 copies of
+		the primary phone and email, so searching the whole payload would flag values that the
+		parent doctype publishes by design rather than anything get_versions leaked.
+		"""
+		tables, changed, blob = set(), set(), ""
+		for version in versions:
+			data = frappe.parse_json(version.data)
+			for key in ("added", "removed", "row_changed"):
+				tables.update(log[0] for log in data.get(key) or [])
+				blob += frappe.as_json(data.get(key) or [])
+			changed.update(log[0] for log in data.get("changed") or [])
+		return tables, changed, blob
+
+	def _child_fields(self, versions, table_fieldname):
+		"""Every child fieldname reported for one table, across added/removed/row_changed."""
+		fields = set()
+		for version in versions:
+			data = frappe.parse_json(version.data)
+			for log in data.get("row_changed") or []:
+				if log[0] == table_fieldname:
+					fields.update(entry[0] for entry in log[3] or [])
+			for key in ("added", "removed"):
+				for log in data.get(key) or []:
+					if log[0] == table_fieldname:
+						fields.update(log[1].keys())
+		return fields
+
+	def test_restricted_table_field_excluded_from_versions(self):
+		contact = self._make_contact()
+
+		with self.set_user(self.RESTRICTED_USER):
+			versions = get_versions(frappe.get_doc("Contact", contact.name))
+
+		self.assertTrue(versions, "expected at least one version to be recorded")
+		tables, changed, blob = self._collect(versions)
+
+		self.assertNotIn("phone_nos", tables)
+		# no historical value from the restricted table may survive in the table sections
+		self.assertNotIn("9999999999", blob)
+		self.assertNotIn("2222222222", blob)
+
+		# the fix must be targeted: a table the user *can* read still reports its changes
+		self.assertIn("email_ids", tables)
+		self.assertIn("designation", changed)
+
+	def test_restricted_child_field_excluded_from_versions(self):
+		"""A readable table still hides the child fields sitting above the user's permlevel."""
+		contact = self._make_contact()
+
+		with self.set_user(self.RESTRICTED_USER):
+			versions = get_versions(frappe.get_doc("Contact", contact.name))
+
+		tables, _, _ = self._collect(versions)
+		self.assertIn("email_ids", tables)
+
+		child_fields = self._child_fields(versions, "email_ids")
+		self.assertIn("email_id", child_fields)
+		self.assertNotIn("is_primary", child_fields)
+
+	def test_permlevel_one_role_sees_restricted_table(self):
+		"""Granting the role read at permlevel 1 brings the table back."""
+		contact = self._make_contact()
+		add("Contact", "Sales User", 1)
+		update("Contact", "Sales User", 1, "read", 1)
+
+		with self.set_user(self.RESTRICTED_USER):
+			versions = get_versions(frappe.get_doc("Contact", contact.name))
+
+		tables, _, _ = self._collect(versions)
+		self.assertIn("phone_nos", tables)
+		self.assertIn("email_ids", tables)
+		self.assertIn("is_primary", self._child_fields(versions, "email_ids"))
+
+	def test_roleless_user_sees_nothing_without_a_share(self):
+		"""Precondition for the share test: no role means no permlevel access at all."""
+		contact = self._make_contact()
+
+		with self.set_user(self.SHARED_USER):
+			doc = frappe.get_doc("Contact", contact.name)
+			self.assertEqual(doc.get_permlevel_access(permission_type="read"), [])
+			versions = get_versions(doc)
+
+		tables, changed, _ = self._collect(versions)
+		self.assertFalse(tables)
+		self.assertFalse(changed)
+
+	def test_shared_document_grants_permlevel_zero_only(self):
+		"""A DocShare unlocks permlevel 0, and must not drag permlevel 1 along with it."""
+		contact = self._make_contact()
+		add_share("Contact", contact.name, self.SHARED_USER, read=1)
+
+		with self.set_user(self.SHARED_USER):
+			versions = get_versions(frappe.get_doc("Contact", contact.name))
+
+		tables, changed, blob = self._collect(versions)
+
+		# the share granted permlevel 0 ...
+		self.assertIn("designation", changed)
+		self.assertIn("email_ids", tables)
+
+		# ... and nothing above it
+		self.assertNotIn("phone_nos", tables)
+		self.assertNotIn("is_primary", self._child_fields(versions, "email_ids"))
+		self.assertNotIn("9999999999", blob)
+
+	def test_administrator_sees_restricted_table_in_versions(self):
+		contact = self._make_contact()
+
+		versions = get_versions(frappe.get_doc("Contact", contact.name))
+
+		tables, changed, _ = self._collect(versions)
+		self.assertIn("phone_nos", tables)
+		self.assertIn("email_ids", tables)
+		self.assertIn("designation", changed)
+		self.assertIn("is_primary", self._child_fields(versions, "email_ids"))
 
 
 def get_blog(blog_name):


### PR DESCRIPTION
### Description 

Currently system fetches latest 10 doc versions and on the UI it is filtered based on the User's read/write permissions, to show or not to show the change logs in Activity Timeline. Now here the problem is if user does not have access to the particular field and it is updated and captured in version logs, it is first fetched and then filtered resulting in data available in network logs.
In general case it should be filtered and then served to the client.