### PR TITLE
fix: hide bulk export when user lacks export permission

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -3144,7 +3144,10 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			actions_menu_items.push(bulk_edit());
 		}
 
-		if (frappe.model.can_export(doctype)) {
+		if (
+			frappe.model.can_export(doctype) &&
+			!frappe.boot.user.can_export_owner_only?.includes(doctype)
+		) {
 			actions_menu_items.push(bulk_export());
 		}
 

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -3144,7 +3144,9 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			actions_menu_items.push(bulk_edit());
 		}
 
-		actions_menu_items.push(bulk_export());
+		if (frappe.model.can_export(doctype)) {
+			actions_menu_items.push(bulk_export());
+		}
 
 		// bulk assignment
 		actions_menu_items.push(bulk_assignment());

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -28,6 +28,7 @@ from frappe.tests import IntegrationTestCase
 from frappe.tests.test_helpers import setup_for_tests
 from frappe.tests.utils import make_test_records_for_doctype
 from frappe.utils.data import now_datetime
+from frappe.utils.user import UserPermissions
 
 EXTRA_TEST_RECORD_DEPENDENCIES = ["User", "Contact", "Salutation"]
 
@@ -102,6 +103,48 @@ class TestPermissions(IntegrationTestCase):
 		full_record = frappe.get_all("Test Blog Post", fields="*", limit=1)[0]
 		self.assertNotEqual(permitted_record, full_record)
 		self.assertSequenceSubset(post.meta.default_fields + post.meta.get_search_fields(), permitted_record)
+
+	def test_owner_only_export_stays_in_can_export(self):
+		role_name = "Test Export Boot Role"
+		user_name = "test_export_boot@example.com"
+		owner_only_dt = "Test Owner Only Export Boot"
+		shared_dt = "Test Shared Export Boot"
+
+		frappe.set_user("Administrator")
+		frappe.delete_doc("User", user_name, ignore_missing=True, force=True)
+		for name in (owner_only_dt, shared_dt):
+			frappe.delete_doc("DocType", name, ignore_missing=True, force=True)
+		frappe.delete_doc("Role", role_name, ignore_missing=True, force=True)
+
+		frappe.get_doc(doctype="Role", role_name=role_name, desk_access=1).insert()
+
+		for name, if_owner in ((owner_only_dt, 1), (shared_dt, 0)):
+			new_doctype(
+				name,
+				fields=[{"fieldname": "title", "fieldtype": "Data", "label": "Title"}],
+				permissions=[{"role": role_name, "read": 1, "export": 1, "if_owner": if_owner}],
+			).insert()
+
+		user = frappe.get_doc(
+			doctype="User", email=user_name, first_name="Export Boot", send_welcome_email=0
+		).insert()
+		user.add_roles(role_name)
+
+		frappe.clear_cache(user=user_name)
+		frappe.set_user(user_name)
+		perms = UserPermissions()
+		perms.build_permissions()
+		frappe.set_user("Administrator")
+
+		self.assertIn(owner_only_dt, perms.can_export)
+		self.assertIn(owner_only_dt, perms.can_export_owner_only)
+		self.assertIn(shared_dt, perms.can_export)
+		self.assertNotIn(shared_dt, perms.can_export_owner_only)
+
+		frappe.delete_doc("User", user_name, force=True)
+		for name in (owner_only_dt, shared_dt):
+			frappe.delete_doc("DocType", name, force=True)
+		frappe.delete_doc("Role", role_name, force=True)
 
 	def test_user_permissions_in_doc(self):
 		add_user_permission("Test Blog Category", "_Test Blog Category 1", "test2@example.com")

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -116,35 +116,45 @@ class TestPermissions(IntegrationTestCase):
 			frappe.delete_doc("DocType", name, ignore_missing=True, force=True)
 		frappe.delete_doc("Role", role_name, ignore_missing=True, force=True)
 
-		frappe.get_doc(doctype="Role", role_name=role_name, desk_access=1).insert()
+		def boot_perms():
+			frappe.clear_cache(user=user_name)
+			frappe.set_user(user_name)
+			perms = UserPermissions()
+			perms.build_permissions()
+			frappe.set_user("Administrator")
+			return perms
 
-		for name, if_owner in ((owner_only_dt, 1), (shared_dt, 0)):
-			new_doctype(
-				name,
-				fields=[{"fieldname": "title", "fieldtype": "Data", "label": "Title"}],
-				permissions=[{"role": role_name, "read": 1, "export": 1, "if_owner": if_owner}],
+		try:
+			frappe.get_doc(doctype="Role", role_name=role_name, desk_access=1).insert()
+
+			for name, if_owner in ((owner_only_dt, 1), (shared_dt, 0)):
+				new_doctype(
+					name,
+					fields=[{"fieldname": "title", "fieldtype": "Data", "label": "Title"}],
+					permissions=[{"role": role_name, "read": 1, "export": 1, "if_owner": if_owner}],
+				).insert()
+
+			user = frappe.get_doc(
+				doctype="User", email=user_name, first_name="Export Boot", send_welcome_email=0
 			).insert()
+			user.add_roles(role_name)
 
-		user = frappe.get_doc(
-			doctype="User", email=user_name, first_name="Export Boot", send_welcome_email=0
-		).insert()
-		user.add_roles(role_name)
+			perms = boot_perms()
+			self.assertIn(owner_only_dt, perms.can_export)
+			self.assertIn(owner_only_dt, perms.can_export_owner_only)
+			self.assertIn(shared_dt, perms.can_export)
+			self.assertNotIn(shared_dt, perms.can_export_owner_only)
 
-		frappe.clear_cache(user=user_name)
-		frappe.set_user(user_name)
-		perms = UserPermissions()
-		perms.build_permissions()
-		frappe.set_user("Administrator")
-
-		self.assertIn(owner_only_dt, perms.can_export)
-		self.assertIn(owner_only_dt, perms.can_export_owner_only)
-		self.assertIn(shared_dt, perms.can_export)
-		self.assertNotIn(shared_dt, perms.can_export_owner_only)
-
-		frappe.delete_doc("User", user_name, force=True)
-		for name in (owner_only_dt, shared_dt):
-			frappe.delete_doc("DocType", name, force=True)
-		frappe.delete_doc("Role", role_name, force=True)
+			user.add_roles("System Manager")
+			perms = boot_perms()
+			self.assertNotIn(owner_only_dt, perms.can_export_owner_only)
+		finally:
+			frappe.set_user("Administrator")
+			frappe.delete_doc("User", user_name, ignore_missing=True, force=True)
+			frappe.delete_doc("Role", role_name, ignore_missing=True, force=True)
+			for name in (owner_only_dt, shared_dt):
+				frappe.delete_doc("DocType", name, ignore_missing=True, force=True)
+			frappe.db.commit()
 
 	def test_user_permissions_in_doc(self):
 		add_user_permission("Test Blog Category", "_Test Blog Category 1", "test2@example.com")

--- a/frappe/utils/user.py
+++ b/frappe/utils/user.py
@@ -41,6 +41,7 @@ class UserPermissions:
 		self.can_get_report = []
 		self.can_import = []
 		self.can_export = []
+		self.can_export_owner_only = []
 		self.can_print = []
 		self.can_email = []
 		self.allow_modules = []
@@ -112,6 +113,8 @@ class UserPermissions:
 			for k in rights:
 				if not self.perm_map[dt].get(k):
 					self.perm_map[dt][k] = r.get(k)
+			if r.get("export") and not r.get("if_owner"):
+				self.perm_map[dt]["export_non_owner"] = True
 
 	def build_permissions(self):
 		"""build lists of what the user can read / write / create
@@ -164,7 +167,7 @@ class UserPermissions:
 			if p.get("read") or p.get("write") or p.get("create"):
 				if p.get("report"):
 					self.can_get_report.append(dt)
-				for key in ("import", "export", "print", "email"):
+				for key in ("import", "print", "email"):
 					if p.get(key):
 						getattr(self, "can_" + key).append(dt)
 
@@ -178,6 +181,12 @@ class UserPermissions:
 							pass
 						else:
 							self.allow_modules.append(dtp.get("module"))
+
+				if p.get("export"):
+					if p.get("export_non_owner"):
+						self.can_export.append(dt)
+					else:
+						self.can_export_owner_only.append(dt)
 
 		self.can_write += self.can_create
 		self.can_write += self.in_create
@@ -298,6 +307,7 @@ class UserPermissions:
 			"can_search",
 			"in_create",
 			"can_export",
+			"can_export_owner_only",
 			"can_import",
 			"can_print",
 			"can_email",

--- a/frappe/utils/user.py
+++ b/frappe/utils/user.py
@@ -183,9 +183,8 @@ class UserPermissions:
 							self.allow_modules.append(dtp.get("module"))
 
 				if p.get("export"):
-					if p.get("export_non_owner"):
-						self.can_export.append(dt)
-					else:
+					self.can_export.append(dt)
+					if not p.get("export_non_owner"):
 						self.can_export_owner_only.append(dt)
 
 		self.can_write += self.can_create

--- a/frappe/utils/user.py
+++ b/frappe/utils/user.py
@@ -205,6 +205,7 @@ class UserPermissions:
 				self.can_read.remove(dt)
 
 		if "System Manager" in self.get_roles():
+			self.can_export_owner_only = []
 			self.can_import += frappe.get_all("DocType", {"allow_import": 1}, pluck="name")
 			self.can_import += frappe.get_all(
 				"Property Setter",


### PR DESCRIPTION
- Hide the bulk export action in list view for users whose export permission is owner-only
- Keep owner-only export doctypes in `boot.user.can_export` so Data Export and report export keep working; `can_export_owner_only` gates only the bulk button
- Regression test for the boot lists

Resolves #40582
Supersedes #40593