### PR TITLE
fix(report): ignore permissions without DocType parent

### DIFF
--- a/frappe/core/report/user_doctype_permissions/test_user_doctype_permissions.py
+++ b/frappe/core/report/user_doctype_permissions/test_user_doctype_permissions.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2026, Frappe Technologies and Contributors
+# License: MIT. See LICENSE
+
+from unittest.mock import patch
+
+from frappe.core.report.user_doctype_permissions.user_doctype_permissions import get_data
+from frappe.tests import UnitTestCase
+
+
+class TestUserDoctypePermissions(UnitTestCase):
+	def test_ignores_permission_without_parent(self):
+		user = "test@example.com"
+		permissions = [
+			{"parent": None, "permlevel": 0, "if_owner": 0, "role": "System Manager", "read": 1},
+			{"parent": "ToDo", "permlevel": 0, "if_owner": 0, "role": "System Manager", "read": 1},
+		]
+
+		with (
+			patch(
+				"frappe.core.report.user_doctype_permissions.user_doctype_permissions.get_valid_perms",
+				return_value=permissions,
+			),
+			patch(
+				"frappe.core.report.user_doctype_permissions.user_doctype_permissions.get_perm_types",
+				return_value=["read"],
+			),
+		):
+			result = get_data({"user": user})
+
+		self.assertEqual(result, [[user, "ToDo", 0, 1]])

--- a/frappe/core/report/user_doctype_permissions/user_doctype_permissions.py
+++ b/frappe/core/report/user_doctype_permissions/user_doctype_permissions.py
@@ -95,6 +95,9 @@ def get_data(filters: dict) -> list[list]:
 			continue
 
 		dt = perm["parent"]
+		if dt is None:
+			continue
+
 		if_owner = perm["if_owner"]
 		role = perm["role"]
 


### PR DESCRIPTION
## What changed

Ignore permission records whose parent DocType is missing before they enter report aggregation, and add regression coverage for a user whose permissions contain both a null parent and a valid DocType.

## Tests

The focused regression test passed in a minimal initialized Frappe unit context, and all applicable pre-commit hooks passed. The standard Bench test command could not run because this checkout is not a Bench directory and has no test site.

Fixes #42435