### PR TITLE
fix(web-form): respect link option access in child tables

### DIFF
--- a/frappe/website/doctype/web_form/test_web_form.py
+++ b/frappe/website/doctype/web_form/test_web_form.py
@@ -54,6 +54,12 @@ class TestWebForm(IntegrationTestCase):
 		self.addCleanup(frappe.delete_doc, "Web Form", web_form.name, force=True, ignore_permissions=True)
 		return web_form
 
+	def _get_link_option_values(self, field):
+		options = field.get("options")
+		if isinstance(options, str):
+			return options.splitlines()
+		return [option["value"] for option in options]
+
 	def test_web_form_mandatory_is_enforced_on_server(self):
 		"""A field mandatory only on the Web Form must not pass just because the
 		browser was skipped."""
@@ -1259,6 +1265,88 @@ class TestWebForm(IntegrationTestCase):
 		with self.assertQueryCount(6):
 			for _ in range(5):
 				process_link_field(link_field(), "manage-events")
+
+	def test_child_table_link_options_respect_table_allow_read_setting(self):
+		user = self.create_website_user("_test_web_form_child_link@example.com")
+		web_form = self.make_temp_web_form(
+			web_form_fields=[
+				{
+					"fieldname": "event_participants",
+					"fieldtype": "Table",
+					"label": "Event Participants",
+					"options": "Event Participants",
+				},
+				{
+					"fieldname": "reference_doctype",
+					"fieldtype": "Link",
+					"label": "Reference Document Type",
+					"options": "DocType",
+				},
+			]
+		)
+		self.assertNotEqual(frappe.db.get_value("DocType", "Event", "owner"), user)
+
+		frappe.set_user(user)
+		restricted = get_form_data(doctype="Event", web_form_name=web_form.name)
+		table_field = next(
+			f for f in restricted.web_form.web_form_fields if f.fieldname == "event_participants"
+		)
+		child_link = next(f for f in table_field.fields if f.get("fieldname") == "reference_doctype")
+		top_level_link = next(
+			f for f in restricted.web_form.web_form_fields if f.fieldname == "reference_doctype"
+		)
+		self.assertNotIn("Event", self._get_link_option_values(child_link))
+		self.assertNotIn("Event", self._get_link_option_values(top_level_link))
+
+		frappe.set_user("Administrator")
+		web_form.reload()
+		table_field = next(f for f in web_form.web_form_fields if f.fieldname == "event_participants")
+		table_field.allow_read_on_all_link_options = 1
+		web_form.save(ignore_permissions=True)
+		frappe.clear_document_cache("Web Form", web_form.name)
+
+		frappe.set_user(user)
+		unrestricted = get_form_data(doctype="Event", web_form_name=web_form.name)
+		table_field = next(
+			f for f in unrestricted.web_form.web_form_fields if f.fieldname == "event_participants"
+		)
+		child_link = next(f for f in table_field.fields if f.get("fieldname") == "reference_doctype")
+		top_level_link = next(
+			f for f in unrestricted.web_form.web_form_fields if f.fieldname == "reference_doctype"
+		)
+		self.assertIn("Event", self._get_link_option_values(child_link))
+		self.assertNotIn("Event", self._get_link_option_values(top_level_link))
+
+	def test_load_form_data_applies_table_allow_read_setting(self):
+		user = self.create_website_user("_test_web_form_child_link_render@example.com")
+		web_form = self.make_temp_web_form(
+			web_form_fields=[
+				{
+					"fieldname": "event_participants",
+					"fieldtype": "Table",
+					"label": "Event Participants",
+					"options": "Event Participants",
+					"allow_read_on_all_link_options": 1,
+				}
+			]
+		)
+		self.addCleanup(setattr, frappe.local, "form_dict", frappe._dict())
+		frappe.local.form_dict = frappe._dict(is_new=1)
+
+		frappe.set_user(user)
+		context = frappe._dict(
+			web_form_doc=web_form.as_dict(no_nulls=True),
+			success_message=None,
+			max_attachment_size=1,
+			title=web_form.title,
+		)
+		web_form.load_form_data(context)
+
+		table_field = next(
+			f for f in context.web_form_doc.web_form_fields if f.fieldname == "event_participants"
+		)
+		child_link = next(f for f in table_field.fields if f.get("fieldname") == "reference_doctype")
+		self.assertIn("Event", self._get_link_option_values(child_link))
 
 	def test_get_link_options_blocked_for_unauthorized_link_on_guest_key_form(self):
 		self.set_web_form_settings(key_required=1, login_required=0)

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -562,7 +562,11 @@ def get_context(context):
 		for field in context.web_form_doc.web_form_fields:
 			if field.fieldtype == "Table":
 				field.fields = get_in_list_view_fields(
-					field.options, self.name, web_form_request_key, docname
+					field.options,
+					self.name,
+					web_form_request_key,
+					docname,
+					allow_read_on_all_link_options=field.allow_read_on_all_link_options,
 				)
 
 			if field.fieldtype == "Link":
@@ -799,12 +803,21 @@ def get_context(context):
 		return permitted_attachments
 
 
-def process_link_field(field, web_form_name, web_form_request_key=None, docname=None):
+def process_link_field(
+	field,
+	web_form_name,
+	web_form_request_key=None,
+	docname=None,
+	allow_read_on_all_link_options=None,
+):
+	if allow_read_on_all_link_options is None:
+		allow_read_on_all_link_options = getattr(field, "allow_read_on_all_link_options", False)
+
 	field.fieldtype = "Autocomplete"
 	field.options = get_link_options(
 		web_form_name,
 		field.options,
-		getattr(field, "allow_read_on_all_link_options", False),
+		allow_read_on_all_link_options,
 		web_form_request_key=web_form_request_key,
 		docname=docname,
 	)
@@ -1137,7 +1150,11 @@ def get_form_data(
 	for field in out.web_form.web_form_fields:
 		if field.fieldtype == "Table":
 			field.fields = get_in_list_view_fields(
-				field.options, web_form_name, web_form_request_key, docname
+				field.options,
+				web_form_name,
+				web_form_request_key,
+				docname,
+				allow_read_on_all_link_options=field.allow_read_on_all_link_options,
 			)
 			out.update({field.fieldname: field.fields})
 
@@ -1162,7 +1179,13 @@ def get_web_form_list_fields(web_form_doc: "WebForm", web_form_request_key: str 
 	return fields
 
 
-def get_in_list_view_fields(doctype, web_form_name=None, web_form_request_key=None, docname=None):
+def get_in_list_view_fields(
+	doctype,
+	web_form_name=None,
+	web_form_request_key=None,
+	docname=None,
+	allow_read_on_all_link_options=False,
+):
 	meta = frappe.get_meta(doctype)
 	fields = []
 
@@ -1182,7 +1205,13 @@ def get_in_list_view_fields(doctype, web_form_name=None, web_form_request_key=No
 
 		df = meta.get_field(fieldname).as_dict()
 		if df.get("options") and df.get("fieldtype") == "Link":
-			process_link_field(df, web_form_name, web_form_request_key, docname)
+			process_link_field(
+				df,
+				web_form_name,
+				web_form_request_key,
+				docname,
+				allow_read_on_all_link_options=allow_read_on_all_link_options,
+			)
 		return df
 
 	return [get_field_df(f) for f in fields]

--- a/frappe/website/doctype/web_form_field/web_form_field.json
+++ b/frappe/website/doctype/web_form_field/web_form_field.json
@@ -51,7 +51,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:doc.fieldtype === 'Link' && parent.login_required",
+   "depends_on": "eval:(doc.fieldtype === 'Link' || doc.fieldtype === 'Table') && parent.login_required",
    "fieldname": "allow_read_on_all_link_options",
    "fieldtype": "Check",
    "label": "Allow Read On All Link Options"


### PR DESCRIPTION
<!--

Note: Your PR will be automatically closed if you're not in list of [vouched users](https://github.com/frappe/frappe/blob/develop/.github/VOUCHED.td).

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](https://www.conventionalcommits.org/en/v1.0.0/).
 3. All tests pass locally, UI and Unit tests.
 4. All business logic and validations must be on the server-side.
 5. Update necessary documentation.
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation
- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md
- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

Web Form Table fields now propagate their `allow_read_on_all_link_options` setting to Link fields rendered from that child DocType, while the restrictive default and top-level Link behavior remain unchanged.
Verification: all 47 Web Form integration tests and the applicable pre-commit hooks passed.

closes #42341

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->