### PR TITLE
fix: clear include filters and hide column picker when a print format is set

### DIFF
--- a/frappe/public/js/frappe/form/print_utils.js
+++ b/frappe/public/js/frappe/form/print_utils.js
@@ -61,6 +61,11 @@ frappe.ui.get_print_settings = function (
 					disabled: 0,
 				},
 			}),
+			onchange: function () {
+				dialog.set_value("include_filters", this.get_value() ? 0 : 1);
+				dialog.set_value("pick_columns", 0);
+				dialog.fields_dict.columns?.select_all(true);
+			},
 		});
 	}
 
@@ -85,7 +90,7 @@ frappe.ui.get_print_settings = function (
 				label: __("Select Columns"),
 				fieldtype: "MultiCheck",
 				fieldname: "columns",
-				depends_on: "pick_columns",
+				depends_on: "eval: doc.pick_columns && !doc.print_format",
 				columns: 2,
 				select_all: true,
 				options: pick_columns.map((df) => ({
@@ -96,7 +101,7 @@ frappe.ui.get_print_settings = function (
 		);
 	}
 
-	return frappe.prompt(
+	const dialog = frappe.prompt(
 		columns,
 		function (settings) {
 			settings = $.extend(print_settings, settings);
@@ -117,6 +122,10 @@ frappe.ui.get_print_settings = function (
 
 			if (settings.print_format) {
 				settings.pick_columns = 0;
+				settings.include_filters = 0;
+			}
+
+			if (!settings.pick_columns) {
 				settings.columns = null;
 			}
 
@@ -124,6 +133,8 @@ frappe.ui.get_print_settings = function (
 		},
 		__("Print Settings")
 	);
+
+	return dialog;
 };
 
 // qz tray connection wrapper


### PR DESCRIPTION
Manual backport of #42528

🤖 Generated with [Claude Code](https://claude.com/claude-code)