### PR TITLE
fix(filters): allow parent groups in filter value searches

### DIFF
--- a/cypress/integration/filter_group.js
+++ b/cypress/integration/filter_group.js
@@ -4,6 +4,60 @@ context("Filter Group", () => {
 		cy.visit("/desk/website");
 	});
 
+	it("does not apply form link filters to filter value searches", () => {
+		cy.window().then(({ frappe, $ }) => {
+			const df = {
+				parent: "Test Document",
+				fieldname: "group",
+				label: "Group",
+				fieldtype: "Link",
+				options: "Test Tree",
+				link_filters: JSON.stringify([["Test Tree", "is_group", "=", 0]]),
+			};
+			const $parent = $('<div><div class="filter-edit-area"></div></div>').appendTo("body");
+			try {
+				const filter = new frappe.ui.Filter({
+					parent: $parent,
+					parent_doctype: df.parent,
+					doctype: df.parent,
+					fieldname: df.fieldname,
+					filter_fields: [df],
+					condition: "=",
+					on_change: () => {},
+				});
+
+				for (const condition of [
+					"=",
+					"descendants of",
+					"descendants of (inclusive)",
+					"not descendants of",
+					"ancestors of",
+					"not ancestors of",
+					"!=",
+				]) {
+					filter.set_condition(condition, true);
+					expect(filter.field.get_search_args("Parent").filters, condition).to.be
+						.undefined;
+				}
+
+				filter.set_condition("like", true);
+				filter.set_condition("descendants of", true);
+				expect(filter.field.get_search_args("Parent").filters).to.be.undefined;
+
+				const form_control = frappe.ui.form.make_control({
+					df,
+					parent: $parent,
+					render_input: true,
+				});
+				expect(form_control.get_search_args("Child").filters).to.deep.equal({
+					is_group: ["=", 0],
+				});
+			} finally {
+				$parent.remove();
+			}
+		});
+	});
+
 	it("preserves numeric filter values with a comma decimal separator", () => {
 		cy.window().then(async ({ frappe, $ }) => {
 			const original_number_format = frappe.boot.sysdefaults.number_format;

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -303,6 +303,8 @@ frappe.ui.Filter = class {
 		df.hidden = 0;
 		df.is_filter = true;
 		delete df.hidden_due_to_dependency;
+		// Form selection constraints can exclude valid filter values, such as tree parents.
+		delete df.link_filters;
 
 		let c = condition ? condition : this.utils.get_default_condition(df);
 		this.set_condition(c);


### PR DESCRIPTION
The Set Filters dialog inherits the selected field's form link filters. For ERPNext's Item Group field, `is_group = 0` hides parent groups even when the operator is Descendants Of.

Remove `link_filters` from the copied filter field definition. This lets users select tree parents in Set Filters and list filters. Normal form Link controls keep their configured restrictions.

Closes frappe/erpnext#58826

Validation:
- Cypress `cypress/integration/filter_group.js`: 2 passed in Chrome on a PostgreSQL test site, with the worktree filter source loaded into the browser. The new test fails before the fix.
- The regression covers equality and tree operators, switching through a text operator, and preservation of normal form link filters.
- Browser check with ERPNext Item metadata: All Item Groups is absent before the fix, then appears and can be selected afterward.
- `pre-commit run --all-files`: passed.

Before:

![Before: parent group is absent from the suggestions](https://raw.githubusercontent.com/mihir-kandoi/frappe/codex/filter-link-constraints-evidence/before.png)

After:

![After: All Item Groups can be selected](https://raw.githubusercontent.com/mihir-kandoi/frappe/codex/filter-link-constraints-evidence/after.png)
