### PR TITLE
fix: correct pointer-events property in desktop title input

### DIFF
--- a/frappe/desk/page/desktop/desktop.css
+++ b/frappe/desk/page/desktop/desktop.css
@@ -543,7 +543,7 @@
   color: var(--neutral-white);
   line-height: 22px;
   z-index: 1;
-  pointers-events: none;
+  pointer-events: none;
   width: 100%;
     text-align: center;
 }


### PR DESCRIPTION
- Fixes typo `pointers-events` -> `pointer-events` in `.title-input-label` CSS rule in desktop.css

Cherry-picked from #42049 (closed), original fix by @Vishal1721. Only affects version-16-hotfix; develop already has the correct property.
