### PR TITLE
docs: add code review guide and agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,6 @@ Read [code_review.md](code_review.md) first and follow its Workflow section in o
 - No before/after screenshot or video for a UI change: ask for one before reviewing anything else.
 - PR not based on `develop`: close it, unless the bug exists only on the stable branch.
 - Any real ask means `REQUEST_CHANGES`. Do not hide a real finding under an approve.
-- Questions listed under Unsettled are for a maintainer, not you.
 
 ## Writing code
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,11 @@ Frappe is a web framework: Python backend, JavaScript desk UI, MariaDB or Postgr
 
 ## Reviewing a PR
 
-Read [code_review.md](code_review.md) first and follow its Workflow section in order. Point to rules by number (`R11`).
+Read [code_review.md](code_review.md) first and follow it in order: the checks before reviewing, what to look for, the verdict.
 
 - No before/after screenshot or video for a UI change: ask for one before reviewing anything else.
 - PR not based on `develop`: close it, unless the bug exists only on the stable branch.
-- Any real ask means `REQUEST_CHANGES`. Do not hide a real finding under an approve.
+- Any real ask means request changes. Do not hide a real finding under an approve.
 
 ## Writing code
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Read [code_review.md](code_review.md) first and follow its Workflow section in o
 - Conventional Commits on the title and every commit.
 - Business logic and validation on the server.
 - Change DocType JSON through the UI, never by hand.
-- No explanatory comments. No AI attribution in commits or PR text.
+- No comments that narrate the code. One short comment is fine for a non-obvious workaround. No AI attribution in commits or PR text.
 - Run `pre-commit run --all-files` before pushing.
 - Smallest correct change. Remove dead code and dead CSS you leave behind.
 - Desk UI: `frappe.utils.icon()`, `es-button`, `es-badge`, design tokens, gray accents.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Agent instructions
+
+Frappe is a web framework: Python backend, JavaScript desk UI, MariaDB or Postgres. ERPNext, HRMS, CRM and other apps are built on it, so every change here affects them.
+
+## Reviewing a PR
+
+Read [code_review.md](code_review.md) first and follow its Workflow section in order. Point to rules by number (`R11`).
+
+- No before/after screenshot or video for a UI change: ask for one before reviewing anything else.
+- PR not based on `develop`: close it, unless the bug exists only on the stable branch.
+- Any real ask means `REQUEST_CHANGES`. Do not hide a real finding under an approve.
+- Questions listed under Unsettled are for a maintainer, not you.
+
+## Writing code
+
+- Target `develop`. Backports go through Mergify.
+- Conventional Commits on the title and every commit.
+- Business logic and validation on the server.
+- Change DocType JSON through the UI, never by hand.
+- No explanatory comments. No AI attribution in commits or PR text.
+- Run `pre-commit run --all-files` before pushing.
+- Smallest correct change. Remove dead code and dead CSS you leave behind.
+- Desk UI: `frappe.utils.icon()`, `es-button`, `es-badge`, design tokens, gray accents.
+- Every user-facing string goes through `_()` or `__()`.
+- New behaviour and bug fixes come with a test that runs as a normal user, with `example.com` test data.
+
+## Never
+
+- Add a field, flag, setting or endpoint when an existing one already does the job.
+- Put ERPNext, CRM or Drive logic inside the framework.
+- Use `ignore_permissions=True` or a blanket role grant to fix a workflow.
+- Commit inside document events.
+- Add work to every request or desk boot for a rare case.
+- Refactor across the repo unless asked.
+- Send automated or AI-generated changes without reviewing them yourself.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Read [code_review.md](code_review.md) first and follow its Workflow section in o
 - Conventional Commits on the title and every commit.
 - Business logic and validation on the server.
 - Change DocType JSON through the UI, never by hand.
-- No comments that narrate the code. One short comment is fine for a non-obvious workaround. No AI attribution in commits or PR text.
+- No comments that narrate the code; keep comments that explain non-obvious workarounds.
 - Run `pre-commit run --all-files` before pushing.
 - Smallest correct change. Remove dead code and dead CSS you leave behind.
 - Desk UI: `frappe.utils.icon()`, `es-button`, `es-badge`, design tokens, gray accents.

--- a/code_review.md
+++ b/code_review.md
@@ -1,499 +1,131 @@
-# Frappe Framework: Code Review Guide
+# Code Review Guide
 
-What maintainers check when they review a pull request to `frappe/frappe`, collected from their review comments. For reviewers, contributors and AI agents.
-
-Read the Workflow section before every review. Rules are numbered so you can point to them in a comment (`R8`). If a rule gives a wrong answer in a real case, change the rule here instead of ignoring it.
+What maintainers check when they review a pull request to `frappe/frappe`. For reviewers, contributors and AI agents.
 
 Contributor-side rules live in the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) and [Coding Standards](https://github.com/frappe/erpnext/wiki/Coding-Standards).
 
----
+## Before reviewing
 
-## Workflow
+Check these first. Ask for the missing piece before reading the code.
 
-### Read first
+- Base branch is `develop`. Hotfix branches only get bugs that do not exist on develop.
+- UI changes have before/after screenshots or a video. Ask again after every UI push.
+- The bug reproduces on latest develop with the steps in the PR. If there are no steps, ask for a traceback or a minimal repro. If it cannot be reproduced, close for now.
+- Branch is rebased with no merge commits or unrelated commits.
+- Pre-commit is green. A reformatted file is not reviewable.
+- Title and commits follow Conventional Commits. The title is what gets squash-merged.
+- Description says what was broken, why, what changed and how to test, and matches the final diff.
+- Read the other reviewers' comments and the linked issue before writing your own.
 
-- Read the PR body and every comment. If the PR was raised on behalf of someone else, that person is the author you talk to.
-- Read other maintainers' comments. Do not repeat them. Check whether earlier asks were addressed.
-- Read the linked issue and check the PR fixes what it describes.
+## What to look for
 
-### Gates
+### Design
 
-Stop at the first failing gate and ask for it. Do not review code behind a failing gate.
+- Does this belong in the framework? App-specific fields, doctypes, roles or conditions belong in the app. The framework provides the hook; the app provides the behaviour.
+- Non-framework features (print backends, spam filters, third-party integrations) go in a separate app.
+- A new framework API ships together with at least one real use inside Frappe. No is temporary, yes is forever.
+- Ask what problem the PR solves before judging how it solves it. Feature work and large refactors need agreement first.
+- No new setting for behaviour one app or one user wants. Ship the sane default, or make it per-DocType through Customize Form. Make it configurable only when users would legitimately disagree.
+- Do not extend surfaces the project is moving away from.
+- The size of the change matches the size of the problem. Extend the existing feature rather than build a parallel one.
 
-1. Base branch is `develop`. A hotfix branch is fine only when the bug does not exist on develop. `version-N` is always wrong.
-2. UI change has before/after screenshots or a video with real data. Anything a user sees counts: desk JS, Vue, SCSS, HTML, print formats, web pages, dialogs, icons. No media, no review. Ask again after every UI push.
-3. The bug reproduces on latest develop with the PR's own steps. No steps: ask for a text traceback, the failing input or the minimal query. Cannot reproduce: close for now. Already fixed: close with the commit.
-4. Branch is rebased, with no merge commits and no foreign commits.
-5. Pre-commit is green. A reformatted file is not reviewable. Do not list files; give the command:
-   ```bash
-   pip install pre-commit && pre-commit run --all-files
-   ```
-6. Title and every commit follow Conventional Commits. The title is what gets squash-merged. `feat:` PRs carry `no-docs` or a docs link. `fixes #N` only if the issue is really fixed.
-7. Description says what was broken, why, what changed and how to test. It matches the final diff.
+### Root cause
 
-### Review steps
+- A fix that makes an error disappear without explaining why it happened is not a fix. Find where the bad state comes from and fix it there, not at one call site.
+- Deleting a guard, condition or method to make a symptom go away is not a fix. The check was protecting something.
+- Read the commit that introduced the behaviour before changing it. Odd code is often intentional.
+- Validation goes in `validate`, `on_trash` or `on_update`, not in one whitelisted caller. Bulk actions, the REST API and `doc.save()` skip a check that lives in one endpoint.
+- If the same bug exists in a sibling (JS and Python, DocField and Custom Field, form and list and print), the fix is incomplete.
 
-Say which steps found nothing. Steps 2, 3 and 4 are the ones most often skipped.
+### Simplicity
 
-1. Root cause. Find where the bad state comes from. If there is one writer, the fix undoes that writer. If the same failure fires later in the flow, the symptom moved. Read the commit that introduced the behaviour before accepting a change to it.
-2. Should this exist in this shape. For every new field, flag, param, endpoint, setting or status: list the existing values next to it. If they already express the thing, the new one is redundant. Try the contradicting combination (old value says X, new flag says Y). `depends_on` only hides a field; a stale value still applies. A new status needs every abnormal exit covered.
-3. Residue. Dead code, no-op CSS, orphan flags, classes, callers, tests, junk rows. Grep before calling a CSS rule a no-op. Residue is blocking.
-4. Incomplete fix. Grep the buggy expression across the repo. Sibling files with the same bug (JS vs Python, DocField vs Custom Field vs Customize Form Field, MariaDB vs Postgres, form vs grid vs list vs print) make the fix incomplete. Check the sibling is reachable first.
-5. Correctness and security. `None`, empty, `0`, `"0"`, negative, huge; docstatus 0, 1, 2; permissions; multi-site; translations; both databases. Every whitelisted method checks permission before reading and takes identity from `frappe.session.user`. Every new throw leaves the user a way out. Existing records keep working.
-6. Conventions. DocType JSON edited through the UI with a bumped `modified`. `frappe.throw` with a title. `_()` / `__()` on user-facing strings. No comments, `console.log`, `print`, commented-out code, `var`. Desk UI uses `frappe.utils.icon()`, `es-button`, `es-badge`, design tokens, gray accents, no duplicate CSS. Fixtures use `example.com`. New server functions have tests.
-7. CI. Name the failing check. Test failures block. Semgrep on unchanged code, the docs check and the dependency check do not block on their own.
+- Before adding a field, flag, parameter, endpoint or patch, check whether an existing one already expresses the same thing. Two mechanisms for one meaning will disagree.
+- Reuse `frappe.utils`, `frappe.ui`, the database API and the standard library before writing a helper. One implementation per piece of logic.
+- Prefer the smallest correct change. Plain functions and `if` blocks; no inheritance towers, monkey-patching or global state unless proven necessary.
+- Leftover code is a blocking finding: unused parameters, unreachable branches, no-op CSS, flags nothing reads, commented-out code.
+- Functions take named arguments, not dict or kwargs bags. State goes on `doc.flags`, not `frappe.flags`. A function returns one shape.
+- No hardcoded doctype names, `Administrator` checks, hosts or paths. Read hooks, defaults and config.
+- Every new branch handles `None`, duplicates, submitted documents and deleted doctypes, and a new guard must not block the path the user takes to fix it.
 
-Before reporting any finding, grep the exact symbol, string or class you name, in the repo and in the diff. If it is not there, drop it. Cite a file:line you read. One true sentence per finding. Bot findings (Greptile, Copilot, Semgrep) are reproduced on the branch and answered with facts.
+### Backward compatibility
 
-### Verdict
+- Break established behaviour only when the cost of not breaking it is clearly higher. List who depends on it across frappe, erpnext, hrms and the other apps.
+- Public functions, paths and parameters get a `deprecation_warning`, one major for apps to migrate, then removal.
+- Defaults never flip. New behaviour is opt-in.
+- Never repurpose or retype a field. Add a new one, migrate, hide the old one. New arguments go last with a default.
+- Exports and report columns are an API.
+- A new constraint or validation that existing rows would violate blocks `bench migrate`. Ship a patch or drop the constraint.
+- Breaking changes use `fix!:` or `feat!:`, stay on develop, and land after the dependent app PR.
+- Do not make a common workflow harder for regular users. Put the burden on system managers.
 
-Any real ask means changes requested. Ready with nits is only for things you would not actually ask to change. Send to a maintainer when it is a product call.
+### Security
 
-Blocking, not a nit: a new crash, blank screen or uncaught exception; leftover no-op code; a sibling file with the same bug; a missing `modified` bump; a missing permission check on a new endpoint; a stuck status; a breaking change without `!` and a migration path.
+- Business logic and validation live on the server. The REST API, data import and server scripts never run client code.
+- `ignore_permissions=True` and blanket role grants are not fixes. Use `check_permission`, `has_permission` and `only_for`, and give the user the right permission.
+- Every whitelisted method checks permission before reading and takes identity from `frappe.session.user`, never from the client. Guest and security-critical endpoints restrict `methods`. Secrets are stored hashed and never returned.
+- Escape at render time, per context. Never sanitise at storage; stripping loses data.
+- A security claim needs a demonstrated bypass. Harden once in the shared layer, not per input. But any path that lets a normal user gain admin is blocked whatever the UX cost.
+- Fail loudly. No blanket `try/except`, no `log_error` without a traceback, catch the specific exception.
+- Never destroy data silently. Disable instead of delete, confirm bulk actions, no `ELSE NULL` in update queries.
 
-Do not downgrade a finding to approve. Do not upgrade a style nit to look thorough.
+### Performance
 
-```
-PR #N: <title>
-Verdict: READY | CHANGES REQUESTED | NEEDS HUMAN JUDGMENT
-Prior review: none | addressed | partly (what remains)
-Rationale: up to 3 sentences
-Findings:
-  - blocking | nit, file:line, the one-sentence claim, the ask (rule ID), replacement text if one-line
-Steps that found nothing: <numbers>
-Repro: snippet that shows the bug on develop, or "UI-only"
-```
+- Nothing lands in the hot path for everyone. Anything that runs on every request, save or desk boot is opt-in or free. Read from `frappe.boot` instead of calling the server on page load.
+- Think in 100k rows. No `get_doc` in loops, no unindexed filters, no full-table sorts, no unbounded fetches.
+- Work over a few seconds, third-party calls and bulk operations go to a background job. Patches use bulk updates and commit in batches.
+- Performance changes come with numbers: profiler output, `EXPLAIN`, or bundle deltas, measured as a real user. No cache without a measured cost it removes.
 
-### Writing the review
+### Database
 
-- Comment on the exact line. Use a suggestion block when the fix is a one-liner. Keep the review body for asks that have no line, such as missing tests or a wrong title.
+- Use the highest-level API that does the job: ORM, then query builder, never hand-written SQL. Do not bypass `delete_doc` and controller hooks with `frappe.db.delete`.
+- No `commit()` in document events. Side effects that must survive run `after_commit`.
+- Convert inputs into query builder objects; never regex-check or rewrite generated SQL. MariaDB is the reference; DB-specific code lives in `frappe/database/<db>/`. Sorts that feed pagination are deterministic.
+- Pick the right cache and prove invalidation. `site_cache` is per process and never invalidated.
+- DocType JSON is changed through the UI, never by hand, and committed with a bumped `modified`. Patches only when data actually needs to move.
+
+### UI
+
+- Colours, weights and spacing come from design tokens. Reuse existing CSS classes; delete rules with no user. No inline styles or `!important`.
+- Use `es-button` and `es-badge`, icons from `frappe.utils.icon()`, gray accents. New controls follow the sibling control.
+- Defaults serve non-technical users. Labels say what happens, in short plain words, with no internal terms like "DocType".
+- Bundle size is a budget. Features used by a minority load on first use.
+- A button and dialog on the existing doctype beats a new doctype. A permission beats a setting.
+- Confirm destructive actions. Secondary actions are not primary buttons. Keyboard keeps working. Any change marks the form dirty. Console stays clean.
+- Client work is scoped to the instance, runs once, and cleans up its listeners. Client checks also work when the value is set programmatically.
+
+### Code
+
+- Comments explain why, never what. Keep one for a non-obvious workaround. No `console.log`, `print`, commented-out code or `var`.
+- Names say what the thing does. Fieldname mirrors label. Checkbox names are positive.
+- Annotate all parameters and the return type, or none. Compare dates with `getdate()`, checkboxes with `cint`. `None`, `""` and `0` are different.
+- Translate whole sentences with `{0}` placeholders. Never build a translatable string from pieces. Do not translate fieldnames, file names or user-authored labels.
+- No guards for states that cannot happen. Flat functions with early returns.
+- Tests never leak into production code. No `if frappe.in_test`.
+
+### Tests
+
+- New behaviour and bug fixes ship with a test that fails without the fix. A test that only checks nothing raised, or asserts on generated SQL, proves nothing.
+- Test through public interfaces as a real user, not Administrator. Permission tests use `get_list`, not `get_all`. Fixtures use `example.com`.
+- Flaky tests are fixed, not disabled. Changed behaviour updates the existing tests.
+
+### Process
+
+- Fix develop first, then backport via Mergify. Features wait on develop before reaching a stable branch. Breaking changes are never backported.
+- One concern per PR. Unrelated refactors, formatting and independent bugs go in their own PR.
+- New hooks, config keys and public utilities are documented on docs.frappe.io. Translations go to Crowdin.
+- A merged change that causes regressions is reverted first and fixed later.
+- Stale or half-done PRs are closed with an offer to reopen.
+- PRs generated without manual review, scripted typo sweeps and vendored-library edits are closed. Code taken from an issue or another PR keeps its original author.
+
+## Verdict
+
+- Any real ask means changes requested. Approve when there is none. "Ready with nits" is only for things you would not actually ask to change.
+- Blocking, not a nit: a new crash or uncaught exception, leftover no-op code, the same bug in a sibling file, a missing `modified` bump, a missing permission check, a breaking change without `!` and a migration path.
+- Before reporting a finding, confirm the symbol, string or class you name exists where you say it does. Cite a file and line you actually read.
+- Bot findings (Greptile, Copilot, Semgrep) are reproduced and answered with evidence, not dismissed and not repeated blindly.
+
+## Writing the review
+
+- Comment on the exact line, with a suggestion block when the fix is a one-liner. The review body is for asks with no line, such as missing tests or a wrong title.
 - One concern per comment, in short plain sentences. Say what is wrong and what to do instead. Show code when that is clearer than words.
-- Back the ask with the rule number, the issue or the docs.
-- Request changes when there is a real ask. Approve when there is none.
-- Answer bot findings with evidence: confirm with a line reference or reject with a reason.
-
----
-
-## Scope
-
-### R1. No app-specific code in the framework
-Frappe must behave the same for every app. Do not add a field, doctype, role or `if doctype == "Sales Invoice"` branch that only ERPNext, CRM, HRMS or Drive needs. Add a hook in the framework and let the app implement it in its own code.
-Why: the framework cannot see how apps use it. A special case for one app breaks silently when that app changes.
-Exception: something generic that every app could use may move from an app into the framework.
-
-```python
-# Bad: framework code checks an ERPNext doctype
-if doc.doctype == "Sales Invoice" and doc.is_return:
-    reverse_stock(doc)
-
-# Good: framework offers a hook, ERPNext implements it in its hooks.py
-for method in frappe.get_hooks("on_return_document"):
-    frappe.call(method, doc=doc)
-```
-
-### R2. Non-framework features go in a separate app; framework features need a user
-Print backends, spam filters, third-party integrations and similar live in an app that hooks in. A new framework API ships together with at least one real use inside Frappe.
-Why: no is temporary, yes is forever. Plumbing without a consumer rots.
-
-### R3. Ask for the use case before reading the code
-If the PR does not state a user-facing problem, ask what the author is trying to do. Feature work and big refactors need a nod first (an issue or a discussion). Refactors of critical areas (caching, database APIs, `Document`) are done by core maintainers.
-Why: reviewing a mechanism for a problem nobody has wastes both sides' time.
-Exception: a small, clearly useful fix with no ticket still merges.
-
-### R4. No new setting for niche behaviour
-No System Settings switch, config key or checkbox for behaviour one app or one user wants. Ship the sane default or make it per-DocType through Customize Form.
-Why: every toggle doubles the test matrix and stays forever.
-Exception: when users would legitimately disagree about a visible behaviour, make it configurable per user or per DocType.
-
-### R5. Direction beats local utility
-Do not extend surfaces the project is leaving: the website module (Builder replaces it), report-view aggregation (Insights), legacy client JS, `frappe.call` where API v2 is the target. Ask a maintainer when unsure.
-Why: every addition to a legacy surface has to be migrated or dropped later.
-
-### R6. Change size matches the problem
-A small ask arriving as a large diff is pushed back. If an existing doctype, page, library or API does most of the job, add the missing part there. A "new X" next to an existing X needs a stated limitation of the current one. Half-done PRs are closed, not merged to iterate later.
-Why: parallel implementations drift and double the maintenance.
-
-## Root cause
-
-### R7. Fix the root cause where it lives
-A fix that makes an error go away without explaining why it happened is rejected. Fix it in the layer that owns it (ORM, util, datatable, shared control), not at one call site. Deleting a guard, condition, style or method to make a symptom disappear is not a fix; the check was protecting something. Read the commit that introduced the behaviour before changing it; odd code is often intentional.
-Why: a symptom patch leaves the bug for the next caller.
-Exception: a harmless shallow fix may merge under release pressure, with the deep fix noted in the PR.
-
-### R8. Do not add what already exists
-Before adding a field, flag, param, endpoint, setting or patch, check whether an existing value, argument, default or `None` already carries the meaning. Make an existing flag tri-state before adding a second one. No patch for things `migrate` already syncs.
-Why: two mechanisms for one meaning can disagree, and every new surface is API forever.
-
-```python
-# Bad
-def get_list(doctype, order_by="modified desc", no_order=False):
-
-# Good: order_by=None means no ordering
-def get_list(doctype, order_by="modified desc"):
-```
-
-### R9. Reuse before reimplementing
-Check `frappe.utils`, `frappe.ui`, the database API and the standard library before writing a helper; most of what a PR needs (caching, hashing, icons, shortcuts, freezing the UI) already exists. One implementation per piece of logic; extract a helper at the second or third repeat.
-Why: copies drift, and custom apps copy whatever core does.
-Exception: a little duplication beats coupling unrelated modules.
-
-### R10. Smallest correct change, simplest mechanism, no residue
-Prefer the one-line fix. Plain functions and `if` blocks; no inheritance towers, monkey-patching, global mutable state, threads or Lua scripts unless proven necessary. Remove unused boot data, unreachable branches, single-use wrappers, params only ever passed one value, properties nothing reads, commented-out code, no-op CSS. Residue is blocking.
-Why: complexity and dead code are paid on every read.
-
-### R11. Finish the sweep, keep every surface consistent
-A change to one of a parallel set (DocField / Custom Field / Customize Form Field; Link / Dynamic Link; wkhtmltopdf / Chrome; form / grid / list / report / print) is incomplete until the siblings are done. A display or behaviour change applies everywhere the value appears, or not at all.
-Why: two surfaces that disagree are a new bug.
-
-### R12. Put the check at the choke point
-Validation goes in `validate`, `on_trash` or `on_update`, not in one whitelisted caller.
-Why: list view bulk actions, `frappe.client.*`, the REST API and `doc.save()` all skip a check that lives in one endpoint.
-
-```python
-# Bad
-@frappe.whitelist()
-def rename_route(name, route):
-    if route_exists(route):
-        frappe.throw(_("Route already exists"))
-
-# Good
-class WebPage(Document):
-    def validate(self):
-        self.validate_unique_route()
-```
-
-### R13. Do not hardcode what the framework knows
-No hardcoded doctype names, `Administrator` checks, naming series, countries, logos, hosts or binary paths. Read hooks, defaults and config. Per-doctype behaviour goes on a DocType or DocField checkbox exposed in Customize Form.
-Why: hardcoded values are the branches nobody finds until a site differs.
-
-### R14. Explicit arguments, one return shape
-Functions and hooks take named parameters (`doctype`, `name`, `doc`), not dict or kwargs bags. State goes on `doc.flags`, not `frappe.flags`. No sentinel strings. A function returns one shape. Rename on the client, not in the server response.
-Why: callers can read a signature; they cannot read a bag.
-Exception: hook callbacks may take kwargs so the signature can grow.
-
-### R15. Cover the edge cases, and leave the user a way out
-For every new branch ask what happens on `None`, duplicates, the user's own record, a queued job, a submitted document, a deleted doctype, `[Select]`. A new guard must not make the flow that resolves it also throw.
-Why: "clearing the field then throws `UpdateAfterSubmitError`; there is no way out."
-Exception: no fallbacks for states that cannot happen.
-
-## Backward compatibility
-
-### R16. Break only when not breaking costs more
-Established behaviour (select values, ordering defaults, signatures, lifecycle semantics, exception classes, hook timing, export and report columns) is not changed for one use case. List who depends on it across frappe, erpnext, hrms and the other apps. Take the non-breaking variant when there is one. Internal symbols can be dropped; public ones need a compatibility path. Unreleased code owes nothing.
-Why: every app on every site pays for a break.
-Exception: behaviour that never worked, or hurts most users, may change.
-
-### R17. Deprecate one major before removing
-Public functions, paths and params get a `deprecation_warning` in place, one major for apps to migrate, then removal. No proxy classes or inspect-based machinery. Prefer fixing over deleting.
-Why: before a major, grep `deprecation_warning` and remove that code. Nothing else to remember.
-
-### R18. Defaults never flip
-A new option ships with the old behaviour as default. Experimental capabilities ship opt-in or marked beta. A rejected default may live on as an opt-in setting.
-Why: people do not notice a new checkbox. They notice their site changed.
-
-### R19. Add new, migrate, hide old
-Never repurpose or retype a field, and never change what `modified` or `creation` mean. Add a new field, migrate on save plus a patch, hide the old one, remove next major. Do not rename or remove CLI flags, kwargs, argument order, module paths or icons apps may use. New arguments go last with a default.
-Why: existing rows and calls must survive `bench migrate`.
-
-### R20. Constraint changes ship with a patch
-A new unique constraint, validation or default that existing rows would violate blocks `bench migrate`. Ship a patch that repairs the data, or drop the constraint. A patch that needs new schema calls `frappe.reload_doctype` first.
-Why: sites with old data cannot update otherwise.
-
-### R21. Breaking changes carry `!` and stay on develop
-Use `fix!:` or `feat!:`. Do not backport them. A framework change that needs an ERPNext change lands after the ERPNext PR, with an ERPNext CI run linked. Query builder, permission and core-model changes get that run too.
-Why: release notes and the migration guide come from the prefix.
-
-### R22. Do not take features away from regular users
-A change that makes a common workflow harder for non-technical users, or quietly disables a feature (data import mapping, URL attachments, saved filters), is reverted. Put the burden on system managers.
-Why: users use templates; system managers create them.
-
-## Server side and security
-
-### R23. Business logic lives on the server, completely
-A rule enforced in JS (mandatory-depends-on, `set_query` filters, computed values) is also enforced in the controller. Params a check depends on are mandatory. Settings that gate a user are permlevel > 0. Search and validate agree.
-Why: the REST API, data import and server scripts never run client code.
-Exception: a purely cosmetic client-side permission (hiding a print button) needs no server check.
-
-```python
-class Event(Document):
-    def validate(self):
-        if not self.ends_on:
-            frappe.throw(_("End date is required"), title=_("Missing Value"))
-```
-
-### R24. Never punch holes in permissions
-`ignore_permissions=True`, blanket role grants and permission-less endpoints are not fixes. Use `doc.check_permission()`, `frappe.has_permission` and `frappe.only_for` so Is Owner and User Permissions apply, and give the user the right permission instead. Prefer permlevels over ad-hoc code. Check before `get_doc` or any return, on every branch. Identity comes from `frappe.session.user`, never from the client.
-Why: better to give the user the right permission than to create a hole.
-
-```python
-# Bad
-@frappe.whitelist()
-def get_report(user, name):
-    return frappe.get_doc("Prepared Report", name, ignore_permissions=True)
-
-# Good
-@frappe.whitelist()
-def get_report(name):
-    doc = frappe.get_doc("Prepared Report", name)
-    doc.check_permission("read")
-    return doc
-```
-
-### R25. Whitelisted endpoints are public URLs
-Set `methods=[...]` on security-critical and guest endpoints. Store only hashes of keys and tokens. Never return `site_config` secrets. Website users can call whitelisted methods too. No `allow_guest` on flows that need login.
-
-```python
-@frappe.whitelist(allow_guest=True, methods=["POST"])
-def subscribe(email):
-    ...
-```
-
-### R26. Escape at render, never at storage
-Do not sanitise on store or globally in a formatter. Escape where the value goes into HTML, per fieldtype. Escape rather than strip. Use `|e` in Jinja.
-Why: storing anything is safe; injecting it as HTML is not. Stripping loses data.
-
-```javascript
-// Bad
-$wrapper.html(`<div>${doc.title}</div>`);
-
-// Good
-$wrapper.html(`<div>${frappe.utils.escape_html(doc.title)}</div>`);
-```
-
-### R27. A security claim needs a demonstrated bypass
-Ask where exactly permissions are bypassed; close if it cannot be shown. Reject rate limits and information hiding that cost more than they protect. Harden once in the shared layer, not per input. But any path that lets a normal user gain admin is blocked whatever the UX cost. Do not widen `safe_exec` or Jinja globals, read files from user input, or allow expressions in `autoname`.
-Why: there is no end to designing for stupidity, but privilege escalation beats UX.
-Exception: System Manager-authored Jinja and HTML is trusted. Other holes do not justify a new one.
-
-### R28. Fail loudly, catch the specific exception
-Permission failures raise `frappe.PermissionError`. No blanket `try/except`, no `log_error` without a traceback, chain with `raise ... from exc`. Promises get `.catch`. Background jobs already log. A friendly catch is scoped to exactly its condition.
-Why: failing is better than silently ignoring.
-
-```python
-# Bad
-try:
-    doc.submit()
-except Exception:
-    pass
-
-# Good
-try:
-    doc.submit()
-except frappe.ValidationError:
-    frappe.msgprint(_("Could not submit {0}").format(doc.name))
-    raise
-```
-
-### R29. Never destroy data silently
-No `ELSE NULL` in update queries, no sanitisers that drop content, no defaults that overwrite `creation`, `owner` or `name`. Disable instead of delete. Confirm bulk and destructive actions. Audit tables are immutable.
-Why: bad UX beats irrecoverable data loss.
-
-## Performance
-
-### R30. Nothing lands in the hot path for everyone
-Anything that runs on every request, document load, save or desk boot is opt-in or free. The common case never pays for the edge case. No API calls or queries on page load; read from `frappe.boot`. Anything added to boot is cached.
-Why: per-request overhead multiplies across every site.
-Exception: a few bytes in boot beat a separate request.
-
-```javascript
-// Bad: one request per form load
-frappe.db.get_single_value("System Settings", "float_precision").then(...)
-
-// Good
-const precision = frappe.boot.sysdefaults.float_precision;
-```
-
-### R31. Think in 100k rows
-No `get_doc` in loops or to update one field, no unindexed filters, no full-table sorts, no `limit: 0`, no O(N) Redis scans. Hoist meta lookups and hooks out of loops. Batch link fetches. Cap `IN (...)` near 1000.
-Why: users import lakhs of records.
-
-```python
-# Bad
-for name in names:
-    doc = frappe.get_doc("Item", name)
-    doc.disabled = 1
-    doc.save()
-
-# Good
-frappe.db.set_value("Item", {"name": ("in", names)}, "disabled", 1)
-```
-
-### R32. Slow or external work goes to a background job
-Work over about ten seconds, third-party API calls, bulk PDFs, renames and notification emails are enqueued, never run in a request or `validate`. Heavy work uses `queue="long"`. Jobs are idempotent because hooks run on every retry. Files a job writes on a schedule get a retention window and cleanup. In patches, use an `update` query or `bulk_insert` and commit in batches, never one row at a time.
-Why: a worker blocked for a minute is a site down for everyone on that worker.
-
-### R33. Performance changes need numbers
-Show profiler output, `EXPLAIN`, benchmarks or bundle deltas at production scale, measured as a real user, not Administrator. A perf change names the cost it removes. No caches that cannot hit, no cache on top of `get_meta` or settings (already cached), no micro-optimisation that adds code for a tiny gain.
-Why: a cache is a key, a TTL, invalidation sites and tests, all to skip one indexed query.
-Exception: do not optimise paths that run once in a blue moon.
-
-## Database
-
-### R34. Use the highest-level API that does the job
-ORM (`frappe.db.get_value`, `set_value`, `get_list`) when it expresses the query; query builder when the ORM cannot; never hand-written dialect SQL. Do not bypass `delete_doc` and controller hooks with `frappe.db.delete` without a stated reason. Let the schema enforce invariants: mandatory fields become `NOT NULL`, a unique constraint beats app-level dedup.
-Why: lower-level APIs skip caching, permissions, hooks and portability.
-
-### R35. No `commit()` in document events
-Doc-event code never commits; requests commit at the end. Side effects that must survive run `after_commit`. Every state transition calls `check_if_latest`, with no bypass flag.
-Why: a commit inside `validate` persists a half-saved document.
-Exception: a helper reachable from a GET may commit, and patches commit in batches.
-
-### R36. Parse, don't validate; MariaDB is the reference
-Turn known inputs into query builder objects and let it emit SQL. Never regex-check or rewrite generated SQL. When drivers disagree, MariaDB is canonical and Postgres adapts; DB-specific code lives in `frappe/database/<db>/`. Permission filters go in `WHERE`, not `JOIN`. Pass `order_by=None` when order does not matter; tie-break paginated sorts with a unique column. Avoid `ifnull` and `coalesce`, never on `name`.
-Why: non-deterministic order makes pagination wrong.
-
-### R37. Pick the right cache and prove invalidation
-`@site_cache` is per process and never invalidated; use `@request_cache` for permission-dependent data. Single values use `frappe.cache.get_value`, not a hash. Keys are stable and prefixed. Invalidation covers every mutation; clear and recompute rather than maintain by hand.
-Why: a stale permission cache is a security bug.
-
-### R38. Patches only when data moves; DocType JSON only through the UI
-No patch for what `migrate` already syncs (doctypes, workspaces, module defs, new-field defaults). DocType JSON is changed through the DocType form or Customize Form and the export committed with its bumped `modified`, child tables included. A hand-edited JSON is sent back. A `modified`-only bump with no field change is reverted. Index changes need a patch or a `modified` bump so `on_doctype_update` runs.
-Why: DocType JSON is generated by code; humans and agents should not touch it directly.
-
-## UI
-
-### R39. Design tokens, no CSS duplication, right file
-Every colour, weight and spacing is a token or CSS variable; check both themes. Reuse existing classes. Repeated rules go on a parent class. Delete rules with no user. View-specific CSS lives in that view's file. No inline styles, `!important`, `position: fixed` or fixed-height hacks.
-Why: more CSS means a larger bundle and more to maintain.
-Exception: print CSS stays light; no dark-mode tokens in PDFs.
-
-```scss
-// Bad
-.sidebar-item { color: #1f272e; font-weight: 420; }
-
-// Good
-.sidebar-item { color: var(--text-color); font-weight: var(--weight-medium); }
-```
-
-### R40. Espresso components, sprite icons, gray accents
-New desk UI uses `es-button` and `es-badge` with data attributes, not bootstrap `btn` and `badge`. Icons come from `frappe.utils.icon()` with names in the sprite; no hand-written SVG, no emoji. Accents are gray, not blue. A new control follows the sibling control; match avatars, indicators, labels, column order and empty states.
-Why: keep the design consistent with existing components.
-
-```javascript
-// Bad
-$(`<button class="btn btn-primary btn-sm"><svg …></svg> Add</button>`)
-
-// Good
-$(`<button class="es-button" data-variant="subtle" data-size="sm">${frappe.utils.icon("add", "sm")} ${__("Add")}</button>`)
-```
-
-### R41. Defaults serve non-technical users; copy is short
-Defaults are the safe, obvious choice (a filter defaults to `=`, not `%`). No internal terms like "DocType" or "Property Setter" in labels. No icon-only buttons in dialogs. Labels say what happens ("Export all matching rows?", "3 rows updated"). Messages name things the user can find (row number, not a hash). Errors are red; non-fatal messages are warnings. `PermissionError` only for permission problems. Short plain sentences, as brief as the sibling labels.
-Why: regular users over power users.
-
-### R42. Bundle size is a budget
-The bundle-size check must pass or be justified. New dialogs and panels load on first use via `frappe.require`. Libraries used by a minority stay out of the default bundle. No second frontend framework. No new dependency for trivial things.
-Why: bundles grow a few KB at a time until it is 300 KB.
-
-### R43. A dialog beats a new doctype; a permission beats a setting
-No doctype for a one-off action or dev-only report; use a button and dialog on the existing doctype, a virtual doctype, or an existing control. Prefer a permission over a setting. A justified setting lives in System Settings with a User-level override that wins. New DocType or DocField properties are exposed in Customize Form.
-Why: do not create new UI when you do not need it.
-
-### R44. UX guardrails
-Confirm destructive and bulk actions. Secondary actions are not primary buttons. Success toast only when nothing failed; failures name the records. Tab, Enter and Escape keep working. Any control change marks the form dirty. Console stays clean. No forced refresh, no extra scrollbars, no dangerous one-click control next to a frequent action.
-Exception: skip the confirm where the label already says it ("Send now").
-
-### R45. Client work is scoped, runs once, cleans up
-`this.wrapper.find()`, not global `$()`. No work per row render or animation frame. `.off()` namespaced listeners before `.on()`. Dialogs are singletons. No `setTimeout` or `MutationObserver` when a lifecycle hook exists. No unscoped `localStorage` keys. Client-side checks must also work when the value is set programmatically (`set_value`, paste, quick entry, grid rows) and when the control is used outside a form.
-Why: a check per animation frame runs sixty times a second.
-
-```javascript
-// Bad
-$(document).on("click", ".sidebar-toggle", () => this.toggle());
-
-// Good
-this.wrapper.off("click.sidebar").on("click.sidebar", ".sidebar-toggle", () => this.toggle());
-```
-
-## Code hygiene
-
-### R46. No comments that say what, no debug noise
-Comments that narrate the code are removed. Issue numbers never go in code. Docstrings that restate the name are dropped; the reasoning goes in the PR. Strip `console.log`, `print`, commented-out code, unused imports, TODOs for another PR. Use `let`/`const`, `??`, `?.`, `.includes()`. Keep methods on the class, not on `frappe.provide` namespaces. No `# nosemgrep` in core.
-Why: comments rot; two of them are already wrong.
-Exception: a non-obvious workaround gets one comment saying why.
-
-### R47. Names say what the thing does
-Fieldname mirrors label. Checkbox fieldnames are positive ("Allow X"). No abbreviations or `d`. Plural names return plurals. No `decorators.py` or `functions.py` grab-bags. `snake_case`; `DocType` and `JSON` casing.
-Why: it should at least resemble what it does.
-
-### R48. Type discipline
-Annotate all params and the return type, or none. Hints must be true (`str | int` for docnames on whitelisted methods; a `Document` cannot cross the API boundary). Lazy imports go behind `if TYPE_CHECKING`. Compare dates with `getdate()`, not strings. `None`, `""` and `0` are different. Compare checkbox and boot values with `cint`, never `=== "1"`. Raise `NotImplementedError` instead of returning a wrong result.
-
-```python
-# Bad
-if doc.posting_date > today():
-
-# Good
-if getdate(doc.posting_date) > getdate():
-```
-
-### R49. Translate whole sentences, and only sentences
-Wrap the full sentence in `_()` / `__()` with `{0}` placeholders. Never build it from f-strings, `+`, ternaries or template literals. Format after translating. No HTML inside the source string; use `frappe.bold()` or a placeholder. Do not translate `"{0}"`, empty strings, fieldnames, file names, user-authored labels, `df.label` or link values.
-Why: constructed strings never get a translation.
-
-```python
-# Bad
-frappe.throw(_("Cannot delete " + doc.name + " because it is submitted"))
-
-# Good
-frappe.throw(_("Cannot delete {0} because it is submitted").format(frappe.bold(doc.name)))
-```
-
-### R50. Flat functions, no guards for impossible states
-Short functions, early return, `if x := ...:`, `a or default`. Inline a two-line helper used once. No `and`/`or` chaining tricks, nested ternaries, `True if … else False`, redundant casts. `.replace()` and `startswith` over regex. No `getattr`, `hasattr`, `isinstance` or empty-list guards for values that are always set. No `None` defaults on API args that cannot be handled.
-Why: guards for impossible states hide real bugs.
-
-### R51. Tests never leak into production code
-No `if frappe.in_test`, no `in_import` or `in_patch` escape hatches, no edge case added to make a test pass. `assert` is for invariants and is not blocked by lint.
-Why: if you have to do this, you broke something.
-
-## Tests
-
-### R52. New behaviour and bug fixes ship with a test that can fail
-Permissions, backups, schema, docstatus transitions, number parsing and anything touching every list view get a test for every promised case. A test that passes without the fix, only checks that nothing raised, swallows the exception, or asserts on generated SQL is rejected. Use `assertQueryCount` for caching claims. Confirm the test fails with the fix reverted.
-Exception: a trivial one-liner, a small UI change with a video, or a race the harness cannot reproduce. Say so.
-
-### R53. Test through interfaces, as a real user, with clean fixtures
-Assert via public interfaces, not cache internals. Use `new_doctype`, `freeze_time`, `set_request`. Tests set their own preconditions and rely on auto-rollback; no manual commit, no leftover Redis state. A feature that only works as Administrator is a bug: switch user. A permission test that calls `get_all` proves nothing; use `get_list`. Fixtures use `example.com`, never real domains, companies, emails or keys, and stay tiny. No issue numbers in test names.
-
-```python
-# Bad
-def test_permission(self):
-    self.assertTrue(frappe.get_all("Note"))
-
-# Good
-def test_permission(self):
-    frappe.set_user("test@example.com")
-    self.assertFalse(frappe.get_list("Note"))
-```
-
-### R54. Flaky tests are fixed, not disabled
-The author investigates red CI: run locally, remove the new test to isolate, rebase. A related failure blocks; an unrelated one is named per check and re-run. Never skip a test to get green. If a test expects the old behaviour, update it. UI behaviour changes get a Cypress test when the repro is deterministic.
-Why: a disabled test comes back to haunt you.
-
-## PR process
-
-### R55. Develop first, backport later
-Fix develop, then `@mergify backport version-N-hotfix` so authorship is kept. A manual port matches the develop diff exactly and carries its dependencies; check the target branch has the prerequisite APIs. Features and behaviour changes wait one to three weeks on develop, or are not backported. Breaking changes stay on develop. Retargeting a PR does not work; open a new one.
-Why: stable branches are where customers are.
-Exception: security and dependency fixes go to stable quickly. A fix that no longer applies on develop may target the hotfix branch. A customer-blocking fix may skip the soak.
-
-### R56. One concern per PR
-Unrelated refactors, renames, formatting, `yarn.lock` churn, `.po` hunks and independent bugs go in their own PR so they can be backported and blamed separately. A targeted fix does not touch the surrounding flow. But do not split a six-line change into four PRs, or open a second PR for a tweak to an open one.
-Why: unrelated changes in one commit make it hard to find and backport anything.
-
-### R57. User-facing docs live on docs.frappe.io; translations on Crowdin
-Hooks, config keys, settings and public utilities land with user-facing docs on docs.frappe.io; internal helpers do not. "Why `no-docs`?" is a fair question. `.po` and `.pot` edits go to Crowdin, never into the repository.
-
-### R58. Revert first, fix later
-A merged change that causes support tickets, crashes, performance regressions, bundle-size failures or broken defaults is reverted immediately, before the cause is understood. The revert says why. The author re-raises with the fix.
-Why: every hour a regression stays on develop it reaches more sites.
-
-### R59. Stale or unfinished PRs are closed with an open door
-Not-ready work goes to Draft; draft means not mergeable. After a nudge, inactive PRs or PRs with too many open issues are closed "for now" with an offer to reopen.
-
-### R60. No automated or AI-generated changesets
-A PR generated without manual review, that references code not in the diff, hides the real cause or reimplements an existing component is closed. Suspected AI code needs a video and a plain explanation before further review. No scripted typo sweeps, vendored-library edits or typo-in-comment PRs. Code lifted from an issue, another PR or another app carries the original author (`git commit --author=`); backport the original PR rather than re-author it.
-Why: reviewer time is the scarcest resource in the project.
-Exception: maintainers may run automated changes themselves after an issue is agreed.
-
+- Back the ask with the issue, the docs or this guide.

--- a/code_review.md
+++ b/code_review.md
@@ -73,7 +73,6 @@ Repro: snippet that shows the bug on develop, or "UI-only"
 - Cite the rule ID. Link the issue or docs when they exist.
 - No preamble, praise, thanks, summary, signature or emoji.
 - `REQUEST_CHANGES` when asks exist, `APPROVE` when none. `COMMENT` only on a PR you created yourself, because GitHub blocks the other two there.
-- No AI attribution in reviews, commits or PR bodies.
 - Answer every bot finding: confirm with a line reference or reject with a reason.
 
 Example:
@@ -420,8 +419,8 @@ this.wrapper.off("click.sidebar").on("click.sidebar", ".sidebar-toggle", () => t
 
 ## Code hygiene
 
-### R46. No comments that say what, no debug noise, no AI attribution
-Comments that narrate the code are removed. Issue numbers never go in code. Docstrings that restate the name are dropped; the reasoning goes in the PR. Strip `console.log`, `print`, commented-out code, unused imports, TODOs for another PR. Use `let`/`const`, `??`, `?.`, `.includes()`. Keep methods on the class, not on `frappe.provide` namespaces. `Co-Authored-By: <AI>` and "Generated with …" lines are removed. No `# nosemgrep` in core.
+### R46. No comments that say what, no debug noise
+Comments that narrate the code are removed. Issue numbers never go in code. Docstrings that restate the name are dropped; the reasoning goes in the PR. Strip `console.log`, `print`, commented-out code, unused imports, TODOs for another PR. Use `let`/`const`, `??`, `?.`, `.includes()`. Keep methods on the class, not on `frappe.provide` namespaces. No `# nosemgrep` in core.
 Why: comments rot; two of them are already wrong.
 Exception: a non-obvious workaround gets one comment saying why.
 

--- a/code_review.md
+++ b/code_review.md
@@ -8,7 +8,6 @@ Contributor-side rules live in the [Pull Request Checklist](https://github.com/f
 
 Check these first. Ask for the missing piece before reading the code.
 
-- Base branch is `develop`. Hotfix branches only get bugs that do not exist on develop.
 - UI changes have before/after screenshots or a video. Ask again after every UI push.
 - The bug reproduces on latest develop with the steps in the PR. If there are no steps, ask for a traceback or a minimal repro. If it cannot be reproduced, close for now.
 - Branch is rebased with no merge commits or unrelated commits.
@@ -107,15 +106,6 @@ Check these first. Ask for the missing piece before reading the code.
 - New behaviour and bug fixes ship with a test that fails without the fix. A test that only checks nothing raised, or asserts on generated SQL, proves nothing.
 - Test through public interfaces as a real user, not Administrator. Permission tests use `get_list`, not `get_all`. Fixtures use `example.com`.
 - Flaky tests are fixed, not disabled. Changed behaviour updates the existing tests.
-
-### Process
-
-- Fix develop first, then backport via Mergify. Features wait on develop before reaching a stable branch. Breaking changes are never backported.
-- One concern per PR. Unrelated refactors, formatting and independent bugs go in their own PR.
-- New hooks, config keys and public utilities are documented on docs.frappe.io. Translations go to Crowdin.
-- A merged change that causes regressions is reverted first and fixed later.
-- Stale or half-done PRs are closed with an offer to reopen.
-- PRs generated without manual review, scripted typo sweeps and vendored-library edits are closed. Code taken from an issue or another PR keeps its original author.
 
 ## Verdict
 

--- a/code_review.md
+++ b/code_review.md
@@ -1,0 +1,571 @@
+# Frappe Framework: Code Review Guide
+
+What maintainers check when they review a pull request to `frappe/frappe`, collected from their review comments. For reviewers, contributors and AI agents.
+
+Read the Workflow section before every review. Rules are numbered so you can point to them in a comment (`R11`). If a rule gives a wrong answer in a real case, change the rule here instead of ignoring it.
+
+Contributor-side rules live in the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) and [Coding Standards](https://github.com/frappe/erpnext/wiki/Coding-Standards).
+
+---
+
+## Workflow
+
+### Read first
+
+- Read the PR body and every comment. Maintainers often raise PRs on behalf of contributors ("raised on behalf of @x"). That person is the author you talk to.
+- Read other maintainers' comments. Do not repeat them. Check whether earlier asks were addressed.
+- Read the linked issue and check the PR fixes what it describes.
+
+### Gates
+
+Stop at the first failing gate and ask for it. Do not review code behind a failing gate.
+
+1. Base branch is `develop`. A hotfix branch is fine only when the bug does not exist on develop. `version-N` is always wrong.
+2. UI change has before/after screenshots or a video with real data. Anything a user sees counts: desk JS, Vue, SCSS, HTML, print formats, web pages, dialogs, icons. No media, no review. Ask again after every UI push.
+3. The bug reproduces on latest develop with the PR's own steps. No steps: ask for a text traceback, the failing input or the minimal query. Cannot reproduce: close for now. Already fixed: close with the commit.
+4. Branch is rebased, with no merge commits and no foreign commits.
+5. Pre-commit is green. A reformatted file is not reviewable. Do not list files; give the command:
+   ```bash
+   pip install pre-commit && pre-commit run --all-files
+   ```
+6. Title and every commit follow Conventional Commits. The title is what gets squash-merged. `feat:` PRs carry `no-docs` or a docs link. `fixes #N` only if the issue is really fixed.
+7. Description says what was broken, why, what changed and how to test. It matches the final diff.
+
+### Review steps
+
+Say which steps found nothing. Steps 2, 3 and 4 are the ones most often skipped.
+
+1. Root cause. Find where the bad state comes from. If there is one writer, the fix undoes that writer. If the same failure fires later in the flow, the symptom moved. Read the commit that introduced the behaviour before accepting a change to it.
+2. Should this exist in this shape. For every new field, flag, param, endpoint, setting or status: list the existing values next to it. If they already express the thing, the new one is redundant. Try the contradicting combination (old value says X, new flag says Y). `depends_on` only hides a field; a stale value still applies. A new status needs every abnormal exit covered.
+3. Residue. Dead code, no-op CSS, orphan flags, classes, callers, tests, junk rows. Grep before calling a CSS rule a no-op. Residue is blocking.
+4. Incomplete fix. Grep the buggy expression across the repo. Sibling files with the same bug (JS vs Python, DocField vs Custom Field vs Customize Form Field, MariaDB vs Postgres, form vs grid vs list vs print) make the fix incomplete. Check the sibling is reachable first.
+5. Correctness and security. `None`, empty, `0`, `"0"`, negative, huge; docstatus 0, 1, 2; permissions; multi-site; translations; both databases. Every whitelisted method checks permission before reading and takes identity from `frappe.session.user`. Every new throw leaves the user a way out. Existing records keep working.
+6. Conventions. DocType JSON edited through the UI with a bumped `modified`. `frappe.throw` with a title. `_()` / `__()` on user-facing strings. No comments, `console.log`, `print`, commented-out code, `var`. Desk UI uses `frappe.utils.icon()`, `es-button`, `es-badge`, design tokens, gray accents, no duplicate CSS. Fixtures use `example.com`. New server functions have tests.
+7. CI. Name the failing check. Test failures block. Semgrep on unchanged code, the docs check and the dependency check do not block on their own.
+
+Before reporting any finding, grep the exact symbol, string or class you name, in the repo and in the diff. If it is not there, drop it. Cite a file:line you read. One true sentence per finding. Bot findings (Greptile, Copilot, Semgrep) are reproduced on the branch and answered with facts.
+
+### Verdict
+
+Any real ask means changes requested. Ready with nits is only for things you would not actually ask to change. Send to a maintainer when the answer is in the Unsettled section or is a product call.
+
+Blocking, not a nit: a new crash, blank screen or uncaught exception; leftover no-op code; a sibling file with the same bug; a missing `modified` bump; a missing permission check on a new endpoint; a stuck status; a breaking change without `!` and a migration path.
+
+Do not downgrade a finding to approve. Do not upgrade a style nit to look thorough.
+
+```
+PR #N: <title>
+Verdict: READY | CHANGES REQUESTED | NEEDS HUMAN JUDGMENT
+Prior review: none | addressed | partly (what remains)
+Rationale: up to 3 sentences
+Findings:
+  - blocking | nit, file:line, the one-sentence claim, the ask (rule ID), replacement text if one-line
+Steps that found nothing: <numbers>
+Repro: snippet that shows the bug on develop, or "UI-only"
+```
+
+### Writing the review
+
+- Inline comments on the exact line, with a ` ```suggestion ` block when the fix is one line. The body is only for asks with no line (add tests, fix the title, add a video). Never write "see inline".
+- `@handle` once, in the first comment, then ask: "@user, could you please …".
+- One concern per comment. One to three short sentences. Plain words a non-native speaker reads once.
+- For "do X instead", show X as a one-line code example.
+- Cite the rule ID. Link the issue or docs when they exist.
+- No preamble, praise, thanks, summary, signature or emoji.
+- `REQUEST_CHANGES` when asks exist, `APPROVE` when none. `COMMENT` only on a PR you created yourself, because GitHub blocks the other two there.
+- No AI attribution in reviews, commits or PR bodies.
+- Answer every bot finding: confirm with a line reference or reject with a reason.
+
+Example:
+
+> @author, could you please move this check into `validate()`? List view bulk delete and `frappe.client.delete` skip it right now (R16).
+>
+> ```suggestion
+> def validate(self):
+>     self.validate_unique_route()
+> ```
+
+---
+
+## Scope
+
+### R1. No app-specific code in the framework
+Frappe must behave the same for every app. Do not add a field, doctype, role or `if doctype == "Sales Invoice"` branch that only ERPNext, CRM, HRMS or Drive needs. Add a hook in the framework and let the app implement it in its own code.
+Why: the framework cannot see how apps use it. A special case for one app breaks silently when that app changes.
+Exception: something generic that every app could use may move from an app into the framework.
+
+```python
+# Bad: framework code checks an ERPNext doctype
+if doc.doctype == "Sales Invoice" and doc.is_return:
+    reverse_stock(doc)
+
+# Good: framework offers a hook, ERPNext implements it in its hooks.py
+for method in frappe.get_hooks("on_return_document"):
+    frappe.call(method, doc=doc)
+```
+
+### R2. Non-framework features go in a separate app; framework features need a user
+Print backends, spam filters, third-party integrations and similar live in an app that hooks in. A new framework API ships together with at least one real use inside Frappe.
+Why: no is temporary, yes is forever. Plumbing without a consumer rots.
+
+### R3. Ask for the use case before reading the code
+If the PR does not state a user-facing problem, ask what the author is trying to do. Feature work and big refactors need a nod first (an issue or a discussion). Refactors of critical areas (caching, database APIs, `Document`) are done by core maintainers.
+Why: reviewing a mechanism for a problem nobody has wastes both sides' time.
+Exception: a small, clearly useful fix with no ticket still merges.
+
+### R4. No new setting for niche behaviour
+No System Settings switch, config key or checkbox for behaviour one app or one user wants. Ship the sane default or make it per-DocType through Customize Form.
+Why: every toggle doubles the test matrix and stays forever.
+Exception: when users would legitimately disagree about a visible behaviour, make it configurable per user or per DocType.
+
+### R5. Direction beats local utility
+Do not extend surfaces the project is leaving: the website module (Builder replaces it), report-view aggregation (Insights), legacy client JS, `frappe.call` where API v2 is the target.
+Why: every addition to a legacy surface has to be migrated or dropped later.
+
+### R6. Change size matches the problem
+A small ask arriving as a large diff is pushed back. If an existing doctype, page, library or API does most of the job, add the missing part there. A "new X" next to an existing X needs a stated limitation of the current one.
+Why: parallel implementations drift and double the maintenance.
+
+### R7. Unfinished or experimental work is closed or gated
+Half-done PRs are closed. Experimental capabilities (new database backend, integer primary keys) ship opt-in or marked beta. Unused features and promotional banners are removed, not fixed.
+Why: users install what is merged.
+
+## Root cause
+
+### R8. Fix the root cause where it lives
+A fix that makes an error go away without explaining why it happened is rejected. Fix it in the layer that owns it (ORM, util, datatable, shared control), not at one call site.
+Why: a symptom patch leaves the bug for the next caller.
+Exception: a harmless shallow fix may merge under release pressure, with the deep fix noted in the PR.
+
+### R9. Removing a check is not a fix
+Deleting a guard, condition, style or method to make a symptom disappear is rejected.
+Why: the check was protecting something. The PR has to say what, and why that no longer applies.
+
+### R10. Understand the original design first
+Read the commit that introduced the behaviour. Search callers and blame. Odd code is often intentional.
+Why: "you are making a new assumption; this is not what the original design was."
+
+### R11. Do not add what already exists
+Before adding a field, flag, param, endpoint, setting or patch, check whether an existing value, argument, default or `None` already carries the meaning. Make an existing flag tri-state before adding a second one. No patch for things `migrate` already syncs.
+Why: two mechanisms for one meaning can disagree, and every new surface is API forever.
+
+```python
+# Bad
+def get_list(doctype, order_by="modified desc", no_order=False):
+
+# Good: order_by=None means no ordering
+def get_list(doctype, order_by="modified desc"):
+```
+
+### R12. Reuse before reimplementing
+Use `@redis_cache`, `cached_property`, `frappe.generate_hash`, `frappe.db.set_value(update_modified=False)`, `frappe.ui.keys.add_shortcut`, `frappe.ui.freeze`, `frappe.utils.icon`, `str.join` and library defaults before writing new code. One implementation per piece of logic; extract a helper at the second or third repeat.
+Why: copies drift, and custom apps copy whatever core does.
+Exception: a little duplication beats coupling unrelated modules.
+
+### R13. Smallest correct change, no residue
+Prefer the one-line fix. Remove unused boot data, unreachable branches, single-use wrappers, params only ever passed one value, properties nothing reads, commented-out code, stale docstrings, no-op CSS. Residue is blocking.
+Why: dead code is read by everyone who comes after, and a no-op rule looks like it does something.
+
+### R14. Simplest mechanism wins
+Plain functions and `if` blocks. No inheritance towers, monkey-patching, global mutable state, threads, savepoints or Lua scripts unless proven necessary.
+Why: complexity is paid on every read.
+
+### R15. Finish the sweep, keep every surface consistent
+A change to one of a parallel set (DocField / Custom Field / Customize Form Field; Link / Dynamic Link; wkhtmltopdf / Chrome; form / grid / list / report / print) is incomplete until the siblings are done. A display or behaviour change applies everywhere the value appears, or not at all.
+Why: two surfaces that disagree are a new bug.
+
+### R16. Put the check at the choke point
+Validation goes in `validate`, `on_trash` or `on_update`, not in one whitelisted caller.
+Why: list view bulk actions, `frappe.client.*`, the REST API and `doc.save()` all skip a check that lives in one endpoint.
+
+```python
+# Bad
+@frappe.whitelist()
+def rename_route(name, route):
+    if route_exists(route):
+        frappe.throw(_("Route already exists"))
+
+# Good
+class WebPage(Document):
+    def validate(self):
+        self.validate_unique_route()
+```
+
+### R17. Do not hardcode what the framework knows
+No hardcoded doctype names, `Administrator` checks, naming series, countries, logos, hosts or binary paths. Read hooks, defaults and config. Per-doctype behaviour goes on a DocType or DocField checkbox exposed in Customize Form.
+Why: hardcoded values are the branches nobody finds until a site differs.
+
+### R18. Explicit arguments, one return shape
+Functions and hooks take named parameters (`doctype`, `name`, `doc`), not dict or kwargs bags. State goes on `doc.flags`, not `frappe.flags`. No sentinel strings. A function returns one shape. Rename on the client, not in the server response.
+Why: callers can read a signature; they cannot read a bag.
+Exception: hook callbacks may take kwargs so the signature can grow.
+
+### R19. Cover the edge cases, and leave the user a way out
+For every new branch ask what happens on `None`, duplicates, the user's own record, a queued job, a submitted document, a deleted doctype, `[Select]`. A new guard must not make the flow that resolves it also throw.
+Why: "clearing the field then throws `UpdateAfterSubmitError`; there is no way out."
+Exception: no fallbacks for states that cannot happen.
+
+### R20. Keep extension points
+Do not move or remove a hook without checking what depends on its timing. Core checks must not throw before app hooks run. Add a hook to the existing function, not a parallel one.
+Why: apps depend on hook order.
+
+## Backward compatibility
+
+### R21. Break only when not breaking costs more
+Established behaviour (select values, ordering defaults, signatures, lifecycle semantics, exception classes) is not changed for one use case. List who depends on it across frappe, erpnext, hrms and the other apps. Take the non-breaking variant when there is one. Internal symbols can be dropped; public ones need a compatibility path. Unreleased code owes nothing.
+Why: every app on every site pays for a break.
+Exception: behaviour that never worked, or hurts most users, may change.
+
+### R22. Deprecate one major before removing
+Public functions, paths and params get a `deprecation_warning` in place, one major for apps to migrate, then removal. No proxy classes or inspect-based machinery. Prefer fixing over deleting.
+Why: before a major, grep `deprecation_warning` and remove that code. Nothing else to remember.
+
+### R23. Defaults never flip
+A new option ships with the old behaviour as default. A rejected default may live on as an opt-in setting.
+Why: people do not notice a new checkbox. They notice their site changed.
+
+### R24. Add new, migrate, hide old
+Never repurpose or retype a field, and never change what `modified` or `creation` mean. Add a new field, migrate on save plus a patch, hide the old one, remove next major. Do not rename or remove CLI flags, kwargs, argument order, module paths or icons apps may use. New arguments go last with a default.
+Why: existing rows and calls must survive `bench migrate`.
+
+### R25. Exports and reports are an API
+Changing what CSV or Excel exports and report rows contain is breaking. Make it opt-in at export time or add columns. Never backport it.
+Why: exports get re-imported and parsed by other systems.
+
+### R26. Constraint changes ship with a patch
+A new unique constraint, validation or default that existing rows would violate blocks `bench migrate`. Ship a patch that repairs the data, or drop the constraint. A patch that needs new schema calls `frappe.reload_doctype` first.
+Why: sites with old data cannot update otherwise.
+
+### R27. Breaking changes carry `!` and stay on develop
+Use `fix!:` or `feat!:`. Do not backport them. A framework change that needs an ERPNext change lands after the ERPNext PR, with an ERPNext CI run linked. Query builder, permission and core-model changes get that run too.
+Why: release notes and the migration guide come from the prefix.
+
+### R28. Working as designed closes the PR
+`on_update` runs after insert (use `after_insert`). User timezone is display-only. `Link` is a string. Prepared reports are owner-scoped. Several client scripts per doctype is a feature. A PR that "fixes" one of these is closed with the reason.
+Why: apps are built on these semantics.
+
+### R29. Do not take features away from regular users
+A change that makes a common workflow harder for non-technical users, or quietly disables a feature (data import mapping, URL attachments, saved filters), is reverted. Put the burden on system managers.
+Why: users use templates; system managers create them.
+
+## Server side and security
+
+### R30. Business logic lives on the server, completely
+A rule enforced in JS (mandatory-depends-on, `set_query` filters, computed values) is also enforced in the controller. Params a check depends on are mandatory. Settings that gate a user are permlevel > 0. Search and validate agree.
+Why: the REST API, data import and server scripts never run client code.
+Exception: a purely cosmetic client-side permission (hiding a print button) needs no server check.
+
+```python
+class Event(Document):
+    def validate(self):
+        if not self.ends_on:
+            frappe.throw(_("End date is required"), title=_("Missing Value"))
+```
+
+### R31. Never punch holes in permissions
+`ignore_permissions=True`, blanket role grants and permission-less endpoints are not fixes. Use `doc.check_permission()`, `frappe.has_permission` and `frappe.only_for` so Is Owner and User Permissions apply, and give the user the right permission instead. Check before `get_doc` or any return, on every branch. Identity comes from `frappe.session.user`, never from the client.
+Why: better to give the user the right permission than to create a hole.
+
+```python
+# Bad
+@frappe.whitelist()
+def get_report(user, name):
+    return frappe.get_doc("Prepared Report", name, ignore_permissions=True)
+
+# Good
+@frappe.whitelist()
+def get_report(name):
+    doc = frappe.get_doc("Prepared Report", name)
+    doc.check_permission("read")
+    return doc
+```
+
+### R32. The right permission primitive in the right place
+Internal code uses `frappe.get_all`; user-facing results use `frappe.get_list`. Permlevels over ad-hoc code. If custom DocPerms exist, only they apply. API v2 endpoints check manually. Logs need only `read`.
+Why: a permission check in internal code is a bug; a missing one in user-facing code is a hole.
+Exception: `get_list` does not work on child tables.
+
+### R33. Whitelisted endpoints are public URLs
+Set `methods=[...]` on security-critical and guest endpoints. Store only hashes of keys and tokens. Never return `site_config` secrets. Website users can call whitelisted methods too. No `allow_guest` on flows that need login.
+
+```python
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+def subscribe(email):
+    ...
+```
+
+### R34. Escape at render, never at storage
+Do not sanitise on store or globally in a formatter. Escape where the value goes into HTML, per fieldtype. Escape rather than strip. Use `|e` in Jinja.
+Why: storing anything is safe; injecting it as HTML is not. Stripping loses data.
+
+```javascript
+// Bad
+$wrapper.html(`<div>${doc.title}</div>`);
+
+// Good
+$wrapper.html(`<div>${frappe.utils.escape_html(doc.title)}</div>`);
+```
+
+### R35. A security claim needs a demonstrated bypass
+Ask where exactly permissions are bypassed; close if it cannot be shown. Reject rate limits and information hiding that cost more than they protect. Harden once in the shared layer, not per input. But any path that lets a normal user gain admin is blocked whatever the UX cost. Do not widen `safe_exec` or Jinja globals, read files from user input, or allow expressions in `autoname`.
+Why: there is no end to designing for stupidity, but privilege escalation beats UX.
+Exception: System Manager-authored Jinja and HTML is trusted. Other holes do not justify a new one.
+
+### R36. Fail loudly, catch the specific exception
+Permission failures raise `frappe.PermissionError`. No blanket `try/except`, no `log_error` without a traceback, chain with `raise ... from exc`. Promises get `.catch`. Background jobs already log. A friendly catch is scoped to exactly its condition.
+Why: failing is better than silently ignoring.
+
+```python
+# Bad
+try:
+    doc.submit()
+except Exception:
+    pass
+
+# Good
+try:
+    doc.submit()
+except frappe.ValidationError:
+    frappe.msgprint(_("Could not submit {0}").format(doc.name))
+    raise
+```
+
+### R37. Never destroy data silently
+No `ELSE NULL` in update queries, no sanitisers that drop content, no defaults that overwrite `creation`, `owner` or `name`. Disable instead of delete. Confirm bulk and destructive actions. Audit tables are immutable.
+Why: bad UX beats irrecoverable data loss.
+
+## Performance
+
+### R38. Nothing lands in the hot path for everyone
+Anything that runs on every request, document load, save or desk boot is opt-in or free. The common case never pays for the edge case. No API calls or queries on page load; read from `frappe.boot`. Anything added to boot is cached.
+Why: per-request overhead multiplies across every site.
+Exception: a few bytes in boot beat a separate request.
+
+```javascript
+// Bad: one request per form load
+frappe.db.get_single_value("System Settings", "float_precision").then(...)
+
+// Good
+const precision = frappe.boot.sysdefaults.float_precision;
+```
+
+### R39. Think in 100k rows
+No `get_doc` in loops or to update one field, no unindexed filters, no full-table sorts, no `limit: 0`, no O(N) Redis scans. Hoist meta lookups and hooks out of loops. Batch link fetches. Cap `IN (...)` near 1000.
+Why: users import lakhs of records.
+
+```python
+# Bad
+for name in names:
+    doc = frappe.get_doc("Item", name)
+    doc.disabled = 1
+    doc.save()
+
+# Good
+frappe.db.set_value("Item", {"name": ("in", names)}, "disabled", 1)
+```
+
+### R40. Slow or external work goes to a background job
+Work over about ten seconds, third-party API calls, bulk PDFs, renames and notification emails are enqueued, never run in a request or `validate`. Heavy work uses `queue="long"`. In patches, use an `update` query or `bulk_insert` and commit in batches, never one row at a time.
+Why: a worker blocked for a minute is a site down for everyone on that worker.
+
+### R41. Performance changes need numbers
+Show profiler output, `EXPLAIN`, benchmarks or bundle deltas at production scale, measured as a real user, not Administrator. A perf change names the cost it removes. No caches that cannot hit, no cache on top of `get_meta` or settings (already cached), no micro-optimisation that adds code for a tiny gain.
+Why: a cache is a key, a TTL, invalidation sites and tests, all to skip one indexed query.
+Exception: do not optimise paths that run once in a blue moon.
+
+## Database
+
+### R42. Use the highest-level API that does the job
+ORM (`frappe.db.get_value`, `set_value`, `get_list`) when it expresses the query; query builder when the ORM cannot; never hand-written dialect SQL. Do not bypass `delete_doc` and controller hooks with `frappe.db.delete` without a stated reason.
+Why: lower-level APIs skip caching, permissions, hooks and portability.
+
+### R43. No `commit()` in document events
+Doc-event code never commits; requests commit at the end. Side effects that must survive run `after_commit`. Every state transition calls `check_if_latest`, with no bypass flag.
+Why: a commit inside `validate` persists a half-saved document.
+Exception: a helper reachable from a GET may commit, and patches commit in batches.
+
+### R44. Parse, don't validate; MariaDB is the reference
+Turn known inputs into query builder objects and let it emit SQL. Never regex-check or rewrite generated SQL. When drivers disagree, MariaDB is canonical and Postgres adapts; DB-specific code lives in `frappe/database/<db>/`. Permission filters go in `WHERE`, not `JOIN`. Do not add columns to `DISTINCT` or `GROUP BY` to satisfy Postgres. Pass `order_by=None` when order does not matter; tie-break paginated sorts with a unique column. Avoid `ifnull` and `coalesce`, never on `name`.
+Why: non-deterministic order makes pagination wrong.
+
+### R45. Pick the right cache and prove invalidation
+`@site_cache` is per process and never invalidated; use `@request_cache` for permission-dependent data. Single values use `frappe.cache.get_value`, not a hash. Keys are stable and prefixed. Invalidation covers every mutation; clear and recompute rather than maintain by hand.
+Why: a stale permission cache is a security bug.
+
+### R46. Patches only when data moves; DocType JSON only through the UI
+No patch for what `migrate` already syncs (doctypes, workspaces, module defs, new-field defaults). DocType JSON is changed through the DocType form or Customize Form and the export committed with its bumped `modified`, child tables included. A hand-edited JSON is sent back. A `modified`-only bump with no field change is reverted. Index changes need a patch or a `modified` bump so `on_doctype_update` runs.
+Why: DocType JSON is generated by code; humans and agents should not touch it directly.
+
+### R47. Let the schema enforce invariants; jobs are idempotent
+Mandatory fields become `NOT NULL`. A unique constraint beats app-level dedup. Hooks run on every retry, so jobs are idempotent and take context from `frappe.job`. New log-like doctypes register `clear_old_logs`. Files written on a schedule get a retention window and cleanup that cannot hit user data.
+Why: otherwise they are persisted forever.
+
+## UI
+
+### R48. Design tokens, no CSS duplication, right file
+Every colour, weight and spacing is a token or CSS variable; check both themes. Reuse existing classes. Repeated rules go on a parent class. Delete rules with no user. View-specific CSS lives in that view's file. No inline styles, `!important`, `position: fixed` or fixed-height hacks.
+Why: more CSS means a larger bundle and more to maintain.
+Exception: print CSS stays light; no dark-mode tokens in PDFs.
+
+```scss
+// Bad
+.sidebar-item { color: #1f272e; font-weight: 420; }
+
+// Good
+.sidebar-item { color: var(--text-color); font-weight: var(--weight-medium); }
+```
+
+### R49. Espresso components, sprite icons, gray accents
+New desk UI uses `es-button` and `es-badge` with data attributes, not bootstrap `btn` and `badge`. Icons come from `frappe.utils.icon()` with names in the sprite; no hand-written SVG, no emoji. Accents are gray, not blue. A new control follows the sibling control; match avatars, indicators, labels, column order and empty states.
+Why: keep the design consistent with existing components.
+
+```javascript
+// Bad
+$(`<button class="btn btn-primary btn-sm"><svg …></svg> Add</button>`)
+
+// Good
+$(`<button class="es-button" data-variant="subtle" data-size="sm">${frappe.utils.icon("add", "sm")} ${__("Add")}</button>`)
+```
+
+### R50. Defaults serve non-technical users; copy is short
+Default filter operator is `=`, not `%`. No "Property Setter" or "DocType" in labels. No icon-only buttons in dialogs. Labels say what happens ("Export all matching rows?", "3 rows updated"). Messages name things the user can find (row number, not a hash). Errors are red; non-fatal messages are warnings. `PermissionError` only for permission problems. Short plain sentences, as brief as the sibling labels.
+Why: regular users over power users.
+
+### R51. Bundle size is a budget
+The bundle-size check must pass or be justified. New dialogs and panels load on first use via `frappe.require`. Libraries used by a minority stay out of the default bundle. No second frontend framework. No new dependency for trivial things.
+Why: bundles grow a few KB at a time until it is 300 KB.
+
+### R52. A dialog beats a new doctype; a permission beats a setting
+No doctype for a one-off action or dev-only report; use a button and dialog on the existing doctype, a virtual doctype, or an existing control. Prefer a permission over a setting. A justified setting lives in System Settings with a User-level override that wins. Desk branding lives in Navbar Settings. New DocType or DocField properties are exposed in Customize Form.
+Why: do not create new UI when you do not need it.
+
+### R53. UX guardrails
+Confirm destructive and bulk actions. Secondary actions are not primary buttons. Dropdowns close on select. Success toast only when nothing failed; failures name the records. Disabled pages 404. Tab, Enter and Escape keep working. Any control change marks the form dirty. Console stays clean. No forced refresh, no extra scrollbars, no dangerous one-click control next to a frequent action.
+Exception: skip the confirm where the label already says it ("Send now").
+
+### R54. Client work is scoped, runs once, cleans up
+`this.wrapper.find()`, not global `$()`. No work per row render or animation frame. `.off()` namespaced listeners before `.on()`. Dialogs are singletons. No `setTimeout` or `MutationObserver` when a lifecycle hook exists. No unscoped `localStorage` keys. JS validation must not depend on the awesomplete list, `.grid`, `:visible` or `frm`; think of `set_value`, paste, quick entry and grid rows.
+Why: a check per animation frame runs sixty times a second.
+
+```javascript
+// Bad
+$(document).on("click", ".sidebar-toggle", () => this.toggle());
+
+// Good
+this.wrapper.off("click.sidebar").on("click.sidebar", ".sidebar-toggle", () => this.toggle());
+```
+
+## Code hygiene
+
+### R55. No comments that say what, no debug noise, no AI attribution
+Comments that narrate the code are removed. Issue numbers never go in code. Docstrings that restate the name are dropped; the reasoning goes in the PR. Strip `console.log`, `print`, commented-out code, unused imports, TODOs for another PR. Use `let`/`const`, `??`, `?.`, `.includes()`. Keep methods on the class, not on `frappe.provide` namespaces. `Co-Authored-By: <AI>` and "Generated with …" lines are removed. No `# nosemgrep` in core.
+Why: comments rot; two of them are already wrong.
+Exception: a non-obvious workaround gets one comment saying why.
+
+### R56. Names say what the thing does
+Fieldname mirrors label. Checkbox fieldnames are positive ("Allow X"). No abbreviations or `d`. Plural names return plurals. No `decorators.py` or `functions.py` grab-bags. `snake_case`; `DocType` and `JSON` casing.
+Why: it should at least resemble what it does.
+
+### R57. Type discipline
+Annotate all params and the return type, or none. Hints must be true (`str | int` for docnames on whitelisted methods; a `Document` cannot cross the API boundary). Lazy imports go behind `if TYPE_CHECKING`. Compare dates with `getdate()`, not strings. `None`, `""` and `0` are different. Compare checkbox and boot values with `cint`, never `=== "1"`. Raise `NotImplementedError` instead of returning a wrong result.
+
+```python
+# Bad
+if doc.posting_date > today():
+
+# Good
+if getdate(doc.posting_date) > getdate():
+```
+
+### R58. Translate whole sentences, and only sentences
+Wrap the full sentence in `_()` / `__()` with `{0}` placeholders. Never build it from f-strings, `+`, ternaries or template literals. Format after translating. No HTML inside the source string; use `frappe.bold()` or a placeholder. Do not translate `"{0}"`, empty strings, fieldnames, file names, user-authored labels, `df.label` or link values.
+Why: constructed strings never get a translation.
+
+```python
+# Bad
+frappe.throw(_("Cannot delete " + doc.name + " because it is submitted"))
+
+# Good
+frappe.throw(_("Cannot delete {0} because it is submitted").format(frappe.bold(doc.name)))
+```
+
+### R59. Flat functions, no guards for impossible states
+Short functions, early return, `if x := ...:`, `a or default`. Inline a two-line helper used once. No `and`/`or` chaining tricks, nested ternaries, `True if … else False`, redundant casts. `.replace()` and `startswith` over regex. No `getattr`, `hasattr`, `isinstance` or empty-list guards for values that are always set. No `None` defaults on API args that cannot be handled.
+Why: guards for impossible states hide real bugs.
+
+### R60. Tests never leak into production code
+No `if frappe.in_test`, no `in_import` or `in_patch` escape hatches, no edge case added to make a test pass. `assert` is for invariants and is not blocked by lint.
+Why: if you have to do this, you broke something.
+
+## Tests
+
+### R61. New behaviour and bug fixes ship with a test that can fail
+Permissions, backups, schema, docstatus transitions, number parsing and anything touching every list view get a test for every promised case. A test that passes without the fix, only checks that nothing raised, swallows the exception, or asserts on generated SQL is rejected. Use `assertQueryCount` for caching claims. Confirm the test fails with the fix reverted.
+Exception: a trivial one-liner, a small UI change with a video, or a race the harness cannot reproduce. Say so.
+
+### R62. Test through interfaces, as a real user, with clean fixtures
+Assert via public interfaces, not cache internals. Use `new_doctype`, `freeze_time`, `set_request`. Tests set their own preconditions and rely on auto-rollback; no manual commit, no leftover Redis state. A feature that only works as Administrator is a bug: switch user. A permission test that calls `get_all` proves nothing; use `get_list`. Fixtures use `example.com`, never real domains, companies, emails or keys, and stay tiny. No issue numbers in test names.
+
+```python
+# Bad
+def test_permission(self):
+    self.assertTrue(frappe.get_all("Note"))
+
+# Good
+def test_permission(self):
+    frappe.set_user("test@example.com")
+    self.assertFalse(frappe.get_list("Note"))
+```
+
+### R63. Flaky tests are fixed, not disabled
+The author investigates red CI: run locally, remove the new test to isolate, rebase. A related failure blocks; an unrelated one is named per check and re-run. Never skip a test to get green. If a test expects the old behaviour, update it. UI behaviour changes get a Cypress test when the repro is deterministic.
+Why: a disabled test comes back to haunt you.
+
+### R64. The reviewer runs the branch
+Check out the PR and follow the author's own steps. A fix that fails on its own steps goes back. Ask the author to confirm the final state before merging. Claims are backed by a bench console repro or measured numbers.
+
+## PR process
+
+### R65. Develop first, backport later
+Fix develop, then `@mergify backport version-N-hotfix` so authorship is kept. A manual port matches the develop diff exactly and carries its dependencies; check the target branch has the prerequisite APIs. Features and behaviour changes wait one to three weeks on develop, or are not backported. A v15 label usually needs v16 too. Breaking changes stay on develop. Retargeting a PR does not work; open a new one.
+Why: stable branches are where customers are.
+Exception: security and dependency fixes go to stable quickly. A fix that no longer applies on develop may target the hotfix branch. A customer-blocking fix may skip the soak.
+
+### R66. One concern per PR
+Unrelated refactors, renames, formatting, `yarn.lock` churn, `.po` hunks and independent bugs go in their own PR so they can be backported and blamed separately. A targeted fix does not touch the surrounding flow. But do not split a six-line change into four PRs, or open a second PR for a tweak to an open one.
+Why: unrelated changes in one commit make it hard to find and backport anything.
+
+### R67. Docs for new APIs; translations and docs never in the repo
+Hooks, config keys, settings and public utilities land with docs on docs.frappe.io; internal helpers do not. "Why `no-docs`?" is a fair question. `.po` and `.pot` edits go to Crowdin. No documentation files in the repository.
+
+### R68. Revert first, fix later
+A merged change that causes support tickets, crashes, performance regressions, bundle-size failures or broken defaults is reverted immediately, before the cause is understood. The revert says why. The author re-raises with the fix.
+Why: every hour a regression stays on develop it reaches more sites.
+
+### R69. Stale or unfinished PRs are closed with an open door
+Not-ready work goes to Draft; draft means not mergeable. After a nudge, inactive PRs or PRs with too many open issues are closed "for now" with an offer to reopen.
+
+### R70. No automated or AI-generated changesets
+A PR generated without manual review, that references code not in the diff, hides the real cause or reimplements an existing component is closed. Suspected AI code needs a video and a plain explanation before further review. No scripted typo sweeps, vendored-library edits or typo-in-comment PRs. Code lifted from an issue, another PR or another app carries the original author (`git commit --author=`); backport the original PR rather than re-author it.
+Why: reviewer time is the scarcest resource in the project.
+Exception: maintainers may run automated changes themselves after an issue is agreed.
+
+---
+
+## Unsettled
+
+Maintainers disagree on these. State both positions and tag a maintainer.
+
+1. Docstrings: required on every new function, or stripped along with comments.
+2. `# nosemgrep`: never in core, or fine with a stated reason.
+3. Settings toggles: how strictly R4's exception applies.
+4. Explicit `commit()`: never in doc events is agreed; GET-reachable helpers and long patches are not.
+5. `get_list` vs `get_all`: where "user-facing" ends and "internal" begins.
+6. MariaDB parity vs Postgres strictness for query semantics.
+7. Hotfix-branch PRs: always re-raise on develop, or accept when the develop fix no longer applies.
+8. Backport soak time: one week, two, three, or "once stable".
+9. Docs as a merge gate, or a non-blocking check.
+10. Tests for small fixes: always, or manual verification is enough.
+11. Duplication vs coupling: no written test for "weird coupling".
+12. Admin-authored expressions: Jinja and `visible_if` are trusted, `autoname` expressions were rejected.
+13. Deprecation ladder: warn one major and remove the next, or drop internal symbols without warning. "Internal" is not defined.

--- a/code_review.md
+++ b/code_review.md
@@ -47,7 +47,7 @@ Before reporting any finding, grep the exact symbol, string or class you name, i
 
 ### Verdict
 
-Any real ask means changes requested. Ready with nits is only for things you would not actually ask to change. Send to a maintainer when the answer is in the Unsettled section or is a product call.
+Any real ask means changes requested. Ready with nits is only for things you would not actually ask to change. Send to a maintainer when it is a product call.
 
 Blocking, not a nit: a new crash, blank screen or uncaught exception; leftover no-op code; a sibling file with the same bug; a missing `modified` bump; a missing permission check on a new endpoint; a stuck status; a breaking change without `!` and a migration path.
 
@@ -497,22 +497,3 @@ A PR generated without manual review, that references code not in the diff, hide
 Why: reviewer time is the scarcest resource in the project.
 Exception: maintainers may run automated changes themselves after an issue is agreed.
 
----
-
-## Unsettled
-
-Maintainers disagree on these. State both positions and tag a maintainer.
-
-1. Docstrings: required on every new function, or stripped along with comments.
-2. `# nosemgrep`: never in core, or fine with a stated reason.
-3. Settings toggles: how strictly R4's exception applies.
-4. Explicit `commit()`: never in doc events is agreed; GET-reachable helpers and long patches are not.
-5. `get_list` vs `get_all`: where "user-facing" ends and "internal" begins.
-6. MariaDB parity vs Postgres strictness for query semantics.
-7. Hotfix-branch PRs: always re-raise on develop, or accept when the develop fix no longer applies.
-8. Backport soak time: one week, two, three, or "once stable".
-9. Docs as a merge gate, or a non-blocking check.
-10. Tests for small fixes: always, or manual verification is enough.
-11. Duplication vs coupling: no written test for "weird coupling".
-12. Admin-authored expressions: Jinja and `visible_if` are trusted, `autoname` expressions were rejected.
-13. Deprecation ladder: warn one major and remove the next, or drop internal symbols without warning. "Internal" is not defined.

--- a/code_review.md
+++ b/code_review.md
@@ -11,7 +11,7 @@ Check these first. Ask for the missing piece before reading the code.
 - UI changes have before/after screenshots or a video. Ask again after every UI push.
 - The bug reproduces on latest develop with the steps in the PR. If there are no steps, ask for a traceback or a minimal repro. If it cannot be reproduced, close for now.
 - Branch is rebased with no merge commits or unrelated commits.
-- Title and commits follow Conventional Commits. The title is what gets squash-merged.
+- Title and commits follow Conventional Commits.
 - Description says what was broken, why, what changed and how to test, and matches the final diff.
 - Read the other reviewers' comments and the linked issue before writing your own.
 

--- a/code_review.md
+++ b/code_review.md
@@ -12,7 +12,7 @@ Contributor-side rules live in the [Pull Request Checklist](https://github.com/f
 
 ### Read first
 
-- Read the PR body and every comment. Maintainers often raise PRs on behalf of contributors ("raised on behalf of @x"). That person is the author you talk to.
+- Read the PR body and every comment. If the PR was raised on behalf of someone else, that person is the author you talk to.
 - Read other maintainers' comments. Do not repeat them. Check whether earlier asks were addressed.
 - Read the linked issue and check the PR fixes what it describes.
 
@@ -66,23 +66,11 @@ Repro: snippet that shows the bug on develop, or "UI-only"
 
 ### Writing the review
 
-- Inline comments on the exact line, with a ` ```suggestion ` block when the fix is one line. The body is only for asks with no line (add tests, fix the title, add a video). Never write "see inline".
-- `@handle` once, in the first comment, then ask: "@user, could you please …".
-- One concern per comment. One to three short sentences. Plain words a non-native speaker reads once.
-- For "do X instead", show X as a one-line code example.
-- Cite the rule ID. Link the issue or docs when they exist.
-- No preamble, praise, thanks, summary, signature or emoji.
-- `REQUEST_CHANGES` when asks exist, `APPROVE` when none. `COMMENT` only on a PR you created yourself, because GitHub blocks the other two there.
-- Answer every bot finding: confirm with a line reference or reject with a reason.
-
-Example:
-
-> @author, could you please move this check into `validate()`? List view bulk delete and `frappe.client.delete` skip it right now (R12).
->
-> ```suggestion
-> def validate(self):
->     self.validate_unique_route()
-> ```
+- Comment on the exact line. Use a suggestion block when the fix is a one-liner. Keep the review body for asks that have no line, such as missing tests or a wrong title.
+- One concern per comment, in short plain sentences. Say what is wrong and what to do instead. Show code when that is clearer than words.
+- Back the ask with the rule number, the issue or the docs.
+- Request changes when there is a real ask. Approve when there is none.
+- Answer bot findings with evidence: confirm with a line reference or reject with a reason.
 
 ---
 
@@ -145,7 +133,7 @@ def get_list(doctype, order_by="modified desc"):
 ```
 
 ### R9. Reuse before reimplementing
-Use `@redis_cache`, `cached_property`, `frappe.generate_hash`, `frappe.db.set_value(update_modified=False)`, `frappe.ui.keys.add_shortcut`, `frappe.ui.freeze`, `frappe.utils.icon`, `str.join` and library defaults before writing new code. One implementation per piece of logic; extract a helper at the second or third repeat.
+Check `frappe.utils`, `frappe.ui`, the database API and the standard library before writing a helper; most of what a PR needs (caching, hashing, icons, shortcuts, freezing the UI) already exists. One implementation per piece of logic; extract a helper at the second or third repeat.
 Why: copies drift, and custom apps copy whatever core does.
 Exception: a little duplication beats coupling unrelated modules.
 
@@ -390,7 +378,7 @@ $(`<button class="es-button" data-variant="subtle" data-size="sm">${frappe.utils
 ```
 
 ### R41. Defaults serve non-technical users; copy is short
-Default filter operator is `=`, not `%`. No "Property Setter" or "DocType" in labels. No icon-only buttons in dialogs. Labels say what happens ("Export all matching rows?", "3 rows updated"). Messages name things the user can find (row number, not a hash). Errors are red; non-fatal messages are warnings. `PermissionError` only for permission problems. Short plain sentences, as brief as the sibling labels.
+Defaults are the safe, obvious choice (a filter defaults to `=`, not `%`). No internal terms like "DocType" or "Property Setter" in labels. No icon-only buttons in dialogs. Labels say what happens ("Export all matching rows?", "3 rows updated"). Messages name things the user can find (row number, not a hash). Errors are red; non-fatal messages are warnings. `PermissionError` only for permission problems. Short plain sentences, as brief as the sibling labels.
 Why: regular users over power users.
 
 ### R42. Bundle size is a budget
@@ -406,7 +394,7 @@ Confirm destructive and bulk actions. Secondary actions are not primary buttons.
 Exception: skip the confirm where the label already says it ("Send now").
 
 ### R45. Client work is scoped, runs once, cleans up
-`this.wrapper.find()`, not global `$()`. No work per row render or animation frame. `.off()` namespaced listeners before `.on()`. Dialogs are singletons. No `setTimeout` or `MutationObserver` when a lifecycle hook exists. No unscoped `localStorage` keys. JS validation must not depend on the awesomplete list, `.grid`, `:visible` or `frm`; think of `set_value`, paste, quick entry and grid rows.
+`this.wrapper.find()`, not global `$()`. No work per row render or animation frame. `.off()` namespaced listeners before `.on()`. Dialogs are singletons. No `setTimeout` or `MutationObserver` when a lifecycle hook exists. No unscoped `localStorage` keys. Client-side checks must also work when the value is set programmatically (`set_value`, paste, quick entry, grid rows) and when the control is used outside a form.
 Why: a check per animation frame runs sixty times a second.
 
 ```javascript
@@ -486,7 +474,7 @@ Why: a disabled test comes back to haunt you.
 ## PR process
 
 ### R55. Develop first, backport later
-Fix develop, then `@mergify backport version-N-hotfix` so authorship is kept. A manual port matches the develop diff exactly and carries its dependencies; check the target branch has the prerequisite APIs. Features and behaviour changes wait one to three weeks on develop, or are not backported. A v15 label usually needs v16 too. Breaking changes stay on develop. Retargeting a PR does not work; open a new one.
+Fix develop, then `@mergify backport version-N-hotfix` so authorship is kept. A manual port matches the develop diff exactly and carries its dependencies; check the target branch has the prerequisite APIs. Features and behaviour changes wait one to three weeks on develop, or are not backported. Breaking changes stay on develop. Retargeting a PR does not work; open a new one.
 Why: stable branches are where customers are.
 Exception: security and dependency fixes go to stable quickly. A fix that no longer applies on develop may target the hotfix branch. A customer-blocking fix may skip the soak.
 

--- a/code_review.md
+++ b/code_review.md
@@ -11,7 +11,6 @@ Check these first. Ask for the missing piece before reading the code.
 - UI changes have before/after screenshots or a video. Ask again after every UI push.
 - The bug reproduces on latest develop with the steps in the PR. If there are no steps, ask for a traceback or a minimal repro. If it cannot be reproduced, close for now.
 - Branch is rebased with no merge commits or unrelated commits.
-- Pre-commit is green. A reformatted file is not reviewable.
 - Title and commits follow Conventional Commits. The title is what gets squash-merged.
 - Description says what was broken, why, what changed and how to test, and matches the final diff.
 - Read the other reviewers' comments and the linked issue before writing your own.

--- a/code_review.md
+++ b/code_review.md
@@ -2,7 +2,7 @@
 
 What maintainers check when they review a pull request to `frappe/frappe`, collected from their review comments. For reviewers, contributors and AI agents.
 
-Read the Workflow section before every review. Rules are numbered so you can point to them in a comment (`R11`). If a rule gives a wrong answer in a real case, change the rule here instead of ignoring it.
+Read the Workflow section before every review. Rules are numbered so you can point to them in a comment (`R8`). If a rule gives a wrong answer in a real case, change the rule here instead of ignoring it.
 
 Contributor-side rules live in the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) and [Coding Standards](https://github.com/frappe/erpnext/wiki/Coding-Standards).
 
@@ -78,7 +78,7 @@ Repro: snippet that shows the bug on develop, or "UI-only"
 
 Example:
 
-> @author, could you please move this check into `validate()`? List view bulk delete and `frappe.client.delete` skip it right now (R16).
+> @author, could you please move this check into `validate()`? List view bulk delete and `frappe.client.delete` skip it right now (R12).
 >
 > ```suggestion
 > def validate(self):
@@ -119,33 +119,21 @@ Why: every toggle doubles the test matrix and stays forever.
 Exception: when users would legitimately disagree about a visible behaviour, make it configurable per user or per DocType.
 
 ### R5. Direction beats local utility
-Do not extend surfaces the project is leaving: the website module (Builder replaces it), report-view aggregation (Insights), legacy client JS, `frappe.call` where API v2 is the target.
+Do not extend surfaces the project is leaving: the website module (Builder replaces it), report-view aggregation (Insights), legacy client JS, `frappe.call` where API v2 is the target. Ask a maintainer when unsure.
 Why: every addition to a legacy surface has to be migrated or dropped later.
 
 ### R6. Change size matches the problem
-A small ask arriving as a large diff is pushed back. If an existing doctype, page, library or API does most of the job, add the missing part there. A "new X" next to an existing X needs a stated limitation of the current one.
+A small ask arriving as a large diff is pushed back. If an existing doctype, page, library or API does most of the job, add the missing part there. A "new X" next to an existing X needs a stated limitation of the current one. Half-done PRs are closed, not merged to iterate later.
 Why: parallel implementations drift and double the maintenance.
-
-### R7. Unfinished or experimental work is closed or gated
-Half-done PRs are closed. Experimental capabilities (new database backend, integer primary keys) ship opt-in or marked beta. Unused features and promotional banners are removed, not fixed.
-Why: users install what is merged.
 
 ## Root cause
 
-### R8. Fix the root cause where it lives
-A fix that makes an error go away without explaining why it happened is rejected. Fix it in the layer that owns it (ORM, util, datatable, shared control), not at one call site.
+### R7. Fix the root cause where it lives
+A fix that makes an error go away without explaining why it happened is rejected. Fix it in the layer that owns it (ORM, util, datatable, shared control), not at one call site. Deleting a guard, condition, style or method to make a symptom disappear is not a fix; the check was protecting something. Read the commit that introduced the behaviour before changing it; odd code is often intentional.
 Why: a symptom patch leaves the bug for the next caller.
 Exception: a harmless shallow fix may merge under release pressure, with the deep fix noted in the PR.
 
-### R9. Removing a check is not a fix
-Deleting a guard, condition, style or method to make a symptom disappear is rejected.
-Why: the check was protecting something. The PR has to say what, and why that no longer applies.
-
-### R10. Understand the original design first
-Read the commit that introduced the behaviour. Search callers and blame. Odd code is often intentional.
-Why: "you are making a new assumption; this is not what the original design was."
-
-### R11. Do not add what already exists
+### R8. Do not add what already exists
 Before adding a field, flag, param, endpoint, setting or patch, check whether an existing value, argument, default or `None` already carries the meaning. Make an existing flag tri-state before adding a second one. No patch for things `migrate` already syncs.
 Why: two mechanisms for one meaning can disagree, and every new surface is API forever.
 
@@ -157,24 +145,20 @@ def get_list(doctype, order_by="modified desc", no_order=False):
 def get_list(doctype, order_by="modified desc"):
 ```
 
-### R12. Reuse before reimplementing
+### R9. Reuse before reimplementing
 Use `@redis_cache`, `cached_property`, `frappe.generate_hash`, `frappe.db.set_value(update_modified=False)`, `frappe.ui.keys.add_shortcut`, `frappe.ui.freeze`, `frappe.utils.icon`, `str.join` and library defaults before writing new code. One implementation per piece of logic; extract a helper at the second or third repeat.
 Why: copies drift, and custom apps copy whatever core does.
 Exception: a little duplication beats coupling unrelated modules.
 
-### R13. Smallest correct change, no residue
-Prefer the one-line fix. Remove unused boot data, unreachable branches, single-use wrappers, params only ever passed one value, properties nothing reads, commented-out code, stale docstrings, no-op CSS. Residue is blocking.
-Why: dead code is read by everyone who comes after, and a no-op rule looks like it does something.
+### R10. Smallest correct change, simplest mechanism, no residue
+Prefer the one-line fix. Plain functions and `if` blocks; no inheritance towers, monkey-patching, global mutable state, threads or Lua scripts unless proven necessary. Remove unused boot data, unreachable branches, single-use wrappers, params only ever passed one value, properties nothing reads, commented-out code, no-op CSS. Residue is blocking.
+Why: complexity and dead code are paid on every read.
 
-### R14. Simplest mechanism wins
-Plain functions and `if` blocks. No inheritance towers, monkey-patching, global mutable state, threads, savepoints or Lua scripts unless proven necessary.
-Why: complexity is paid on every read.
-
-### R15. Finish the sweep, keep every surface consistent
+### R11. Finish the sweep, keep every surface consistent
 A change to one of a parallel set (DocField / Custom Field / Customize Form Field; Link / Dynamic Link; wkhtmltopdf / Chrome; form / grid / list / report / print) is incomplete until the siblings are done. A display or behaviour change applies everywhere the value appears, or not at all.
 Why: two surfaces that disagree are a new bug.
 
-### R16. Put the check at the choke point
+### R12. Put the check at the choke point
 Validation goes in `validate`, `on_trash` or `on_update`, not in one whitelisted caller.
 Why: list view bulk actions, `frappe.client.*`, the REST API and `doc.save()` all skip a check that lives in one endpoint.
 
@@ -191,66 +175,54 @@ class WebPage(Document):
         self.validate_unique_route()
 ```
 
-### R17. Do not hardcode what the framework knows
+### R13. Do not hardcode what the framework knows
 No hardcoded doctype names, `Administrator` checks, naming series, countries, logos, hosts or binary paths. Read hooks, defaults and config. Per-doctype behaviour goes on a DocType or DocField checkbox exposed in Customize Form.
 Why: hardcoded values are the branches nobody finds until a site differs.
 
-### R18. Explicit arguments, one return shape
+### R14. Explicit arguments, one return shape
 Functions and hooks take named parameters (`doctype`, `name`, `doc`), not dict or kwargs bags. State goes on `doc.flags`, not `frappe.flags`. No sentinel strings. A function returns one shape. Rename on the client, not in the server response.
 Why: callers can read a signature; they cannot read a bag.
 Exception: hook callbacks may take kwargs so the signature can grow.
 
-### R19. Cover the edge cases, and leave the user a way out
+### R15. Cover the edge cases, and leave the user a way out
 For every new branch ask what happens on `None`, duplicates, the user's own record, a queued job, a submitted document, a deleted doctype, `[Select]`. A new guard must not make the flow that resolves it also throw.
 Why: "clearing the field then throws `UpdateAfterSubmitError`; there is no way out."
 Exception: no fallbacks for states that cannot happen.
 
-### R20. Keep extension points
-Do not move or remove a hook without checking what depends on its timing. Core checks must not throw before app hooks run. Add a hook to the existing function, not a parallel one.
-Why: apps depend on hook order.
-
 ## Backward compatibility
 
-### R21. Break only when not breaking costs more
-Established behaviour (select values, ordering defaults, signatures, lifecycle semantics, exception classes) is not changed for one use case. List who depends on it across frappe, erpnext, hrms and the other apps. Take the non-breaking variant when there is one. Internal symbols can be dropped; public ones need a compatibility path. Unreleased code owes nothing.
+### R16. Break only when not breaking costs more
+Established behaviour (select values, ordering defaults, signatures, lifecycle semantics, exception classes, hook timing, export and report columns) is not changed for one use case. List who depends on it across frappe, erpnext, hrms and the other apps. Take the non-breaking variant when there is one. Internal symbols can be dropped; public ones need a compatibility path. Unreleased code owes nothing.
 Why: every app on every site pays for a break.
 Exception: behaviour that never worked, or hurts most users, may change.
 
-### R22. Deprecate one major before removing
+### R17. Deprecate one major before removing
 Public functions, paths and params get a `deprecation_warning` in place, one major for apps to migrate, then removal. No proxy classes or inspect-based machinery. Prefer fixing over deleting.
 Why: before a major, grep `deprecation_warning` and remove that code. Nothing else to remember.
 
-### R23. Defaults never flip
-A new option ships with the old behaviour as default. A rejected default may live on as an opt-in setting.
+### R18. Defaults never flip
+A new option ships with the old behaviour as default. Experimental capabilities ship opt-in or marked beta. A rejected default may live on as an opt-in setting.
 Why: people do not notice a new checkbox. They notice their site changed.
 
-### R24. Add new, migrate, hide old
+### R19. Add new, migrate, hide old
 Never repurpose or retype a field, and never change what `modified` or `creation` mean. Add a new field, migrate on save plus a patch, hide the old one, remove next major. Do not rename or remove CLI flags, kwargs, argument order, module paths or icons apps may use. New arguments go last with a default.
 Why: existing rows and calls must survive `bench migrate`.
 
-### R25. Exports and reports are an API
-Changing what CSV or Excel exports and report rows contain is breaking. Make it opt-in at export time or add columns. Never backport it.
-Why: exports get re-imported and parsed by other systems.
-
-### R26. Constraint changes ship with a patch
+### R20. Constraint changes ship with a patch
 A new unique constraint, validation or default that existing rows would violate blocks `bench migrate`. Ship a patch that repairs the data, or drop the constraint. A patch that needs new schema calls `frappe.reload_doctype` first.
 Why: sites with old data cannot update otherwise.
 
-### R27. Breaking changes carry `!` and stay on develop
+### R21. Breaking changes carry `!` and stay on develop
 Use `fix!:` or `feat!:`. Do not backport them. A framework change that needs an ERPNext change lands after the ERPNext PR, with an ERPNext CI run linked. Query builder, permission and core-model changes get that run too.
 Why: release notes and the migration guide come from the prefix.
 
-### R28. Working as designed closes the PR
-`on_update` runs after insert (use `after_insert`). User timezone is display-only. `Link` is a string. Prepared reports are owner-scoped. Several client scripts per doctype is a feature. A PR that "fixes" one of these is closed with the reason.
-Why: apps are built on these semantics.
-
-### R29. Do not take features away from regular users
+### R22. Do not take features away from regular users
 A change that makes a common workflow harder for non-technical users, or quietly disables a feature (data import mapping, URL attachments, saved filters), is reverted. Put the burden on system managers.
 Why: users use templates; system managers create them.
 
 ## Server side and security
 
-### R30. Business logic lives on the server, completely
+### R23. Business logic lives on the server, completely
 A rule enforced in JS (mandatory-depends-on, `set_query` filters, computed values) is also enforced in the controller. Params a check depends on are mandatory. Settings that gate a user are permlevel > 0. Search and validate agree.
 Why: the REST API, data import and server scripts never run client code.
 Exception: a purely cosmetic client-side permission (hiding a print button) needs no server check.
@@ -262,8 +234,8 @@ class Event(Document):
             frappe.throw(_("End date is required"), title=_("Missing Value"))
 ```
 
-### R31. Never punch holes in permissions
-`ignore_permissions=True`, blanket role grants and permission-less endpoints are not fixes. Use `doc.check_permission()`, `frappe.has_permission` and `frappe.only_for` so Is Owner and User Permissions apply, and give the user the right permission instead. Check before `get_doc` or any return, on every branch. Identity comes from `frappe.session.user`, never from the client.
+### R24. Never punch holes in permissions
+`ignore_permissions=True`, blanket role grants and permission-less endpoints are not fixes. Use `doc.check_permission()`, `frappe.has_permission` and `frappe.only_for` so Is Owner and User Permissions apply, and give the user the right permission instead. Prefer permlevels over ad-hoc code. Check before `get_doc` or any return, on every branch. Identity comes from `frappe.session.user`, never from the client.
 Why: better to give the user the right permission than to create a hole.
 
 ```python
@@ -280,12 +252,7 @@ def get_report(name):
     return doc
 ```
 
-### R32. The right permission primitive in the right place
-Internal code uses `frappe.get_all`; user-facing results use `frappe.get_list`. Permlevels over ad-hoc code. If custom DocPerms exist, only they apply. API v2 endpoints check manually. Logs need only `read`.
-Why: a permission check in internal code is a bug; a missing one in user-facing code is a hole.
-Exception: `get_list` does not work on child tables.
-
-### R33. Whitelisted endpoints are public URLs
+### R25. Whitelisted endpoints are public URLs
 Set `methods=[...]` on security-critical and guest endpoints. Store only hashes of keys and tokens. Never return `site_config` secrets. Website users can call whitelisted methods too. No `allow_guest` on flows that need login.
 
 ```python
@@ -294,7 +261,7 @@ def subscribe(email):
     ...
 ```
 
-### R34. Escape at render, never at storage
+### R26. Escape at render, never at storage
 Do not sanitise on store or globally in a formatter. Escape where the value goes into HTML, per fieldtype. Escape rather than strip. Use `|e` in Jinja.
 Why: storing anything is safe; injecting it as HTML is not. Stripping loses data.
 
@@ -306,12 +273,12 @@ $wrapper.html(`<div>${doc.title}</div>`);
 $wrapper.html(`<div>${frappe.utils.escape_html(doc.title)}</div>`);
 ```
 
-### R35. A security claim needs a demonstrated bypass
+### R27. A security claim needs a demonstrated bypass
 Ask where exactly permissions are bypassed; close if it cannot be shown. Reject rate limits and information hiding that cost more than they protect. Harden once in the shared layer, not per input. But any path that lets a normal user gain admin is blocked whatever the UX cost. Do not widen `safe_exec` or Jinja globals, read files from user input, or allow expressions in `autoname`.
 Why: there is no end to designing for stupidity, but privilege escalation beats UX.
 Exception: System Manager-authored Jinja and HTML is trusted. Other holes do not justify a new one.
 
-### R36. Fail loudly, catch the specific exception
+### R28. Fail loudly, catch the specific exception
 Permission failures raise `frappe.PermissionError`. No blanket `try/except`, no `log_error` without a traceback, chain with `raise ... from exc`. Promises get `.catch`. Background jobs already log. A friendly catch is scoped to exactly its condition.
 Why: failing is better than silently ignoring.
 
@@ -330,13 +297,13 @@ except frappe.ValidationError:
     raise
 ```
 
-### R37. Never destroy data silently
+### R29. Never destroy data silently
 No `ELSE NULL` in update queries, no sanitisers that drop content, no defaults that overwrite `creation`, `owner` or `name`. Disable instead of delete. Confirm bulk and destructive actions. Audit tables are immutable.
 Why: bad UX beats irrecoverable data loss.
 
 ## Performance
 
-### R38. Nothing lands in the hot path for everyone
+### R30. Nothing lands in the hot path for everyone
 Anything that runs on every request, document load, save or desk boot is opt-in or free. The common case never pays for the edge case. No API calls or queries on page load; read from `frappe.boot`. Anything added to boot is cached.
 Why: per-request overhead multiplies across every site.
 Exception: a few bytes in boot beat a separate request.
@@ -349,7 +316,7 @@ frappe.db.get_single_value("System Settings", "float_precision").then(...)
 const precision = frappe.boot.sysdefaults.float_precision;
 ```
 
-### R39. Think in 100k rows
+### R31. Think in 100k rows
 No `get_doc` in loops or to update one field, no unindexed filters, no full-table sorts, no `limit: 0`, no O(N) Redis scans. Hoist meta lookups and hooks out of loops. Batch link fetches. Cap `IN (...)` near 1000.
 Why: users import lakhs of records.
 
@@ -364,45 +331,41 @@ for name in names:
 frappe.db.set_value("Item", {"name": ("in", names)}, "disabled", 1)
 ```
 
-### R40. Slow or external work goes to a background job
-Work over about ten seconds, third-party API calls, bulk PDFs, renames and notification emails are enqueued, never run in a request or `validate`. Heavy work uses `queue="long"`. In patches, use an `update` query or `bulk_insert` and commit in batches, never one row at a time.
+### R32. Slow or external work goes to a background job
+Work over about ten seconds, third-party API calls, bulk PDFs, renames and notification emails are enqueued, never run in a request or `validate`. Heavy work uses `queue="long"`. Jobs are idempotent because hooks run on every retry. Files a job writes on a schedule get a retention window and cleanup. In patches, use an `update` query or `bulk_insert` and commit in batches, never one row at a time.
 Why: a worker blocked for a minute is a site down for everyone on that worker.
 
-### R41. Performance changes need numbers
+### R33. Performance changes need numbers
 Show profiler output, `EXPLAIN`, benchmarks or bundle deltas at production scale, measured as a real user, not Administrator. A perf change names the cost it removes. No caches that cannot hit, no cache on top of `get_meta` or settings (already cached), no micro-optimisation that adds code for a tiny gain.
 Why: a cache is a key, a TTL, invalidation sites and tests, all to skip one indexed query.
 Exception: do not optimise paths that run once in a blue moon.
 
 ## Database
 
-### R42. Use the highest-level API that does the job
-ORM (`frappe.db.get_value`, `set_value`, `get_list`) when it expresses the query; query builder when the ORM cannot; never hand-written dialect SQL. Do not bypass `delete_doc` and controller hooks with `frappe.db.delete` without a stated reason.
+### R34. Use the highest-level API that does the job
+ORM (`frappe.db.get_value`, `set_value`, `get_list`) when it expresses the query; query builder when the ORM cannot; never hand-written dialect SQL. Do not bypass `delete_doc` and controller hooks with `frappe.db.delete` without a stated reason. Let the schema enforce invariants: mandatory fields become `NOT NULL`, a unique constraint beats app-level dedup.
 Why: lower-level APIs skip caching, permissions, hooks and portability.
 
-### R43. No `commit()` in document events
+### R35. No `commit()` in document events
 Doc-event code never commits; requests commit at the end. Side effects that must survive run `after_commit`. Every state transition calls `check_if_latest`, with no bypass flag.
 Why: a commit inside `validate` persists a half-saved document.
 Exception: a helper reachable from a GET may commit, and patches commit in batches.
 
-### R44. Parse, don't validate; MariaDB is the reference
-Turn known inputs into query builder objects and let it emit SQL. Never regex-check or rewrite generated SQL. When drivers disagree, MariaDB is canonical and Postgres adapts; DB-specific code lives in `frappe/database/<db>/`. Permission filters go in `WHERE`, not `JOIN`. Do not add columns to `DISTINCT` or `GROUP BY` to satisfy Postgres. Pass `order_by=None` when order does not matter; tie-break paginated sorts with a unique column. Avoid `ifnull` and `coalesce`, never on `name`.
+### R36. Parse, don't validate; MariaDB is the reference
+Turn known inputs into query builder objects and let it emit SQL. Never regex-check or rewrite generated SQL. When drivers disagree, MariaDB is canonical and Postgres adapts; DB-specific code lives in `frappe/database/<db>/`. Permission filters go in `WHERE`, not `JOIN`. Pass `order_by=None` when order does not matter; tie-break paginated sorts with a unique column. Avoid `ifnull` and `coalesce`, never on `name`.
 Why: non-deterministic order makes pagination wrong.
 
-### R45. Pick the right cache and prove invalidation
+### R37. Pick the right cache and prove invalidation
 `@site_cache` is per process and never invalidated; use `@request_cache` for permission-dependent data. Single values use `frappe.cache.get_value`, not a hash. Keys are stable and prefixed. Invalidation covers every mutation; clear and recompute rather than maintain by hand.
 Why: a stale permission cache is a security bug.
 
-### R46. Patches only when data moves; DocType JSON only through the UI
+### R38. Patches only when data moves; DocType JSON only through the UI
 No patch for what `migrate` already syncs (doctypes, workspaces, module defs, new-field defaults). DocType JSON is changed through the DocType form or Customize Form and the export committed with its bumped `modified`, child tables included. A hand-edited JSON is sent back. A `modified`-only bump with no field change is reverted. Index changes need a patch or a `modified` bump so `on_doctype_update` runs.
 Why: DocType JSON is generated by code; humans and agents should not touch it directly.
 
-### R47. Let the schema enforce invariants; jobs are idempotent
-Mandatory fields become `NOT NULL`. A unique constraint beats app-level dedup. Hooks run on every retry, so jobs are idempotent and take context from `frappe.job`. New log-like doctypes register `clear_old_logs`. Files written on a schedule get a retention window and cleanup that cannot hit user data.
-Why: otherwise they are persisted forever.
-
 ## UI
 
-### R48. Design tokens, no CSS duplication, right file
+### R39. Design tokens, no CSS duplication, right file
 Every colour, weight and spacing is a token or CSS variable; check both themes. Reuse existing classes. Repeated rules go on a parent class. Delete rules with no user. View-specific CSS lives in that view's file. No inline styles, `!important`, `position: fixed` or fixed-height hacks.
 Why: more CSS means a larger bundle and more to maintain.
 Exception: print CSS stays light; no dark-mode tokens in PDFs.
@@ -415,7 +378,7 @@ Exception: print CSS stays light; no dark-mode tokens in PDFs.
 .sidebar-item { color: var(--text-color); font-weight: var(--weight-medium); }
 ```
 
-### R49. Espresso components, sprite icons, gray accents
+### R40. Espresso components, sprite icons, gray accents
 New desk UI uses `es-button` and `es-badge` with data attributes, not bootstrap `btn` and `badge`. Icons come from `frappe.utils.icon()` with names in the sprite; no hand-written SVG, no emoji. Accents are gray, not blue. A new control follows the sibling control; match avatars, indicators, labels, column order and empty states.
 Why: keep the design consistent with existing components.
 
@@ -427,23 +390,23 @@ $(`<button class="btn btn-primary btn-sm"><svg …></svg> Add</button>`)
 $(`<button class="es-button" data-variant="subtle" data-size="sm">${frappe.utils.icon("add", "sm")} ${__("Add")}</button>`)
 ```
 
-### R50. Defaults serve non-technical users; copy is short
+### R41. Defaults serve non-technical users; copy is short
 Default filter operator is `=`, not `%`. No "Property Setter" or "DocType" in labels. No icon-only buttons in dialogs. Labels say what happens ("Export all matching rows?", "3 rows updated"). Messages name things the user can find (row number, not a hash). Errors are red; non-fatal messages are warnings. `PermissionError` only for permission problems. Short plain sentences, as brief as the sibling labels.
 Why: regular users over power users.
 
-### R51. Bundle size is a budget
+### R42. Bundle size is a budget
 The bundle-size check must pass or be justified. New dialogs and panels load on first use via `frappe.require`. Libraries used by a minority stay out of the default bundle. No second frontend framework. No new dependency for trivial things.
 Why: bundles grow a few KB at a time until it is 300 KB.
 
-### R52. A dialog beats a new doctype; a permission beats a setting
-No doctype for a one-off action or dev-only report; use a button and dialog on the existing doctype, a virtual doctype, or an existing control. Prefer a permission over a setting. A justified setting lives in System Settings with a User-level override that wins. Desk branding lives in Navbar Settings. New DocType or DocField properties are exposed in Customize Form.
+### R43. A dialog beats a new doctype; a permission beats a setting
+No doctype for a one-off action or dev-only report; use a button and dialog on the existing doctype, a virtual doctype, or an existing control. Prefer a permission over a setting. A justified setting lives in System Settings with a User-level override that wins. New DocType or DocField properties are exposed in Customize Form.
 Why: do not create new UI when you do not need it.
 
-### R53. UX guardrails
-Confirm destructive and bulk actions. Secondary actions are not primary buttons. Dropdowns close on select. Success toast only when nothing failed; failures name the records. Disabled pages 404. Tab, Enter and Escape keep working. Any control change marks the form dirty. Console stays clean. No forced refresh, no extra scrollbars, no dangerous one-click control next to a frequent action.
+### R44. UX guardrails
+Confirm destructive and bulk actions. Secondary actions are not primary buttons. Success toast only when nothing failed; failures name the records. Tab, Enter and Escape keep working. Any control change marks the form dirty. Console stays clean. No forced refresh, no extra scrollbars, no dangerous one-click control next to a frequent action.
 Exception: skip the confirm where the label already says it ("Send now").
 
-### R54. Client work is scoped, runs once, cleans up
+### R45. Client work is scoped, runs once, cleans up
 `this.wrapper.find()`, not global `$()`. No work per row render or animation frame. `.off()` namespaced listeners before `.on()`. Dialogs are singletons. No `setTimeout` or `MutationObserver` when a lifecycle hook exists. No unscoped `localStorage` keys. JS validation must not depend on the awesomplete list, `.grid`, `:visible` or `frm`; think of `set_value`, paste, quick entry and grid rows.
 Why: a check per animation frame runs sixty times a second.
 
@@ -457,16 +420,16 @@ this.wrapper.off("click.sidebar").on("click.sidebar", ".sidebar-toggle", () => t
 
 ## Code hygiene
 
-### R55. No comments that say what, no debug noise, no AI attribution
+### R46. No comments that say what, no debug noise, no AI attribution
 Comments that narrate the code are removed. Issue numbers never go in code. Docstrings that restate the name are dropped; the reasoning goes in the PR. Strip `console.log`, `print`, commented-out code, unused imports, TODOs for another PR. Use `let`/`const`, `??`, `?.`, `.includes()`. Keep methods on the class, not on `frappe.provide` namespaces. `Co-Authored-By: <AI>` and "Generated with …" lines are removed. No `# nosemgrep` in core.
 Why: comments rot; two of them are already wrong.
 Exception: a non-obvious workaround gets one comment saying why.
 
-### R56. Names say what the thing does
+### R47. Names say what the thing does
 Fieldname mirrors label. Checkbox fieldnames are positive ("Allow X"). No abbreviations or `d`. Plural names return plurals. No `decorators.py` or `functions.py` grab-bags. `snake_case`; `DocType` and `JSON` casing.
 Why: it should at least resemble what it does.
 
-### R57. Type discipline
+### R48. Type discipline
 Annotate all params and the return type, or none. Hints must be true (`str | int` for docnames on whitelisted methods; a `Document` cannot cross the API boundary). Lazy imports go behind `if TYPE_CHECKING`. Compare dates with `getdate()`, not strings. `None`, `""` and `0` are different. Compare checkbox and boot values with `cint`, never `=== "1"`. Raise `NotImplementedError` instead of returning a wrong result.
 
 ```python
@@ -477,7 +440,7 @@ if doc.posting_date > today():
 if getdate(doc.posting_date) > getdate():
 ```
 
-### R58. Translate whole sentences, and only sentences
+### R49. Translate whole sentences, and only sentences
 Wrap the full sentence in `_()` / `__()` with `{0}` placeholders. Never build it from f-strings, `+`, ternaries or template literals. Format after translating. No HTML inside the source string; use `frappe.bold()` or a placeholder. Do not translate `"{0}"`, empty strings, fieldnames, file names, user-authored labels, `df.label` or link values.
 Why: constructed strings never get a translation.
 
@@ -489,21 +452,21 @@ frappe.throw(_("Cannot delete " + doc.name + " because it is submitted"))
 frappe.throw(_("Cannot delete {0} because it is submitted").format(frappe.bold(doc.name)))
 ```
 
-### R59. Flat functions, no guards for impossible states
+### R50. Flat functions, no guards for impossible states
 Short functions, early return, `if x := ...:`, `a or default`. Inline a two-line helper used once. No `and`/`or` chaining tricks, nested ternaries, `True if … else False`, redundant casts. `.replace()` and `startswith` over regex. No `getattr`, `hasattr`, `isinstance` or empty-list guards for values that are always set. No `None` defaults on API args that cannot be handled.
 Why: guards for impossible states hide real bugs.
 
-### R60. Tests never leak into production code
+### R51. Tests never leak into production code
 No `if frappe.in_test`, no `in_import` or `in_patch` escape hatches, no edge case added to make a test pass. `assert` is for invariants and is not blocked by lint.
 Why: if you have to do this, you broke something.
 
 ## Tests
 
-### R61. New behaviour and bug fixes ship with a test that can fail
+### R52. New behaviour and bug fixes ship with a test that can fail
 Permissions, backups, schema, docstatus transitions, number parsing and anything touching every list view get a test for every promised case. A test that passes without the fix, only checks that nothing raised, swallows the exception, or asserts on generated SQL is rejected. Use `assertQueryCount` for caching claims. Confirm the test fails with the fix reverted.
 Exception: a trivial one-liner, a small UI change with a video, or a race the harness cannot reproduce. Say so.
 
-### R62. Test through interfaces, as a real user, with clean fixtures
+### R53. Test through interfaces, as a real user, with clean fixtures
 Assert via public interfaces, not cache internals. Use `new_doctype`, `freeze_time`, `set_request`. Tests set their own preconditions and rely on auto-rollback; no manual commit, no leftover Redis state. A feature that only works as Administrator is a bug: switch user. A permission test that calls `get_all` proves nothing; use `get_list`. Fixtures use `example.com`, never real domains, companies, emails or keys, and stay tiny. No issue numbers in test names.
 
 ```python
@@ -517,35 +480,32 @@ def test_permission(self):
     self.assertFalse(frappe.get_list("Note"))
 ```
 
-### R63. Flaky tests are fixed, not disabled
+### R54. Flaky tests are fixed, not disabled
 The author investigates red CI: run locally, remove the new test to isolate, rebase. A related failure blocks; an unrelated one is named per check and re-run. Never skip a test to get green. If a test expects the old behaviour, update it. UI behaviour changes get a Cypress test when the repro is deterministic.
 Why: a disabled test comes back to haunt you.
 
-### R64. The reviewer runs the branch
-Check out the PR and follow the author's own steps. A fix that fails on its own steps goes back. Ask the author to confirm the final state before merging. Claims are backed by a bench console repro or measured numbers.
-
 ## PR process
 
-### R65. Develop first, backport later
+### R55. Develop first, backport later
 Fix develop, then `@mergify backport version-N-hotfix` so authorship is kept. A manual port matches the develop diff exactly and carries its dependencies; check the target branch has the prerequisite APIs. Features and behaviour changes wait one to three weeks on develop, or are not backported. A v15 label usually needs v16 too. Breaking changes stay on develop. Retargeting a PR does not work; open a new one.
 Why: stable branches are where customers are.
 Exception: security and dependency fixes go to stable quickly. A fix that no longer applies on develop may target the hotfix branch. A customer-blocking fix may skip the soak.
 
-### R66. One concern per PR
+### R56. One concern per PR
 Unrelated refactors, renames, formatting, `yarn.lock` churn, `.po` hunks and independent bugs go in their own PR so they can be backported and blamed separately. A targeted fix does not touch the surrounding flow. But do not split a six-line change into four PRs, or open a second PR for a tweak to an open one.
 Why: unrelated changes in one commit make it hard to find and backport anything.
 
-### R67. Docs for new APIs; translations and docs never in the repo
-Hooks, config keys, settings and public utilities land with docs on docs.frappe.io; internal helpers do not. "Why `no-docs`?" is a fair question. `.po` and `.pot` edits go to Crowdin. No documentation files in the repository.
+### R57. User-facing docs live on docs.frappe.io; translations on Crowdin
+Hooks, config keys, settings and public utilities land with user-facing docs on docs.frappe.io; internal helpers do not. "Why `no-docs`?" is a fair question. `.po` and `.pot` edits go to Crowdin, never into the repository.
 
-### R68. Revert first, fix later
+### R58. Revert first, fix later
 A merged change that causes support tickets, crashes, performance regressions, bundle-size failures or broken defaults is reverted immediately, before the cause is understood. The revert says why. The author re-raises with the fix.
 Why: every hour a regression stays on develop it reaches more sites.
 
-### R69. Stale or unfinished PRs are closed with an open door
+### R59. Stale or unfinished PRs are closed with an open door
 Not-ready work goes to Draft; draft means not mergeable. After a nudge, inactive PRs or PRs with too many open issues are closed "for now" with an offer to reopen.
 
-### R70. No automated or AI-generated changesets
+### R60. No automated or AI-generated changesets
 A PR generated without manual review, that references code not in the diff, hides the real cause or reimplements an existing component is closed. Suspected AI code needs a video and a plain explanation before further review. No scripted typo sweeps, vendored-library edits or typo-in-comment PRs. Code lifted from an issue, another PR or another app carries the original author (`git commit --author=`); backport the original PR rather than re-author it.
 Why: reviewer time is the scarcest resource in the project.
 Exception: maintainers may run automated changes themselves after an issue is agreed.

--- a/code_review.md
+++ b/code_review.md
@@ -83,7 +83,7 @@ Check these first. Ask for the missing piece before reading the code.
 
 ### UI
 
-- Colours, weights and spacing come from design tokens. Reuse existing CSS classes; delete rules with no user. No inline styles or `!important`.
+- Any CSS property that has a token (colour, font size and weight, spacing, radius, shadow, border, z-index) uses the `var(--*)` token, never a literal value. Reuse existing CSS classes; delete rules with no user. No inline styles or `!important`.
 - Use `es-button` and `es-badge`, icons from `frappe.utils.icon()`, gray accents. New controls follow the sibling control.
 - Defaults serve non-technical users. Labels say what happens, in short plain words, with no internal terms like "DocType".
 - Bundle size is a budget. Features used by a minority load on first use.

--- a/code_review.md
+++ b/code_review.md
@@ -88,7 +88,7 @@ Check these first. Ask for the missing piece before reading the code.
 - Defaults serve non-technical users. Labels say what happens, in short plain words, with no internal terms like "DocType".
 - Bundle size is a budget. Features used by a minority load on first use.
 - A button and dialog on the existing doctype beats a new doctype. A permission beats a setting.
-- Confirm destructive actions. Secondary actions are not primary buttons. Keyboard keeps working. Any change marks the form dirty. Console stays clean.
+- Confirm destructive actions. Only one primary button is visible on a page or dialog; secondary actions are not primary buttons. Keyboard keeps working. Any change marks the form dirty. Console stays clean.
 - Client work is scoped to the instance, runs once, and cleans up its listeners. Client checks also work when the value is set programmatically.
 
 ### Code


### PR DESCRIPTION
- Add `code_review.md`: the checks maintainers apply when reviewing a PR, collected from review comments, with numbered rules (R1 to R70) that can be cited in a comment
- Add `AGENTS.md`: short instructions for AI agents, pointing at the guide before any review

Why: reviewers and agents keep re-deciding the same things.