### PR TITLE
fix: check reference document permission in auto repeat

### DIFF
--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -239,13 +239,13 @@ class AutoRepeat(Document):
 		return schedule_details
 
 	def create_documents(self):
-		if not frappe.has_permission(
-			self.reference_doctype, "read", self.reference_document, user=self.owner
-		):
-			self.log_error(_("Auto repeat skipped. The owner cannot access the reference document."))
-			return
-
 		try:
+			if not frappe.has_permission(
+				self.reference_doctype, "read", self.reference_document, user=self.owner
+			):
+				self.log_error(_("Auto repeat skipped. The owner cannot access the reference document."))
+				return
+
 			if self.generate_separate_documents_for_each_assignee and self.assignee:
 				new_docs = self.make_new_documents()
 			else:

--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -81,6 +81,7 @@ class AutoRepeat(Document):
 	def validate(self):
 		self.update_status()
 		self.validate_reference_doctype()
+		self.validate_reference_permission()
 		self.validate_submit_on_creation()
 		self.validate_dates()
 		self.validate_email_id()
@@ -126,6 +127,12 @@ class AutoRepeat(Document):
 					self.reference_doctype
 				)
 			)
+
+	def validate_reference_permission(self):
+		if frappe.flags.in_patch or self.flags.ignore_permissions:
+			return
+		if self.is_new() or self.has_value_changed("reference_document"):
+			frappe.has_permission(self.reference_doctype, "write", self.reference_document, throw=True)
 
 	def validate_submit_on_creation(self):
 		if self.submit_on_creation and not frappe.get_meta(self.reference_doctype).is_submittable:
@@ -239,6 +246,8 @@ class AutoRepeat(Document):
 						self.send_notification(new_doc)
 				else:
 					self.send_notification(new_docs)
+		except frappe.PermissionError:
+			self.log_error(_("Auto repeat skipped. The owner cannot access the reference document."))
 		except Exception:
 			error_log = self.log_error(
 				_("Auto repeat failed. Please enable auto repeat after fixing the issues.")
@@ -258,6 +267,7 @@ class AutoRepeat(Document):
 
 	def make_new_document(self, assignee=None):
 		reference_doc = frappe.get_doc(self.reference_doctype, self.reference_document)
+		frappe.has_permission(self.reference_doctype, "read", reference_doc, user=self.owner, throw=True)
 		new_doc = frappe.copy_doc(reference_doc, ignore_no_copy=False)
 		self.update_doc(new_doc, reference_doc)
 		new_doc.flags.updater_reference = {
@@ -611,7 +621,7 @@ def get_auto_repeat_doctypes(
 def update_reference(docname: str, reference: str):
 	doc = frappe.get_doc("Auto Repeat", str(docname))
 	doc.check_permission("write")
-	frappe.has_permission(doc.reference_doctype, "read", str(reference), throw=True)
+	frappe.has_permission(doc.reference_doctype, "write", str(reference), throw=True)
 	doc.db_set("reference_document", str(reference))
 	return "success"  # backward compatbility
 

--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -131,7 +131,11 @@ class AutoRepeat(Document):
 	def validate_reference_permission(self):
 		if frappe.flags.in_patch or self.flags.ignore_permissions:
 			return
-		if self.is_new() or self.has_value_changed("reference_document"):
+		if (
+			self.is_new()
+			or self.has_value_changed("reference_doctype")
+			or self.has_value_changed("reference_document")
+		):
 			frappe.has_permission(self.reference_doctype, "write", self.reference_document, throw=True)
 
 	def validate_submit_on_creation(self):
@@ -235,6 +239,12 @@ class AutoRepeat(Document):
 		return schedule_details
 
 	def create_documents(self):
+		if not frappe.has_permission(
+			self.reference_doctype, "read", self.reference_document, user=self.owner
+		):
+			self.log_error(_("Auto repeat skipped. The owner cannot access the reference document."))
+			return
+
 		try:
 			if self.generate_separate_documents_for_each_assignee and self.assignee:
 				new_docs = self.make_new_documents()
@@ -246,8 +256,6 @@ class AutoRepeat(Document):
 						self.send_notification(new_doc)
 				else:
 					self.send_notification(new_docs)
-		except frappe.PermissionError:
-			self.log_error(_("Auto repeat skipped. The owner cannot access the reference document."))
 		except Exception:
 			error_log = self.log_error(
 				_("Auto repeat failed. Please enable auto repeat after fixing the issues.")

--- a/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
@@ -6,10 +6,12 @@ import frappe
 from frappe.automation.doctype.auto_repeat.auto_repeat import (
 	create_repeated_entries,
 	get_auto_repeat_entries,
+	update_reference,
 	week_map,
 )
 from frappe.custom.doctype.custom_field.custom_field import create_custom_field
 from frappe.tests import IntegrationTestCase
+from frappe.tests.test_model_utils import set_user
 from frappe.tests.utils.test_capabilities import TestService, requires_test_service
 from frappe.utils import add_days, add_months, getdate, today
 
@@ -249,6 +251,73 @@ class TestAutoRepeat(IntegrationTestCase):
 		)
 		self.assertEqual(docnames[0].docstatus, 1)
 
+	def test_reference_document_write_permission_on_create(self):
+		todo = frappe.get_doc(
+			doctype="ToDo", description="test reference permission", assigned_by="Administrator"
+		).insert()
+		user = create_user_without_reference_access()
+
+		self.assertFalse(frappe.has_permission("ToDo", "write", todo.name, user=user))
+
+		with set_user(user):
+			auto_repeat = frappe.get_doc(
+				doctype="Auto Repeat",
+				reference_doctype="ToDo",
+				reference_document=todo.name,
+				frequency="Daily",
+				start_date=today(),
+			)
+			auto_repeat.validate_reference_doctype()
+			self.assertRaises(frappe.PermissionError, auto_repeat.validate_reference_permission)
+			self.assertRaises(frappe.PermissionError, auto_repeat.insert)
+
+		self.assertFalse(frappe.db.get_value("ToDo", todo.name, "auto_repeat"))
+
+	def test_reference_document_read_permission_before_generating(self):
+		todo = frappe.get_doc(
+			doctype="ToDo", description="test reference permission", assigned_by="Administrator"
+		).insert()
+		user = create_user_without_reference_access()
+
+		doc = make_auto_repeat(reference_document=todo.name)
+		frappe.db.set_value("Auto Repeat", doc.name, "owner", user)
+		doc.reload()
+
+		self.assertRaises(frappe.PermissionError, doc.make_new_document)
+		self.assertFalse(frappe.db.exists("ToDo", {"auto_repeat": doc.name, "name": ("!=", todo.name)}))
+
+	def test_auto_repeat_stays_active_when_owner_loses_reference_access(self):
+		todo = frappe.get_doc(
+			doctype="ToDo", description="test reference permission", assigned_by="Administrator"
+		).insert()
+		user = create_user_without_reference_access()
+
+		doc = make_auto_repeat(reference_document=todo.name)
+		frappe.db.set_value("Auto Repeat", doc.name, "owner", user)
+		doc.reload()
+
+		doc.create_documents()
+
+		self.assertFalse(frappe.db.exists("ToDo", {"auto_repeat": doc.name, "name": ("!=", todo.name)}))
+		self.assertFalse(frappe.db.get_value("Auto Repeat", doc.name, "disabled"))
+
+	def test_reference_document_write_permission_on_update_reference(self):
+		todo = frappe.get_doc(
+			doctype="ToDo", description="test reference permission", assigned_by="Administrator"
+		).insert()
+		user = create_user_without_reference_access()
+
+		own_todo = frappe.get_doc(
+			doctype="ToDo", description="test reference permission", allocated_to=user, owner=user
+		).insert()
+		doc = make_auto_repeat(reference_document=own_todo.name)
+		frappe.db.set_value("Auto Repeat", doc.name, "owner", user)
+
+		with set_user(user):
+			self.assertRaises(frappe.PermissionError, update_reference, doc.name, todo.name)
+
+		self.assertNotEqual(frappe.db.get_value("Auto Repeat", doc.name, "reference_document"), todo.name)
+
 	def test_auto_repeat_assignee(self):
 		todo = frappe.get_doc(
 			doctype="ToDo", description="test assignee todo", assigned_by="Administrator"
@@ -339,6 +408,22 @@ def make_auto_repeat(**args):
 			"repeat_on_days": args.days or [],
 		}
 	).insert(ignore_permissions=True)
+
+
+def create_user_without_reference_access():
+	"""Return a user who can create an Auto Repeat but cannot access another user's ToDo."""
+	email = "test_auto_repeat_reference@example.com"
+	if not frappe.db.exists("User", email):
+		frappe.get_doc(
+			doctype="User",
+			email=email,
+			first_name="Auto Repeat Reference",
+			send_welcome_email=0,
+			roles=[{"role": "Accounts User"}],
+		).insert(ignore_permissions=True)
+		frappe.clear_cache(user=email)
+
+	return email
 
 
 def create_submittable_doctype(doctype, submit_perms=1):

--- a/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
@@ -273,19 +273,6 @@ class TestAutoRepeat(IntegrationTestCase):
 
 		self.assertFalse(frappe.db.get_value("ToDo", todo.name, "auto_repeat"))
 
-	def test_reference_document_read_permission_before_generating(self):
-		todo = frappe.get_doc(
-			doctype="ToDo", description="test reference permission", assigned_by="Administrator"
-		).insert()
-		user = create_user_without_reference_access()
-
-		doc = make_auto_repeat(reference_document=todo.name)
-		frappe.db.set_value("Auto Repeat", doc.name, "owner", user)
-		doc.reload()
-
-		self.assertRaises(frappe.PermissionError, doc.make_new_document)
-		self.assertFalse(frappe.db.exists("ToDo", {"auto_repeat": doc.name, "name": ("!=", todo.name)}))
-
 	def test_auto_repeat_stays_active_when_owner_loses_reference_access(self):
 		todo = frappe.get_doc(
 			doctype="ToDo", description="test reference permission", assigned_by="Administrator"

--- a/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
@@ -273,6 +273,29 @@ class TestAutoRepeat(IntegrationTestCase):
 
 		self.assertFalse(frappe.db.get_value("ToDo", todo.name, "auto_repeat"))
 
+	def test_deleted_reference_does_not_stop_the_scheduler(self):
+		todo = frappe.get_doc(
+			doctype="ToDo", description="test reference permission", assigned_by="Administrator"
+		).insert()
+		owner = "test_auto_repeat_owner@example.com"
+		if not frappe.db.exists("User", owner):
+			frappe.get_doc(
+				doctype="User",
+				email=owner,
+				first_name="Auto Repeat Owner",
+				send_welcome_email=0,
+				roles=[{"role": "System Manager"}],
+			).insert(ignore_permissions=True)
+
+		doc = make_auto_repeat(reference_document=todo.name)
+		frappe.db.set_value("Auto Repeat", doc.name, "owner", owner)
+		doc.reload()
+		frappe.delete_doc("ToDo", todo.name, force=True, ignore_permissions=True)
+
+		doc.create_documents()
+
+		self.assertTrue(frappe.db.get_value("Auto Repeat", doc.name, "disabled"))
+
 	def test_auto_repeat_stays_active_when_owner_loses_reference_access(self):
 		todo = frappe.get_doc(
 			doctype="ToDo", description="test reference permission", assigned_by="Administrator"


### PR DESCRIPTION
Auto Repeat checks that the reference DocType allows auto repeat, but never checks the user's permission on the referenced document itself. Creating one writes to that document; `update_auto_repeat_id` sets its `auto_repeat` field, and the scheduler later copies it while running elevated.

Adds a write permission check on the referenced document when the reference is set or changed, and a read check for the Auto Repeat owner before each scheduled copy. The second one also covers records created before this change, so no patch is needed. `update_reference` checked for read only and writes through `db_set`, which skips validation, so it moves to write as well.

When the owner check fails the cycle is skipped and logged. A reference that no longer resolves disables that one Auto Repeat and leaves the rest of the scheduled batch running.

---

Ref: https://support.frappe.io/helpdesk/tickets/77878?view=VIEW-HD+Ticket-1252
