### PR TITLE
fix(print): omit empty options from PDF link

### DIFF
--- a/frappe/tests/test_website.py
+++ b/frappe/tests/test_website.py
@@ -268,6 +268,7 @@ class TestWebsite(IntegrationTestCase):
 		content = get_response_content("/Language/ru")
 		self.assertIn('<div class="print-format">', content)
 		self.assertIn("<div>Language</div>", content)
+		self.assertNotIn("&no_letterhead=None", content)
 
 	def test_custom_base_template_path(self):
 		content = get_response_content("/_test/_test_folder/_test_page")

--- a/frappe/www/printview.html
+++ b/frappe/www/printview.html
@@ -19,7 +19,7 @@
 			{{ _("Print") }}
 		</a>
 		<a class="p-2"
-			href="/api/method/frappe.utils.print_format.download_pdf?doctype={{doctype|e}}&name={{name|e}}&format={{print_format|e}}&letterhead={{letterhead|e}}&no_letterhead={{no_letterhead|e}}&_lang={{lang|e}}&key={{key|e}}&pdf_generator={{pdf_generator|e}}">
+			href="/api/method/frappe.utils.print_format.download_pdf?doctype={{doctype|e}}&name={{name|e}}&format={{print_format|e}}{% if letterhead %}&letterhead={{letterhead|e}}{% endif %}{% if no_letterhead %}&no_letterhead={{no_letterhead|e}}{% endif %}{% if lang %}&_lang={{lang|e}}{% endif %}{% if key %}&key={{key|e}}{% endif %}{% if pdf_generator %}&pdf_generator={{pdf_generator|e}}{% endif %}">
 			{{ _('Get PDF') }}
 		</a>
 	</div>


### PR DESCRIPTION
Backports the print-view PDF link fix from https://github.com/frappe/frappe/pull/40782.
Ticket: https://support.frappe.io/helpdesk/tickets/77976?view=VIEW-HD+Ticket-1547