### PR TITLE
fix: email read-receipt update does not notify realtime listeners

### DIFF
--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -328,16 +328,45 @@ def update_communication_as_read(name):
 	if not name or not isinstance(name, str):
 		return
 
-	communication = frappe.db.get_value("Communication", name, "read_by_recipient", as_dict=True)
+	communication = frappe.db.get_value(
+		"Communication",
+		name,
+		["read_by_recipient", "reference_doctype", "reference_name"],
+		as_dict=True,
+	)
 
 	if not communication or communication.read_by_recipient:
 		return
 
+	read_by_recipient_on = get_datetime()
 	frappe.db.set_value(
 		"Communication",
 		name,
-		{"read_by_recipient": 1, "delivery_status": "Read", "read_by_recipient_on": get_datetime()},
+		{"read_by_recipient": 1, "delivery_status": "Read", "read_by_recipient_on": read_by_recipient_on},
 	)
+
+	# Notify anyone viewing the linked document (e.g. a CRM Lead/Deal timeline)
+	# that this email was just read, so a read-receipt indicator can update
+	# live instead of only after a manual page reload.
+	if communication.reference_doctype and communication.reference_name:
+		frappe.publish_realtime(
+			"docinfo_update",
+			{
+				"doc": {
+					"name": name,
+					"reference_doctype": communication.reference_doctype,
+					"reference_name": communication.reference_name,
+					"read_by_recipient": 1,
+					"delivery_status": "Read",
+					"read_by_recipient_on": read_by_recipient_on,
+				},
+				"key": "communications",
+				"action": "update",
+			},
+			doctype=communication.reference_doctype,
+			docname=communication.reference_name,
+			after_commit=True,
+		)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Bug

`update_communication_as_read()` (hit by the tracking-pixel endpoint `mark_email_as_seen`) marks a `Communication` as read with a raw `frappe.db.set_value()` call. That bypasses document controller hooks entirely, so `Communication.notify_change()` - which is what publishes the `docinfo_update` realtime event other clients rely on (e.g. Frappe CRM's Lead/Deal timeline) - never runs for a read-receipt update.

End result: the read-receipt is correctly written to the database when a recipient opens a tracked email, but nothing tells anyone currently viewing the linked document. It only becomes visible after a manual page reload.

## Fix

Publish the same `docinfo_update` event (`key="communications"`) that `notify_change()` already uses, right after the `read_by_recipient` fields are set, scoped to the communication's `reference_doctype`/`reference_name` via `doctype=`/`docname=` (same room-scoping `notify_change()` uses).

## Testing

Verified live against a real deployment running this app (Frappe CRM):
- A "Sent" Communication was linked to a document, and that document's timeline was left open in a browser tab (no interaction).
- Hitting `mark_email_as_seen` for that communication (what the tracking pixel does when a recipient opens the email) updated the open tab's status badge from "Sent" to "Read" within ~1s, no reload.
- Without this fix, only the database was updated - the open tab never changed until manually refreshed.

Companion frontend fix for Frappe CRM (which currently ignores `communications`-keyed `docinfo_update` events even when they are published): https://github.com/frappe/crm/pull/2797

🤖 Generated with [Claude Code](https://claude.com/claude-code)