### PR TITLE
fix(grid): keep child table dropdowns anchored to the field when the page is scrolled

### DIFF
--- a/cypress/integration/grid_dropdown_position.js
+++ b/cypress/integration/grid_dropdown_position.js
@@ -1,0 +1,38 @@
+context("Grid dropdown position", () => {
+	before(() => {
+		cy.login("Administrator");
+		cy.visit("/desk/");
+		return cy
+			.window()
+			.its("frappe")
+			.then((frappe) => {
+				return frappe.xcall(
+					"frappe.tests.ui_test_helpers.create_webform_with_child_table_dropdown"
+				);
+			});
+	});
+
+	it("draws the child table dropdown next to the field on a scrolled web form", () => {
+		cy.visit("/test-grid-dropdown/new");
+
+		const cell = '.grid-body .rows .grid-row .col[data-fieldname="item"]';
+		cy.get(".grid-add-row").click();
+		cy.get(cell).first().click();
+		cy.get(`${cell} input`).first().type("a");
+		cy.get(".awesomplete > ul:visible li").should("be.visible");
+
+		// the dropdown is positioned by hand, and used to be displaced by the page scroll
+		cy.window().its("scrollY").should("be.greaterThan", 100);
+
+		cy.get(`${cell} input`)
+			.first()
+			.then(($input) => {
+				cy.get(".awesomplete > ul:visible").then(($list) => {
+					const gap =
+						$list[0].getBoundingClientRect().top -
+						$input[0].getBoundingClientRect().bottom;
+					expect(gap, "gap between field and dropdown").to.be.within(-20, 20);
+				});
+			});
+	});
+});

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -1048,9 +1048,12 @@ export default class GridRow {
 						$wrapper.append($dropdown);
 
 						let element_position = event.target.getBoundingClientRect();
+						// both rects are viewport relative; jQuery's offset() is document
+						// relative, and mixing the two shifts the dropdown by the page scroll
+						let grid_field_position = $grid_field[0].getBoundingClientRect();
 
-						let left_difference = element_position.left - $grid_field.offset().left;
-						let top_difference = element_position.top - $grid_field.offset().top + 30;
+						let left_difference = element_position.left - grid_field_position.left;
+						let top_difference = element_position.top - grid_field_position.top + 30;
 						$wrapper.css({
 							position: "absolute",
 							top: `${top_difference + 10}px`,

--- a/frappe/tests/ui_test_helpers.py
+++ b/frappe/tests/ui_test_helpers.py
@@ -773,3 +773,87 @@ def create_list_layout_test_layout(
 		}
 	).insert(ignore_permissions=True)
 	return doc.name
+
+
+@whitelist_for_tests()
+def create_webform_with_child_table_dropdown():
+	"""Set up a Web Form that is long enough to scroll and has a child table with an
+	Autocomplete field, so tests can check where the dropdown is drawn."""
+	frappe.delete_doc_if_exists("Web Form", "test-grid-dropdown")
+	frappe.delete_doc_if_exists("DocType", "Test Grid Dropdown Parent")
+	frappe.delete_doc_if_exists("DocType", "Test Grid Dropdown Child")
+
+	frappe.get_doc(
+		{
+			"doctype": "DocType",
+			"name": "Test Grid Dropdown Child",
+			"module": "Custom",
+			"custom": 1,
+			"istable": 1,
+			"editable_grid": 1,
+			"fields": [
+				{
+					"fieldname": "item",
+					"label": "Item",
+					"fieldtype": "Autocomplete",
+					"options": "Almond\nBlueberry\nChocolate\nCinnamon",
+					"in_list_view": 1,
+					"columns": 4,
+				},
+				{"fieldname": "qty", "label": "Qty", "fieldtype": "Int", "in_list_view": 1, "columns": 2},
+			],
+		}
+	).insert()
+
+	# filler fields so the child table sits well below the fold
+	fields = [{"fieldname": "title", "label": "Title", "fieldtype": "Data"}]
+	fields += [
+		{"fieldname": f"filler_{i}", "label": f"Filler {i}", "fieldtype": "Small Text"} for i in range(8)
+	]
+	fields.append(
+		{
+			"fieldname": "rows",
+			"label": "Rows",
+			"fieldtype": "Table",
+			"options": "Test Grid Dropdown Child",
+		}
+	)
+
+	frappe.get_doc(
+		{
+			"doctype": "DocType",
+			"name": "Test Grid Dropdown Parent",
+			"module": "Custom",
+			"custom": 1,
+			"naming_rule": "Expression",
+			"autoname": "format:TEST-GRID-DROPDOWN-{#####}",
+			"fields": fields,
+			"permissions": [
+				{"role": "System Manager", "read": 1, "write": 1, "create": 1, "delete": 1},
+				{"role": "Guest", "read": 1, "write": 1, "create": 1},
+			],
+		}
+	).insert()
+
+	meta = frappe.get_meta("Test Grid Dropdown Parent")
+	frappe.get_doc(
+		{
+			"doctype": "Web Form",
+			"title": "Test Grid Dropdown",
+			"route": "test-grid-dropdown",
+			"doc_type": "Test Grid Dropdown Parent",
+			"module": "Custom",
+			"published": 1,
+			"login_required": 0,
+			"allow_multiple": 1,
+			"web_form_fields": [
+				{
+					"fieldname": df.fieldname,
+					"label": df.label,
+					"fieldtype": df.fieldtype,
+					"options": df.options,
+				}
+				for df in meta.fields
+			],
+		}
+	).insert()


### PR DESCRIPTION
Link/Autocomplete dropdowns in a child table were positioned by subtracting a document-relative `offset()` from a viewport-relative `getBoundingClientRect()`, so they were displaced by the page scroll. On a Web Form long enough to scroll, the options list lands hundreds of pixels above the table.

Support ticket: https://support.frappe.io/helpdesk/tickets/77327