### PR TITLE
feat(desk-v2): a page frame with a pinned header row

### DIFF
--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -2,10 +2,9 @@
   Three things behind one route: the index at `/apps`, an app's home, and a modular app's module list.
 -->
 <template>
-	<ScrollArea class="min-h-0 flex-1" viewportClass="p-8">
-		<template v-if="boot.app">
-			<h1 class="text-xl font-semibold">{{ boot.app }}</h1>
-			<p class="mt-1 text-sm text-ink-gray-6">
+	<PageFrame :title="boot.app ?? 'Apps'">
+		<div v-if="boot.app" class="py-5">
+			<p class="text-sm text-ink-gray-6">
 				Served by the framework shell at <code>{{ boot.shell_base }}</code
 				>.
 			</p>
@@ -36,11 +35,10 @@
 					</RouterLink>
 				</li>
 			</ul>
-		</template>
+		</div>
 
-		<template v-else>
-			<h1 class="text-xl font-semibold">Apps</h1>
-			<ul class="mt-6 grid max-w-2xl grid-cols-2 gap-2">
+		<div v-else class="py-5">
+			<ul class="grid max-w-2xl grid-cols-2 gap-2">
 				<li v-for="app in boot.apps ?? []" :key="app.app">
 					<!-- A real navigation, not a `router.push`: crossing a prefix needs a boot re-fetch. -->
 					<a
@@ -53,18 +51,18 @@
 					</a>
 				</li>
 			</ul>
-		</template>
-	</ScrollArea>
+		</div>
+	</PageFrame>
 </template>
 
 <script setup lang="ts">
-import { ScrollArea } from "frappe-ui";
 import { computed, inject } from "vue";
 import { RouterLink } from "vue-router";
 import type { Boot } from "@/boot";
 import type { Addresses } from "@/addresses";
 import { routeFor, routeForModule, isModular } from "@/router/routeFor";
 import { useContents } from "@/contents";
+import PageFrame from "@/shell/PageFrame.vue";
 
 const boot = inject<Boot>("boot")!;
 const addresses = inject<Addresses>("addresses")!;

--- a/frontend/src/pages/List.vue
+++ b/frontend/src/pages/List.vue
@@ -1,31 +1,35 @@
+<!--
+  The generated list page, a plain table for now. It owns its scroll, since the list surface that
+  replaces the table scrolls both ways under a sticky column header.
+-->
 <template>
-	<ScrollArea class="min-h-0 flex-1" viewportClass="p-8">
-		<h1 class="text-lg font-semibold">{{ doctype ?? "Unknown" }}</h1>
+	<PageFrame :title="doctype ?? 'Unknown'" :scroll="false">
+		<ScrollArea class="min-h-0 flex-1" :viewportClass="[pageGutter, 'py-5']">
+			<p v-if="!doctype" class="text-sm text-ink-gray-6">
+				No doctype is served at <code>{{ route.params.doctype }}</code> under this prefix.
+			</p>
 
-		<p v-if="!doctype" class="mt-2 text-sm text-ink-gray-6">
-			No doctype is served at <code>{{ route.params.doctype }}</code> under this prefix.
-		</p>
-
-		<table v-else class="mt-4 w-full max-w-3xl text-sm">
-			<tbody>
-				<tr v-for="row in rows" :key="row.name" class="border-b border-outline-gray-1">
-					<td class="py-1.5">
-						<!-- `routeFor`, never a template literal: under a modular prefix the hand-built form
+			<table v-else class="w-full max-w-3xl text-sm">
+				<tbody>
+					<tr v-for="row in rows" :key="row.name" class="border-b border-outline-gray-1">
+						<td class="py-1.5">
+							<!-- `routeFor`, never a template literal: under a modular prefix the hand-built form
 													resolves to the wrong page. -->
-						<RouterLink
-							:to="routeFor(doctype!, row.name)"
-							class="text-ink-blue-3 hover:underline"
-						>
-							{{ row.name }}
-						</RouterLink>
-					</td>
-					<td v-for="column in columns" :key="column" class="py-1.5 text-ink-gray-7">
-						{{ row[column] }}
-					</td>
-				</tr>
-			</tbody>
-		</table>
-	</ScrollArea>
+							<RouterLink
+								:to="routeFor(doctype!, row.name)"
+								class="text-ink-blue-3 hover:underline"
+							>
+								{{ row.name }}
+							</RouterLink>
+						</td>
+						<td v-for="column in columns" :key="column" class="py-1.5 text-ink-gray-7">
+							{{ row[column] }}
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</ScrollArea>
+	</PageFrame>
 </template>
 
 <script setup lang="ts">
@@ -35,6 +39,7 @@ import { RouterLink, useRoute } from "vue-router";
 import type { Addresses } from "@/addresses";
 import { routeFor } from "@/router/routeFor";
 import { listHandlersFor } from "@/contributions/registry";
+import PageFrame, { pageGutter } from "@/shell/PageFrame.vue";
 
 const addresses = inject<Addresses>("addresses")!;
 const route = useRoute();

--- a/frontend/src/pages/Module.vue
+++ b/frontend/src/pages/Module.vue
@@ -3,9 +3,8 @@
   address space.
 -->
 <template>
-	<ScrollArea class="min-h-0 flex-1" viewportClass="p-8">
-		<h1 class="text-xl font-semibold">{{ title }}</h1>
-		<p class="mt-1 text-sm text-ink-gray-6">
+	<PageFrame :title="title">
+		<p class="pt-5 text-sm text-ink-gray-6">
 			<!-- "0 doctypes you can read" is a real answer, so it must not also be what a pending fetch looks like. -->
 			<template v-if="loading">Loading…</template>
 			<template v-else-if="failed"> Could not load this module's doctypes. </template>
@@ -14,7 +13,7 @@
 			</template>
 		</p>
 
-		<ul class="mt-6 grid max-w-2xl grid-cols-2 gap-2">
+		<ul class="my-6 grid max-w-2xl grid-cols-2 gap-2">
 			<li v-for="entry in entries" :key="entry.doctype">
 				<RouterLink
 					:to="routeFor(entry.doctype)"
@@ -24,17 +23,17 @@
 				</RouterLink>
 			</li>
 		</ul>
-	</ScrollArea>
+	</PageFrame>
 </template>
 
 <script setup lang="ts">
-import { ScrollArea } from "frappe-ui";
 import { computed, inject } from "vue";
 import { RouterLink, useRoute } from "vue-router";
 import type { Boot } from "@/boot";
 import type { Addresses } from "@/addresses";
 import { routeFor } from "@/router/routeFor";
 import { useContents } from "@/contents";
+import PageFrame from "@/shell/PageFrame.vue";
 
 const boot = inject<Boot>("boot")!;
 const addresses = inject<Addresses>("addresses")!;

--- a/frontend/src/shell/PageFrame.vue
+++ b/frontend/src/shell/PageFrame.vue
@@ -1,0 +1,51 @@
+<!--
+  A generated page's root: the pinned header row and, unless `scroll=false`, the scroll region.
+  The page owns the row's contents, its top and bottom padding, and its max width.
+-->
+<template>
+	<!-- The header is declared inside the viewport, so its click-to-top finds this page's scroll. -->
+	<ScrollArea v-if="scroll" class="min-h-0 flex-1" :viewportClass="pageGutter">
+		<PageHeader v-if="headed">
+			<slot name="header"><PageHeaderTitle :title="title" /></slot>
+		</PageHeader>
+		<slot />
+	</ScrollArea>
+
+	<!-- No padding here: a pane that scrolls both ways puts the gutter on its own viewport. -->
+	<div v-else class="flex min-h-0 flex-1 flex-col overflow-hidden">
+		<PageHeader v-if="headed">
+			<slot name="header"><PageHeaderTitle :title="title" /></slot>
+		</PageHeader>
+		<slot />
+	</div>
+</template>
+
+<script lang="ts">
+/** The side padding a page's content shares with the header row: `PageHeader`'s own classes. */
+export const pageGutter = "px-3 sm:px-5";
+</script>
+
+<script setup lang="ts">
+import { computed, useSlots } from "vue";
+import { PageHeader, PageHeaderTitle, ScrollArea } from "frappe-ui";
+
+const props = withDefaults(
+	defineProps<{
+		/** Rendered as the row's title; the `header` slot replaces the row's whole content. */
+		title?: string;
+		/** `false` hands the scroll to the page: a list that scrolls both ways, a record in panes. */
+		scroll?: boolean;
+	}>(),
+	{ scroll: true }
+);
+
+defineSlots<{
+	header?: () => unknown;
+	default?: () => unknown;
+}>();
+
+const slots = useSlots();
+
+// Without a `PageHeader` the shell's target keeps no height.
+const headed = computed(() => !!props.title || !!slots.header);
+</script>

--- a/frontend/src/shell/SidebarPanel.vue
+++ b/frontend/src/shell/SidebarPanel.vue
@@ -13,7 +13,8 @@
 			:class="collapsed ? 'border-0' : 'border-l border-outline-gray-1'"
 			:inert="collapsed"
 		>
-			<div class="flex shrink-0 items-center py-2 pl-4 pr-2">
+			<!-- 48px, no border: level with the page's header row, whose border stops at this panel's edge. -->
+			<div class="flex h-12 shrink-0 items-center pl-4 pr-2">
 				<p v-if="title" class="truncate text-base font-medium text-ink-gray-8">
 					{{ title }}
 				</p>

--- a/frontend/src/shell/tests/pageFrame.test.ts
+++ b/frontend/src/shell/tests/pageFrame.test.ts
@@ -1,0 +1,88 @@
+// The page frame: its header row teleports to the shell's target, and `scroll` picks who scrolls.
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, defineComponent, h, nextTick, type Component } from "vue";
+import { PageHeaderTarget } from "frappe-ui";
+
+import PageFrame, { pageGutter } from "../PageFrame.vue";
+
+const mounted: ReturnType<typeof createApp>[] = [];
+
+afterEach(() => {
+	for (const app of mounted.splice(0)) app.unmount();
+	document.body.innerHTML = "";
+});
+
+/** A shell in miniature: the pinned target above the page, as `DesktopShell` lays it out. */
+async function mount(page: Component) {
+	const root = document.createElement("div");
+	document.body.appendChild(root);
+
+	const app = createApp(
+		defineComponent({
+			render: () => [
+				h("div", { "data-testid": "target" }, [h(PageHeaderTarget)]),
+				h("div", { "data-testid": "page" }, [h(page)]),
+			],
+		})
+	);
+	app.mount(root);
+	mounted.push(app);
+	// The target registers on mount, and a deferred teleport moves on the tick after that.
+	await nextTick();
+	await nextTick();
+
+	return {
+		target: root.querySelector<HTMLElement>('[data-testid="target"]')!,
+		page: root.querySelector<HTMLElement>('[data-testid="page"]')!,
+	};
+}
+
+describe("the header row", () => {
+	it("teleports the title into the shell's target, out of the page's own tree", async () => {
+		const { target, page } = await mount(() => h(PageFrame, { title: "Lead" }, () => "rows"));
+
+		const header = target.querySelector("header");
+		expect(header?.textContent).toContain("Lead");
+		expect(page.querySelector("header")).toBeNull();
+		expect(page.textContent).toContain("rows");
+	});
+
+	it("renders the header slot in place of the title", async () => {
+		const { target } = await mount(() =>
+			h(PageFrame, { title: "Unused" }, { header: () => h("h1", "Leads, mine") })
+		);
+
+		const header = target.querySelector("header")!;
+		expect(header.textContent).toContain("Leads, mine");
+		expect(header.textContent).not.toContain("Unused");
+	});
+
+	it("leaves the target empty on a page with nothing for the row", async () => {
+		const { target, page } = await mount(() => h(PageFrame, null, () => "body"));
+
+		expect(target.querySelector("header")).toBeNull();
+		expect(target.textContent).toBe("");
+		expect(page.textContent).toContain("body");
+	});
+});
+
+describe("the scroll prop", () => {
+	it("scrolls the body itself by default, with the gutter on the viewport", async () => {
+		const { page } = await mount(() => h(PageFrame, { title: "Home" }, () => "body"));
+
+		const viewport = page.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]');
+		expect(viewport).not.toBeNull();
+		for (const cls of pageGutter.split(" ")) expect(viewport!.classList.contains(cls)).toBe(true);
+	});
+
+	it("hands the scroll to the page with scroll=false, and applies no gutter", async () => {
+		const { page } = await mount(() =>
+			h(PageFrame, { title: "Lead", scroll: false }, () => h("p", "body"))
+		);
+
+		expect(page.querySelector('[data-slot="scroll-area"]')).toBeNull();
+		const pane = page.firstElementChild as HTMLElement;
+		expect(pane.className).toContain("overflow-hidden");
+		expect(pane.className).not.toContain("px-");
+	});
+});


### PR DESCRIPTION
Build ticket on the shell-and-list map: frappe/frappe#42616. The spelling is the page-frame grilling's resolution (frappe/frappe#42584).

## What changes

- **`frontend/src/shell/PageFrame.vue`** is a generated page's root. Props: `title` and `scroll` (default `true`). Slot `header` replaces the row's whole content and wins over `title`; the default slot is the body. The row renders through frappe-ui's `PageHeader` and teleports into `DesktopShell`'s pinned target. A page with nothing for the row renders no `PageHeader`, so the target keeps no height.
- **`scroll=true`**: the body is a `ScrollArea` with the gutter on its viewport, and the `PageHeader` is declared inside that viewport so frappe-ui's click-to-top finds the page's own scroll region. **`scroll=false`**: a fixed-height pane with no padding; the page owns its scroll and imports the gutter.
- **`pageGutter`** is one exported class string, `px-3 sm:px-5`, the same as `PageHeader`'s own. The page owns its top padding and its max width.
- **The sidebar's title row** is 48px with no bottom border, level with the header row. The header's border stops at the panel's edge.
- **Home and Module** take `title` and the default scroll. **List** takes `scroll=false`, puts the gutter on its own `ScrollArea`, and keeps its table; the list ticket replaces the table inside this frame. The record page is not touched; its move is a task on the record map.

## Walked

The Lead list at `/apps/crm/crm-lead`, 1440px wide. Measured after: header row at top 0, 48px tall; the sidebar title row 48px; the list's first link 21px in from the content edge, under the title's own 20px gutter plus the border; the list scrolled to its end with the row still at top 0. No console output.

| Before | After | After, scrolled |
| --- | --- | --- |
| ![before](https://raw.githubusercontent.com/shariquerik/frappe/media/page-frame/media/page-frame/before-lead.png) | ![after](https://raw.githubusercontent.com/shariquerik/frappe/media/page-frame/media/page-frame/after-lead.png) | ![after, scrolled](https://raw.githubusercontent.com/shariquerik/frappe/media/page-frame/media/page-frame/after-lead-scrolled.png) |

Home, after: ![home, after](https://raw.githubusercontent.com/shariquerik/frappe/media/page-frame/media/page-frame/after-home.png)

## Tests

`frontend/src/shell/tests/pageFrame.test.ts`, five tests: the title teleports into the target and out of the page's tree; the `header` slot replaces the title; a page with nothing for the row leaves the target empty; `scroll=true` renders a viewport carrying the gutter; `scroll=false` renders no `ScrollArea` and no gutter. Suite: 32 files, 501 tests, green.

## Performance, caching and security

Nothing. The frame fetches no data, adds nothing to boot, and gates nothing. The `PageHeaderTarget` is one empty `div` that `DesktopShell` already rendered. The frame exposes no act, no global and no shell object.

## Review gates

Quality review in a fresh subagent: no blockers; three should-fix findings taken (a three-line file comment, a slot test that could not fail, Home and Module losing their bottom padding) and one nit (a restating comment). Comment check: every comment the diff adds carries a constraint the code cannot state, two lines at most, no ticket numbers.

>no-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
