### PR TITLE
feat(desk-v2): the record page's header row moves into PageFrame

### DIFF
--- a/frontend/src/pages/Record.vue
+++ b/frontend/src/pages/Record.vue
@@ -1,14 +1,10 @@
 <!--
   The generated record page every app gets at /apps/<prefix>/<slug>/<name>: a host for the
-  record-page engine with a real header row, and no form layout, tabs or panel yet.
+  record-page engine with a real header row, no form layout yet, and its own scroll (it will split into panes).
 -->
 <template>
-	<ScrollArea class="min-h-0 flex-1" viewportClass="p-8">
-		<p v-if="!doctype" class="text-sm text-ink-gray-6">
-			No doctype is served at <code>{{ route.params.doctype }}</code> under this prefix.
-		</p>
-
-		<template v-else>
+	<PageFrame :scroll="false">
+		<template v-if="doctype" #header>
 			<RecordHeader
 				v-if="controller"
 				:projection="header"
@@ -16,32 +12,40 @@
 				:saving="saving"
 				@run="runAction"
 			/>
-			<header v-else class="flex items-center gap-3">
+			<div v-else class="flex items-center gap-3">
 				<h1 class="text-lg font-semibold">{{ route.params.name }}</h1>
 				<span class="text-sm text-ink-gray-5">{{ doctype }}</span>
-			</header>
-
-			<!-- Contributed quick actions, in the run order the registry decided. -->
-			<div v-if="quickActions.length" class="mt-4 flex gap-2">
-				<Button
-					v-for="action in quickActions"
-					:key="action.name"
-					:label="action.label"
-					@click="runAction(action)"
-				/>
 			</div>
-
-			<p v-if="actionError" class="mt-4 text-sm text-ink-red-4">{{ actionError }}</p>
-			<p v-if="error" class="mt-4 text-sm text-ink-red-4">{{ error }}</p>
-
-			<dl v-else class="mt-6 grid max-w-2xl grid-cols-[12rem_1fr] gap-y-1.5 text-sm">
-				<template v-for="[field, value] in fields" :key="field">
-					<dt class="text-ink-gray-6">{{ field }}</dt>
-					<dd class="text-ink-gray-8">{{ value }}</dd>
-				</template>
-			</dl>
 		</template>
-	</ScrollArea>
+
+		<ScrollArea class="min-h-0 flex-1" :viewportClass="[pageGutter, 'py-5']">
+			<p v-if="!doctype" class="text-sm text-ink-gray-6">
+				No doctype is served at <code>{{ route.params.doctype }}</code> under this prefix.
+			</p>
+
+			<template v-else>
+				<!-- Contributed quick actions, in the run order the registry decided. -->
+				<div v-if="quickActions.length" class="flex gap-2">
+					<Button
+						v-for="action in quickActions"
+						:key="action.name"
+						:label="action.label"
+						@click="runAction(action)"
+					/>
+				</div>
+
+				<p v-if="actionError" class="mt-4 text-sm text-ink-red-4">{{ actionError }}</p>
+				<p v-if="error" class="mt-4 text-sm text-ink-red-4">{{ error }}</p>
+
+				<dl v-else class="mt-6 grid max-w-2xl grid-cols-[12rem_1fr] gap-y-1.5 text-sm">
+					<template v-for="[field, value] in fields" :key="field">
+						<dt class="text-ink-gray-6">{{ field }}</dt>
+						<dd class="text-ink-gray-8">{{ value }}</dd>
+					</template>
+				</dl>
+			</template>
+		</ScrollArea>
+	</PageFrame>
 </template>
 
 <script setup lang="ts">
@@ -57,6 +61,7 @@ import {
 } from "@/recordPage";
 import { routeFor } from "@/router/routeFor";
 import RecordHeader from "./record/RecordHeader.vue";
+import PageFrame, { pageGutter } from "@/shell/PageFrame.vue";
 import type { Boot } from "@/boot";
 import type { Addresses } from "@/addresses";
 

--- a/frontend/src/pages/record/RecordHeader.vue
+++ b/frontend/src/pages/record/RecordHeader.vue
@@ -1,6 +1,9 @@
-<!-- The record's header row, drawn from `page.header`: crumbs left; controls, `⋯` and Save right. -->
+<!--
+  The record's header row, drawn from `page.header`: crumbs left; controls, `⋯` and Save right.
+  A div, not a header: it fills the frame's pinned row, which is the `<header>` element.
+-->
 <template>
-	<header class="flex items-center justify-between gap-3">
+	<div class="flex min-w-0 flex-1 items-center justify-between gap-3">
 		<nav class="flex min-w-0 items-center gap-1 text-base">
 			<template v-for="(control, index) in projection.left" :key="control.item.name">
 				<span
@@ -107,7 +110,7 @@
 				</div>
 			</Dropdown>
 		</div>
-	</header>
+	</div>
 </template>
 
 <script setup lang="ts">

--- a/frontend/src/shell/PageFrame.vue
+++ b/frontend/src/shell/PageFrame.vue
@@ -3,9 +3,10 @@
   The page owns the row's contents, its top and bottom padding, and its max width.
 -->
 <template>
-	<!-- The header is declared inside the viewport, so its click-to-top finds this page's scroll. -->
+	<!-- Read in the template, not a computed: the slots object is not reactive, and a page can
+	     supply its header after mount. Without a `PageHeader` the shell's target keeps no height. -->
 	<ScrollArea v-if="scroll" class="min-h-0 flex-1" :viewportClass="pageGutter">
-		<PageHeader v-if="headed">
+		<PageHeader v-if="title || $slots.header">
 			<slot name="header"><PageHeaderTitle :title="title" /></slot>
 		</PageHeader>
 		<slot />
@@ -13,7 +14,7 @@
 
 	<!-- No padding here: a pane that scrolls both ways puts the gutter on its own viewport. -->
 	<div v-else class="flex min-h-0 flex-1 flex-col overflow-hidden">
-		<PageHeader v-if="headed">
+		<PageHeader v-if="title || $slots.header">
 			<slot name="header"><PageHeaderTitle :title="title" /></slot>
 		</PageHeader>
 		<slot />
@@ -26,10 +27,9 @@ export const pageGutter = "px-3 sm:px-5";
 </script>
 
 <script setup lang="ts">
-import { computed, useSlots } from "vue";
 import { PageHeader, PageHeaderTitle, ScrollArea } from "frappe-ui";
 
-const props = withDefaults(
+withDefaults(
 	defineProps<{
 		/** Rendered as the row's title; the `header` slot replaces the row's whole content. */
 		title?: string;
@@ -43,9 +43,4 @@ defineSlots<{
 	header?: () => unknown;
 	default?: () => unknown;
 }>();
-
-const slots = useSlots();
-
-// Without a `PageHeader` the shell's target keeps no height.
-const headed = computed(() => !!props.title || !!slots.header);
 </script>

--- a/frontend/src/shell/tests/pageFrame.test.ts
+++ b/frontend/src/shell/tests/pageFrame.test.ts
@@ -1,6 +1,13 @@
 // The page frame: its header row teleports to the shell's target, and `scroll` picks who scrolls.
 import { afterEach, describe, expect, it } from "vitest";
-import { createApp, defineComponent, h, nextTick, type Component } from "vue";
+import {
+  createApp,
+  defineComponent,
+  h,
+  nextTick,
+  ref,
+  type Component,
+} from "vue";
 import { PageHeaderTarget } from "frappe-ui";
 
 import PageFrame, { pageGutter } from "../PageFrame.vue";
@@ -8,81 +15,107 @@ import PageFrame, { pageGutter } from "../PageFrame.vue";
 const mounted: ReturnType<typeof createApp>[] = [];
 
 afterEach(() => {
-	for (const app of mounted.splice(0)) app.unmount();
-	document.body.innerHTML = "";
+  for (const app of mounted.splice(0)) app.unmount();
+  document.body.innerHTML = "";
 });
 
 /** A shell in miniature: the pinned target above the page, as `DesktopShell` lays it out. */
 async function mount(page: Component) {
-	const root = document.createElement("div");
-	document.body.appendChild(root);
+  const root = document.createElement("div");
+  document.body.appendChild(root);
 
-	const app = createApp(
-		defineComponent({
-			render: () => [
-				h("div", { "data-testid": "target" }, [h(PageHeaderTarget)]),
-				h("div", { "data-testid": "page" }, [h(page)]),
-			],
-		})
-	);
-	app.mount(root);
-	mounted.push(app);
-	// The target registers on mount, and a deferred teleport moves on the tick after that.
-	await nextTick();
-	await nextTick();
+  const app = createApp(
+    defineComponent({
+      render: () => [
+        h("div", { "data-testid": "target" }, [h(PageHeaderTarget)]),
+        h("div", { "data-testid": "page" }, [h(page)]),
+      ],
+    })
+  );
+  app.mount(root);
+  mounted.push(app);
+  // The target registers on mount, and a deferred teleport moves on the tick after that.
+  await nextTick();
+  await nextTick();
 
-	return {
-		target: root.querySelector<HTMLElement>('[data-testid="target"]')!,
-		page: root.querySelector<HTMLElement>('[data-testid="page"]')!,
-	};
+  return {
+    target: root.querySelector<HTMLElement>('[data-testid="target"]')!,
+    page: root.querySelector<HTMLElement>('[data-testid="page"]')!,
+  };
 }
 
 describe("the header row", () => {
-	it("teleports the title into the shell's target, out of the page's own tree", async () => {
-		const { target, page } = await mount(() => h(PageFrame, { title: "Lead" }, () => "rows"));
+  it("teleports the title into the shell's target, out of the page's own tree", async () => {
+    const { target, page } = await mount(() =>
+      h(PageFrame, { title: "Lead" }, () => "rows")
+    );
 
-		const header = target.querySelector("header");
-		expect(header?.textContent).toContain("Lead");
-		expect(page.querySelector("header")).toBeNull();
-		expect(page.textContent).toContain("rows");
-	});
+    const header = target.querySelector("header");
+    expect(header?.textContent).toContain("Lead");
+    expect(page.querySelector("header")).toBeNull();
+    expect(page.textContent).toContain("rows");
+  });
 
-	it("renders the header slot in place of the title", async () => {
-		const { target } = await mount(() =>
-			h(PageFrame, { title: "Unused" }, { header: () => h("h1", "Leads, mine") })
-		);
+  it("renders the header slot in place of the title", async () => {
+    const { target } = await mount(() =>
+      h(
+        PageFrame,
+        { title: "Unused" },
+        { header: () => h("h1", "Leads, mine") }
+      )
+    );
 
-		const header = target.querySelector("header")!;
-		expect(header.textContent).toContain("Leads, mine");
-		expect(header.textContent).not.toContain("Unused");
-	});
+    const header = target.querySelector("header")!;
+    expect(header.textContent).toContain("Leads, mine");
+    expect(header.textContent).not.toContain("Unused");
+  });
 
-	it("leaves the target empty on a page with nothing for the row", async () => {
-		const { target, page } = await mount(() => h(PageFrame, null, () => "body"));
+  it("draws the row for a header slot that appears after mount", async () => {
+    const headed = ref(false);
+    const { target } = await mount(() =>
+      h(PageFrame, null, headed.value ? { header: () => h("h1", "Late") } : {})
+    );
+    expect(target.querySelector("header")).toBeNull();
 
-		expect(target.querySelector("header")).toBeNull();
-		expect(target.textContent).toBe("");
-		expect(page.textContent).toContain("body");
-	});
+    headed.value = true;
+    await nextTick();
+    await nextTick();
+    expect(target.querySelector("header")?.textContent).toContain("Late");
+  });
+
+  it("leaves the target empty on a page with nothing for the row", async () => {
+    const { target, page } = await mount(() =>
+      h(PageFrame, null, () => "body")
+    );
+
+    expect(target.querySelector("header")).toBeNull();
+    expect(target.textContent).toBe("");
+    expect(page.textContent).toContain("body");
+  });
 });
 
 describe("the scroll prop", () => {
-	it("scrolls the body itself by default, with the gutter on the viewport", async () => {
-		const { page } = await mount(() => h(PageFrame, { title: "Home" }, () => "body"));
+  it("scrolls the body itself by default, with the gutter on the viewport", async () => {
+    const { page } = await mount(() =>
+      h(PageFrame, { title: "Home" }, () => "body")
+    );
 
-		const viewport = page.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]');
-		expect(viewport).not.toBeNull();
-		for (const cls of pageGutter.split(" ")) expect(viewport!.classList.contains(cls)).toBe(true);
-	});
+    const viewport = page.querySelector<HTMLElement>(
+      '[data-slot="scroll-area-viewport"]'
+    );
+    expect(viewport).not.toBeNull();
+    for (const cls of pageGutter.split(" "))
+      expect(viewport!.classList.contains(cls)).toBe(true);
+  });
 
-	it("hands the scroll to the page with scroll=false, and applies no gutter", async () => {
-		const { page } = await mount(() =>
-			h(PageFrame, { title: "Lead", scroll: false }, () => h("p", "body"))
-		);
+  it("hands the scroll to the page with scroll=false, and applies no gutter", async () => {
+    const { page } = await mount(() =>
+      h(PageFrame, { title: "Lead", scroll: false }, () => h("p", "body"))
+    );
 
-		expect(page.querySelector('[data-slot="scroll-area"]')).toBeNull();
-		const pane = page.firstElementChild as HTMLElement;
-		expect(pane.className).toContain("overflow-hidden");
-		expect(pane.className).not.toContain("px-");
-	});
+    expect(page.querySelector('[data-slot="scroll-area"]')).toBeNull();
+    const pane = page.firstElementChild as HTMLElement;
+    expect(pane.className).toContain("overflow-hidden");
+    expect(pane.className).not.toContain("px-");
+  });
 });


### PR DESCRIPTION
Part of desk v2 (#42061), the record-page map (#42271). Resolves the task that moves the record page's header row into the shell's page frame (#42618), as the shell map's page-frame grilling ruled (#42584).

## What changes

- `Record.vue` is now a `<PageFrame :scroll="false">`. `RecordHeader` renders in the frame's `header` slot, so the crumbs and Save land in the shell's pinned row, level with the sidebar's title, and stay put while the body scrolls. The page owns its scroll and applies the frame's `pageGutter` on its own viewport, as `List.vue` does.
- `RecordHeader`'s root is a `div`, not a `header`: frappe-ui's `PageHeader` already renders the `<header>` element, and `min-w-0 flex-1` lets the row fill it.
- The row's contents do not change. That stays the record map's.

## A frame fix the move exposed

`PageFrame` decided whether to draw the row from a `computed` over `useSlots()`. The slots object is not reactive, so a header slot supplied after mount never drew the row. The record page is the first page to supply the slot late: an unknown doctype resolving to a known one on a param-only route change (browser back from a mistyped URL, or a script's `router.push`). The frame now reads `$slots.header` in the template. A new test in `pageFrame.test.ts` mounts with no slot, supplies one, and expects the row; it fails on the old frame.

## Checked

- `yarn vitest run` in `frontend/`: 32 files, 505 tests, green.
- Walked on a local site: a lead's record shows crumbs and Save in the pinned row (screenshots below). An unknown-doctype URL draws no row. A `router.push` from that URL to the lead draws the row.

## Before / after

Before: the row scrolls with the body, below the sidebar's title line.

![before](https://raw.githubusercontent.com/shariquerik/frappe/media/record-page-frame/media/record-page-frame/before-lead.png)

After: crumbs and Save in the pinned row, level with the sidebar's title.

![after](https://raw.githubusercontent.com/shariquerik/frappe/media/record-page-frame/media/record-page-frame/after-lead.png)

>no-docs
