### PR TITLE
fix(lang): Give the calendar and date picker the locale given

### DIFF
--- a/frappe/public/js/calendar.bundle.js
+++ b/frappe/public/js/calendar.bundle.js
@@ -3,6 +3,11 @@ import dayGridPlugin from "@fullcalendar/daygrid";
 import listPlugin from "@fullcalendar/list";
 import timeGridPlugin from "@fullcalendar/timegrid";
 import interactionPlugin from "@fullcalendar/interaction";
+import allLocales from "@fullcalendar/core/locales-all";
 
 frappe.FullCalendar = FullCalendar;
 frappe.FullCalendar.Plugins = [listPlugin, dayGridPlugin, timeGridPlugin, interactionPlugin];
+// The view passes `locale: frappe.boot.lang`, but FullCalendar can only honour a
+// locale it has been given. Without this the option is accepted and ignored, and
+// every calendar renders its month names, day names and buttons in English.
+frappe.FullCalendar.Locales = allLocales;

--- a/frappe/public/js/frappe/form/controls/datepicker_i18n.js
+++ b/frappe/public/js/frappe/form/controls/datepicker_i18n.js
@@ -423,3 +423,44 @@ import "air-datepicker/dist/js/i18n/datepicker.zh.js";
 		firstDay: 1,
 	};
 })(jQuery);
+
+(function ($) {
+	$.fn.datepicker.language["ja"] = {
+		days: ["日曜日", "月曜日", "火曜日", "水曜日", "木曜日", "金曜日", "土曜日"],
+		daysShort: ["日", "月", "火", "水", "木", "金", "土"],
+		daysMin: ["日", "月", "火", "水", "木", "金", "土"],
+		months: [
+			"1月",
+			"2月",
+			"3月",
+			"4月",
+			"5月",
+			"6月",
+			"7月",
+			"8月",
+			"9月",
+			"10月",
+			"11月",
+			"12月",
+		],
+		monthsShort: [
+			"1月",
+			"2月",
+			"3月",
+			"4月",
+			"5月",
+			"6月",
+			"7月",
+			"8月",
+			"9月",
+			"10月",
+			"11月",
+			"12月",
+		],
+		today: "今日",
+		clear: "クリア",
+		dateFormat: "yyyy/mm/dd",
+		timeFormat: "hh:ii",
+		firstDay: 0,
+	};
+})(jQuery);

--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -320,10 +320,13 @@ frappe.views.Calendar = class Calendar {
 			plugins: frappe.FullCalendar.Plugins,
 			initialView: defaults.initialView || "dayGridMonth",
 			locale: frappe.boot.lang,
+			locales: frappe.FullCalendar.Locales,
 			eventTimeFormat: {
 				hour: "numeric",
 				minute: "2-digit",
-				hour12: true,
+				// Follow the site's Time Format rather than assuming a 12-hour
+				// clock, which most locales do not use.
+				hour12: (frappe.boot.sysdefaults?.time_format || "").includes("hh"),
 			},
 			firstDay: frappe.datetime.get_first_day_of_the_week_index(),
 			eventDisplay: "block",


### PR DESCRIPTION
Three small omissions leave every non-English desk showing an English calendar.

The date picker has language definitions for 25 languages and no Japanese one. `date.js` falls back to English for any language it cannot find, so a Japanese user sees English month and day names in every date field. The definition added here follows the same shape as the others.

The calendar view already passes `locale: frappe.boot.lang` to FullCalendar, but `calendar.bundle.js` never imports any locale, so FullCalendar has nothing to resolve the code against and quietly renders in English. The translations exist in the package we already depend on — `ja.js` there carries 前/次/今日/終日 and the rest — they were simply never loaded. Measured cost: `calendar.bundle.js` grows from 258 KB to 293 KB, and that bundle is only fetched when a calendar view opens.

`eventTimeFormat` hard-coded `hour12: true`. Most locales do not use a 12-hour clock, and the site already records the answer in System Settings > Time Format.

Reported by a user at LUSH Japan, who asked simply for the calendar to follow Japanese conventions.


(cherry picked from commit ff9940380b3d28e8e67a9326ee84b6e5869f7bb7)

Raising this PR on behalf of @masakazu-nomura2022