### PR TITLE
fix: handle missing preload library in Postgres Query Stats

### DIFF
--- a/frappe/core/report/postgres_query_stats/postgres_query_stats.py
+++ b/frappe/core/report/postgres_query_stats/postgres_query_stats.py
@@ -54,7 +54,6 @@ def execute(filters=None):
 			as_dict=True,
 		)
 	except ObjectNotInPrerequisiteState:
-		frappe.db.rollback()
 		frappe.throw(
 			_(
 				"pg_stat_statements is enabled in this site's database but not loaded on the server. "

--- a/frappe/core/report/postgres_query_stats/postgres_query_stats.py
+++ b/frappe/core/report/postgres_query_stats/postgres_query_stats.py
@@ -12,6 +12,7 @@ from frappe.utils import cint
 
 # frappe quotes table identifiers, so tables appear as "tabDoctype Name" in the normalized query text
 TABLE_IN_QUERY = re.compile(r'"tab([^"]+)"')
+SAVE_POINT = "postgres_query_stats"
 
 
 def get_columns():
@@ -31,7 +32,24 @@ def execute(filters=None):
 	if frappe.db.db_type != "postgres":
 		frappe.throw(_("This report is only available on PostgreSQL sites."))
 
-	limit = cint((filters or {}).get("limit")) or 50
+	data = get_query_stats(cint((filters or {}).get("limit")) or 50)
+
+	app_map = get_doctype_app_map()
+	for row in data:
+		# pg_stat_statements returns "<insufficient privilege>" for queries run by other roles
+		# (grant pg_read_all_stats to see them), or NULL if the text was evicted. The datatable
+		# eats the angle brackets as an HTML tag, so relabel those so the cell is never blank.
+		text = row.get("query") or ""
+		row["app"] = _apps_in_query(text, app_map)
+		if not text or (text.startswith("<") and text.endswith(">")):
+			row["query"] = text.strip("<>") or "(query text unavailable)"
+
+	return get_columns(), data
+
+
+def get_query_stats(limit: int) -> list[dict]:
+	"""Top queries by total execution time, or a message naming the missing setup step."""
+	frappe.db.savepoint(SAVE_POINT)
 	try:
 		# scope to current_database() so a shared cluster only shows this site's queries
 		data = frappe.db.sql(
@@ -53,7 +71,20 @@ def execute(filters=None):
 			{"limit": limit},
 			as_dict=True,
 		)
-	except ObjectNotInPrerequisiteState:
+	except Exception as exception:
+		# postgres aborts the whole transaction on a failed statement. Undo just this query so
+		# the checks below, and the caller's error reporting, still have a usable connection --
+		# a plain rollback would also discard unrelated work done earlier in the request.
+		frappe.db.rollback(save_point=SAVE_POINT)
+		_throw_missing_setup_step(exception)
+	else:
+		frappe.db.release_savepoint(SAVE_POINT)
+		return data
+
+
+def _throw_missing_setup_step(exception: Exception) -> None:
+	"""Name the exact pg_stat_statements setup step the administrator is missing."""
+	if isinstance(exception, ObjectNotInPrerequisiteState):
 		frappe.throw(
 			_(
 				"pg_stat_statements is enabled in this site's database but not loaded on the server. "
@@ -61,43 +92,31 @@ def execute(filters=None):
 				"and restart PostgreSQL."
 			)
 		)
-	except Exception as e:
-		frappe.db.rollback()
-		# Only a missing pg_stat_statements view means the extension isn't enabled. Re-raise
-		# anything else (privilege error, connection drop, a future column rename) so it is not
-		# misreported as "extension not installed".
-		if not frappe.db.is_table_missing(e):
-			raise
-		# CREATE EXTENSION is per-database, so a cluster can have the library preloaded yet the
-		# view missing on this site's DB. Point the admin at the exact missing step.
-		preloaded = "pg_stat_statements" in (frappe.db.sql("SHOW shared_preload_libraries")[0][0] or "")
-		if preloaded:
-			frappe.throw(
-				_(
-					"pg_stat_statements is loaded on the server but not enabled in this site's "
-					"database. A PostgreSQL superuser must run, connected to THIS database:"
-				)
-				+ "\n\n    CREATE EXTENSION pg_stat_statements;"
-			)
+
+	# Only a missing pg_stat_statements view means the extension isn't enabled. Re-raise
+	# anything else (privilege error, connection drop, a future column rename) so it is not
+	# misreported as "extension not installed".
+	if not frappe.db.is_table_missing(exception):
+		raise exception
+
+	# CREATE EXTENSION is per-database, so a cluster can have the library preloaded yet the
+	# view missing on this site's DB. Point the admin at the exact missing step.
+	if "pg_stat_statements" in (frappe.db.sql("SHOW shared_preload_libraries")[0][0] or ""):
 		frappe.throw(
 			_(
-				"pg_stat_statements is not enabled. A PostgreSQL superuser must add "
-				"'pg_stat_statements' to shared_preload_libraries, restart PostgreSQL, then run "
-				"CREATE EXTENSION pg_stat_statements; in this site's database."
+				"pg_stat_statements is loaded on the server but not enabled in this site's "
+				"database. A PostgreSQL superuser must run, connected to THIS database:"
 			)
+			+ "\n\n    CREATE EXTENSION pg_stat_statements;"
 		)
 
-	app_map = get_doctype_app_map()
-	for row in data:
-		# pg_stat_statements returns "<insufficient privilege>" for queries run by other roles
-		# (grant pg_read_all_stats to see them), or NULL if the text was evicted. The datatable
-		# eats the angle brackets as an HTML tag, so relabel those so the cell is never blank.
-		text = row.get("query") or ""
-		row["app"] = _apps_in_query(text, app_map)
-		if not text or (text.startswith("<") and text.endswith(">")):
-			row["query"] = text.strip("<>") or "(query text unavailable)"
-
-	return get_columns(), data
+	frappe.throw(
+		_(
+			"pg_stat_statements is not enabled. A PostgreSQL superuser must add "
+			"'pg_stat_statements' to shared_preload_libraries, restart PostgreSQL, then run "
+			"CREATE EXTENSION pg_stat_statements; in this site's database."
+		)
+	)
 
 
 def _apps_in_query(query: str, app_map: dict) -> str:

--- a/frappe/core/report/postgres_query_stats/postgres_query_stats.py
+++ b/frappe/core/report/postgres_query_stats/postgres_query_stats.py
@@ -3,6 +3,8 @@
 
 import re
 
+from psycopg2.errors import ObjectNotInPrerequisiteState
+
 import frappe
 from frappe import _
 from frappe.modules.utils import get_doctype_app_map
@@ -50,6 +52,15 @@ def execute(filters=None):
 			""",
 			{"limit": limit},
 			as_dict=True,
+		)
+	except ObjectNotInPrerequisiteState:
+		frappe.db.rollback()
+		frappe.throw(
+			_(
+				"pg_stat_statements is enabled in this site's database but not loaded on the server. "
+				"A PostgreSQL administrator must add 'pg_stat_statements' to shared_preload_libraries "
+				"and restart PostgreSQL."
+			)
 		)
 	except Exception as e:
 		frappe.db.rollback()

--- a/frappe/core/report/postgres_query_stats/test_postgres_query_stats.py
+++ b/frappe/core/report/postgres_query_stats/test_postgres_query_stats.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2025, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+import unittest
+from contextlib import suppress
+
+from psycopg2.errors import ObjectNotInPrerequisiteState
+
+import frappe
+from frappe.core.report.postgres_query_stats.postgres_query_stats import get_query_stats
+from frappe.tests import IntegrationTestCase
+
+STATS_TABLE = "pg_stat_statements s"
+
+
+@unittest.skipUnless(frappe.db.db_type == "postgres", "pg_stat_statements is PostgreSQL only")
+class TestPostgresQueryStats(IntegrationTestCase):
+	def fail_stats_query(self, exception: Exception):
+		"""Stand in for PostgreSQL: abort the transaction for real, then raise `exception`."""
+		real_sql = frappe.db.sql
+
+		def sql(query, *args, **kwargs):
+			if STATS_TABLE not in str(query):
+				return real_sql(query, *args, **kwargs)
+			# abort the transaction through the driver, skipping frappe's query error logging
+			with suppress(Exception):
+				frappe.db._cursor.execute("SELECT 1 FROM pg_stat_statements_not_loaded")
+			raise exception
+
+		frappe.db.sql = sql
+		self.addCleanup(lambda: delattr(frappe.db, "sql"))
+
+	def test_preload_library_missing_names_the_setup_step(self):
+		self.fail_stats_query(ObjectNotInPrerequisiteState("pg_stat_statements must be loaded"))
+
+		with self.assertRaises(frappe.ValidationError) as raised:
+			get_query_stats(50)
+
+		self.assertIn("shared_preload_libraries", str(raised.exception))
+		# the savepoint rollback must leave the connection usable for the rest of the request
+		self.assertEqual(frappe.db.sql("SELECT 1")[0][0], 1)
+
+	def test_unrelated_failure_is_reraised(self):
+		self.fail_stats_query(RuntimeError("connection reset"))
+
+		with self.assertRaises(RuntimeError):
+			get_query_stats(50)


### PR DESCRIPTION
Postgres Query Stats raises an unhandled `ObjectNotInPrerequisiteState` when the extension exists in the database but its server library is not loaded.

Catch this error and show instructions to add `pg_stat_statements` to `shared_preload_libraries` and restart PostgreSQL. The request handler manages the transaction rollback. The error handler does not require permission to inspect server settings. Other database errors retain their existing behavior.

Validation: reproduced the configuration error on a PostgreSQL site and confirmed the report returns the setup message. Ruff, formatting, and all applicable commit hooks pass.
