### PR TITLE
fix(postgres): cast JSON fields before filter comparisons

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -1309,6 +1309,12 @@ class Engine:
 			# Note: Comma handling is done in parse_fields before this method is called
 			return self.parse_string_field(field)
 
+	def _uncast_json_column(self, term: Term) -> Term:
+		"""The column a JSON cast wraps, for the checks that match a selected field by name."""
+		if isinstance(term, functions.Cast) and isinstance(term.args[0], Field):
+			return term.args[0]
+		return term
+
 	def _cast_json_select_field(self, field: Term) -> Term:
 		"""Keep the alias so the cast does not rename the column in the result."""
 		cast = self._cast_json_column(field)
@@ -1398,6 +1404,7 @@ class Engine:
 			terms = self._get_star_fields(term) if isinstance(term, Star) else [term]
 			selected_field_count += len(terms)
 			for term in terms:
+				term = self._uncast_json_column(term)
 				if not isinstance(term, Field):
 					continue
 				table = term.table if term.table is not None else self.table

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -42,6 +42,9 @@ CORE_DOCTYPES = DOCTYPES_FOR_DOCTYPE | frozenset(
 	)
 )
 
+# Tables that carry no DocType record, so no DocField can be resolved for them.
+TABLES_WITHOUT_DOCTYPE = frozenset(("Singles", "Sessions", "Series"))
+
 
 def _cast_autoincrement_name(field: Field, doctype: str) -> Term:
 	if frappe.db.db_type == "postgres" and frappe.get_meta(doctype).autoname == "autoincrement":
@@ -306,7 +309,7 @@ class Engine:
 			self.query = qb.from_(self.table, immutable=False).delete()
 		else:
 			self.query = qb.from_(self.table, immutable=False)
-			self.apply_fields(fields)
+			self.apply_fields(fields, cast_json_columns=self.is_postgres and bool(distinct or group_by))
 			is_select = True
 
 		self.apply_filters(filters)
@@ -372,7 +375,7 @@ class Engine:
 		self.query.immutable = True
 		return self.query
 
-	def apply_fields(self, fields):
+	def apply_fields(self, fields, cast_json_columns: bool = False):
 		self.fields = self.parse_fields(fields)
 
 		# Track field aliases for use in group_by/order_by
@@ -385,6 +388,10 @@ class Engine:
 
 		if not self.fields:
 			self.fields = [self.table.name]
+
+		if cast_json_columns:
+			# After the permission pass: a Cast is a Term, which that pass lets through unchecked.
+			self.fields = [self._cast_json_select_field(field) for field in self.fields]
 
 		self.query._child_queries = []
 		has_select_field = False
@@ -599,13 +606,7 @@ class Engine:
 		# Child/link table fields live in a different doctype than the parent; NULL-fallback
 		# typing must resolve against the field's own doctype, else a numeric child field gets
 		# an empty-string fallback and postgres rejects `COALESCE(col, '') < 200`.
-		filter_doctype = doctype or self.doctype
-		field_table = getattr(_field, "table", None)
-		if field_table is not None:
-			try:
-				filter_doctype = get_doctype_name(field_table.get_sql())
-			except Exception:
-				pass
+		filter_doctype = self._get_field_doctype(_field, doctype or self.doctype)
 
 		if isinstance(value, Field):
 			_value = value
@@ -699,15 +700,11 @@ class Engine:
 			)
 			return operator_fn(_field, nodes or ("",))
 
-		filter_field_name = (
-			_field.name
-			if isinstance(_field, Field)
-			else (field if isinstance(field, str) else getattr(_field, "name", str(_field))).split(".")[-1]
-		)
+		filter_field_name = (_field.name if hasattr(_field, "name") else str(_field)).split(".")[-1]
+		# Only postgres needs the field's type here, so skip the lookup on other backends.
+		filter_df = self._get_filter_docfield(filter_doctype, filter_field_name) if self.is_postgres else None
 		is_json_field = (
-			self.is_postgres
-			and isinstance(_field, Field)
-			and self._is_json_field(filter_doctype, filter_field_name)
+			self.is_postgres and isinstance(_field, Field) and getattr(filter_df, "fieldtype", None) == "JSON"
 		)
 		# JSON has no comparison operators. Cast before NULL fallbacks, which use an empty string.
 		comparison_field = functions.Cast(_field, "varchar") if is_json_field else _field
@@ -721,17 +718,7 @@ class Engine:
 		if self.is_postgres and _operator.casefold() == "is" and isinstance(_field, Field):
 			value_token = str(_value).strip().lower()
 			if value_token in ("set", "not set"):
-				fallback_sql = self._get_ifnull_fallback(filter_doctype, filter_field_name)
-				if fallback_sql == "''":
-					fallback_value = ""
-				elif fallback_sql.startswith("'") and fallback_sql.endswith("'"):
-					fallback_value = fallback_sql[1:-1]
-				else:
-					try:
-						fallback_value = int(fallback_sql)
-					except (ValueError, TypeError):
-						fallback_value = fallback_sql
-
+				fallback_value = self._get_ifnull_fallback_value(filter_doctype, filter_field_name)
 				if value_token == "set":
 					return comparison_field != fallback_value
 				return _field.isnull() | (comparison_field == fallback_value)
@@ -744,19 +731,7 @@ class Engine:
 			operator_fn = OPERATOR_MAP[_operator.casefold()]
 		if _value is None and isinstance(_field, Field):
 			if operator_fn == builtin_operator.ne:
-				target_doctype = filter_doctype
-				fallback_sql = self._get_ifnull_fallback(target_doctype, filter_field_name)
-
-				if fallback_sql == "''":
-					fallback_value = ""
-				elif fallback_sql.startswith("'") and fallback_sql.endswith("'"):
-					fallback_value = fallback_sql[1:-1]
-				else:
-					try:
-						fallback_value = int(fallback_sql)
-					except (ValueError, TypeError):
-						fallback_value = fallback_sql
-
+				fallback_value = self._get_ifnull_fallback_value(filter_doctype, filter_field_name)
 				return operator_fn(comparison_field, ValueWrapper(fallback_value))
 			else:
 				return _field.isnull()
@@ -767,17 +742,7 @@ class Engine:
 			if not isinstance(_field, functions.IfNull | functions.Coalesce) and self._should_apply_ifnull(
 				target_doctype, filter_field_name, _operator, _value
 			):
-				fallback_sql = self._get_ifnull_fallback(target_doctype, filter_field_name)
-				if fallback_sql == "''":
-					fallback_value = ""
-				elif fallback_sql.startswith("'") and fallback_sql.endswith("'"):
-					fallback_value = fallback_sql[1:-1]
-				else:
-					try:
-						fallback_value = int(fallback_sql)
-					except (ValueError, TypeError):
-						fallback_value = fallback_sql
-
+				fallback_value = self._get_ifnull_fallback_value(target_doctype, filter_field_name)
 				if fallback_value == _value:
 					if _operator == "=":
 						return _field.isnull() | comparison_field.eq(_value)
@@ -790,31 +755,69 @@ class Engine:
 				self.is_postgres
 				and not is_json_field
 				and _operator.casefold() in ("like", "not like", "ilike")
-				and is_non_text_field(target_doctype, filter_field_name)
+				and is_non_text_field(target_doctype, filter_field_name, df=filter_df)
 			):
 				comparison_field = functions.Cast(comparison_field, "varchar")
 
 			return operator_fn(comparison_field, _value)
 
-	def _is_json_field(self, doctype: str, fieldname: str) -> bool:
+	def _get_field_doctype(self, field: Term, default: str) -> str:
+		"""The doctype a parsed field belongs to, which is not the query's own for a joined table."""
+		table = getattr(field, "table", None)
+		if table is None:
+			return default
+		try:
+			# `get_sql()` renders the alias too, which is not part of the table name.
+			return get_doctype_name(getattr(table, "_table_name", None) or table.get_sql())
+		except Exception:
+			return default
+
+	def _cast_json_column(self, field: Term) -> Term:
+		"""postgres `json` has no equality or ordering operators, which every clause but SELECT needs."""
+		if not self.is_postgres or not isinstance(field, Field) or field.name == "*":
+			return field
+
+		df = self._get_filter_docfield(self._get_field_doctype(field, self.doctype), field.name)
+		if getattr(df, "fieldtype", None) != "JSON":
+			return field
+
+		return functions.Cast(field, "varchar")
+
+	def _get_filter_docfield(self, doctype: str, fieldname: str) -> "Document | frappe._dict | None":
+		"""Resolve the DocField a filter targets, without loading metadata that queries this engine."""
 		from frappe.model.meta import get_default_df
 
-		if get_default_df(fieldname) or fieldname in OPTIONAL_FIELDS:
-			return False
-		if doctype.startswith("__") or doctype in ("Singles", "Sessions", "Series"):
-			return False
+		if fieldname in OPTIONAL_FIELDS:
+			return None
+		if default_df := get_default_df(fieldname):
+			return default_df
+		if doctype.startswith("__") or doctype in TABLES_WITHOUT_DOCTYPE:
+			return None
 
+		# A cached meta cannot recurse and carries custom fields, so prefer it.
+		meta = frappe.client_cache.get_value(f"doctype_meta::{doctype}")
+		if meta is None:
+			meta = self._load_meta_quietly(doctype)
+		if meta is None:
+			return None
+
+		fields = meta.get("fields", {"fieldname": fieldname})
+		return fields[0] if fields else None
+
+	def _load_meta_quietly(self, doctype: str):
+		"""Load metadata for a type probe. A missing doctype is the query's problem, not the user's."""
+		mute_messages = frappe.flags.mute_messages
+		frappe.flags.mute_messages = True
 		try:
 			if doctype in CORE_DOCTYPES:
-				# Processing core metadata queries these same tables before their metadata is cached.
-				meta = frappe.get_cached_doc("DocType", doctype)
-				df = next((df for df in meta.fields if df.fieldname == fieldname), None)
-			else:
-				df = frappe.get_meta(doctype).get_field(fieldname)
+				# Loading core metadata queries these same tables before their metadata is cached,
+				# so read the stored DocType instead. Its custom fields stay invisible until then.
+				return frappe.get_cached_doc("DocType", doctype)
+			return frappe.get_meta(doctype)
 		except frappe.DoesNotExistError:
-			return False
-
-		return bool(df and df.fieldtype == "JSON")
+			return None
+		finally:
+			frappe.flags.mute_messages = mute_messages
 
 	def _parse_nested_filters(self, nested_list: list | tuple) -> "Criterion | None":
 		"""Parses a nested filter list like [cond1, 'and', cond2, 'or', cond3, ...] into a pypika Criterion."""
@@ -1306,6 +1309,11 @@ class Engine:
 			# Note: Comma handling is done in parse_fields before this method is called
 			return self.parse_string_field(field)
 
+	def _cast_json_select_field(self, field: Term) -> Term:
+		"""Keep the alias so the cast does not rename the column in the result."""
+		cast = self._cast_json_column(field)
+		return cast if cast is field else cast.as_(field.alias or field.name)
+
 	def _normalize_postgres_order_field(self, field):
 		"""In PostgreSQL order_by fields need to either be in group_by or be aggregated
 		when used with select and group_by"""
@@ -1480,7 +1488,7 @@ class Engine:
 			if parsed := self._parse_backtick_field_notation(field_name):
 				table_name, field_name = parsed
 				self.check_filter_field_permission(table_name, field_name)
-				return frappe.qb.DocType(table_name)[field_name]
+				return self._cast_json_column(frappe.qb.DocType(table_name)[field_name])
 
 			# If parsing failed, fall through to error handling below
 			frappe.throw(
@@ -1504,7 +1512,7 @@ class Engine:
 
 			# Apply join for the dynamic field
 			self.query = dynamic_field.apply_join(self.query, engine=self)
-			return dynamic_field.field
+			return self._cast_json_column(dynamic_field.field)
 		else:
 			# Validate as simple field name (alphanumeric + underscore only)
 			if not SIMPLE_FIELD_PATTERN.match(field_name):
@@ -1519,7 +1527,7 @@ class Engine:
 			self.check_filter_field_permission(self.doctype, field_name)
 
 			# Create Field object for simple field
-			return self.table[field_name]
+			return self._cast_json_column(self.table[field_name])
 
 	def _validate_group_by(self, group_by: str) -> list[Field]:
 		"""Validate the group_by string argument, apply joins for dynamic fields, and return parsed Field objects."""
@@ -2052,6 +2060,16 @@ class Engine:
 			pass
 
 		return "''"
+
+	def _get_ifnull_fallback_value(self, doctype: str, fieldname: str) -> str | int:
+		"""Python equivalent of the SQL literal `_get_ifnull_fallback` returns."""
+		fallback_sql = self._get_ifnull_fallback(doctype, fieldname)
+		if fallback_sql.startswith("'") and fallback_sql.endswith("'"):
+			return fallback_sql[1:-1]
+		try:
+			return int(fallback_sql)
+		except (ValueError, TypeError):
+			return fallback_sql
 
 	def _should_apply_ifnull(self, doctype: str, fieldname: str, operator: str, value: Any) -> bool:
 		"""Determine if IFNULL wrapping is needed for a filter condition."""

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -699,6 +699,19 @@ class Engine:
 			)
 			return operator_fn(_field, nodes or ("",))
 
+		filter_field_name = (
+			_field.name
+			if isinstance(_field, Field)
+			else (field if isinstance(field, str) else getattr(_field, "name", str(_field))).split(".")[-1]
+		)
+		is_json_field = (
+			self.is_postgres
+			and isinstance(_field, Field)
+			and self._is_json_field(filter_doctype, filter_field_name)
+		)
+		# JSON has no comparison operators. Cast before NULL fallbacks, which use an empty string.
+		comparison_field = functions.Cast(_field, "varchar") if is_json_field else _field
+
 		# The `is` ("set"/"not set") operator compares against an empty string (`= ''`).
 		# MariaDB silently coerces `''` to the column's type (e.g. `0` for an int), but
 		# postgres rejects `date/numeric = ''` outright. Compare against the
@@ -708,15 +721,7 @@ class Engine:
 		if self.is_postgres and _operator.casefold() == "is" and isinstance(_field, Field):
 			value_token = str(_value).strip().lower()
 			if value_token in ("set", "not set"):
-				is_field_name = (
-					field
-					if isinstance(field, str)
-					else (_field.name if hasattr(_field, "name") else str(_field))
-				)
-				if "." in is_field_name:
-					is_field_name = is_field_name.split(".")[-1]
-
-				fallback_sql = self._get_ifnull_fallback(filter_doctype, is_field_name)
+				fallback_sql = self._get_ifnull_fallback(filter_doctype, filter_field_name)
 				if fallback_sql == "''":
 					fallback_value = ""
 				elif fallback_sql.startswith("'") and fallback_sql.endswith("'"):
@@ -728,8 +733,8 @@ class Engine:
 						fallback_value = fallback_sql
 
 				if value_token == "set":
-					return _field != fallback_value
-				return _field.isnull() | (_field == fallback_value)
+					return comparison_field != fallback_value
+				return _field.isnull() | (comparison_field == fallback_value)
 
 		if (
 			self.is_postgres and _operator.casefold() == "like"
@@ -739,14 +744,6 @@ class Engine:
 			operator_fn = OPERATOR_MAP[_operator.casefold()]
 		if _value is None and isinstance(_field, Field):
 			if operator_fn == builtin_operator.ne:
-				filter_field_name = (
-					field
-					if isinstance(field, str)
-					else (_field.name if hasattr(_field, "name") else str(_field))
-				)
-				if "." in filter_field_name:
-					filter_field_name = filter_field_name.split(".")[-1]
-
 				target_doctype = filter_doctype
 				fallback_sql = self._get_ifnull_fallback(target_doctype, filter_field_name)
 
@@ -760,17 +757,10 @@ class Engine:
 					except (ValueError, TypeError):
 						fallback_value = fallback_sql
 
-				return operator_fn(_field, ValueWrapper(fallback_value))
+				return operator_fn(comparison_field, ValueWrapper(fallback_value))
 			else:
 				return _field.isnull()
 		else:
-			filter_field_name = (
-				field if isinstance(field, str) else (_field.name if hasattr(_field, "name") else str(_field))
-			)
-
-			if "." in filter_field_name:
-				filter_field_name = filter_field_name.split(".")[-1]
-
 			target_doctype = filter_doctype
 
 			# Skip applying ifnull if field already has null-handling function
@@ -790,20 +780,41 @@ class Engine:
 
 				if fallback_value == _value:
 					if _operator == "=":
-						return _field.isnull() | _field.eq(_value)
+						return _field.isnull() | comparison_field.eq(_value)
 					elif _operator == "!=":
-						return operator_fn(_field, _value)
+						return operator_fn(comparison_field, _value)
 
-				_field = functions.IfNull(_field, ValueWrapper(fallback_value))
+				comparison_field = functions.IfNull(comparison_field, ValueWrapper(fallback_value))
 
 			if (
 				self.is_postgres
+				and not is_json_field
 				and _operator.casefold() in ("like", "not like", "ilike")
 				and is_non_text_field(target_doctype, filter_field_name)
 			):
-				_field = functions.Cast(_field, "varchar")
+				comparison_field = functions.Cast(comparison_field, "varchar")
 
-			return operator_fn(_field, _value)
+			return operator_fn(comparison_field, _value)
+
+	def _is_json_field(self, doctype: str, fieldname: str) -> bool:
+		from frappe.model.meta import get_default_df
+
+		if get_default_df(fieldname) or fieldname in OPTIONAL_FIELDS:
+			return False
+		if doctype.startswith("__") or doctype in ("Singles", "Sessions", "Series"):
+			return False
+
+		try:
+			if doctype in CORE_DOCTYPES:
+				# Processing core metadata queries these same tables before their metadata is cached.
+				meta = frappe.get_cached_doc("DocType", doctype)
+				df = next((df for df in meta.fields if df.fieldname == fieldname), None)
+			else:
+				df = frappe.get_meta(doctype).get_field(fieldname)
+		except frappe.DoesNotExistError:
+			return False
+
+		return bool(df and df.fieldtype == "JSON")
 
 	def _parse_nested_filters(self, nested_list: list | tuple) -> "Criterion | None":
 		"""Parses a nested filter list like [cond1, 'and', cond2, 'or', cond3, ...] into a pypika Criterion."""

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -3094,6 +3094,162 @@ class TestQuery(IntegrationTestCase):
 		self.assertIn(todo.name, [r.name for r in rows])
 
 
+class TestJSONFilters(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.value_doctype = "Test Query JSON Value"
+		cls.child_doctype = "Test Query JSON Child"
+		cls.source_doctype = "Test Query JSON Source"
+		for name, fields, options in (
+			(
+				cls.value_doctype,
+				[
+					{"fieldname": "some_fieldname", "label": "Label", "fieldtype": "Data"},
+					{"fieldname": "payload", "label": "Payload", "fieldtype": "JSON"},
+				],
+				{"autoname": "field:some_fieldname"},
+			),
+			(
+				cls.child_doctype,
+				[{"fieldname": "payload", "label": "Payload", "fieldtype": "JSON"}],
+				{"istable": 1},
+			),
+			(
+				cls.source_doctype,
+				[
+					{"fieldname": "some_fieldname", "label": "Label", "fieldtype": "Data"},
+					{"fieldname": "payload", "label": "Payload", "fieldtype": "Data"},
+					{"fieldname": "link", "label": "Link", "fieldtype": "Link", "options": cls.value_doctype},
+					{
+						"fieldname": "rows",
+						"label": "Rows",
+						"fieldtype": "Table",
+						"options": cls.child_doctype,
+					},
+				],
+				{"autoname": "field:some_fieldname"},
+			),
+		):
+			new_doctype(name, fields=fields, **options).insert(ignore_if_duplicate=True)
+
+		cls.samples = {
+			"sql_null": None,
+			"empty_array": "[]",
+			"empty_object": "{}",
+			"json_null": "null",
+			"json_empty_string": '""',
+			"populated": '["x"]',
+			"compact": '{"a":1,"b":2}',
+			"spaced": '{"a": 1, "b": 2}',
+			"reordered": '{"b":2,"a":1}',
+		}
+		for label, payload in cls.samples.items():
+			frappe.get_doc(doctype=cls.value_doctype, some_fieldname=label, payload=payload).insert()
+			if label in ("sql_null", "empty_array"):
+				frappe.get_doc(
+					doctype=cls.source_doctype,
+					some_fieldname=label,
+					payload="parent text",
+					link=label,
+					rows=[{"payload": payload}],
+				).insert()
+
+	def test_json_filter_operators(self):
+		all_names = set(self.samples)
+		set_names = all_names - {"sql_null"}
+		for compat in (False, True):
+			null_names = {"sql_null"} if compat else set()
+			cases = [
+				("is", "not set", {"sql_null"}),
+				("is", "set", set_names),
+				("=", "[]", {"empty_array"}),
+				("!=", "[]", (set_names - {"empty_array"}) | null_names),
+				("in", ["[]"], {"empty_array"}),
+				("not in", ["[]"], (set_names - {"empty_array"}) | null_names),
+				("like", "%x%", {"populated"}),
+				("not like", "%x%", (set_names - {"populated"}) | null_names),
+				("=", None, {"sql_null"}),
+				("!=", None, set_names),
+				("=", "", null_names),
+				("!=", "", set_names),
+				("in", ["", "[]"], {"sql_null", "empty_array"}),
+				("not in", ["", "[]"], set_names - {"empty_array"}),
+				("in", [], set()),
+				("not in", [], all_names),
+			]
+			for label in ("compact", "spaced", "reordered"):
+				cases.append(("=", self.samples[label], {label}))
+
+			for operator, value, expected in cases:
+				with self.subTest(compat=compat, operator=operator, value=value):
+					query = frappe.qb.get_query(
+						self.value_doctype, filters={"payload": [operator, value]}, db_query_compat=compat
+					)
+					self.assertEqual(set(query.run(pluck=True)), expected)
+
+	def test_json_filters_on_related_fields(self):
+		for compat in (False, True):
+			for field in ("link.payload", "rows.payload"):
+				for operator, value, expected in (
+					("=", "[]", {"empty_array"}),
+					("is", "not set", {"sql_null"}),
+					("!=", "[]", {"sql_null"} if compat else set()),
+				):
+					with self.subTest(compat=compat, field=field, operator=operator):
+						query = frappe.qb.get_query(
+							self.source_doctype, filters={field: [operator, value]}, db_query_compat=compat
+						)
+						self.assertEqual(set(query.run(pluck=True)), expected)
+
+		query = frappe.qb.get_query(self.source_doctype, filters=[[self.child_doctype, "payload", "=", "[]"]])
+		self.assertEqual(query.run(pluck=True), ["empty_array"])
+
+	def test_json_filter_field_references(self):
+		table = frappe.qb.DocType(self.value_doctype)
+		for field in (Field("payload"), table.payload, f"`tab{self.value_doctype}`.`payload`"):
+			with self.subTest(field=str(field)):
+				query = frappe.qb.get_query(self.value_doctype, filters={field: "[]"})
+				self.assertEqual(query.run(pluck=True), ["empty_array"])
+
+	def test_json_cast_precedes_null_fallback(self):
+		for operator in ("!=", "not in", "not like"):
+			value = ["[]"] if operator == "not in" else "[]"
+			query = frappe.qb.get_query(
+				self.value_doctype, filters={"payload": [operator, value]}, db_query_compat=True
+			)
+			sql = query.get_sql().upper()
+			if frappe.db.db_type == "postgres":
+				self.assertIn('IFNULL(CAST("PAYLOAD" AS VARCHAR),', sql)
+				self.assertEqual(sql.count("CAST("), 1)
+			else:
+				self.assertNotIn("CAST(", sql)
+
+	def test_custom_field_list_json_filters(self):
+		rows = frappe.get_list("Custom Field", fields=["name", "link_filters"], limit=0)
+		for value in ("set", "not set"):
+			with self.subTest(value=value):
+				expected = {row.name for row in rows if bool(row.link_filters) == (value == "set")}
+				result = frappe.get_list(
+					"Custom Field", filters={"link_filters": ["is", value]}, pluck="name", limit=0
+				)
+				self.assertEqual(set(result), expected)
+
+	@run_only_if(db_type_is.POSTGRES)
+	def test_json_filters_with_cold_metadata(self):
+		for doctype in ("DocType", "Custom Field", "Property Setter", self.value_doctype):
+			frappe.clear_cache(doctype=doctype)
+			frappe.clear_document_cache("DocType", doctype)
+
+		# Loading this metadata reads Custom Field and Property Setter through the same filter builder.
+		query = frappe.qb.get_query(self.value_doctype, filters={"payload": "[]"})
+		self.assertEqual(query.run(pluck=True), ["empty_array"])
+		rows = frappe.get_list(
+			"Custom Field", fields=["link_filters"], filters={"link_filters": ["is", "not set"]}, limit=0
+		)
+		self.assertTrue(all(row.link_filters is None for row in rows))
+
+
 # This function is used as a permission query condition hook
 def test_permission_hook_condition(user):
 	return "`tabDashboard Settings`.`name` = 'Administrator'"

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -3107,6 +3107,13 @@ class TestJSONFilters(IntegrationTestCase):
 				[
 					{"fieldname": "some_fieldname", "label": "Label", "fieldtype": "Data"},
 					{"fieldname": "payload", "label": "Payload", "fieldtype": "JSON"},
+					{"fieldname": "quantity", "label": "Quantity", "fieldtype": "Int"},
+					{
+						"fieldname": "secret_payload",
+						"label": "Secret Payload",
+						"fieldtype": "JSON",
+						"permlevel": 1,
+					},
 				],
 				{"autoname": "field:some_fieldname"},
 			),
@@ -3225,21 +3232,91 @@ class TestJSONFilters(IntegrationTestCase):
 			else:
 				self.assertNotIn("CAST(", sql)
 
-	def test_custom_field_list_json_filters(self):
-		rows = frappe.get_list("Custom Field", fields=["name", "link_filters"], limit=0)
-		for value in ("set", "not set"):
+	def test_json_filters_on_core_doctype(self):
+		docfield = frappe.db.get_value(
+			"DocField", {"parent": self.value_doctype, "fieldname": "payload"}, "name"
+		)
+		frappe.db.set_value("DocField", docfield, "link_filters", '[["User", "enabled", "=", 1]]')
+		for value, matches in (("set", True), ("not set", False)):
 			with self.subTest(value=value):
-				expected = {row.name for row in rows if bool(row.link_filters) == (value == "set")}
-				result = frappe.get_list(
-					"Custom Field", filters={"link_filters": ["is", value]}, pluck="name", limit=0
+				names = frappe.get_all(
+					"DocField", filters={"link_filters": ["is", value]}, pluck="name", limit=0
 				)
-				self.assertEqual(set(result), expected)
+				self.assertIs(docfield in names, matches)
+
+	def test_json_field_sorting_and_grouping(self):
+		"""List views sort, dedupe and group by a column; postgres `json` supports none of them."""
+		from frappe.desk.listview import get_group_by_count
+
+		self.assertTrue(frappe.get_all(self.value_doctype, order_by="payload asc", limit=1))
+		self.assertTrue(frappe.get_all(self.value_doctype, fields=["payload"], distinct=True, limit=1))
+		self.assertTrue(get_group_by_count(self.value_doctype, "[]", "payload"))
+
+	def test_permlevel_json_field_with_distinct(self):
+		"""The cast must run after the permission pass, which lets any Term through unchecked."""
+		test_role = "JSONFilterPermTestRole"
+		test_user = "test2@example.com"
+
+		frappe.get_doc({"doctype": "Role", "role_name": test_role}).insert(ignore_if_duplicate=True)
+		add_permission(self.value_doctype, test_role, 0, ptype="read")
+		update_permission_property(self.value_doctype, test_role, 1, "read", 0, validate=False)
+		add_permission(self.value_doctype, "System Manager", 1, ptype="read")
+
+		user = frappe.get_doc("User", test_user)
+		user.add_roles(test_role)
+		self.addCleanup(user.remove_roles, test_role)
+		self.addCleanup(frappe.set_user, "Administrator")
+
+		fields = ["some_fieldname", "secret_payload"]
+		frappe.set_user(test_user)
+		restricted = frappe.qb.get_query(
+			self.value_doctype, fields=fields, distinct=True, ignore_permissions=False
+		).get_sql()
+		self.assertNotIn("secret_payload", restricted)
+
+		frappe.set_user("Administrator")
+		permitted = frappe.qb.get_query(
+			self.value_doctype, fields=fields, distinct=True, ignore_permissions=False
+		).get_sql()
+		self.assertIn("secret_payload", permitted)
+
+	def test_json_filter_on_aliased_table(self):
+		table = frappe.qb.DocType(self.value_doctype).as_("alias")
+		sql = frappe.qb.get_query(self.value_doctype, filters={table.payload: "[]"}).get_sql()
+		if frappe.db.db_type == "postgres":
+			self.assertIn("CAST(", sql)
+		else:
+			self.assertNotIn("CAST(", sql)
+
+	def test_backtick_field_reference_types_null_fallback(self):
+		"""A fully quoted key must resolve the same field, and so the same fallback, as a bare one."""
+		frappe.get_meta(self.value_doctype)
+		for fieldname, expects_ifnull in (("quantity", False), ("payload", True)):
+			plain = frappe.qb.get_query(
+				self.value_doctype, filters={fieldname: ["!=", "x"]}, db_query_compat=True
+			).get_sql()
+			quoted = frappe.qb.get_query(
+				self.value_doctype,
+				filters={f"`tab{self.value_doctype}`.`{fieldname}`": ["!=", "x"]},
+				db_query_compat=True,
+			).get_sql()
+			with self.subTest(fieldname=fieldname):
+				self.assertEqual("IFNULL" in plain.upper(), expects_ifnull)
+				self.assertEqual("IFNULL" in quoted.upper(), expects_ifnull)
+
+	def test_type_probe_stays_silent_for_unknown_doctypes(self):
+		from frappe.database.query import Engine
+
+		message_log = frappe.local.message_log
+		frappe.local.message_log = []
+		self.addCleanup(setattr, frappe.local, "message_log", message_log)
+
+		self.assertIsNone(Engine()._get_filter_docfield("Test Query JSON Missing", "payload"))
+		self.assertEqual(frappe.local.message_log, [])
 
 	@run_only_if(db_type_is.POSTGRES)
 	def test_json_filters_with_cold_metadata(self):
-		for doctype in ("DocType", "Custom Field", "Property Setter", self.value_doctype):
-			frappe.clear_cache(doctype=doctype)
-			frappe.clear_document_cache("DocType", doctype)
+		frappe.clear_cache()
 
 		# Loading this metadata reads Custom Field and Property Setter through the same filter builder.
 		query = frappe.qb.get_query(self.value_doctype, filters={"payload": "[]"})

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -3280,6 +3280,16 @@ class TestJSONFilters(IntegrationTestCase):
 		).get_sql()
 		self.assertIn("secret_payload", permitted)
 
+	def test_json_distinct_with_qualified_order_by(self):
+		"""A qualified order-by must survive the DISTINCT check, which matches selected fields by name."""
+		for order_by in ("payload asc", f"`tab{self.value_doctype}`.`payload` asc"):
+			with self.subTest(order_by=order_by):
+				query = frappe.qb.get_query(
+					self.value_doctype, fields=["payload"], distinct=True, order_by=order_by, limit=2
+				)
+				self.assertIn("ORDER BY", query.get_sql())
+				self.assertTrue(query.run())
+
 	def test_json_filter_on_aliased_table(self):
 		table = frappe.qb.DocType(self.value_doctype).as_("alias")
 		sql = frappe.qb.get_query(self.value_doctype, filters={table.payload: "[]"}).get_sql()


### PR DESCRIPTION
On PostgreSQL a `json` column has no equality or ordering operator. Every filter that frappe compiles into `col = value` fails, and so do sorting, `DISTINCT`, and the list sidebar group-by count. MariaDB stores the same field as `longtext`, so this affects PostgreSQL only.

Cast the column to `varchar` wherever the query builder compares or groups it:

- Filters cast before the NULL fallback, which uses an empty string.
- `ORDER BY` and `GROUP BY` cast at the parser both clauses share.
- `DISTINCT` and `GROUP BY` also cast the selected column, with the alias kept, so the result keys do not change. This runs after the permission pass, because that pass lets any cast expression through unchecked.

The column type does not change, so no migration is needed. Serialized JSON still matches byte for byte, and PostgreSQL still validates JSON on write.

Two notes for reviewers:

- A fully quoted filter key, such as `` `tabUser`.`birth_date` ``, now resolves its real field type. The NULL fallback for such a key changes on MariaDB too. A non-nullable Int key now gives `col <> 5` in place of `IFNULL(col,'') <> 5`.
- SQL that the query builder does not build still needs its own cast. This includes permission query conditions, query reports, and app code that calls `frappe.db.sql`.

Closes #42579.

### Validation

- PostgreSQL: `frappe.tests.test_query` and `frappe.tests.test_db_query` pass, apart from two failures that also fail on the base commit. The 11 tests in `TestJSONFilters` pass, and 7 of them fail without this fix.
- Verified on a real `json` column that sorting, `DISTINCT`, and `get_group_by_count` now run.
- Ruff and the pre-commit hooks pass.
