### PR TITLE
fix: check reference document permission in auto repeat (backport #42604)

### DIFF
--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -74,6 +74,7 @@ class AutoRepeat(Document):
 	def validate(self):
 		self.update_status()
 		self.validate_reference_doctype()
+		self.validate_reference_permission()
 		self.validate_submit_on_creation()
 		self.validate_dates()
 		self.validate_email_id()
@@ -119,6 +120,16 @@ class AutoRepeat(Document):
 					self.reference_doctype
 				)
 			)
+
+	def validate_reference_permission(self):
+		if frappe.flags.in_patch or self.flags.ignore_permissions:
+			return
+		if (
+			self.is_new()
+			or self.has_value_changed("reference_doctype")
+			or self.has_value_changed("reference_document")
+		):
+			frappe.has_permission(self.reference_doctype, "write", self.reference_document, throw=True)
 
 	def validate_submit_on_creation(self):
 		if self.submit_on_creation and not frappe.get_meta(self.reference_doctype).is_submittable:
@@ -222,6 +233,12 @@ class AutoRepeat(Document):
 
 	def create_documents(self):
 		try:
+			if not frappe.has_permission(
+				self.reference_doctype, "read", self.reference_document, user=self.owner
+			):
+				self.log_error(_("Auto repeat skipped. The owner cannot access the reference document."))
+				return
+
 			new_doc = self.make_new_document()
 			if self.notify_by_email and self.recipients:
 				self.send_notification(new_doc)
@@ -237,6 +254,7 @@ class AutoRepeat(Document):
 
 	def make_new_document(self):
 		reference_doc = frappe.get_doc(self.reference_doctype, self.reference_document)
+		frappe.has_permission(self.reference_doctype, "read", reference_doc, user=self.owner, throw=True)
 		new_doc = frappe.copy_doc(reference_doc, ignore_no_copy=False)
 		self.update_doc(new_doc, reference_doc)
 		new_doc.flags.updater_reference = {
@@ -581,7 +599,7 @@ def get_auto_repeat_doctypes(
 def update_reference(docname: str, reference: str):
 	doc = frappe.get_doc("Auto Repeat", str(docname))
 	doc.check_permission("write")
-	frappe.has_permission(doc.reference_doctype, "read", str(reference), throw=True)
+	frappe.has_permission(doc.reference_doctype, "write", str(reference), throw=True)
 	doc.db_set("reference_document", str(reference))
 	return "success"  # backward compatbility
 

--- a/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
@@ -6,9 +6,11 @@ import frappe
 from frappe.automation.doctype.auto_repeat.auto_repeat import (
 	create_repeated_entries,
 	get_auto_repeat_entries,
+	update_reference,
 	week_map,
 )
 from frappe.custom.doctype.custom_field.custom_field import create_custom_field
+from frappe.tests.test_model_utils import set_user
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_days, add_months, getdate, today
 
@@ -231,6 +233,73 @@ class TestAutoRepeat(FrappeTestCase):
 		)
 		self.assertEqual(docnames[0].docstatus, 1)
 
+	def test_reference_document_write_permission_on_create(self):
+		todo = frappe.get_doc(
+			doctype="ToDo", description="test reference permission", assigned_by="Administrator"
+		).insert()
+		user = user_without_reference_access()
+
+		self.assertFalse(frappe.has_permission("ToDo", "write", todo.name, user=user))
+
+		with set_user(user):
+			auto_repeat = frappe.get_doc(
+				doctype="Auto Repeat",
+				reference_doctype="ToDo",
+				reference_document=todo.name,
+				frequency="Daily",
+				start_date=today(),
+			)
+			auto_repeat.validate_reference_doctype()
+			self.assertRaises(frappe.PermissionError, auto_repeat.validate_reference_permission)
+			self.assertRaises(frappe.PermissionError, auto_repeat.insert)
+
+		self.assertFalse(frappe.db.get_value("ToDo", todo.name, "auto_repeat"))
+
+	def test_deleted_reference_does_not_stop_the_scheduler(self):
+		todo = frappe.get_doc(
+			doctype="ToDo", description="test reference permission", assigned_by="Administrator"
+		).insert()
+		doc = make_auto_repeat(reference_document=todo.name)
+		frappe.db.set_value("Auto Repeat", doc.name, "owner", "test@example.com")
+		doc.reload()
+		frappe.delete_doc("ToDo", todo.name, force=True, ignore_permissions=True)
+
+		doc.create_documents()
+
+		self.assertTrue(frappe.db.get_value("Auto Repeat", doc.name, "disabled"))
+
+	def test_auto_repeat_stays_active_when_owner_loses_reference_access(self):
+		todo = frappe.get_doc(
+			doctype="ToDo", description="test reference permission", assigned_by="Administrator"
+		).insert()
+		user = user_without_reference_access()
+
+		doc = make_auto_repeat(reference_document=todo.name)
+		frappe.db.set_value("Auto Repeat", doc.name, "owner", user)
+		doc.reload()
+
+		doc.create_documents()
+
+		self.assertFalse(frappe.db.exists("ToDo", {"auto_repeat": doc.name, "name": ("!=", todo.name)}))
+		self.assertFalse(frappe.db.get_value("Auto Repeat", doc.name, "disabled"))
+
+	def test_reference_document_write_permission_on_update_reference(self):
+		todo = frappe.get_doc(
+			doctype="ToDo", description="test reference permission", assigned_by="Administrator"
+		).insert()
+		user = user_without_reference_access()
+
+		own_todo = frappe.get_doc(
+			doctype="ToDo", description="test reference permission", allocated_to=user, owner=user
+		).insert()
+		doc = make_auto_repeat(reference_document=own_todo.name)
+		frappe.db.set_value("Auto Repeat", doc.name, "owner", user)
+
+		with set_user(user):
+			self.assertRaises(frappe.PermissionError, update_reference, doc.name, todo.name)
+
+		self.assertNotEqual(frappe.db.get_value("Auto Repeat", doc.name, "reference_document"), todo.name)
+
 
 def make_auto_repeat(**args):
 	args = frappe._dict(args)
@@ -250,6 +319,15 @@ def make_auto_repeat(**args):
 			"repeat_on_days": args.days or [],
 		}
 	).insert(ignore_permissions=True)
+
+
+def user_without_reference_access():
+	"""Return a user who can create an Auto Repeat but cannot access another user's ToDo."""
+	user = frappe.get_doc("User", "test2@example.com")
+	user.add_roles("Accounts User")
+	frappe.clear_cache(user=user.name)
+
+	return user.name
 
 
 def create_submittable_doctype(doctype, submit_perms=1):


### PR DESCRIPTION
- Backports the Auto Repeat reference-document permission checks from #42604 to v15
- Drops the unrelated `after_save` -> `on_update` rename that the mergify backport in #42608 carried in from develop context

Why: #42608 is red on Unit Tests; v15 has `after_save` here, so the rename is out of scope for a hotfix. Supersedes #42608.