### PR TITLE
fix: change dock based on doctype

### DIFF
--- a/cypress/integration/sidebar_resolution.js
+++ b/cypress/integration/sidebar_resolution.js
@@ -18,21 +18,29 @@ context("Cold-entry sidebar resolution", () => {
 
 	// An entity's home is decided against this payload; `items` only ever needs `link_to` here.
 	//
-	// A shell maps to its links, or to `{ links, computed }` when the test needs to say the
-	// sidebar was built from the module's contents rather than shipped by an app. These shells are
-	// all named after their module, which is the ordinary case: the payload is keyed by shell
-	// identity and every entry carries both its own `name` and the module it belongs to.
+	// A shell maps to its links, or to `{ links, computed, app }` when the test needs to say the
+	// sidebar was built from the module's contents rather than shipped by an app, or which app
+	// owns it. These shells are all named after their module, which is the ordinary case: the
+	// payload is keyed by shell identity and every entry carries both its own `name` and the
+	// module it belongs to.
+	//
+	// `app` is left undefined unless a test sets it, so every case that says nothing about apps
+	// resolves as it did before app boundaries were a step: a shell with no app crosses no
+	// boundary.
 	const payload = (sidebars) =>
 		Object.fromEntries(
 			Object.entries(sidebars).map(([module, value]) => {
-				const { links = [], computed = 0 } = Array.isArray(value)
-					? { links: value }
-					: value;
+				const {
+					links = [],
+					computed = 0,
+					app,
+				} = Array.isArray(value) ? { links: value } : value;
 				return [
 					module,
 					{
 						name: module,
 						module,
+						app,
 						computed,
 						items: links.map((link_to) => ({ link_to })),
 					},
@@ -51,8 +59,10 @@ context("Cold-entry sidebar resolution", () => {
 			pages = {},
 			dashboards = [],
 			heirs = {},
+			rail_hosts = {},
 			persisted,
 			sticky,
+			on_screen = false,
 			route,
 		},
 		then
@@ -66,6 +76,7 @@ context("Cold-entry sidebar resolution", () => {
 				page_info: frappe.boot.page_info,
 				dashboards: frappe.boot.dashboards,
 				code_only_module_heirs: frappe.boot.code_only_module_heirs,
+				app_rail_host: frappe.boot.app_rail_host,
 				get_meta: frappe.get_meta,
 				selected_module: win.localStorage.getItem("selected_module"),
 			};
@@ -76,6 +87,7 @@ context("Cold-entry sidebar resolution", () => {
 			frappe.boot.page_info = pages;
 			frappe.boot.dashboards = dashboards;
 			frappe.boot.code_only_module_heirs = heirs;
+			frappe.boot.app_rail_host = rail_hosts;
 			frappe.get_meta = (name) => metas[name] || null;
 			if (persisted) win.localStorage.setItem("selected_module", persisted);
 			else win.localStorage.removeItem("selected_module");
@@ -89,7 +101,7 @@ context("Cold-entry sidebar resolution", () => {
 				resolved =
 					sticky === undefined
 						? sidebar.resolve_initial_sidebar(route)
-						: sidebar.resolve_sidebar_for(route, sticky);
+						: sidebar.resolve_sidebar_for(route, sticky, on_screen);
 			} finally {
 				frappe.boot.module_sidebars = real.module_sidebars;
 				frappe.boot.entity_module = real.entity_module;
@@ -97,6 +109,7 @@ context("Cold-entry sidebar resolution", () => {
 				frappe.boot.page_info = real.page_info;
 				frappe.boot.dashboards = real.dashboards;
 				frappe.boot.code_only_module_heirs = real.code_only_module_heirs;
+				frappe.boot.app_rail_host = real.app_rail_host;
 				frappe.get_meta = real.get_meta;
 				if (real.selected_module) {
 					win.localStorage.setItem("selected_module", real.selected_module);
@@ -493,6 +506,125 @@ context("Cold-entry sidebar resolution", () => {
 			resolve({ ...world, sticky: null }, (resolved) => {
 				expect(resolved.sidebar).to.equal("HR");
 			});
+		});
+	});
+
+	// Step 1 holds the shell you are standing in whatever the route is, so a curated cross-app link
+	// does not move it. The one thing it does not survive is leaving the app: the dock is the app
+	// that owns the shell, so a shell held across an app boundary leaves the rail naming an app the
+	// page has nothing to do with.
+	context("the shell on screen holds inside its app, and only inside it", () => {
+		// The shape measured on a site with erpnext and hrms installed. Accounts is where you are;
+		// Job Applicant belongs to HR, which hrms owns.
+		const cross_app = {
+			sidebars: {
+				Accounts: { links: ["Journal Entry", "Sales Order"], app: "erpnext" },
+				HR: { links: ["Job Applicant"], app: "hrms" },
+			},
+			metas: {
+				"Journal Entry": { module: "Accounts" },
+				"Sales Order": { module: "Accounts" },
+				"Job Applicant": { module: "HR" },
+			},
+		};
+
+		it("keeps the shell for a route inside the same app", () => {
+			resolve(
+				{
+					...cross_app,
+					route: ["List", "Sales Order"],
+					sticky: "Accounts",
+					on_screen: true,
+				},
+				(resolved) => {
+					expect(resolved.sidebar).to.equal("Accounts");
+				}
+			);
+		});
+
+		it("moves the shell for a route that belongs to another app", () => {
+			resolve(
+				{
+					...cross_app,
+					route: ["List", "Job Applicant"],
+					sticky: "Accounts",
+					on_screen: true,
+				},
+				(resolved) => {
+					expect(resolved.sidebar).to.equal("HR");
+				}
+			);
+		});
+
+		it("keeps a cross-app entity the shell on screen curates a link to", () => {
+			// The reason the boundary is not simply "the entity's app wins": a sidebar that lists
+			// a foreign entity said it belongs here, and that outranks where it was authored.
+			const curated = {
+				...cross_app,
+				sidebars: {
+					...cross_app.sidebars,
+					Accounts: {
+						links: ["Journal Entry", "Sales Order", "Job Applicant"],
+						app: "erpnext",
+					},
+				},
+			};
+			resolve(
+				{
+					...curated,
+					route: ["List", "Job Applicant"],
+					sticky: "Accounts",
+					on_screen: true,
+				},
+				(resolved) => {
+					expect(resolved.sidebar).to.equal("Accounts");
+				}
+			);
+		});
+
+		it("keeps the shell when a companion app mounts on the same rail", () => {
+			// india_payroll has no rail of its own; its entries live on hrms's. Both sides of the
+			// boundary resolve through the host, so there is no boundary to cross.
+			const companion = {
+				sidebars: {
+					HR: { links: ["Job Applicant"], app: "hrms" },
+					"India Payroll": { links: ["Salary Slip"], app: "india_payroll" },
+				},
+				metas: {
+					"Job Applicant": { module: "HR" },
+					"Salary Slip": { module: "India Payroll" },
+				},
+				rail_hosts: { india_payroll: "hrms" },
+			};
+			resolve(
+				{
+					...companion,
+					route: ["List", "Salary Slip"],
+					sticky: "HR",
+					on_screen: true,
+				},
+				(resolved) => {
+					expect(resolved.sidebar).to.equal("HR");
+				}
+			);
+		});
+
+		it("keeps the shell when the entity belongs to no app", () => {
+			// An unplaced custom module carries no app, and a null app crosses nothing, so it
+			// neither holds a shell nor moves one.
+			const unplaced = {
+				sidebars: {
+					Accounts: { links: ["Journal Entry"], app: "erpnext" },
+					Bookings: ["Booking"],
+				},
+				metas: { Booking: { module: "Bookings" } },
+			};
+			resolve(
+				{ ...unplaced, route: ["List", "Booking"], sticky: "Accounts", on_screen: true },
+				(resolved) => {
+					expect(resolved.sidebar).to.equal("Accounts");
+				}
+			);
 		});
 	});
 

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -358,6 +358,37 @@ frappe.ui.Sidebar = class Sidebar {
 			: null;
 	}
 
+	// The app a shell belongs to, as the rail names it, or null. `get_sidebar_app` answers the
+	// same question for the shell on screen and returns the app_data entry the rail renders from;
+	// this answers it for any shell and returns just the name, which is all a comparison needs.
+	//
+	// A shell belonging to no app answers null, and null is never equal to an app, so an unplaced
+	// or orphaned module neither holds a shell nor moves one.
+	app_for_sidebar(shell) {
+		const sidebar = shell && frappe.boot.module_sidebars?.[shell];
+		const app_name = sidebar && sidebar.app;
+		return app_name ? this.rail_host_app(app_name) : null;
+	}
+
+	// Whether moving to `entity_shell` leaves the app `shell` belongs to.
+	//
+	// This is the one thing the shell on screen does not survive (see resolve_sidebar_for step 1).
+	// App context in the desk means only what supplies the rail, so a shell kept across an app
+	// boundary is a rail whose logo and rows belong to an app the page is not in: reaching Job
+	// Applicant from a Journal Entry left erpnext's rail on screen over an hrms document.
+	//
+	// It asks about the entity's own shell and nothing else, so it says nothing while the module
+	// is unreadable, and an unreadable module holds the shell rather than moving it. A doctype
+	// route reached through the router is readable by then, since router.route() awaits
+	// `with_doctype` before firing the `change` this resolves on; anything still unreadable is
+	// already flagged provisional below and re-resolved on the second pass.
+	crosses_app(shell, entity_shell) {
+		if (!entity_shell || entity_shell === shell) return false;
+		const here = this.app_for_sidebar(shell);
+		const there = this.app_for_sidebar(entity_shell);
+		return !!here && !!there && here !== there;
+	}
+
 	// The module the shell on screen belongs to.
 	//
 	// `current_module` is a shell identity, the key `frappe.boot.module_sidebars` is built on.
@@ -1410,18 +1441,32 @@ frappe.ui.Sidebar = class Sidebar {
 		// Resolved up front rather than at step 4, because steps 1 and 3 are both membership
 		// tests against it: whether the sidebar links the entity is the same question either way.
 		const candidates = this.get_modules_linking(entity);
+		// The entity's own shell, resolved once here and reused by steps 1, 3 and 3b. Step 1 asks
+		// only which app it belongs to; the later steps take the shell itself.
+		const from_module = this.sidebar_from_module(entity, route, candidates);
 
 		// 1. The shell you are in, or the last one selected when it can show the entity.
 		//
 		// `on_screen` says the shell is a stated fact rather than a leftover: it is the sidebar
 		// you are standing in, and you got here by following a link out of it. A shell stated
-		// that way holds whatever the route is, which is what stops a link into another module
-		// moving the shell underneath you. A sticky read from localStorage is only a memory, so
-		// it still has to prove it can show the entity.
-		if (persisted && (on_screen || candidates.includes(persisted))) {
+		// that way holds across the app it belongs to, whatever the route is, which is what stops
+		// a link into another module moving the shell underneath you. A sticky read from
+		// localStorage is only a memory, so it still has to prove it can show the entity.
+		//
+		// What it does not survive is leaving the app (see crosses_app): the rail is the app that
+		// owns the shell, so holding erpnext's shell while standing on an hrms document leaves the
+		// rail naming an app the page has nothing to do with. A shell that lists the entity is
+		// exempt, since curating a cross-app link is how a sidebar says the entity belongs here.
+		if (
+			persisted &&
+			(candidates.includes(persisted) ||
+				(on_screen && !this.crosses_app(persisted, from_module)))
+		) {
 			return {
 				sidebar: persisted,
-				reason: `last selected sidebar "${persisted}" — route entity "${entity}" is linked in it, so the selection is kept over the entity's owner and its module`,
+				reason: candidates.includes(persisted)
+					? `last selected sidebar "${persisted}" — route entity "${entity}" is linked in it, so the selection is kept over the entity's owner and its module`
+					: `sidebar "${persisted}" is the shell on screen and "${entity}" does not leave its app, so the shell is kept`,
 				provisional: false,
 			};
 		}
@@ -1448,7 +1493,6 @@ frappe.ui.Sidebar = class Sidebar {
 		//    past a display limit. Reading that as a decision would hand the entity to whichever
 		//    other sidebar happens to link it. A module always contains its own entities, so for
 		//    a computed sidebar the module answers regardless.
-		const from_module = this.sidebar_from_module(entity, route, candidates);
 		if (from_module && (candidates.includes(from_module) || this.is_computed(from_module))) {
 			return {
 				sidebar: from_module,


### PR DESCRIPTION
When I am on Journal Entry I am seeing erpnext's dock. When I use asweomsbar to go to Job applicant which is in HR it still was showing the same erpnext dock