### PR TITLE
fix: include parent name for child queries

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -336,6 +336,11 @@ class Engine:
 				)
 
 		self.add_permission_conditions()
+		# Child queries need the parent document name internally
+		# to associate child rows with their parent.
+		if getattr(self, "_child_query_needs_name", False):
+			self.query = self.query.select(self.table.name)
+			self.query._child_query_internal_name = True
 
 		if self.apply_permissions:
 			# Store metadata for masked field processing during execution.
@@ -360,20 +365,41 @@ class Engine:
 		if not self.fields:
 			self.fields = [self.table.name]
 
-		self.query._child_queries = []
+		child_queries = []
 		has_select_field = False
+		has_name_field = False
+
 		for field in self.fields:
+
 			if isinstance(field, DynamicTableField):
 				self.query = field.apply_select(self.query, engine=self)
 				has_select_field = True
+
 			elif isinstance(field, ChildQuery):
-				self.query._child_queries.append(field)
+				child_queries.append(field)
+
 			else:
 				self.query = self.query.select(field)
 				has_select_field = True
 
+				# Check whether the parent `name` was explicitly selected.
+				if isinstance(field, Field) and field.name == "name":
+					has_name_field = True
+
+		# If no fields were selected, select name by default.
 		if not has_select_field:
 			self.query = self.query.select(self.table.name)
+			has_name_field = True
+
+		# Store child queries on the Engine because PyPika may create
+		# new query objects during query construction.
+		self._child_queries = child_queries
+
+		# Child queries need the parent document name internally
+		# to associate child rows with their parent.
+		self._child_query_needs_name = bool(
+			child_queries and not has_name_field
+		)
 
 	def apply_filters(
 		self,

--- a/frappe/query_builder/utils.py
+++ b/frappe/query_builder/utils.py
@@ -135,6 +135,7 @@ def execute_query(query, *args, **kwargs):
 	parent_dt = query.__dict__.get("_parent_doctype")
 	fields = query.__dict__.get("_fields_list", [])
 	child_queries = query._child_queries
+	internal_name = query.__dict__.get("_child_query_internal_name", False)
 	query, params = prepare_query(query)
 	result = frappe.local.db.sql(query, params, *args, **kwargs)  # nosemgrep
 
@@ -148,6 +149,10 @@ def execute_query(query, *args, **kwargs):
 		result = mask_fields(
 			dt, fields, result, as_dict=as_dict, pluck=kwargs.get("pluck", False), parent_doctype=parent_dt
 		)
+	# Remove the internally added parent name.
+	if internal_name and result and isinstance(result[0], dict):
+		for row in result:
+			row.pop("name", None)
 
 	return result
 

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -925,6 +925,28 @@ class TestQuery(IntegrationTestCase):
 		note1.delete()
 		note2.delete()
 
+	def test_child_query_without_parent_name(self):
+		note = frappe.get_doc(
+			doctype="Note",
+			title="Note 3",
+			seen_by=[{"user": "Administrator"}, {"user": "Guest"}],
+		).insert()
+		self.addCleanup(note.delete)
+
+		result = frappe.qb.get_query(
+			"Note",
+			filters={"name": note.name},
+			fields=[
+				"title as note_title",
+				{"seen_by": ["user"]},
+			],
+		).run(as_dict=1)
+		self.assertEqual(result[0].note_title, "Note 3")
+		self.assertNotIn("name", result[0])
+		self.assertEqual(len(result[0].seen_by), 2)
+		self.assertEqual(result[0].seen_by[0].user, "Administrator")
+		self.assertEqual(result[0].seen_by[1].user, "Guest")
+
 	def test_build_match_conditions(self):
 		from frappe.permissions import add_user_permission, clear_user_permissions_for_doctype
 


### PR DESCRIPTION
## Description

Fixes an issue where child query results are not returned when the parent
`name` field is not explicitly included in the selected fields.

Child queries require the parent document name to associate child rows with
their parent. The query builder now selects the parent `name` internally when
needed and removes it from the final result.

## Testing

- Added a regression test for child queries without explicitly selecting the
  parent `name`.
- Targeted test passes:
  `TestQuery.test_child_query_without_parent_name`
- `git diff --check` passes.
- Full `frappe.tests.test_query` could not complete because the test site is
  missing the `Company` DocType.

Closes 42627