### PR TITLE
fix: no access to dashboard shouldn't take the site down

### DIFF
--- a/frappe/desk/desk_views.py
+++ b/frappe/desk/desk_views.py
@@ -112,7 +112,14 @@ class DeskViews:
 			# `module` rides along so the client can resolve a dashboard's home sidebar; the row
 			# stays a dict in a list rather than becoming a name-keyed map, so search_utils'
 			# get_dashboards() is untouched.
-			dashboards = frappe.get_list("Dashboard", fields=["name", "module"])
+			try:
+				dashboards = frappe.get_list("Dashboard", fields=["name", "module"])
+			except frappe.PermissionError:
+				# a user with no read access to `Dashboard` simply has no dashboards. This runs
+				# during boot, so the error must not escape and take the desk down with it.
+				frappe.clear_last_message()
+				return []
+
 			if not dashboards:
 				return []
 

--- a/frappe/desk/utils.py
+++ b/frappe/desk/utils.py
@@ -57,7 +57,9 @@ def is_item_allowed(name, item_type, ctx):
 			frappe.clear_last_message()
 			return False
 	if item_type == "page":
-		return name in ctx.allowed_pages and name in ctx.restricted_pages
+		# `restricted_pages` is None while a patch, install or migrate is running, the same as
+		# `restricted_doctypes` above, so it is coalesced rather than iterated blindly.
+		return name in (ctx.allowed_pages or {}) and name in (ctx.restricted_pages or [])
 	if item_type == "report":
 		return not frappe.db.get_value("Report", name, "disabled", cache=True) and name in ctx.allowed_reports
 	if item_type == "dashboard":


### PR DESCRIPTION
No access to dashboard should not take the site down
