### PR TITLE
fix: login fails when using email while User.name differs from email

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -868,7 +868,7 @@ class User(Document):
 		login_with_mobile = cint(frappe.get_system_settings("allow_login_using_mobile_number"))
 		login_with_username = cint(frappe.get_system_settings("allow_login_using_user_name"))
 
-		or_filters = [{"name": user_name}]
+		or_filters = [{"name": user_name}, {"email": user_name}]
 		if login_with_mobile:
 			or_filters.append({"mobile_no": user_name})
 		if login_with_username:


### PR DESCRIPTION
## Bug

`User.find_by_credentials()` is documented to find the user by email by default:

```python
"""Find the user by credentials.

This is a login utility that needs to check login related system settings while finding the user.
1. Find user by email ID by default
2. If allow_login_using_mobile_number is set, you can use mobile number while finding the user.
3. If allow_login_using_user_name is set, you can use username while finding the user.
"""
```

But the actual `or_filters` built right below never include an email filter:

```python
or_filters = [{"name": user_name}]
if login_with_mobile:
    or_filters.append({"mobile_no": user_name})
if login_with_username:
    or_filters.append({"username": user_name})
```

For any account whose `name` (docname) is not literally its email address, logging in by typing that email fails every time with "Invalid login credentials" - regardless of whether the password is correct - because no `User` row has `name == <the typed email>`, and the `email` field is never checked.

The most common account this bites is `Administrator`: its `email` can be set to a real mailbox, but its `name` stays `"Administrator"`. Typing the email at the login screen never works; typing `Administrator` works fine. Since the docname login path works, the account doesn't look broken at all - only login-by-email silently doesn't work, which is easy to miss (I initially assumed it was a wrong/cached password on the user's end, until checking the Activity Log showed every attempt with the email failing and every attempt with the docname succeeding, same password).

## Fix

Add the email filter to `or_filters` unconditionally, matching the docstring's stated default behavior and consistent with how the mobile/username filters are already additive on top of it.

## Testing

Verified against a live Frappe CRM site. Before the fix: `User.find_by_credentials("contact@illith.com", pwd)` returned `None` for an Administrator user whose email is `contact@illith.com`, no matter the password. After the fix, it correctly resolves to `{"name": "Administrator", ...}` and login succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)