### PR TITLE
fix: include first tag in Document.get_tags

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1979,8 +1979,7 @@ class Document(BaseDocument):
 	def get_tags(self):
 		"""Return a list of Tags attached to this document"""
 		from frappe.desk.doctype.tag.tag import DocTags
-
-		return DocTags(self.doctype).get_tags(self.name).split(",")[1:]
+		return DocTags(self.doctype).get_tags(self.name).split(",")[:]
 
 	def deferred_insert(self) -> None:
 		"""Push the document to redis temporarily and insert later.


### PR DESCRIPTION
## Issue

`Document.get_tags()` omits the first tag associated with a document.

## Fix

The existing implementation uses `[1:]` after splitting the comma-separated tag string, which skips the first tag.

Changed:

```python
return DocTags(self.doctype).get_tags(self.name).split(",")[:]

## Screenshots/GIFs

Not applicable. This is a backend/API behavior fix with no UI changes.

closes #42637