### PR TITLE
fix: implicitly fetch parent name for child queries in QB

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -371,13 +371,7 @@ class Engine:
 
 		if getattr(self.query, "_name_field_injected", False) and (distinct or self.is_aggregate_query):
 			frappe.throw(
-				_(
-					"Cannot use distinct=True with child table fields unless the "
-					"parent 'name' field is also explicitly included in `fields`. "
-					"'name' must be selected internally to fetch child rows, which "
-					"would otherwise silently change what distinct treats as a duplicate."
-				),
-				title=_("Ambiguous Distinct Query"),
+				_("Child table fields need 'name' in `fields` when using distinct or aggregate queries."),
 				exc=frappe.ValidationError,
 			)
 

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -369,6 +369,18 @@ class Engine:
 			self.query._parent_doctype = self.parent_doctype
 			self.query._fields_list = getattr(self, "fields", [])
 
+		if getattr(self.query, "_name_field_injected", False) and (distinct or self.is_aggregate_query):
+			frappe.throw(
+				_(
+					"Cannot use distinct=True with child table fields unless the "
+					"parent 'name' field is also explicitly included in `fields`. "
+					"'name' must be selected internally to fetch child rows, which "
+					"would otherwise silently change what distinct treats as a duplicate."
+				),
+				title=_("Ambiguous Distinct Query"),
+				exc=frappe.ValidationError,
+			)
+
 		self.query.immutable = True
 		return self.query
 
@@ -387,19 +399,33 @@ class Engine:
 			self.fields = [self.table.name]
 
 		self.query._child_queries = []
+		self.query._name_field_injected = False
 		has_select_field = False
+		has_child_queries = False
+		has_name_field = False
+
 		for field in self.fields:
 			if isinstance(field, DynamicTableField):
 				self.query = field.apply_select(self.query, engine=self)
 				has_select_field = True
 			elif isinstance(field, ChildQuery):
 				self.query._child_queries.append(field)
+				has_child_queries = True
 			else:
 				self.query = self.query.select(field)
 				has_select_field = True
 
+				output_key = getattr(field, "alias", None) or getattr(field, "name", None)
+				if output_key == "name" or isinstance(field, Star):
+					has_name_field = True
+
 		if not has_select_field:
 			self.query = self.query.select(self.table.name)
+			has_name_field = True
+
+		if has_child_queries and not has_name_field:
+			self.query = self.query.select(self.table.name)
+			self.query._name_field_injected = True
 
 	def apply_filters(
 		self,

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -415,8 +415,7 @@ class Engine:
 				self.query = self.query.select(field)
 				has_select_field = True
 
-				output_key = getattr(field, "alias", None) or getattr(field, "name", None)
-				if output_key == "name" or isinstance(field, Star):
+				if getattr(field, "name", None) == "name" or isinstance(field, Star):
 					has_name_field = True
 
 		if not has_select_field:

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -408,8 +408,10 @@ class Engine:
 			else:
 				self.query = self.query.select(field)
 				has_select_field = True
+				is_source_name = getattr(field, "name", None) == "name"
+				alias = getattr(field, "alias", None)
 
-				if getattr(field, "name", None) == "name" or isinstance(field, Star):
+				if isinstance(field, Star) or (is_source_name and alias in (None, "name")):
 					has_name_field = True
 
 		if not has_select_field:

--- a/frappe/query_builder/utils.py
+++ b/frappe/query_builder/utils.py
@@ -164,6 +164,7 @@ def execute_query(query, *args, **kwargs):
 	parent_dt = query.__dict__.get("_parent_doctype")
 	fields = query.__dict__.get("_fields_list", [])
 	child_queries = query._child_queries
+	name_field_injected = query.__dict__.get("_name_field_injected", False)
 	query, params = prepare_query(query)
 	result = frappe.local.db.sql(query, params, *args, **kwargs)  # nosemgrep
 
@@ -178,6 +179,10 @@ def execute_query(query, *args, **kwargs):
 		result = mask_fields(
 			dt, fields, result, as_dict=as_dict, pluck=kwargs.get("pluck", False), parent_doctype=parent_dt
 		)
+
+	if name_field_injected and result and isinstance(result[0], dict):
+		for row in result:
+			row.pop("name", None)
 
 	return result
 

--- a/frappe/query_builder/utils.py
+++ b/frappe/query_builder/utils.py
@@ -180,9 +180,15 @@ def execute_query(query, *args, **kwargs):
 			dt, fields, result, as_dict=as_dict, pluck=kwargs.get("pluck", False), parent_doctype=parent_dt
 		)
 
-	if name_field_injected and result and isinstance(result[0], dict):
-		for row in result:
-			row.pop("name", None)
+	if name_field_injected and result and not kwargs.get("pluck"):
+		if isinstance(result[0], dict):
+			for row in result:
+				row.pop("name", None)
+		else:
+			if isinstance(result, tuple):
+				result = tuple(row[:-1] for row in result)
+			else:
+				result = [row[:-1] for row in result]
 
 	return result
 

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -1862,6 +1862,16 @@ class TestDBQuery(IntegrationTestCase):
 		).run(as_dict=True)
 		self.assertTrue(result)
 
+	def test_child_query_with_aliased_name_still_injects(self):
+		result = frappe.qb.get_query(
+			"User",
+			fields=["name as pk", "first_name", {"roles": ["role"]}],
+			filters={"name": "Administrator"},
+		).run(as_dict=True)
+		self.assertIn("pk", result[0])
+		self.assertIn("roles", result[0])
+		self.assertTrue(result[0]["roles"])
+
 
 class TestReportView(IntegrationTestCase):
 	def test_get_count(self):

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -1824,6 +1824,44 @@ class TestDBQuery(IntegrationTestCase):
 		self.assertNotIn("0", query)
 		self.assertNotIn("ifnull", query)
 
+	def test_child_query_without_explicit_name_field(self):
+		q = frappe.qb.get_query(
+			"User",
+			fields=["first_name", {"roles": ["role"]}],
+			filters={"name": "Administrator"},
+		)
+		result = q.run(as_dict=True)
+
+		self.assertEqual(len(result), 1)
+		self.assertIn("roles", result[0], "Child table data is missing when parent name is omitted")
+		self.assertTrue(len(result[0]["roles"]) > 0, "Child table is empty")
+		self.assertNotIn("name", result[0], "Injected 'name' field leaked into the final output")
+
+	def test_distinct_with_injected_name_raises(self):
+		with self.assertRaises(frappe.ValidationError):
+			frappe.qb.get_query(
+				"User",
+				fields=["first_name", {"roles": ["role"]}],
+				distinct=True,
+			).run(as_dict=True)
+
+	def test_group_by_with_injected_name_raises(self):
+		with self.assertRaises(frappe.ValidationError):
+			frappe.qb.get_query(
+				"User",
+				fields=["first_name", {"roles": ["role"]}],
+				group_by="first_name",
+			).run(as_dict=True)
+
+	def test_distinct_with_explicit_name_does_not_raise(self):
+		result = frappe.qb.get_query(
+			"User",
+			fields=["name", "first_name", {"roles": ["role"]}],
+			distinct=True,
+			filters={"name": "Administrator"},
+		).run(as_dict=True)
+		self.assertTrue(result)
+
 
 class TestReportView(IntegrationTestCase):
 	def test_get_count(self):


### PR DESCRIPTION
When using frappe.qb.get_query to fetch child table fields, the underlying stitching logic requires the parent's name field. If omitted from the fields list, it silently dropped the child data.

This injects the parent name field into the query builder when child tables are requested and cleans it up post execution, preventing the silent failure while preserving the user's expected output. Also adds guardrails to prevent implicit injection on DISTINCT/aggregated queries.

fix(not full ss): 
<img width="764" height="889" alt="image" src="https://github.com/user-attachments/assets/0a5e5c48-5fe5-42b0-91e2-cd509a699832" />


fixes #42627 