### PR TITLE
fix: enforce field level and print permissions on website routes

### DIFF
--- a/frappe/www/list.py
+++ b/frappe/www/list.py
@@ -60,6 +60,15 @@ def get(
 
 		if not list_context.get_list and not isinstance(new_context.doc, Document):
 			new_context.doc = frappe.get_doc(doc.doctype, doc.name)
+
+		# `get_list_context` implementations and the `get_doc` above both return whole
+		# documents, bypassing the field level permissions that `frappe.get_list` applies.
+		# Strip them here so permlevel restricted values never reach the row template or
+		# the serialized `raw_result`.
+		if isinstance(new_context.doc, Document):
+			new_context.doc.apply_fieldlevel_read_permissions()
+
+		if not list_context.get_list and not isinstance(doc, Document):
 			new_context.update(new_context.doc.as_dict())
 
 		if not frappe.flags.in_test:

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -365,11 +365,10 @@ def get_rendered_raw_commands(doc: str, name: str | None = None, print_format: s
 
 
 def validate_print_permission(doc):
-	for ptype in ("read", "print"):
-		if frappe.has_permission(doc.doctype, ptype, doc):
-			return
+	if frappe.has_permission(doc.doctype, "print", doc):
+		return
 
-	if frappe.has_website_permission(doc):
+	if frappe.has_website_permission(doc, ptype="print"):
 		return
 
 	if (key := frappe.form_dict.key) and isinstance(key, str) and validate_key(key, doc) is not False:


### PR DESCRIPTION
Fixes two permission checks that the website (portal) routes skip while the equivalent
desk routes apply them. Reported in #42640.

### 1. Portal list pages expose permlevel-restricted values

`frappe.get_list` applies field-level read permissions, but `www/list.py` then discards
that filtering: each row is either replaced by `frappe.get_doc(...)` or supplied by a
`get_list_context`-provided `get_list` (every ERPNext transaction does this). The
unfiltered document reaches both the row template and the serialized `raw_result`.

With `Sales Order.ignore_pricing_rule` at permlevel 1 and a user holding only `Sales User`
(level 0):

```
frappe.get_list("Sales Order", fields="distinct *")   -> ignore_pricing_rule absent   (correct)
frappe.client.get("Sales Order", name)                -> ignore_pricing_rule = None   (correct)
/api/method/frappe.www.list.get?doctype=Sales Order   -> ignore_pricing_rule = 1       (leak)
```

Same with a permlevel field that is `in_list_view` — the value is printed straight into
the rendered row HTML.

### 2. `read` permission implies `print` permission

`validate_print_permission` accepted `read` **or** `print`, so `print` could not be
withheld. `PrintPage` maps `/<DocType>/<name>` to the print view for any doctype, so this
is reachable directly over the website. A role with `read = 1, print = 0` rendered the
full print page with HTTP 200.

This was inconsistent with the rest of the codebase: the desk UI gates printing on
`can_print` (`public/js/frappe/model/perm.js`), and `utils/weasyprint.py` already calls
`doc.check_permission("print")`. `print` defaults to `1` on new DocPerm rows, so this only
affects roles where it was deliberately cleared.

The website-permission fallback in the same function was also effectively checking `read`,
since `ptype` defaults to `"read"`; it now asks for `print`.

> On sites with ERPNext installed this fix needs its companion,
> **frappe/erpnext#COMPANION** — ERPNext's `has_website_permission` ignores the `ptype` it
> is given and grants any permission type to anyone with `read`, which keeps the print
> fallback open. Verified: frappe alone is not sufficient there.

### Verification

Run against a live v15 site with ERPNext installed, before and after:

- permlevel values gone from both the rendered rows and `raw_result`; row counts and
  non-restricted fields (`grand_total`, `items`) unchanged
- `GET /Sales Order/<name>` → **403** for a role with `print = 0`, **200** for `print = 1`
- portal list still renders for both roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2RHD69wk94YCZbLuBXhud
