### PR TITLE
fix: reset unique field when autoname changes

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1124,14 +1124,28 @@ def validate_series(dt, autoname=None, name=None):
 	# validate field name if autoname field:fieldname is used
 	# Create unique index on autoname field automatically.
 	if autoname and autoname.startswith("field:"):
-		field = autoname.split(":")[1]
-		if not field or field not in [df.fieldname for df in dt.fields]:
-			frappe.throw(_("Invalid fieldname '{0}' in autoname").format(field))
-		else:
-			for df in dt.fields:
-				if df.fieldname == field:
-					df.unique = 1
-					break
+			field = autoname.split(":")[1]
+			if not field or field not in [df.fieldname for df in dt.fields]:
+					frappe.throw(_("Invalid fieldname '{0}' in autoname").format(field))
+			else:
+					previous_autoname = getattr(dt.get_doc_before_save(), "autoname", "")
+
+					for df in dt.fields:
+							if df.fieldname == field:
+									df.unique = 1
+							elif previous_autoname == f"field:{df.fieldname}":
+									df.unique = 0
+
+	elif dt.get_doc_before_save():
+			previous_autoname = getattr(dt.get_doc_before_save(), "autoname", "")
+
+			if previous_autoname and previous_autoname.startswith("field:"):
+					previous_field = previous_autoname.split(":", 1)[1]
+
+					for df in dt.fields:
+							if df.fieldname == previous_field:
+									df.unique = 0
+									break
 
 	if (
 		autoname

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -49,6 +49,23 @@ class TestDocType(IntegrationTestCase):
 			doc = new_doctype(name).insert()
 			doc.delete()
 
+	    def test_field_autoname_unique_removed_when_autoname_changed(self):
+            dt = new_doctype(self._testMethodName, autoname="field:some_fieldname")  
+            dt.insert(ignore_permissions=True)                                       
+
+            self.assertEqual(
+                    dt.get("fields", {"fieldname": "some_fieldname"})[0].unique,
+                    1,
+            )
+
+            dt.autoname = "hash"
+            dt.save(ignore_permissions=True)
+
+            self.assertEqual(
+                    dt.get("fields", {"fieldname": "some_fieldname"})[0].unique,
+                    0,
+            )
+
 	@skipIf(
 		frappe.conf and frappe.conf.db_type == "sqlite",
 		"Not for SQLite for now",


### PR DESCRIPTION
## Description

When a DocType uses **Naming Rule → By fieldname**, Frappe automatically sets the selected field's **Unique** property to enabled.

For example, if a DocType has a field `student_name` and the naming rule is:

`field:student_name`

the `student_name` field is correctly marked as unique.

However, when the naming rule is later changed from `field:student_name` to another naming method, or when field-based naming is removed, the **Unique** property remains enabled on the previously selected field.

This causes the field to remain unique even though it is no longer being used for field-based autonaming.

This change ensures that the automatically-added **Unique** property is removed when the field is no longer used for field-based autonaming.

## Reproduction

1. Create a new DocType.
2. Add a field named `student_name`.
3. Set the naming rule to **By fieldname**.
4. Select `student_name` as the naming field.
5. Save the DocType.
6. Verify that `student_name` has **Unique = Yes**.
7. Change the naming rule from `field:student_name` to another naming method such as `hash`.
8. Save the DocType again.
9. Check the `student_name` field.

### Observed result

The `student_name` field remains:

```text
Unique = Yes

Before changing the naming rule:

autoname = field:student_name

student_name
    Unique = Yes

After changing the naming rule:

autoname = hash

student_name
    Unique = Yes
    
    Expected result

When a field is used for field-based autonaming:

autoname = field:student_name

the field should automatically be marked as unique:

student_name
    Unique = Yes

When the naming rule is changed to another naming method:

autoname = hash

the previously selected field should have its automatically-added uniqueness removed:

student_name
    Unique = No

Similarly, when changing from one field-based naming rule to another:

field:student_name
        ↓
field:student_id

the expected result is:

student_name
    Unique = No

student_id
    Unique = Yes
    
    Changes made

The DocType autoname validation logic was updated to track the previous autoname value.

When the previous autoname uses the field: pattern, the corresponding field's automatically-added unique property is cleared when that field is no longer the active field-based autoname field.

A test was also added to verify that the unique property is removed when the autoname is changed from a field-based naming rule to another naming method.

Testing

The following test case was added:

field:some_fieldname
        ↓
hash

The test verifies that the field's unique property changes from:

unique = 1

to:

unique = 0

The modified Python file was also checked successfully using py_compile.

Stacktrace / Full Error Message

No stacktrace or error is produced.

This is a behavioral and metadata consistency issue where the Unique property is not automatically cleared after changing or removing field-based autonaming.