### PR TITLE
fix: 500 with an unparseable body when an after commit callback fails

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -1210,20 +1210,21 @@ class Database:
 			self.begin()
 
 		self.value_cache.clear()
-		self.run_after_commit_callbacks()
+		self.run_after_transaction_callbacks(self.after_commit)
 
-	def run_after_commit_callbacks(self):
-		"""Run the callbacks queued for after the commit, logging the ones that fail.
+	def run_after_transaction_callbacks(self, callbacks: CallbackManager):
+		"""Run the callbacks queued for after the commit or rollback, logging the ones that fail.
 
-		The transaction is durable by now and these callbacks are side effects that can not
-		undo it, so raising here would only destroy the response of a request that succeeded.
+		The transaction has settled by now and these callbacks are side effects that can not
+		undo it, so raising here would only destroy the response of a request whose database
+		work is already finished.
 		"""
-		while len(self.after_commit):
+		while len(callbacks):
 			try:
 				# the failing callback is already off the queue, so this resumes at the next one
-				self.after_commit.run()
+				callbacks.run()
 			except Exception:
-				frappe.log_error("Failed to run after commit callback", defer_insert=True)
+				frappe.log_error("Failed to run after transaction callback", defer_insert=True)
 
 	def rollback(self, *, save_point=None, chain=False):
 		"""`ROLLBACK` current transaction. Optionally rollback to a known save_point."""
@@ -1244,7 +1245,7 @@ class Database:
 				self.begin()
 
 			self.value_cache.clear()
-			self.after_rollback.run()
+			self.run_after_transaction_callbacks(self.after_rollback)
 		else:
 			warnings.warn(message=TRANSACTION_DISABLED_MSG, stacklevel=2)
 

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -1210,7 +1210,20 @@ class Database:
 			self.begin()
 
 		self.value_cache.clear()
-		self.after_commit.run()
+		self.run_after_commit_callbacks()
+
+	def run_after_commit_callbacks(self):
+		"""Run the callbacks queued for after the commit, logging the ones that fail.
+
+		The transaction is durable by now and these callbacks are side effects that can not
+		undo it, so raising here would only destroy the response of a request that succeeded.
+		"""
+		while len(self.after_commit):
+			try:
+				# the failing callback is already off the queue, so this resumes at the next one
+				self.after_commit.run()
+			except Exception:
+				frappe.log_error("Failed to run after commit callback", defer_insert=True)
 
 	def rollback(self, *, save_point=None, chain=False):
 		"""`ROLLBACK` current transaction. Optionally rollback to a known save_point."""

--- a/frappe/database/sqlite/database.py
+++ b/frappe/database/sqlite/database.py
@@ -546,7 +546,7 @@ class SQLiteDatabase(SQLiteExceptionUtil, Database):
 		self.transaction_writes = 0
 		self.begin()  # explicitly start a new transaction
 
-		self.run_after_commit_callbacks()
+		self.run_after_transaction_callbacks(self.after_commit)
 
 	def rollback(self, *, save_point=None, chain=None):
 		"""`ROLLBACK` current transaction. Optionally rollback to a known save_point."""
@@ -563,7 +563,7 @@ class SQLiteDatabase(SQLiteExceptionUtil, Database):
 			self._conn.rollback()
 			self.begin()
 
-			self.after_rollback.run()
+			self.run_after_transaction_callbacks(self.after_rollback)
 		else:
 			warnings.warn(message=TRANSACTION_DISABLED_MSG, stacklevel=2)
 

--- a/frappe/database/sqlite/database.py
+++ b/frappe/database/sqlite/database.py
@@ -546,7 +546,7 @@ class SQLiteDatabase(SQLiteExceptionUtil, Database):
 		self.transaction_writes = 0
 		self.begin()  # explicitly start a new transaction
 
-		self.after_commit.run()
+		self.run_after_commit_callbacks()
 
 	def rollback(self, *, save_point=None, chain=None):
 		"""`ROLLBACK` current transaction. Optionally rollback to a known save_point."""

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -814,6 +814,22 @@ class TestDB(IntegrationTestCase):
 
 		self.assertEqual(order_of_execution, list(range(0, 9)))
 
+	def test_failing_after_commit_callback(self):
+		executed = []
+
+		def fail():
+			raise ValueError("Outgoing mail server is unreachable")
+
+		frappe.db.after_commit.add(fail)
+		frappe.db.after_commit.add(lambda: executed.append("cache cleared"))
+
+		with patch("frappe.log_error") as log_error:
+			frappe.db.commit()
+
+		self.assertEqual(executed, ["cache cleared"])
+		log_error.assert_called_once()
+		self.assertEqual(len(frappe.db.after_commit), 0)
+
 	def test_db_explain(self):
 		frappe.db.sql("select 1", debug=1, explain=1)
 

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -830,6 +830,22 @@ class TestDB(IntegrationTestCase):
 		log_error.assert_called_once()
 		self.assertEqual(len(frappe.db.after_commit), 0)
 
+	def test_failing_after_rollback_callback(self):
+		executed = []
+
+		def fail():
+			raise OSError("File on disk is gone")
+
+		frappe.db.after_rollback.add(fail)
+		frappe.db.after_rollback.add(lambda: executed.append("cache cleared"))
+
+		with patch("frappe.log_error") as log_error:
+			frappe.db.rollback()
+
+		self.assertEqual(executed, ["cache cleared"])
+		log_error.assert_called_once()
+		self.assertEqual(len(frappe.db.after_rollback), 0)
+
 	def test_db_explain(self):
 		frappe.db.sql("select 1", debug=1, explain=1)
 


### PR DESCRIPTION
Creating a user from the list view fails with a 500 whose body is not JSON, so the desk cannot render any message:

```
request.js:384 SyntaxError: Unexpected token '<', "<!doctype "... is not valid JSON
```

The form stays on Not Saved, but the user has in fact been created. Any site whose outgoing email account cannot be reached runs into this, since **Send Welcome Email** is on by default.

## Why it happens

The welcome mail registers `EmailQueue.send` on `frappe.db.after_commit`, and those callbacks run at the end of `commit()`, once the COMMIT has already gone through. `sync_database()` is called from the `else` clause of `application()`, outside the `except` that turns an exception into a proper response, so the SMTP error escapes the WSGI app; werkzeug renders its own HTML page and the response of a request that already committed is lost. Nothing reaches the Error Log either.

## Fix

Callbacks queued on `after_commit` are side effects, and the transaction is durable by the time they run, so a failure among them cannot undo it and raising only costs the response. `commit()` now logs a failing callback to the Error Log and carries on with the ones queued behind it.

`before_commit` is untouched; raising there still aborts the commit. Delivery is unchanged, the Email Queue row already exists with `retry=3`.