### PR TITLE
fix: keep the remote error message in FrappeException

### DIFF
--- a/frappe/frappeclient.py
+++ b/frappe/frappeclient.py
@@ -391,6 +391,8 @@ class FrappeClient:
 					exception = json.loads(rjson["exc"])[0]
 				elif errors := rjson.get("errors"):
 					exception = errors[0].get("exception") or errors[0].get("type")
+					if message := errors[0].get("message"):
+						exception += "\n" + strip_html(message)
 
 				for message in json.loads(rjson.get("_server_messages") or "[]"):
 					exception += "\n" + strip_html(json.loads(message).get("message", ""))

--- a/frappe/frappeclient.py
+++ b/frappe/frappeclient.py
@@ -6,7 +6,7 @@ import base64
 import json
 
 import frappe
-from frappe.utils.data import cstr
+from frappe.utils.data import cstr, strip_html
 
 
 class AuthError(Exception):
@@ -385,20 +385,19 @@ class FrappeClient:
 			raise
 
 		if rjson and (rjson.get("exc") or rjson.get("exc_type") or rjson.get("errors")):
+			exception = cstr(rjson.get("exc_type"))  # Only the type is available outside developer mode
 			try:
-				exception = ""
 				if rjson.get("exc"):
 					exception = json.loads(rjson["exc"])[0]
-				elif rjson.get("exc_type"):  # Just have type available
-					exception = json.loads(rjson["exc_type"])[0]
-				elif errors := rjson.get("errrors"):
+				elif errors := rjson.get("errors"):
 					exception = errors[0].get("exception") or errors[0].get("type")
 
-				exc = "FrappeClient Request Failed\n\n" + exception
+				for message in json.loads(rjson.get("_server_messages") or "[]"):
+					exception += "\n" + strip_html(json.loads(message).get("message", ""))
 			except Exception:
-				exc = rjson.get("exc")
+				pass
 
-			raise FrappeException(exc)
+			raise FrappeException("FrappeClient Request Failed\n\n" + exception)
 		if "message" in rjson:
 			return rjson["message"]
 		elif "data" in rjson:

--- a/frappe/tests/test_frappe_client.py
+++ b/frappe/tests/test_frappe_client.py
@@ -2,6 +2,8 @@
 # License: MIT. See LICENSE
 
 import base64
+import json
+from types import SimpleNamespace
 
 import requests
 
@@ -9,7 +11,7 @@ import frappe
 from frappe.core.doctype.user.user import generate_keys
 from frappe.frappeclient import FrappeClient, FrappeException
 from frappe.model import default_fields
-from frappe.tests import IntegrationTestCase
+from frappe.tests import IntegrationTestCase, UnitTestCase
 from frappe.tests.utils.test_capabilities import TestService, requires_test_service
 from frappe.utils.data import get_url
 
@@ -236,3 +238,41 @@ class TestFrappeClient(IntegrationTestCase):
 		header = {"Authorization": f"token {api_key}:{api_secret}"}
 		res = requests.post(get_url() + "/api/method/frappe.auth.get_logged_user", headers=header)
 		self.assertEqual(res.status_code, 401)
+
+
+class TestFrappeClientErrors(UnitTestCase):
+	def get_raised_message(self, payload):
+		client = FrappeClient.__new__(FrappeClient)
+		with self.assertRaises(FrappeException) as raised:
+			client.post_process(SimpleNamespace(json=lambda: payload))
+
+		return str(raised.exception)
+
+	def test_error_outside_developer_mode(self):
+		message = self.get_raised_message(
+			{
+				"exc_type": "PermissionError",
+				"_server_messages": json.dumps([json.dumps({"message": "No permission for <b>Note</b>"})]),
+			}
+		)
+
+		self.assertIn("PermissionError", message)
+		self.assertIn("No permission for Note", message)
+
+	def test_error_with_traceback(self):
+		message = self.get_raised_message(
+			{
+				"exc_type": "ValidationError",
+				"exc": json.dumps(["Traceback (most recent call last):\nValidationError: Title is required"]),
+			}
+		)
+
+		self.assertIn("ValidationError: Title is required", message)
+
+	def test_error_from_api_v2(self):
+		message = self.get_raised_message(
+			{"errors": [{"type": "DoesNotExistError", "message": "Note <b>get_this</b> not found"}]}
+		)
+
+		self.assertIn("DoesNotExistError", message)
+		self.assertIn("Note get_this not found", message)


### PR DESCRIPTION
## Bug

A `FrappeClient` call against another site fails with an exception carrying no message:

```
File "apps/frappe/frappe/frappeclient.py", line 401, in post_process
  raise FrappeException(exc)
frappe.frappeclient.FrappeException: None
```

The remote did say why it refused; `post_process` throws that away before raising.

## Fix

`report_error` sets `exc_type` on every v1 error but sets `exc` only in developer mode, so a production site returns `exc_type` and `_server_messages`. `post_process` ran `json.loads` on `exc_type`, which is a bare class name and not JSON; the decode threw and the handler fell back to `exc`, absent in exactly that case.

`exception` now starts from `exc_type` and picks up `_server_messages`, which is where the `frappe.throw` text lives and is not gated on developer mode. Markup in it is stripped. The v2 branch also reached for `errrors` and so never ran.

The call above now raises:

```
FrappeException: FrappeClient Request Failed

PermissionError
No permission for Note
```

Only the error path changes.