### PR TITLE
fix(data_import): run the import through the document's own importer

### DIFF
--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -222,12 +222,7 @@ def start_import(data_import):
 	# Apply same delimiter/sniffer settings as preview so CSV is parsed correctly (e.g. EU ";" delimiter)
 	data_import.set_delimiters_flag()
 	try:
-		i = Importer(
-			data_import.reference_doctype,
-			data_import=data_import,
-			use_sniffer=data_import.use_csv_sniffer,
-		)
-		i.import_data()
+		data_import.get_importer().import_data()
 	except JobTimeoutException:
 		frappe.db.rollback()
 		data_import.db_set("status", "Timed Out")

--- a/frappe/core/doctype/data_import/test_importer.py
+++ b/frappe/core/doctype/data_import/test_importer.py
@@ -1,6 +1,9 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
+from unittest.mock import patch
+
 import frappe
+from frappe.core.doctype.data_import.data_import import DataImport
 from frappe.core.doctype.data_import.importer import (
 	ACTION_INSERT,
 	ACTION_UPDATE,
@@ -59,6 +62,20 @@ class TestImporter(IntegrationTestCase):
 		create_doctype_if_not_exists(
 			doctype_name,
 		)
+
+	def test_import_uses_the_document_importer(self):
+		self.addCleanup(_delete_doctype_records, doctype_name, SAMPLE_IMPORT_DOC_NAMES)
+		import_file = get_import_file("sample_import_file")
+		data_import = self.get_importer(doctype_name, import_file)
+
+		with patch.object(
+			DataImport, "get_importer", autospec=True, side_effect=DataImport.get_importer
+		) as get_importer:
+			data_import.start_import()
+
+		get_importer.assert_called()
+		self.assertEqual(data_import.reload().status, "Success")
+		self.assertTrue(frappe.db.exists(doctype_name, "Test"))
 
 	def test_data_import_from_file(self):
 		self.addCleanup(_delete_doctype_records, doctype_name, SAMPLE_IMPORT_DOC_NAMES)


### PR DESCRIPTION
`start_import` constructed `Importer` directly instead of calling `data_import.get_importer()`.

An app that overrides `get_importer` to return an `Importer` subclass had that subclass used for the preview and validation paths, but not for the actual import. The only way to change importer behaviour for a real run was to fork `start_import`.

The test patches `get_importer` and asserts a background run goes through it. It fails on develop.