### PR TITLE
fix: refresh child currency fields and prevent grid symbol overlap

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -302,6 +302,18 @@ frappe.ui.form.Form = class FrappeForm {
 					let field = me.fields_dict[fieldname];
 					field && field.refresh(fieldname);
 
+					table_fields.forEach((table_df) => {
+						const child_fields = frappe.get_meta(table_df.options).fields;
+						const has_dependent_currency_field = child_fields.some(
+							(child_df) =>
+								child_df.fieldtype === "Currency" && child_df.options === fieldname
+						);
+
+						if (has_dependent_currency_field) {
+							me.fields_dict[table_df.fieldname]?.grid.refresh();
+						}
+					});
+
 					// Validate value for link field explicitly
 					field &&
 						["Link", "Dynamic Link"].includes(field.df.fieldtype) &&

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -537,7 +537,7 @@
 
 	// for left aligned currency symbol
 	.grid-currency-input.grid-currency-has-value:not(.grid-currency-symbol-right) .form-control {
-		padding-left: calc(4px + 1em);
+		padding-left: calc(12px + 1em);
 		position: relative;
 		z-index: 1;
 		text-align: left;


### PR DESCRIPTION
## Issue

There are two issues with Currency fields in editable Grid rows:

1. When the currency of the parent document is changed, dependent Currency fields in child tables are not refreshed immediately.
2. Currency symbols can overlap the entered amount in the Grid when the symbol is wider than the space reserved for it.

For example, when using the AED currency symbol `د.إ`, the symbol can overlap the entered amount in the Grid.

## Root Cause

### 1. Currency change not reflected in child Grid

When the parent document's currency is changed, the dependent Currency fields in child tables are not refreshed, so the child Grid may continue displaying the previous currency until the Grid is refreshed.

### 2. Currency symbol overlap

The currency prefix is positioned inside the Grid currency input, but the input does not reserve enough space for wider currency symbols such as `د.إ`.

The existing left padding is:

`padding-left: calc(4px + 1em);`

This can cause the currency symbol and the input value to overlap.

## Solution

### 1. Refresh dependent child Grids when currency changes

When a parent currency field changes, refresh child table Grids that contain Currency fields dependent on that currency field.

This ensures that the currency displayed in child Grid rows is updated immediately.

### 2. Increase Grid currency input spacing

Increase the left padding to provide sufficient space for the currency prefix.

Changed:

`padding-left: calc(4px + 1em);`

to:

`padding-left: calc(12px + 1em);`

This prevents wider currency symbols from overlapping the entered amount.

https://github.com/user-attachments/assets/3bbac3aa-5a9b-4d60-ba8d-ee59fb69d2ee

https://github.com/user-attachments/assets/2a363392-85cc-4ed2-8e7b-86854c7cc6ae

#42538

