### PR TITLE
fix(ui): notification panel not visible on mobile

### DIFF
--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -227,7 +227,10 @@
 			.standard-items-sections {
 				.dropdown-notifications {
 					.notifications-list {
+						// sidebar is width: 0; overflow: hidden here - go fixed so the panel isn't clipped
+						position: fixed;
 						left: 0;
+						width: 100vw;
 					}
 				}
 			}


### PR DESCRIPTION
On mobile the notification dropdown is a child of the collapsed sidebar (`width: 0; overflow: hidden`), so it opens but is fully clipped — pin it to the viewport instead. Same approach as #39443 on develop.