### PR TITLE
fix(tags): prevent Document.get_tags from dropping the first tag

### DIFF
--- a/frappe/desk/doctype/tag/test_tag.py
+++ b/frappe/desk/doctype/tag/test_tag.py
@@ -1,5 +1,5 @@
 import frappe
-from frappe.desk.doctype.tag.tag import add_tag
+from frappe.desk.doctype.tag.tag import DocTags, add_tag
 from frappe.desk.reportview import get_stats
 from frappe.tests import IntegrationTestCase
 
@@ -32,3 +32,29 @@ class TestTag(IntegrationTestCase):
 			),
 			{"_user_tags": [["Standard", 1], ["No Tags", 0]]},
 		)
+
+	def test_get_tags(self):
+		doc = frappe.get_doc({"doctype": "ToDo", "description": "tag test"}).insert()
+		doctags = DocTags(doc.doctype)
+
+		# no tags
+		self.assertEqual(doc.get_tags(), [])
+
+		doctags.add(doc.name, "tag1")
+		doc.reload()
+		self.assertEqual(doc.get_tags(), ["tag1"])
+
+		doctags.add(doc.name, "tag2")
+		doctags.add(doc.name, "tag3")
+		doc.reload()
+		self.assertEqual(doc.get_tags(), ["tag1", "tag2", "tag3"])
+
+	def test_get_tags_legacy_leading_comma_format(self):
+		"""Pre-v16 sites stored _user_tags with a leading comma
+		(',tag1,tag2'). Untouched old documents can still carry that
+		format after upgrading -- get_tags() must handle both without
+		a data patch."""
+		doc = frappe.get_doc({"doctype": "ToDo", "description": "legacy tag test"}).insert()
+		frappe.db.set_value(doc.doctype, doc.name, "_user_tags", ",tag1,tag2,tag3", update_modified=False)
+		doc.reload()
+		self.assertEqual(doc.get_tags(), ["tag1", "tag2", "tag3"])

--- a/frappe/desk/doctype/tag/test_tag.py
+++ b/frappe/desk/doctype/tag/test_tag.py
@@ -37,7 +37,6 @@ class TestTag(IntegrationTestCase):
 		doc = frappe.get_doc({"doctype": "ToDo", "description": "tag test"}).insert()
 		doctags = DocTags(doc.doctype)
 
-		# no tags
 		self.assertEqual(doc.get_tags(), [])
 
 		doctags.add(doc.name, "tag1")

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -2426,7 +2426,9 @@ class Document(BaseDocument):
 		"""Return a list of Tags attached to this document"""
 		from frappe.desk.doctype.tag.tag import DocTags
 
-		return DocTags(self.doctype).get_tags(self.name).split(",")[1:]
+		tags = DocTags(self.doctype).get_tags(self.name)
+
+		return [tag for tag in tags.split(",") if tag]
 
 	def deferred_insert(self) -> None:
 		"""Push the document to redis temporarily and insert later.


### PR DESCRIPTION
Basically, the API has been accidentally hiding the first tag on documents.

Back in the day, frappe used to save tags to the database with a leading comma, looking something like ,urgent,pending. To deal with that, the codebase used [1:] slice to remove the empty blank space at the beginning whenever it fetched the list

The problem is that modern Frappe now saves tags cleanly as urgent,pending without the extra comma. Since the empty space isn't there anymore, that old [1:] slice is just chopping off the first valid tag entirely

fix: 
<img width="377" height="122" alt="image" src="https://github.com/user-attachments/assets/11e2c6e7-d989-4e71-b0c9-2435bab6413e" />

fixes #42637 