### PR TITLE
fix: remove auto unique when field autoname is removed

### DIFF
--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -312,6 +312,13 @@
   },
   {
    "default": "0",
+   "fieldname": "unique_auto_generated",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Unique Auto Generated"
+  },
+  {
+   "default": "0",
    "depends_on": "eval:doc.fieldtype !== 'Attachment Gallery'",
    "fieldname": "set_only_once",
    "fieldtype": "Check",

--- a/frappe/core/doctype/docfield/docfield.py
+++ b/frappe/core/doctype/docfield/docfield.py
@@ -129,6 +129,7 @@ class DocField(Document):
 		sticky: DF.Check
 		translatable: DF.Check
 		unique: DF.Check
+		unique_auto_generated: DF.Check
 		width: DF.Data | None
 	# end: auto-generated types
 

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1185,16 +1185,31 @@ def validate_series(dt, autoname=None, name=None):
 				title=_("Field Missing"),
 			)
 
-	# validate field name if autoname field:fieldname is used
+	# Remove automatically added unique property when field-based autonaming is removed or changed.
+	previous_doc = dt.get_doc_before_save()
+
+	if previous_doc and previous_doc.autoname and previous_doc.autoname.startswith("field:"):
+		previous_field = previous_doc.autoname.split(":", 1)[1]
+
+		if not autoname or not autoname.startswith("field:") or previous_field != autoname.split(":", 1)[1]:
+			for df in dt.fields:
+				if df.fieldname == previous_field and df.unique_auto_generated:
+					df.unique = 0
+					df.unique_auto_generated = 0
+					break
+
+	# Validate field name if autoname field:fieldname is used.
 	# Create unique index on autoname field automatically.
 	if autoname and autoname.startswith("field:"):
-		field = autoname.split(":")[1]
+		field = autoname.split(":", 1)[1]
 		if not field or field not in [df.fieldname for df in dt.fields]:
 			frappe.throw(_("Invalid fieldname '{0}' in autoname").format(field))
 		else:
 			for df in dt.fields:
 				if df.fieldname == field:
-					df.unique = 1
+					if not df.unique:
+						df.unique = 1
+						df.unique_auto_generated = 1
 					break
 
 	if (

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -126,6 +126,96 @@ class TestDocType(IntegrationTestCase):
 		doc1.delete()
 		doc2.delete()
 
+	def test_autoname_field_unique_removed(self):
+		frappe.delete_doc_if_exists("DocType", self._testMethodName)
+
+		dt = new_doctype(
+				self._testMethodName,
+				fields=[
+						{
+								"label": "Student Code",
+								"fieldname": "student_code",
+								"fieldtype": "Data",
+							}
+				],
+				autoname="field:student_code",
+			)
+		dt.insert()
+
+		student_code_field = next(df for df in dt.fields if df.fieldname == "student_code")
+		self.assertEqual(student_code_field.unique, 1)
+		self.assertEqual(student_code_field.unique_auto_generated, 1)
+
+		dt.autoname = ""
+		dt.save()
+
+		student_code_field = next(df for df in dt.fields if df.fieldname == "student_code")
+		self.assertEqual(student_code_field.unique, 0)
+		self.assertEqual(student_code_field.unique_auto_generated, 0)
+
+	def test_autoname_field_preserves_existing_unique(self):
+		frappe.delete_doc_if_exists("DocType", self._testMethodName)
+
+		dt = new_doctype(
+				self._testMethodName,
+				fields=[
+						{
+								"label": "Student Code",
+								"fieldname": "student_code",
+								"fieldtype": "Data",
+								"unique": 1,
+							}
+				],
+				autoname="field:student_code",
+			)
+		dt.insert()
+
+		student_code_field = next(df for df in dt.fields if df.fieldname == "student_code")
+		self.assertEqual(student_code_field.unique, 1)
+		self.assertEqual(student_code_field.unique_auto_generated, 0)
+
+		dt.autoname = ""
+		dt.save()
+
+		student_code_field = next(df for df in dt.fields if df.fieldname == "student_code")
+		self.assertEqual(student_code_field.unique, 1)
+		self.assertEqual(student_code_field.unique_auto_generated, 0)
+
+
+	def test_autoname_field_switch(self):
+		frappe.delete_doc_if_exists("DocType", self._testMethodName)
+
+		dt = new_doctype(
+				self._testMethodName,
+				fields=[
+						{
+								"label": "Student Code",
+								"fieldname": "student_code",
+								"fieldtype": "Data",
+							},
+						{
+								"label": "Employee Code",
+								"fieldname": "employee_code",
+								"fieldtype": "Data",
+							},
+				],
+				autoname="field:student_code",
+			)
+		dt.insert()
+
+		dt.autoname = "field:employee_code"
+		dt.save()
+
+		student_code_field = next(df for df in dt.fields if df.fieldname == "student_code")
+		employee_code_field = next(df for df in dt.fields if df.fieldname == "employee_code")
+
+		self.assertEqual(student_code_field.unique, 0)
+		self.assertEqual(student_code_field.unique_auto_generated, 0)
+		self.assertEqual(employee_code_field.unique, 1)
+		self.assertEqual(employee_code_field.unique_auto_generated, 1)
+
+		dt.delete()
+
 	def test_change_field_type_with_incompatible_values(self):
 		if frappe.db.exists("DocType", "Test Field Type Change"):
 			frappe.delete_doc("DocType", "Test Field Type Change")


### PR DESCRIPTION
## Description

When a DocType uses field-based autonaming (`field:<fieldname>`), Frappe
automatically marks the selected field as Unique.

When the field-based autoname is later removed or changed to another naming
method, the automatically added Unique property remains enabled.

## Problem

For example:

field:student_name
    ↓
hash

The `student_name` field remains Unique even though it is no longer used
for field-based autonaming.

## Changes

- Track whether the Unique property was automatically generated by
  field-based autonaming.
- Remove the automatically generated Unique property when the field is
  no longer used for field-based autonaming.
- Preserve Unique properties explicitly configured by the user.
- Handle switching from one field-based autoname field to another.

## Tests

Added regression tests covering:

- Removing field-based autoname.
- Preserving an existing user-defined Unique property.
- Switching between field-based autoname fields.

The behavior was also manually verified through the DocType UI.

Closes #42665 