### PR TITLE
refactor: enabling site cache through redis cache.

### DIFF
--- a/frappe/utils/caching.py
+++ b/frappe/utils/caching.py
@@ -77,106 +77,17 @@ def request_cache(func: Callable) -> Callable:
 	return wrapper
 
 
-def site_cache(ttl: int | None = None, maxsize: int | None = None) -> Callable:
-	"""
-	Decorator to cache method calls across requests.
-
-	The cache is stored in `frappe.utils.caching._SITE_CACHE`.
-
-	The cache persists on the parent process.
-
-	It offers a light-weight cache for the current process without the additional
-	overhead of serializing / deserializing Python objects.
-
-	Note: This cache isn't shared among workers. If you need to share data across
-	workers, use redis (frappe.cache API) instead.
-
-	---
-	Usage:
-	```
-	        from frappe.utils.caching import site_cache
-
-	        @site_cache
-	        def calculate_pi():
-	            import math, time
-
-	            precision = get_precision("Math Constant", "Pi") # depends on site data
-	            return round(math.pi, precision)
-
-	        calculate_pi(10) # will calculate value
-	        calculate_pi(10) # will return value from cache
-	        calculate_pi.clear_cache() # clear this function's cache for all sites
-	        calculate_pi(10) # will calculate value
-	```
-	"""
-
-	def time_cache_wrapper(func: Callable | None = None) -> Callable:
-		def clear_cache():
-			"""Clear cache for this function for all sites if not specified."""
-			_SITE_CACHE[func].clear()
-
-		func.clear_cache = clear_cache
-
-		if ttl is not None and not callable(ttl):
-			func.ttl = ttl
-			func.expiration = time.monotonic() + func.ttl
-
-		if maxsize is not None and not callable(maxsize):
-			assert maxsize > 0, "site_cache maxsize must be positive to allow caching"
-			func.maxsize = maxsize
-
-		@wraps(func)
-		def site_cache_wrapper(*args, **kwargs):
-			site = getattr(frappe.local, "site", None)
-			if not site:
-				return func(*args, **kwargs)
-
-			arguments_key = (site, __generate_request_cache_key(args, kwargs))
-
-			if hasattr(func, "ttl") and time.monotonic() >= func.expiration:
-				func.clear_cache()
-				func.expiration = time.monotonic() + func.ttl
-
-			# NOTE: Important things to consider from thread safety POV:
-			#   1. Other thread can issue clear_cache and delete entire dictionary.
-			#   2. Other thread can pop the exact elemement we are reading if maxsize is hit.
-
-			# NOTE: Keep a local reference to dictionary of interest so it doesn't get swapped
-			function_cache = _SITE_CACHE[func]
-
-			try:
-				return function_cache[arguments_key]
-
-			# not handling TypeError here, expecting arguments_key to be hashable
-			except (KeyError, RuntimeError):
-				# NOTE: This is just a cache miss or dictionary was modified while reading it
-				pass
-
-			if hasattr(func, "maxsize") and len(function_cache) >= func.maxsize:
-				# Note: This implements FIFO eviction policy
-				with suppress(RuntimeError):
-					function_cache.pop(next(iter(function_cache)), None)
-
-			result = func(*args, **kwargs)
-			function_cache[arguments_key] = result
-
-			return result
-
-		return site_cache_wrapper
-
-	if callable(ttl):
-		return time_cache_wrapper(ttl)
-
-	return time_cache_wrapper
-
-
-def redis_cache(ttl: int | None = 3600, user: str | bool | None = None, shared: bool = False) -> Callable:
+def redis_cache(
+	ttl: int | None = 3600, user: str | bool | None = None, shared: bool = False, maxsize: int = 8
+) -> Callable:
 	"""Decorator to cache method calls and its return values in Redis
-
+		# TODO: implement some policy to evict, but since `redis_cache` is used very sparingly this adds unexpected complexity and we avoid that for now.
+		# Just set `maxsize` to be double or higher count for desired functions for now.
 	args:
 	        ttl: time to expiry in seconds, defaults to 1 hour
 	        user: `true` should cache be specific to session user.
 	        shared: `true` should cache be shared across sites
+	        maxsize:int   to limit the number of count, a func can be called with different arguments.
 	"""
 
 	def wrapper(func: Callable | None = None) -> Callable:
@@ -184,12 +95,20 @@ def redis_cache(ttl: int | None = 3600, user: str | bool | None = None, shared: 
 
 		def clear_cache():
 			frappe.cache.delete_keys(func_key, user=user, shared=shared)
+			func.cached_values_counter = 0
 
 		func.clear_cache = clear_cache
 		func.ttl = ttl if not callable(ttl) else 3600
+		func.maxsize = maxsize
+		func.cached_values_counter = 0
 
 		@wraps(func)
 		def redis_cache_wrapper(*args, **kwargs):
+			# NOTE: reason for both checks is to support `site_cache` functionality too, but by default it would create
+			# a `boot-strapping` problem, as internally `redis_wrapper` depends on `local.conf`. We also wait for `frappe.cache` to be available.
+			if not (frappe.cache) or not (hasattr(frappe.local, "conf")):
+				return func(*args, **kwargs)
+
 			func_call_key = f"{func_key}::{hash(__generate_request_cache_key(args, kwargs))}"
 			cached_val = frappe.cache.get_value(func_call_key, user=user, shared=shared)
 			if cached_val is not None:
@@ -201,8 +120,12 @@ def redis_cache(ttl: int | None = 3600, user: str | bool | None = None, shared: 
 				return None
 
 			val = func(*args, **kwargs)
+			if (func.cached_values_counter + 1) > func.maxsize:
+				return val
+
 			ttl = getattr(func, "ttl", 3600)
 			frappe.cache.set_value(func_call_key, val, expires_in_sec=ttl, user=user, shared=shared)
+			func.cached_values_counter += 1
 			return val
 
 		return redis_cache_wrapper
@@ -210,6 +133,9 @@ def redis_cache(ttl: int | None = 3600, user: str | bool | None = None, shared: 
 	if callable(ttl):
 		return wrapper(ttl)
 	return wrapper
+
+
+site_cache = redis_cache
 
 
 def http_cache(

--- a/frappe/utils/caching.py
+++ b/frappe/utils/caching.py
@@ -135,6 +135,7 @@ def redis_cache(
 	return wrapper
 
 
+# NOTE: since by default `redis_cache` would have shared = False, it would be site-specific as expected.
 site_cache = redis_cache
 
 

--- a/frappe/utils/caching.py
+++ b/frappe/utils/caching.py
@@ -94,8 +94,9 @@ def redis_cache(
 		func_key = f"{func.__module__}.{func.__qualname__}"
 
 		def clear_cache():
-			frappe.cache.delete_keys(func_key, user=user, shared=shared)
-			func.cached_values_counter = 0
+			if frappe.cache:  # In case called during boot-straping itself, frappe.cache won't be available.
+				frappe.cache.delete_keys(func_key, user=user, shared=shared)
+				func.cached_values_counter = 0
 
 		func.clear_cache = clear_cache
 		func.ttl = ttl if not callable(ttl) else 3600
@@ -124,8 +125,11 @@ def redis_cache(
 				return val
 
 			ttl = getattr(func, "ttl", 3600)
-			frappe.cache.set_value(func_call_key, val, expires_in_sec=ttl, user=user, shared=shared)
-			func.cached_values_counter += 1
+			serialized_val_size = frappe.cache.set_value(
+				func_call_key, val, expires_in_sec=ttl, user=user, shared=shared
+			)
+			if serialized_val_size > 0:
+				func.cached_values_counter += 1
 			return val
 
 		return redis_cache_wrapper

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -75,7 +75,11 @@ class RedisWrapper(redis.Redis):
 		key = self.make_key(key, user, shared)
 
 		frappe.local.cache[key] = val
-		serialized = pickle.dumps(val, protocol=DEFAULT_PICKLE_PROTOCOL)
+		try:
+			serialized = pickle.dumps(val, protocol=DEFAULT_PICKLE_PROTOCOL)
+		except Exception:
+			# TODO: warning ?
+			return 0
 
 		with suppress(redis.exceptions.ConnectionError):
 			self.set(name=key, value=serialized, ex=expires_in_sec)
@@ -213,14 +217,15 @@ class RedisWrapper(redis.Redis):
 	def hset(
 		self,
 		name: str,
-		key: str,
+		key: str | None,
 		value,
 		shared: bool = False,
 		*args,
 		**kwargs,
-	):
+	) -> bool:
+		status = True  # can only be set to False on any error/exception.
 		if key is None:
-			return
+			return False
 
 		_name = self.make_key(name, shared=shared)
 
@@ -229,9 +234,17 @@ class RedisWrapper(redis.Redis):
 
 		# set in redis
 		try:
-			super().hset(_name, key, pickle.dumps(value, protocol=DEFAULT_PICKLE_PROTOCOL), *args, **kwargs)
+			serialized = pickle.dumps(value, protocol=DEFAULT_PICKLE_PROTOCOL)
+		except Exception:
+			# TODO: Warning ?
+			status = False
+			return status
+
+		try:
+			super().hset(_name, key, serialized, *args, **kwargs)
 		except redis.exceptions.ConnectionError:
-			pass
+			status = False
+		return status
 
 	def hexists(self, name: str, key: str, shared: bool = False) -> bool:
 		if key is None:
@@ -250,8 +263,8 @@ class RedisWrapper(redis.Redis):
 		except redis.exceptions.ConnectionError:
 			return False
 
-	def hgetall(self, name):
-		value = super().hgetall(self.make_key(name))
+	def hgetall(self, name, shared: bool = False):
+		value = super().hgetall(self.make_key(name, shared=shared))
 		return {key: pickle.loads(value) for key, value in value.items()}
 
 	def hget(self, name, key, generator=None, shared=False):
@@ -287,7 +300,7 @@ class RedisWrapper(redis.Redis):
 		keys: str | list | tuple,
 		shared=False,
 		pipeline: redis.client.Pipeline | None = None,
-	):
+	) -> bool:
 		"""
 		A wrapper around redis' HDEL command
 
@@ -296,6 +309,7 @@ class RedisWrapper(redis.Redis):
 		:param shared: shared frappe key or not
 		:param pipeline: A redis.client.Pipeline object, if this transaction is to be run in a pipeline
 		"""
+		status = True  # can only be set to False on any error/exception.
 		_name = self.make_key(name, shared=shared)
 
 		name_in_local_cache = _name in frappe.local.cache
@@ -303,14 +317,14 @@ class RedisWrapper(redis.Redis):
 		if not isinstance(keys, list | tuple):
 			if name_in_local_cache and keys in frappe.local.cache[_name]:
 				del frappe.local.cache[_name][keys]
-			if pipeline:
-				pipeline.hdel(_name, keys)
-			else:
-				try:
+			try:
+				if pipeline:
+					pipeline.hdel(_name, keys)
+				else:
 					super().hdel(_name, keys)
-				except redis.exceptions.ConnectionError:
-					pass
-			return
+			except redis.exceptions.ConnectionError:
+				status = False
+			return status
 
 		local_pipeline = False
 
@@ -322,13 +336,17 @@ class RedisWrapper(redis.Redis):
 			if name_in_local_cache:
 				if key in frappe.local.cache[_name]:
 					del frappe.local.cache[_name][key]
-			pipeline.hdel(_name, key)
+			try:
+				pipeline.hdel(_name, key)
+			except redis.exceptions.ConnectionError:
+				status = False
 
 		if local_pipeline:
 			try:
 				pipeline.execute()
 			except redis.exceptions.ConnectionError:
-				pass
+				status = False
+		return status
 
 	def hdel_names(self, names: list | tuple, key: str):
 		"""
@@ -356,9 +374,9 @@ class RedisWrapper(redis.Redis):
 		except redis.exceptions.ConnectionError:
 			pass
 
-	def hkeys(self, name):
+	def hkeys(self, name, shared: bool = False):
 		try:
-			return super().hkeys(self.make_key(name))
+			return super().hkeys(self.make_key(name, shared=shared))
 		except redis.exceptions.ConnectionError:
 			return []
 

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -70,7 +70,7 @@ class RedisWrapper(redis.Redis):
 		:param user: Prepends key with User
 		:param expires_in_sec: Expire value of this key in X seconds
 
-		Return the size of the serialized value in bytes.
+		Return the size of the serialized value in bytes. Zero would mean fail to set value in redis.
 		"""
 		key = self.make_key(key, user, shared)
 


### PR DESCRIPTION
Since `site-cache` (as well as `redis-cache`) are used very sparingly, this PR removes existing implementation of `site-cache`, instead now `site-cache` would be an alias to the existing `redis-cache` implementation.
Necessary changes are made to `redis-cache` to accommodate `maxsize` as expected by (earlier) site-cache.

Necessary miscellaneous fixes are made to `redis_wrapper` to better handle errors. 

<details>
<summary>Testing</summary>
Minimal independent testing can also be performed for <code>RedisCache</code> using by modifying <code>test_caching.py</code> 

```python
import frappe
frappe.init(site = ..., sites_path = ...)
frappe.connect(site_name)
```
and then running: 
```cmd
python3 -m unitttest ./test_caching.py`
```