### PR TITLE
fix(ui): move Filter, SortBy and ColumnSettings to frappe-ui's Popover slots

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -102,7 +102,7 @@
     "@vitejs/plugin-vue": ">=4",
     "@vueuse/core": ">=10.4.1",
     "autoprefixer": "^10.4.0",
-    "frappe-ui": ">=1.0.0-beta.16",
+    "frappe-ui": ">=1.0.0-beta.55",
     "tailwindcss": "^3.4.0",
     "typescript": ">=5",
     "vite": ">=4",

--- a/ui/src/components/ActivityTimeline/AttachmentChip.vue
+++ b/ui/src/components/ActivityTimeline/AttachmentChip.vue
@@ -41,12 +41,12 @@
 				>
 					{{ textContent }}
 				</div>
-				<img v-else-if="preview === 'image'" :src="url" class="m-auto rounded border" />
+				<img v-else-if="preview === 'image'" :src="url" class="m-auto rounded-4 border" />
 				<video
 					v-else-if="preview === 'video'"
 					:src="url"
 					controls
-					class="m-auto max-h-[70vh] rounded border"
+					class="m-auto max-h-[70vh] rounded-4 border"
 				/>
 			</template>
 		</Dialog>

--- a/ui/src/components/ActivityTimeline/TimelineCard.vue
+++ b/ui/src/components/ActivityTimeline/TimelineCard.vue
@@ -1,7 +1,7 @@
 <template>
 	<!-- shared card frame for email/comment rows; the header (incl. its padding) is fully slotted -->
 	<div
-		class="timeline-card grow overflow-hidden rounded-md border border-outline-gray-2 bg-surface-base text-base leading-6 transition-all duration-300 ease-in-out"
+		class="timeline-card grow overflow-hidden rounded-5 border border-outline-gray-2 bg-surface-base text-base leading-6 transition-all duration-300 ease-in-out"
 	>
 		<slot name="header" />
 		<hr class="border-t border-outline-elevation-2" />

--- a/ui/src/components/ActivityTimeline/stories/ActivityTimeline.story.vue
+++ b/ui/src/components/ActivityTimeline/stories/ActivityTimeline.story.vue
@@ -15,7 +15,7 @@
 			<Switch v-model="withSlots" label="Slots" />
 		</div>
 
-		<div class="rounded-lg border border-outline-gray-2 p-4">
+		<div class="rounded-6 border border-outline-gray-2 p-4">
 			<ActivityTimeline
 				:activities="activities"
 				:loading="loading"
@@ -48,7 +48,7 @@
 
 				<!-- a consumer-defined type, rendered entirely through its slot -->
 				<template #item-feedback="{ activity }">
-					<div class="rounded-md bg-surface-gray-2 px-3 py-2 text-p-sm text-ink-gray-7">
+					<div class="rounded-5 bg-surface-gray-2 px-3 py-2 text-p-sm text-ink-gray-7">
 						Feedback — ★ {{ asFeedback(activity).rating }}/5 ·
 						{{ asFeedback(activity).message }}
 					</div>

--- a/ui/src/components/ColumnSettings/ColumnSettings.vue
+++ b/ui/src/components/ColumnSettings/ColumnSettings.vue
@@ -35,98 +35,91 @@
 	</Combobox>
 
 	<!-- Non-empty: the columns popover with its reorder / rename / remove rows. -->
-	<Popover v-else ref="popoverRef" placement="bottom-end">
-		<template #target="{ togglePopover }">
+	<Popover v-else ref="popoverRef" side="bottom" align="end">
+		<template #trigger>
 			<Button
 				:label="hideLabel ? undefined : 'Columns'"
 				:icon="hideLabel ? 'lucide-columns-3' : undefined"
 				:iconLeft="!hideLabel ? 'lucide-columns-3' : undefined"
-				@click="
-					confirmingReset = false;
-					togglePopover();
-				"
+				@click="confirmingReset = false"
 			/>
 		</template>
-		<template #body>
-			<div
-				class="my-2 min-w-40 rounded-lg bg-surface-elevation-2 shadow-2xl ring-1 ring-black ring-opacity-5 focus:outline-none"
-			>
-				<!-- Reorder / rename / remove the shown columns, add more. Width is
-				     not edited here — drag-resize in the table owns it (ADR-0006). -->
-				<div class="min-w-60 p-2">
-					<Draggable
-						v-if="model.length"
-						class="mb-3 flex flex-col gap-2"
-						:modelValue="model"
-						:item-key="(c) => c.fieldname"
-						handle=".column-drag-handle"
-						tag="div"
-						@update:modelValue="reorder"
-					>
-						<template #item="{ element: column, index: i }">
-							<div class="flex items-center gap-1">
-								<div
-									class="column-drag-handle flex h-7 w-7 shrink-0 items-center justify-center"
-								>
-									<span
-										class="lucide-grip-vertical size-4 cursor-grab text-ink-gray-5"
-										aria-hidden="true"
-									/>
-								</div>
-								<!-- The label is always a TextInput: read-only at rest, click to
-								     rename. Editing writes a local `draft` (so Esc reverts and
-								     typing doesn't churn the dragged list); commit on Enter/blur. -->
-								<TextInput
-									:ref="editIndex === i ? focusInput : undefined"
-									size="sm"
-									class="min-w-44 flex-1"
-									:readonly="editIndex !== i"
-									:modelValue="editIndex === i ? draft : column.label"
-									@click="editColumn(i)"
-									@update:modelValue="(value: string) => (draft = value)"
-									@keydown.enter.prevent="commitEdit"
-									@keydown.esc.prevent="cancelEdit"
-									@blur="commitEdit"
+		<template #default>
+			<!-- Reorder / rename / remove the shown columns, add more. Width is
+			     not edited here — drag-resize in the table owns it (ADR-0006). -->
+			<div class="min-w-60 p-2">
+				<Draggable
+					v-if="model.length"
+					class="mb-3 flex flex-col gap-2"
+					:modelValue="model"
+					:item-key="(c) => c.fieldname"
+					handle=".column-drag-handle"
+					tag="div"
+					@update:modelValue="reorder"
+				>
+					<template #item="{ element: column, index: i }">
+						<div class="flex items-center gap-1">
+							<div
+								class="column-drag-handle flex h-7 w-7 shrink-0 items-center justify-center"
+							>
+								<span
+									class="lucide-grip-vertical size-4 cursor-grab text-ink-gray-5"
+									aria-hidden="true"
 								/>
-								<Button variant="ghost" icon="lucide-x" @click="removeColumn(i)" />
 							</div>
+							<!-- The label is always a TextInput: read-only at rest, click to
+							     rename. Editing writes a local `draft` (so Esc reverts and
+							     typing doesn't churn the dragged list); commit on Enter/blur. -->
+							<TextInput
+								:ref="editIndex === i ? focusInput : undefined"
+								size="sm"
+								class="min-w-44 flex-1"
+								:readonly="editIndex !== i"
+								:modelValue="editIndex === i ? draft : column.label"
+								@click="editColumn(i)"
+								@update:modelValue="(value: string) => (draft = value)"
+								@keydown.enter.prevent="commitEdit"
+								@keydown.esc.prevent="cancelEdit"
+								@blur="commitEdit"
+							/>
+							<Button variant="ghost" icon="lucide-x" @click="removeColumn(i)" />
+						</div>
+					</template>
+				</Draggable>
+				<div class="flex items-center justify-between gap-2">
+					<!-- A custom #trigger renders the same ghost Button as "Reset" beside
+					     it (gray-5, `+` icon, no chevron). The label is static, so the old
+					     per-add remount (`:key`) and placeholder hacks are gone. When
+					     Reset is hidden, `!flex-1` fills the row and `!justify-start`
+					     left-aligns the icon/label (Button defaults to justify-center). -->
+					<Combobox
+						:options="addableOptions"
+						:modelValue="null"
+						@update:selectedOption="addColumn"
+					>
+						<template #trigger>
+							<Button
+								variant="ghost"
+								label="Add Column"
+								iconLeft="lucide-plus"
+								:class="[
+									'!text-ink-gray-5',
+									canReset ? undefined : '!flex-1 !justify-start',
+								]"
+							/>
 						</template>
-					</Draggable>
-					<div class="flex items-center justify-between gap-2">
-						<!-- A custom #trigger renders the same ghost Button as "Reset" beside
-						     it (gray-5, `+` icon, no chevron). The label is static, so the old
-						     per-add remount (`:key`) and placeholder hacks are gone. When
-						     Reset is hidden, `!flex-1` fills the row and `!justify-start`
-						     left-aligns the icon/label (Button defaults to justify-center). -->
-						<Combobox
-							:options="addableOptions"
-							:modelValue="null"
-							@update:selectedOption="addColumn"
-						>
-							<template #trigger>
-								<Button
-									variant="ghost"
-									label="Add Column"
-									iconLeft="lucide-plus"
-									:class="[
-										'!text-ink-gray-5',
-										canReset ? undefined : '!flex-1 !justify-start',
-									]"
-								/>
-							</template>
-						</Combobox>
-						<!-- Reset to the Meta defaults. The host owns the defaults (ADR-0006),
-						     so this only emits; `canReset` hides it when nothing to undo. The
-						     first click arms an inline confirm, the second emits. -->
-						<Button
-							v-if="canReset"
-							:class="confirmingReset ? undefined : '!text-ink-gray-5'"
-							:variant="confirmingReset ? 'subtle' : 'ghost'"
-							:theme="confirmingReset ? 'red' : 'gray'"
-							:label="confirmingReset ? 'Confirm Reset' : 'Reset'"
-							@click="onResetClick"
-						/>
-					</div>
+					</Combobox>
+					<!-- Reset to the Meta defaults. The host owns the defaults (ADR-0006),
+					     so this only emits; `canReset` hides it when nothing to undo. The
+					     first click arms an inline confirm, the second emits. -->
+					<Button
+						v-if="canReset"
+						:class="confirmingReset ? undefined : '!text-ink-gray-5'"
+						:variant="confirmingReset ? 'subtle' : 'ghost'"
+						:theme="confirmingReset ? 'red' : 'gray'"
+						:label="confirmingReset ? 'Confirm Reset' : 'Reset'"
+						@click="onResetClick"
+					/>
 				</div>
 			</div>
 		</template>

--- a/ui/src/components/Composer/ComposerEditor.vue
+++ b/ui/src/components/Composer/ComposerEditor.vue
@@ -42,7 +42,7 @@
 							@toggle="onQuoteToggle"
 						>
 							<summary
-								class="w-fit cursor-pointer select-none rounded px-1 text-sm font-bold leading-[1.15] text-ink-gray-5 bg-surface-gray-2 list-none [&::-webkit-details-marker]:hidden"
+								class="w-fit cursor-pointer select-none rounded-4 px-1 text-sm font-bold leading-[1.15] text-ink-gray-5 bg-surface-gray-2 list-none [&::-webkit-details-marker]:hidden"
 							>
 								•••
 							</summary>

--- a/ui/src/components/Composer/EmailComposer/RecipientSelect.vue
+++ b/ui/src/components/Composer/EmailComposer/RecipientSelect.vue
@@ -14,7 +14,7 @@
 				<Avatar size="xs" :image="option?.image" :label="option?.label || value" />
 				<span class="mb-0.5 leading-4 truncate">{{ option?.label || value }}</span>
 				<button
-					class="grid size-4 place-items-center rounded-sm text-ink-gray-5 hover:bg-surface-gray-4"
+					class="grid size-4 place-items-center rounded-1 text-ink-gray-5 hover:bg-surface-gray-4"
 					@click.stop="removeTag"
 				>
 					<FeatherIcon name="x" class="size-3" />

--- a/ui/src/components/Composer/stories/CommentThread.vue
+++ b/ui/src/components/Composer/stories/CommentThread.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="rounded-md border border-outline-gray-2 bg-surface-base p-4">
+	<div class="rounded-5 border border-outline-gray-2 bg-surface-base p-4">
 		<div class="flex flex-col gap-4">
 			<div v-for="comment in comments" :key="comment.id" class="flex gap-3">
 				<Avatar size="md" :label="comment.author" />
@@ -19,7 +19,7 @@
 
 		<div class="mt-4 flex gap-3 border-t border-outline-gray-1 pt-4">
 			<Avatar size="md" label="Sydney" />
-			<div class="min-w-0 flex-1 rounded-md border border-outline-gray-2">
+			<div class="min-w-0 flex-1 rounded-5 border border-outline-gray-2">
 				<CommentComposer
 					ref="composerRef"
 					v-model="draft"

--- a/ui/src/components/Composer/stories/Composer.story.vue
+++ b/ui/src/components/Composer/stories/Composer.story.vue
@@ -23,7 +23,7 @@
 			</p>
 			<TicketReply />
 			<pre
-				class="mt-3 overflow-auto rounded-lg bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
+				class="mt-3 overflow-auto rounded-6 bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
 			><code>{{ ticketSnippet }}</code></pre>
 		</section>
 
@@ -37,7 +37,7 @@
 			</p>
 			<DockedCompose />
 			<pre
-				class="mt-3 overflow-auto rounded-lg bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
+				class="mt-3 overflow-auto rounded-6 bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
 			><code>{{ dockedSnippet }}</code></pre>
 		</section>
 
@@ -50,7 +50,7 @@
 			</p>
 			<CommentThread />
 			<pre
-				class="mt-3 overflow-auto rounded-lg bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
+				class="mt-3 overflow-auto rounded-6 bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
 			><code>{{ commentSnippet }}</code></pre>
 		</section>
 
@@ -63,7 +63,7 @@
 			</p>
 			<QuickReply />
 			<pre
-				class="mt-3 overflow-auto rounded-lg bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
+				class="mt-3 overflow-auto rounded-6 bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
 			><code>{{ quickSnippet }}</code></pre>
 		</section>
 
@@ -75,7 +75,7 @@
 			</p>
 			<CustomUtility />
 			<pre
-				class="mt-3 overflow-auto rounded-lg bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
+				class="mt-3 overflow-auto rounded-6 bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
 			><code>{{ utilitySnippet }}</code></pre>
 		</section>
 	</div>

--- a/ui/src/components/Composer/stories/CustomUtility.vue
+++ b/ui/src/components/Composer/stories/CustomUtility.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="rounded-md border border-outline-gray-2 bg-surface-base p-2">
+	<div class="rounded-5 border border-outline-gray-2 bg-surface-base p-2">
 		<EmailComposer
 			ref="composerRef"
 			v-model="body"

--- a/ui/src/components/Composer/stories/DockedCompose.vue
+++ b/ui/src/components/Composer/stories/DockedCompose.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="rounded-md border border-outline-gray-2 p-4">
+	<div class="rounded-5 border border-outline-gray-2 p-4">
 		<p v-if="lastSent" class="mb-3 text-p-sm text-ink-gray-5">Sent “{{ lastSent }}” ✓</p>
 		<!-- FloatingWindow brings dock, float, and minimize; the draft rides along. -->
 		<FloatingWindow title="New message">

--- a/ui/src/components/Composer/stories/QuickReply.vue
+++ b/ui/src/components/Composer/stories/QuickReply.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="rounded-md border border-outline-gray-2 bg-surface-base">
+	<div class="rounded-5 border border-outline-gray-2 bg-surface-base">
 		<div class="flex gap-3 border-b border-outline-gray-2 px-4 py-3">
 			<Avatar size="md" label="Grace Hopper" />
 			<div class="min-w-0">

--- a/ui/src/components/Composer/stories/TicketReply.vue
+++ b/ui/src/components/Composer/stories/TicketReply.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="rounded-md border border-outline-gray-2 bg-surface-base">
+	<div class="rounded-5 border border-outline-gray-2 bg-surface-base">
 		<div class="flex items-center justify-between border-b border-outline-gray-2 px-4 py-3">
 			<div>
 				<div class="text-base font-medium text-ink-gray-9">

--- a/ui/src/components/ConditionBuilder/ConditionBuilder.vue
+++ b/ui/src/components/ConditionBuilder/ConditionBuilder.vue
@@ -34,7 +34,7 @@
 		<div
 			v-if="fieldsError"
 			data-slot="condition-fields-error"
-			class="mb-4 flex items-center gap-2 rounded-md bg-surface-red-2 p-2 text-p-sm text-ink-red-6"
+			class="mb-4 flex items-center gap-2 rounded-5 bg-surface-red-2 p-2 text-p-sm text-ink-red-6"
 		>
 			<span :id="fieldsErrorId" class="min-w-0 flex-1">{{ labels.fieldsError }}</span>
 			<Button
@@ -54,7 +54,7 @@
 			data-slot="condition-empty"
 			:type="readonly ? undefined : 'button'"
 			:tabindex="readonly ? -1 : undefined"
-			class="flex w-full items-center justify-center gap-2 rounded-md border border-outline-gray-2 p-4 text-p-sm text-ink-gray-5"
+			class="flex w-full items-center justify-center gap-2 rounded-5 border border-outline-gray-2 p-4 text-p-sm text-ink-gray-5"
 			:class="!readonly && 'cursor-pointer'"
 			@click="onEmptyClick"
 		>
@@ -67,7 +67,7 @@
 		<div
 			v-else
 			class="flex w-full flex-col gap-4"
-			:class="bordered !== 'none' && 'rounded-lg border border-outline-gray-2 p-3'"
+			:class="bordered !== 'none' && 'rounded-6 border border-outline-gray-2 p-3'"
 		>
 			<ConditionGroup :group="tree" :path="[]">
 				<template v-if="$slots.condition" #condition="slotProps">

--- a/ui/src/components/ConditionBuilder/ConditionGroup.vue
+++ b/ui/src/components/ConditionBuilder/ConditionGroup.vue
@@ -15,7 +15,7 @@
 		:aria-describedby="describedBy || undefined"
 		:aria-invalid="invalid || undefined"
 		class="flex w-full min-w-0 flex-col gap-4"
-		:class="hasCard && 'rounded-lg border border-outline-gray-2 bg-surface-white p-3'"
+		:class="hasCard && 'rounded-6 border border-outline-gray-2 bg-surface-white p-3'"
 	>
 		<legend v-if="rootTag === 'fieldset'" :id="legendId" class="sr-only">
 			{{ groupName }}
@@ -42,7 +42,7 @@
 			role="list"
 			:data-group-path="path.join('.')"
 			:data-condition-builder="builderId"
-			class="flex w-full min-w-0 list-none flex-col gap-4 rounded-md"
+			class="flex w-full min-w-0 list-none flex-col gap-4 rounded-5"
 			:class="canTakeDrag && 'bg-surface-gray-2'"
 			ghost-class="opacity-40"
 			chosen-class="cursor-grabbing"

--- a/ui/src/components/DataImport/MappingStep.vue
+++ b/ui/src/components/DataImport/MappingStep.vue
@@ -19,7 +19,7 @@
 			</div>
 		</div>
 
-		<div v-if="Object.keys(columnMappings).length" class="border rounded-md space-y-8">
+		<div v-if="Object.keys(columnMappings).length" class="border rounded-5 space-y-8">
 			<div class="grid grid-cols-2 text-ink-gray-5 border-b py-2 px-4">
 				<div>Fields in File</div>
 				<div>Fields in System</div>

--- a/ui/src/components/DataImport/PreviewStep.vue
+++ b/ui/src/components/DataImport/PreviewStep.vue
@@ -24,7 +24,7 @@
 
 		<div v-if="mapping.length" class="space-y-2">
 			<div class="text-ink-gray-5 text-sm">Column Mapping</div>
-			<div class="border rounded-md bg-surface-gray-2 p-4 space-y-4 text-sm text-ink-gray-7">
+			<div class="border rounded-5 bg-surface-gray-2 p-4 space-y-4 text-sm text-ink-gray-7">
 				<div
 					v-for="map in mapping"
 					class="grid grid-cols-[40%,10%,40%] lg:grid-cols-3 space-x-3 items-center"
@@ -44,7 +44,7 @@
 
 		<div v-if="warnings.length" class="space-y-2">
 			<div class="text-ink-gray-5 text-sm">Warnings</div>
-			<div class="rounded-md bg-surface-amber-2 p-2 space-y-2 text-xs">
+			<div class="rounded-5 bg-surface-amber-2 p-2 space-y-2 text-xs">
 				<div v-for="warning in warnings" class="flex items-center space-x-2">
 					<FeatherIcon name="alert-circle" class="size-3 text-ink-amber-6" />
 					<div v-html="warning.message" class="text-ink-amber-6"></div>
@@ -52,9 +52,9 @@
 			</div>
 		</div>
 
-		<div v-if="preview?.data?.length" class="border rounded-md overflow-x-auto">
+		<div v-if="preview?.data?.length" class="border rounded-5 overflow-x-auto">
 			<table class="divide-y">
-				<thead class="rounded-t-md">
+				<thead class="rounded-t-5">
 					<tr>
 						<th
 							v-for="column in previewColumns"
@@ -96,7 +96,7 @@
 		<div v-if="data.status != 'Pending' && importLogs.length" class="space-y-4">
 			<div class="font-semibold text-ink-gray-9">Import Logs</div>
 
-			<div class="rounded-md p-2" :class="importBannerClass">
+			<div class="rounded-5 p-2" :class="importBannerClass">
 				{{ importSuccessCount }} {{ importSuccessCount == 1 ? "row" : "rows" }} imported
 				successfully, {{ importErrorCount }}
 				{{ importErrorCount == 1 ? "row" : "rows" }} failed.
@@ -104,9 +104,9 @@
 
 			<TabButtons :buttons="tabButtons" v-model="activeTab" class="w-fit" />
 
-			<div v-if="filteredLogs.length" class="border rounded-md overflow-x-auto">
+			<div v-if="filteredLogs.length" class="border rounded-5 overflow-x-auto">
 				<table class="table-fixed w-full divide-y">
-					<thead class="rounded-t-md">
+					<thead class="rounded-t-5">
 						<tr>
 							<th
 								class="p-2 text-left text-sm text-ink-gray-5 w-20 border-r text-center"
@@ -122,9 +122,9 @@
 								<div class="flex items-center justify-center space-x-2">
 									<div
 										v-if="row.success"
-										class="size-1.5 bg-surface-green-3 rounded"
+										class="size-1.5 bg-surface-green-3 rounded-4"
 									></div>
-									<div v-else class="size-1.5 bg-surface-red-7 rounded"></div>
+									<div v-else class="size-1.5 bg-surface-red-7 rounded-4"></div>
 									<div>
 										{{ JSON.parse(row["row_indexes"])[0] - 1 }}
 									</div>

--- a/ui/src/components/DataImport/UploadStep.vue
+++ b/ui/src/components/DataImport/UploadStep.vue
@@ -22,7 +22,7 @@
 				v-if="showFileSelector && !importFile"
 				@dragover.prevent
 				@drop.prevent="(e) => uploadFile(e)"
-				class="h-[300px] flex items-center justify-center bg-surface-gray-1 border border-dashed border-outline-gray-3 rounded-md"
+				class="h-[300px] flex items-center justify-center bg-surface-gray-1 border border-dashed border-outline-gray-3 rounded-5"
 			>
 				<div v-if="showFileSelector && !uploading" class="w-4/5 lg:w-2/5 text-center">
 					<FeatherIcon
@@ -54,7 +54,7 @@
 				</div>
 				<div
 					v-else-if="showFileSelector && uploading"
-					class="w-4/5 lg:w-2/5 bg-surface-base border rounded-md p-2"
+					class="w-4/5 lg:w-2/5 bg-surface-base border rounded-5 p-2"
 				>
 					<div class="space-y-2">
 						<div class="font-medium">
@@ -74,10 +74,10 @@
 			</div>
 			<div
 				v-else-if="importFile"
-				class="h-[300px] flex items-center justify-center bg-surface-gray-1 border border-dashed border-outline-gray-3 rounded-md"
+				class="h-[300px] flex items-center justify-center bg-surface-gray-1 border border-dashed border-outline-gray-3 rounded-5"
 			>
 				<div
-					class="w-4/5 lg:w-2/5 bg-surface-base border rounded-md p-2 flex items-center justify-between items-center"
+					class="w-4/5 lg:w-2/5 bg-surface-base border rounded-5 p-2 flex items-center justify-between items-center"
 				>
 					<div class="space-y-2">
 						<div class="font-medium leading-5 text-ink-gray-9">
@@ -97,7 +97,7 @@
 
 			<div
 				v-else-if="showSheetSelector"
-				class="flex flex-col h-[300px] p-4 border border-dashed border-outline-gray-3 rounded-md"
+				class="flex flex-col h-[300px] p-4 border border-dashed border-outline-gray-3 rounded-5"
 			>
 				<div class="flex items-center space-x-2 text-ink-gray-7">
 					<FeatherIcon
@@ -113,7 +113,7 @@
 					<input
 						v-model="googleSheet"
 						type="text"
-						class="w-full border border-outline-gray-2 rounded-md px-2.5 text-base"
+						class="w-full border border-outline-gray-2 rounded-5 px-2.5 text-base"
 						placeholder="Add Google Sheets Link"
 					/>
 					<div class="text-ink-gray-5">

--- a/ui/src/components/Fields/AttachField.vue
+++ b/ui/src/components/Fields/AttachField.vue
@@ -43,14 +43,14 @@
 						<img
 							:src="modelValue"
 							alt=""
-							class="size-4 shrink-0 rounded object-cover"
+							class="size-4 shrink-0 rounded-4 object-cover"
 						/>
 					</template>
 					<template #body-main>
 						<img
 							:src="modelValue"
 							alt=""
-							class="max-h-64 max-w-72 rounded-md object-contain p-1"
+							class="max-h-64 max-w-72 rounded-5 object-contain p-1"
 						/>
 					</template>
 				</Popover>
@@ -73,7 +73,7 @@
 					<button
 						type="button"
 						aria-label="Replace"
-						class="grid size-4 shrink-0 place-items-center rounded-sm text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+						class="grid size-4 shrink-0 place-items-center rounded-1 text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
 						@click.stop="openDialog"
 						@pointerdown.stop
 					>
@@ -83,7 +83,7 @@
 						type="button"
 						aria-label="Clear"
 						data-slot="clear"
-						class="grid size-4 shrink-0 place-items-center rounded-sm text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+						class="grid size-4 shrink-0 place-items-center rounded-1 text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
 						@click.stop="clear"
 						@pointerdown.stop
 					>

--- a/ui/src/components/Fields/CodeEditorField.vue
+++ b/ui/src/components/Fields/CodeEditorField.vue
@@ -83,7 +83,7 @@
 					v-show="previewOpen"
 					:modelValue="value"
 					:language="language"
-					class="mt-1 min-h-[4.5rem] rounded-md border border-outline-gray-1 p-3"
+					class="mt-1 min-h-[4.5rem] rounded-5 border border-outline-gray-1 p-3"
 				/>
 			</div>
 		</div>
@@ -103,7 +103,7 @@
 			<CodePreview
 				:modelValue="value"
 				:language="language"
-				class="min-h-[4.5rem] rounded-md border border-outline-gray-1 p-3"
+				class="min-h-[4.5rem] rounded-5 border border-outline-gray-1 p-3"
 			/>
 		</div>
 	</div>

--- a/ui/src/components/Fields/GeolocationField.vue
+++ b/ui/src/components/Fields/GeolocationField.vue
@@ -30,7 +30,7 @@
 					type="button"
 					aria-label="Clear"
 					data-slot="clear"
-					class="group-hover:grid group-focus:grid group-focus-within:grid hidden size-4 place-items-center rounded-sm text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+					class="group-hover:grid group-focus:grid group-focus-within:grid hidden size-4 place-items-center rounded-1 text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
 					@click.stop="clearLocation"
 					@pointerdown.stop
 				>
@@ -49,11 +49,11 @@
 			     empty map (see loadError). -->
 			<div
 				v-if="loadError"
-				class="flex h-[500px] w-full items-center justify-center rounded border border-dashed border-outline-gray-2 p-6 text-center text-p-sm text-ink-gray-6"
+				class="flex h-[500px] w-full items-center justify-center rounded-4 border border-dashed border-outline-gray-2 p-6 text-center text-p-sm text-ink-gray-6"
 			>
 				{{ loadError }}
 			</div>
-			<div v-else :id="mapId" class="h-[500px] w-full rounded" />
+			<div v-else :id="mapId" class="h-[500px] w-full rounded-4" />
 			<template #actions>
 				<div class="flex items-center justify-end gap-2">
 					<Button

--- a/ui/src/components/Fields/ImageField.vue
+++ b/ui/src/components/Fields/ImageField.vue
@@ -16,7 +16,7 @@
 			role="group"
 			:aria-labelledby="labelledBy"
 			:aria-describedby="describedBy"
-			class="flex items-center justify-center overflow-hidden rounded-lg border border-outline-gray-1 bg-surface-gray-1"
+			class="flex items-center justify-center overflow-hidden rounded-6 border border-outline-gray-1 bg-surface-gray-1"
 			:class="url ? 'min-h-32' : 'min-h-24'"
 		>
 			<img

--- a/ui/src/components/FileUpload/AttachmentsList.vue
+++ b/ui/src/components/FileUpload/AttachmentsList.vue
@@ -2,7 +2,7 @@
 	<div class="flex flex-col gap-2">
 		<div
 			v-if="modelValue.length"
-			class="flex flex-col divide-y divide-outline-gray-1 rounded-lg border border-outline-gray-1"
+			class="flex flex-col divide-y divide-outline-gray-1 rounded-6 border border-outline-gray-1"
 		>
 			<a
 				v-for="(attachment, index) in modelValue"
@@ -13,7 +13,7 @@
 				class="group flex items-center gap-3 px-3 py-2 hover:bg-surface-gray-1"
 			>
 				<span
-					class="grid size-9 shrink-0 place-items-center overflow-hidden rounded border border-outline-gray-1 bg-surface-gray-1"
+					class="grid size-9 shrink-0 place-items-center overflow-hidden rounded-4 border border-outline-gray-1 bg-surface-gray-1"
 				>
 					<img
 						v-if="isImage(attachment.file_url)"
@@ -34,7 +34,7 @@
 				<button
 					type="button"
 					aria-label="Remove"
-					class="grid size-5 shrink-0 place-items-center rounded text-ink-gray-5 opacity-0 hover:bg-surface-gray-3 group-hover:opacity-100"
+					class="grid size-5 shrink-0 place-items-center rounded-4 text-ink-gray-5 opacity-0 hover:bg-surface-gray-3 group-hover:opacity-100"
 					@click.prevent="remove(index)"
 				>
 					<span class="lucide-x size-3.5" />
@@ -43,7 +43,7 @@
 		</div>
 		<div
 			v-else
-			class="rounded-lg border border-dashed border-outline-gray-2 p-4 text-center text-p-sm text-ink-gray-5"
+			class="rounded-6 border border-dashed border-outline-gray-2 p-4 text-center text-p-sm text-ink-gray-5"
 		>
 			No attachments yet.
 		</div>

--- a/ui/src/components/FileUpload/FileUploadDialog.vue
+++ b/ui/src/components/FileUpload/FileUploadDialog.vue
@@ -14,7 +14,7 @@
 			     distinct zone from the add-menu below (same row styling otherwise). -->
 			<div
 				v-if="uploader.items.length && !composing"
-				class="mb-1.5 rounded-lg border border-outline-gray-1 bg-surface-gray-2 p-1"
+				class="mb-1.5 rounded-6 border border-outline-gray-1 bg-surface-gray-2 p-1"
 			>
 				<!-- mini-header: count + bulk Set-all privacy. Optimize is image-only,
 				     so it lives on each image row (below), not here. -->
@@ -23,7 +23,7 @@
 					<Dropdown :options="bulkPrivacyOptions">
 						<button
 							type="button"
-							class="flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-ink-gray-6 hover:bg-surface-gray-3"
+							class="flex items-center gap-1 rounded-4 px-1.5 py-0.5 text-xs text-ink-gray-6 hover:bg-surface-gray-3"
 						>
 							<span :class="[bulkPrivacyIcon, 'size-3']" />
 							{{ bulkPrivacyLabel }}
@@ -35,11 +35,11 @@
 				<div
 					v-for="item in uploader.items"
 					:key="item.id"
-					class="group flex items-center gap-2.5 rounded-md px-2 py-1.5 hover:bg-surface-gray-3"
+					class="group flex items-center gap-2.5 rounded-5 px-2 py-1.5 hover:bg-surface-gray-3"
 				>
 					<!-- thumbnail / kind icon -->
 					<div
-						class="flex size-8 flex-shrink-0 items-center justify-center overflow-hidden rounded bg-surface-gray-2"
+						class="flex size-8 flex-shrink-0 items-center justify-center overflow-hidden rounded-4 bg-surface-gray-2"
 					>
 						<img
 							v-if="thumbUrl(item)"
@@ -211,7 +211,7 @@
 						v-for="option in menu"
 						:key="option.key"
 						type="button"
-						class="flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-left hover:bg-surface-gray-2"
+						class="flex w-full items-center gap-2.5 rounded-5 px-2 py-1.5 text-left hover:bg-surface-gray-2"
 						@click="onMenu(option.key)"
 					>
 						<span :class="[option.icon, 'size-4 text-ink-gray-6']" />
@@ -255,7 +255,7 @@
 			<!-- drop overlay — only while dragging files over this popover -->
 			<div
 				v-if="dragging"
-				class="absolute inset-1 z-10 flex flex-col items-center justify-center gap-1.5 rounded-lg border-2 border-dashed border-outline-gray-4 bg-surface-gray-1/90 text-ink-gray-7"
+				class="absolute inset-1 z-10 flex flex-col items-center justify-center gap-1.5 rounded-6 border-2 border-dashed border-outline-gray-4 bg-surface-gray-1/90 text-ink-gray-7"
 			>
 				<span class="lucide-cloud-upload size-7" />
 				<p class="text-p-sm font-medium">Drop files here</p>

--- a/ui/src/components/FileUpload/ImageCropper.vue
+++ b/ui/src/components/FileUpload/ImageCropper.vue
@@ -2,11 +2,11 @@
 	<div class="flex flex-col gap-3">
 		<div
 			v-if="loadError"
-			class="flex h-80 items-center justify-center rounded-lg border border-dashed border-outline-gray-2 p-6 text-center text-p-sm text-ink-gray-6"
+			class="flex h-80 items-center justify-center rounded-6 border border-dashed border-outline-gray-2 p-6 text-center text-p-sm text-ink-gray-6"
 		>
 			{{ loadError }}
 		</div>
-		<div v-show="!loadError" class="h-[60vh] overflow-hidden rounded-lg bg-surface-gray-10">
+		<div v-show="!loadError" class="h-[60vh] overflow-hidden rounded-6 bg-surface-gray-10">
 			<!-- cropperjs v2 replaces this <img> with a <cropper-canvas> tree. -->
 			<img ref="image" :src="objectUrl" alt="" class="block max-w-full" />
 		</div>

--- a/ui/src/components/FileUpload/UploadTray.vue
+++ b/ui/src/components/FileUpload/UploadTray.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
 		v-if="batches.length"
-		class="fixed z-50 w-80 overflow-hidden rounded-lg border border-outline-gray-2 bg-surface-base shadow-lg"
+		class="fixed z-50 w-80 overflow-hidden rounded-6 border border-outline-gray-2 bg-surface-base shadow-lg"
 		:class="positionClass"
 		@mouseenter="onEnter"
 	>
@@ -28,7 +28,7 @@
 			<button
 				type="button"
 				aria-label="Toggle"
-				class="grid size-5 place-items-center rounded text-ink-gray-5 hover:bg-surface-gray-2"
+				class="grid size-5 place-items-center rounded-4 text-ink-gray-5 hover:bg-surface-gray-2"
 				@click="expanded = !expanded"
 			>
 				<span
@@ -39,7 +39,7 @@
 			<button
 				type="button"
 				aria-label="Close"
-				class="grid size-5 place-items-center rounded text-ink-gray-5 hover:bg-surface-gray-2"
+				class="grid size-5 place-items-center rounded-4 text-ink-gray-5 hover:bg-surface-gray-2"
 				@click="dismiss"
 			>
 				<span class="lucide-x size-4" />
@@ -73,7 +73,7 @@
 						v-if="item.status === 'uploading' && batch.cancel"
 						type="button"
 						aria-label="Cancel"
-						class="grid size-4 place-items-center rounded text-ink-gray-5 hover:bg-surface-gray-2"
+						class="grid size-4 place-items-center rounded-4 text-ink-gray-5 hover:bg-surface-gray-2"
 						@click="batch.cancel(item.id)"
 					>
 						<span class="lucide-x size-3" />
@@ -82,7 +82,7 @@
 						v-if="item.status === 'error' && batch.retry"
 						type="button"
 						aria-label="Retry"
-						class="grid size-4 place-items-center rounded text-ink-gray-5 hover:bg-surface-gray-2"
+						class="grid size-4 place-items-center rounded-4 text-ink-gray-5 hover:bg-surface-gray-2"
 						@click="batch.retry(item.id)"
 					>
 						<span class="lucide-rotate-cw size-3" />

--- a/ui/src/components/FileUpload/sources/CameraSource.vue
+++ b/ui/src/components/FileUpload/sources/CameraSource.vue
@@ -2,7 +2,7 @@
 	<div class="flex flex-col items-center gap-3">
 		<div
 			v-if="error"
-			class="flex min-h-64 w-full items-center justify-center rounded-lg border border-dashed border-outline-gray-2 p-6 text-center text-p-sm text-ink-gray-6"
+			class="flex min-h-64 w-full items-center justify-center rounded-6 border border-dashed border-outline-gray-2 p-6 text-center text-p-sm text-ink-gray-6"
 		>
 			{{ error }}
 		</div>
@@ -10,11 +10,11 @@
 			<video
 				v-show="!snapshot"
 				ref="video"
-				class="max-h-80 w-full rounded-lg bg-surface-gray-10"
+				class="max-h-80 w-full rounded-6 bg-surface-gray-10"
 				autoplay
 				playsinline
 			/>
-			<canvas v-show="snapshot" ref="canvas" class="max-h-80 w-full rounded-lg" />
+			<canvas v-show="snapshot" ref="canvas" class="max-h-80 w-full rounded-6" />
 			<div class="flex w-full items-center justify-end gap-2">
 				<template v-if="!snapshot">
 					<Button

--- a/ui/src/components/Filter/Filter.vue
+++ b/ui/src/components/Filter/Filter.vue
@@ -32,14 +32,13 @@
 	</Combobox>
 
 	<!-- Non-empty: the filter popover with its condition rows. -->
-	<Popover v-else ref="popoverRef" placement="bottom-end">
-		<template #target="{ togglePopover, close }">
+	<Popover v-else ref="popoverRef" side="bottom" align="end">
+		<template #trigger="{ close }">
 			<div class="flex items-center">
 				<Button
 					label="Filter"
 					class="relative rounded-r-none focus-visible:z-10"
 					iconLeft="lucide-list-filter"
-					@click="togglePopover"
 				>
 					<template #suffix>
 						<div
@@ -57,91 +56,87 @@
 				/>
 			</div>
 		</template>
-		<template #body="{ close }">
-			<div
-				class="my-2 min-w-40 rounded-lg bg-surface-elevation-2 shadow-2xl ring-1 ring-black ring-opacity-5 focus:outline-none"
-			>
-				<div class="min-w-72 p-2 sm:min-w-[400px]">
-					<!-- One grid for all rows so the field / operator / value columns
-					     line up across rows instead of each row sizing to its own
-					     content. Columns auto-size to the widest cell; the controls
-					     fill their column (`w-full`) so every box shares a width. -->
-					<div
-						v-if="model.length"
-						class="mb-3 grid grid-cols-[auto_auto_auto_auto_auto] items-center gap-x-2 gap-y-3"
+		<template #default="{ close }">
+			<div class="min-w-72 p-2 sm:min-w-[400px]">
+				<!-- One grid for all rows so the field / operator / value columns
+				     line up across rows instead of each row sizing to its own
+				     content. Columns auto-size to the widest cell; the controls
+				     fill their column (`w-full`) so every box shares a width. -->
+				<div
+					v-if="model.length"
+					class="mb-3 grid grid-cols-[auto_auto_auto_auto_auto] items-center gap-x-2 gap-y-3"
+				>
+					<template v-for="(f, i) in model" :key="i">
+						<div class="w-13 pl-2 text-end text-base text-ink-gray-5">
+							{{ i == 0 ? "Where" : "And" }}
+						</div>
+						<div class="min-w-[140px]">
+							<Combobox
+								class="w-full"
+								trigger="button"
+								variant="subtle"
+								size="md"
+								:modelValue="f.fieldname"
+								:options="allFields"
+								placeholder="Select field"
+								@update:selectedOption="(o) => updateField(o, i)"
+							/>
+						</div>
+						<div>
+							<Select
+								class="w-full"
+								:modelValue="f.operator"
+								:options="getOperators(f.field?.fieldtype ?? '', f.fieldname)"
+								placeholder="Equals"
+								@update:modelValue="(v) => updateOperator(v, i)"
+							/>
+						</div>
+						<div class="w-[180px]">
+							<component
+								:is="VALUE_CONTROLS[valueControl(f).control]"
+								v-bind="valueControl(f).props"
+								class="w-full"
+								:modelValue="f.value"
+								@update:modelValue="(v) => updateValue(v, i)"
+							/>
+						</div>
+						<Button
+							class="flex"
+							variant="ghost"
+							icon="lucide-x"
+							@click="removeFilter(i)"
+						/>
+					</template>
+				</div>
+				<div v-else class="mb-3 flex h-7 items-center px-3 text-sm text-ink-gray-5">
+					Empty - Choose a field to filter by
+				</div>
+				<div class="flex items-center justify-between gap-2">
+					<!-- A custom #trigger renders the same ghost Button as "Clear All
+					     Filters" beside it (gray-5, `+` icon, no chevron). The label is
+					     static, so the old per-add remount (`:key`) and the placeholder /
+					     chevron CSS hacks are no longer needed. -->
+					<Combobox
+						:options="allFields"
+						:modelValue="null"
+						@update:selectedOption="addFilter"
 					>
-						<template v-for="(f, i) in model" :key="i">
-							<div class="w-13 pl-2 text-end text-base text-ink-gray-5">
-								{{ i == 0 ? "Where" : "And" }}
-							</div>
-							<div class="min-w-[140px]">
-								<Combobox
-									class="w-full"
-									trigger="button"
-									variant="subtle"
-									size="md"
-									:modelValue="f.fieldname"
-									:options="allFields"
-									placeholder="Select field"
-									@update:selectedOption="(o) => updateField(o, i)"
-								/>
-							</div>
-							<div>
-								<Select
-									class="w-full"
-									:modelValue="f.operator"
-									:options="getOperators(f.field?.fieldtype ?? '', f.fieldname)"
-									placeholder="Equals"
-									@update:modelValue="(v) => updateOperator(v, i)"
-								/>
-							</div>
-							<div class="w-[180px]">
-								<component
-									:is="VALUE_CONTROLS[valueControl(f).control]"
-									v-bind="valueControl(f).props"
-									class="w-full"
-									:modelValue="f.value"
-									@update:modelValue="(v) => updateValue(v, i)"
-								/>
-							</div>
+						<template #trigger>
 							<Button
-								class="flex"
+								class="!text-ink-gray-5"
 								variant="ghost"
-								icon="lucide-x"
-								@click="removeFilter(i)"
+								label="Add Filter"
+								iconLeft="lucide-plus"
 							/>
 						</template>
-					</div>
-					<div v-else class="mb-3 flex h-7 items-center px-3 text-sm text-ink-gray-5">
-						Empty - Choose a field to filter by
-					</div>
-					<div class="flex items-center justify-between gap-2">
-						<!-- A custom #trigger renders the same ghost Button as "Clear All
-						     Filters" beside it (gray-5, `+` icon, no chevron). The label is
-						     static, so the old per-add remount (`:key`) and the placeholder /
-						     chevron CSS hacks are no longer needed. -->
-						<Combobox
-							:options="allFields"
-							:modelValue="null"
-							@update:selectedOption="addFilter"
-						>
-							<template #trigger>
-								<Button
-									class="!text-ink-gray-5"
-									variant="ghost"
-									label="Add Filter"
-									iconLeft="lucide-plus"
-								/>
-							</template>
-						</Combobox>
-						<Button
-							v-if="model.length"
-							class="!text-ink-gray-5"
-							variant="ghost"
-							label="Clear All Filters"
-							@click="clearAll(close)"
-						/>
-					</div>
+					</Combobox>
+					<Button
+						v-if="model.length"
+						class="!text-ink-gray-5"
+						variant="ghost"
+						label="Clear All Filters"
+						@click="clearAll(close)"
+					/>
 				</div>
 			</div>
 		</template>

--- a/ui/src/components/FormLayout/FormLayout.vue
+++ b/ui/src/components/FormLayout/FormLayout.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
 		class="flex flex-col"
-		:class="{ 'border border-outline-gray-1 border-outline-elevation-2 rounded-lg': hasTabs }"
+		:class="{ 'border border-outline-gray-1 border-outline-elevation-2 rounded-6': hasTabs }"
 	>
 		<Tabs
 			:model-value="activeIndex"

--- a/ui/src/components/Grid/Grid.vue
+++ b/ui/src/components/Grid/Grid.vue
@@ -27,7 +27,7 @@
 
 		<div
 			v-if="columns.length"
-			class="relative isolate overflow-hidden rounded border border-outline-gray-2"
+			class="relative isolate overflow-hidden rounded-4 border border-outline-gray-2"
 			:class="{ 'grid-disabled': disabled }"
 		>
 			<!-- Scroller + shadows share a `relative` box so the shadows clamp to the

--- a/ui/src/components/InviteUser/stories/InviteUser.story.vue
+++ b/ui/src/components/InviteUser/stories/InviteUser.story.vue
@@ -12,7 +12,7 @@
 			<Switch v-model="showResultToasts" label="Result toasts" />
 		</div>
 
-		<div class="rounded-lg border border-outline-gray-2 p-4">
+		<div class="rounded-6 border border-outline-gray-2 p-4">
 			<InviteUser
 				v-bind="controller"
 				:show-result-toasts="showResultToasts"
@@ -28,7 +28,7 @@
 		     owned by the panel. Use a field slot only when you need to replace the
 		     rendered field wholesale. -->
 		<h4 class="mb-2 mt-8 text-lg-semibold text-ink-gray-9">emailProps / rolesProps</h4>
-		<div class="rounded-lg border border-outline-gray-2 p-4">
+		<div class="rounded-6 border border-outline-gray-2 p-4">
 			<InviteUser
 				v-bind="controller"
 				:show-result-toasts="showResultToasts"

--- a/ui/src/components/Link/Link.vue
+++ b/ui/src/components/Link/Link.vue
@@ -28,7 +28,7 @@
 				type="button"
 				aria-label="Clear"
 				data-slot="clear"
-				class="group-hover:grid group-focus:grid group-focus-within:grid hidden size-4 place-items-center rounded-sm text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+				class="group-hover:grid group-focus:grid group-focus-within:grid hidden size-4 place-items-center rounded-1 text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
 				@click.stop="clearValue"
 				@pointerdown.stop
 			>
@@ -39,7 +39,7 @@
 				type="button"
 				aria-label="Edit linked record"
 				data-slot="edit"
-				class="group-hover:grid group-focus:grid group-focus-within:grid hidden size-4 place-items-center rounded-sm text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+				class="group-hover:grid group-focus:grid group-focus-within:grid hidden size-4 place-items-center rounded-1 text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
 				@click.stop="emit('edit', model!)"
 				@pointerdown.stop
 			>
@@ -50,7 +50,7 @@
 				type="button"
 				aria-label="Open linked record"
 				data-slot="redirect"
-				class="group-hover:grid group-focus:grid group-focus-within:grid hidden size-4 place-items-center rounded-sm text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+				class="group-hover:grid group-focus:grid group-focus-within:grid hidden size-4 place-items-center rounded-1 text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
 				@click.stop="emit('redirect', model!)"
 				@pointerdown.stop
 			>

--- a/ui/src/components/ListView/ListViewShell.vue
+++ b/ui/src/components/ListView/ListViewShell.vue
@@ -18,7 +18,7 @@
 -->
 <template>
 	<div
-		class="flex min-h-0 flex-col overflow-hidden rounded-lg border border-outline-gray-1 bg-surface-base"
+		class="flex min-h-0 flex-col overflow-hidden rounded-6 border border-outline-gray-1 bg-surface-base"
 	>
 		<!-- Toolbar region: the home of the list-view controls. The slotted content
 		     owns its own alignment (quick filters left, Filter/Sort right). -->

--- a/ui/src/components/Notifications/stories/Notifications.story.vue
+++ b/ui/src/components/Notifications/stories/Notifications.story.vue
@@ -14,7 +14,7 @@
 			<Switch v-model="errored" label="Error" />
 		</div>
 
-		<div class="h-[480px] rounded-lg border border-outline-gray-2 overflow-hidden">
+		<div class="h-[480px] rounded-6 border border-outline-gray-2 overflow-hidden">
 			<NotificationPanel
 				v-bind="controller"
 				:tabs="withTabs ? tabs : undefined"

--- a/ui/src/components/Onboarding/GettingStartedBanner.vue
+++ b/ui/src/components/Onboarding/GettingStartedBanner.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
 		v-if="!isSidebarCollapsed"
-		class="flex flex-col gap-3 shadow-sm rounded-lg py-2.5 px-3 bg-surface-elevation-2 text-base"
+		class="flex flex-col gap-3 shadow-sm rounded-6 py-2.5 px-3 bg-surface-elevation-2 text-base"
 	>
 		<div v-if="stepsCompleted != totalSteps" class="inline-flex text-ink-gray-9 gap-2">
 			<StepsIcon class="h-4 my-0.5 shrink-0" />

--- a/ui/src/components/Onboarding/HelpCenter.vue
+++ b/ui/src/components/Onboarding/HelpCenter.vue
@@ -21,7 +21,7 @@
 		<div class="flex flex-col gap-1.5 overflow-y-auto">
 			<div v-for="a in parsedArticles" :key="a.title" class="flex flex-col gap-1.5">
 				<div
-					class="flex items-center justify-between p-1.5 hover:bg-surface-gray-1 rounded cursor-pointer"
+					class="flex items-center justify-between p-1.5 hover:bg-surface-gray-1 rounded-4 cursor-pointer"
 					@click="a.opened = !a.opened"
 				>
 					<div class="flex items-center gap-2">
@@ -36,7 +36,7 @@
 					<div
 						v-for="subArticle in a.subArticles"
 						:key="subArticle.name"
-						class="group flex items-center justify-between gap-2 p-1.5 hover:bg-surface-gray-1 rounded cursor-pointer"
+						class="group flex items-center justify-between gap-2 p-1.5 hover:bg-surface-gray-1 rounded-4 cursor-pointer"
 						@click="() => openDoc(subArticle.name)"
 					>
 						<div class="flex items-center gap-2">

--- a/ui/src/components/Onboarding/HelpModal.vue
+++ b/ui/src/components/Onboarding/HelpModal.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
 		v-show="show"
-		class="fixed z-50 right-0 w-80 h-[calc(100%_-_80px)] text-ink-gray-9 m-5 mt-[62px] p-3 flex gap-2 flex-col justify-between rounded-lg bg-surface-elevation-2 shadow-2xl"
+		class="fixed z-50 right-0 w-80 h-[calc(100%_-_80px)] text-ink-gray-9 m-5 mt-[62px] p-3 flex gap-2 flex-col justify-between rounded-6 bg-surface-elevation-2 shadow-2xl"
 		:class="{ 'top-[calc(100%_-_120px)] border': minimize }"
 		@click.stop
 	>
@@ -36,7 +36,7 @@
 		</div>
 		<div v-for="item in footerItems" class="flex flex-col gap-1.5">
 			<div
-				class="w-full flex gap-2 items-center hover:bg-surface-gray-1 text-ink-gray-8 rounded px-2 py-1.5 cursor-pointer"
+				class="w-full flex gap-2 items-center hover:bg-surface-gray-1 text-ink-gray-8 rounded-4 px-2 py-1.5 cursor-pointer"
 				@click="item.onClick"
 			>
 				<component :is="item.icon" class="h-4" />

--- a/ui/src/components/Onboarding/IntermediateStepModal.vue
+++ b/ui/src/components/Onboarding/IntermediateStepModal.vue
@@ -9,7 +9,7 @@
 					<div v-if="currentStep.message">{{ currentStep.message }}</div>
 					<video
 						v-if="currentStep.videoURL"
-						class="w-full rounded"
+						class="w-full rounded-4"
 						controls
 						autoplay
 						muted

--- a/ui/src/components/Onboarding/OnboardingSteps.vue
+++ b/ui/src/components/Onboarding/OnboardingSteps.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="flex flex-col justify-center items-center gap-1 mt-4 mb-7">
-		<component :is="logo" class="size-10 shrink-0 rounded mb-4" />
+		<component :is="logo" class="size-10 shrink-0 rounded-4 mb-4" />
 		<div class="text-base font-medium">
 			{{ "Welcome to " + title }}
 		</div>
@@ -34,7 +34,7 @@
 			<div
 				v-for="step in steps"
 				:key="step.title"
-				class="group w-full flex gap-2 justify-between items-center hover:bg-surface-gray-1 rounded px-2 py-1.5 cursor-pointer"
+				class="group w-full flex gap-2 justify-between items-center hover:bg-surface-gray-1 rounded-4 px-2 py-1.5 cursor-pointer"
 				@click.stop="() => !step.completed && !isDependent(step) && step.onClick?.()"
 			>
 				<component

--- a/ui/src/components/Phone/Phone.vue
+++ b/ui/src/components/Phone/Phone.vue
@@ -33,7 +33,7 @@
 					type="button"
 					data-slot="country"
 					:data-state="open ? 'open' : 'closed'"
-					class="flex min-w-[50px] items-center justify-center gap-1 self-stretch rounded-l px-2 focus:outline-none"
+					class="flex min-w-[50px] items-center justify-center gap-1 self-stretch rounded-l-4 px-2 focus:outline-none"
 					:class="disabled && 'cursor-not-allowed'"
 					:disabled="disabled"
 					:aria-label="
@@ -48,7 +48,7 @@
 						v-if="phoneDetails.country"
 						:src="getFlagUrl(phoneDetails.country)"
 						:alt="phoneDetails.country.name"
-						class="h-3 w-4 rounded-sm object-cover"
+						class="h-3 w-4 rounded-1 object-cover"
 					/>
 					<!-- Same-size placeholder so the chevron never shifts. -->
 					<span v-else class="lucide-globe size-4 shrink-0 text-ink-gray-6" />
@@ -110,7 +110,7 @@
 						<img
 							:src="getFlagUrl(item.country)"
 							alt=""
-							class="h-3 w-4 rounded-sm object-cover"
+							class="h-3 w-4 rounded-1 object-cover"
 							loading="lazy"
 							decoding="async"
 						/>
@@ -218,10 +218,10 @@ const numberInputClasses = computed(() => [
 
 const inputClasses = computed(() => {
 	const sizeClasses = {
-		sm: "h-7 rounded",
-		md: "h-8 rounded",
-		lg: "h-10 rounded-md",
-		xl: "h-10 rounded-md",
+		sm: "h-7 rounded-4",
+		md: "h-8 rounded-4",
+		lg: "h-10 rounded-5",
+		xl: "h-10 rounded-5",
 	}[props.size];
 
 	const variantClasses = props.disabled

--- a/ui/src/components/QuickFilter/QuickFilterInputs.vue
+++ b/ui/src/components/QuickFilter/QuickFilterInputs.vue
@@ -34,29 +34,37 @@
 				@update:modelValue="(v: boolean) => setValue(field, v)"
 			/>
 			<!-- The fieldtype's value control. Free-text fields (and name) carry a
-			     ≈/= operator toggle as a prefix inside the input; clicking it flips
-			     like ↔ equals in place (and, for name, swaps text box ↔ Link pick). -->
-			<component
-				v-else
-				:is="valueControl(field).is"
-				v-bind="valueControl(field).props"
-				class="w-full"
-				:modelValue="displayValue(field)"
-				@update:modelValue="(v: FilterValue) => setValue(field, v)"
-			>
-				<template v-if="hasOperatorToggle(field)" #prefix>
+			     ≈/= operator toggle over the input's start; clicking it flips
+			     like ↔ equals in place (and, for name, swaps text box ↔ Link pick).
+			     The toggle sits outside the control, so the swap neither moves nor
+			     remounts it; the control gets a spacer where the toggle shows. -->
+			<div v-else class="relative flex">
+				<component
+					:is="valueControl(field).is"
+					v-bind="valueControl(field).props"
+					class="w-full"
+					:modelValue="displayValue(field)"
+					@update:modelValue="(v: FilterValue) => setValue(field, v)"
+				>
+					<template v-if="hasOperatorToggle(field)" #prefix>
+						<span class="block w-3.5 shrink-0" aria-hidden="true" />
+					</template>
+				</component>
+				<Tooltip
+					v-if="hasOperatorToggle(field)"
+					:text="operatorLabel(activeOperator(field))"
+				>
 					<button
 						type="button"
-						class="grid size-5 place-items-center rounded text-xs font-medium text-ink-gray-5 hover:bg-surface-gray-4 hover:text-ink-gray-8"
-						:title="operatorLabel(activeOperator(field))"
+						class="absolute start-1 top-1/2 grid size-5 -translate-y-1/2 place-items-center rounded-3 text-xs font-medium text-ink-gray-5 hover:bg-surface-gray-4 hover:text-ink-gray-8"
 						:aria-label="operatorLabel(activeOperator(field))"
 						@pointerdown.stop
 						@click.stop="toggleOperator(field)"
 					>
 						{{ operatorSymbol(activeOperator(field)) }}
 					</button>
-				</template>
-			</component>
+				</Tooltip>
+			</div>
 		</div>
 		<!-- Overflow affordance: collapsed inputs hide behind a count; expanding
 		     shows all and lets them wrap. A `subtle` pill (not bare ghost text) so it
@@ -82,7 +90,7 @@
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from "vue";
-import { Button, Checkbox, TextInput, debounce } from "frappe-ui";
+import { Button, Checkbox, TextInput, Tooltip, debounce } from "frappe-ui";
 import {
 	applyQuick,
 	hasOperatorToggle,
@@ -301,9 +309,14 @@ function bareField(field: FilterField, overrides: Partial<FieldMeta> = {}): Fiel
 function valueControl(field: FilterField): ValueControl {
 	const fieldtype = field.fieldtype;
 	if (isNameField(field)) {
+		// The picker's input fills its trigger, so its text centres like the text box's and the
+		// placeholder stays still when the toggle swaps them.
 		return activeOperator(field) === "equals"
-			? { is: LinkField, props: { field: bareField(field) } }
-			: { is: TextInput, props: { type: "text", placeholder: field.label } };
+			? {
+					is: LinkField,
+					props: { field: bareField(field), class: "[&_input]:h-full" },
+			  }
+			: textControl(field);
 	}
 	if (fieldtype === "Link") {
 		return { is: LinkField, props: { field: bareField(field) } };
@@ -318,6 +331,12 @@ function valueControl(field: FilterField): ValueControl {
 	if (fieldtype === "Date") return { is: DateField, props: { field: bareField(field) } };
 	if (fieldtype === "Datetime") return { is: DatetimeField, props: { field: bareField(field) } };
 	if (fieldtype === "Duration") return { is: DurationField, props: { field: bareField(field) } };
-	return { is: TextInput, props: { type: "text", placeholder: field.label } };
+	return textControl(field);
+}
+
+/** With the toggle over its start, the text box keeps 2px between the toggle and the text. */
+function textControl(field: FilterField): ValueControl {
+	const inset = hasOperatorToggle(field) ? "[&_input]:ps-[26px]" : undefined;
+	return { is: TextInput, props: { type: "text", placeholder: field.label, class: inset } };
 }
 </script>

--- a/ui/src/components/SignupBanner/SignupBanner.vue
+++ b/ui/src/components/SignupBanner/SignupBanner.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
 		v-if="!isSidebarCollapsed"
-		class="flex flex-col gap-3 shadow-sm rounded-lg py-2.5 px-3 bg-surface-base text-base"
+		class="flex flex-col gap-3 shadow-sm rounded-6 py-2.5 px-3 bg-surface-base text-base"
 	>
 		<div class="flex flex-col gap-1">
 			<slot>

--- a/ui/src/components/SortBy/SortBy.vue
+++ b/ui/src/components/SortBy/SortBy.vue
@@ -32,14 +32,13 @@
 	</Combobox>
 
 	<!-- Non-empty: the sort popover (single-sort compact / multi-sort badge). -->
-	<Popover v-else placement="bottom-end">
-		<template #target="{ isOpen, togglePopover }">
+	<Popover v-else side="bottom" align="end">
+		<template #trigger="{ open }">
 			<Button
 				v-if="model.length > 1"
 				:label="'Sort'"
 				:icon="hideLabel ? 'lucide-arrow-up-down' : undefined"
 				:iconLeft="!hideLabel ? 'lucide-arrow-up-down' : undefined"
-				@click="togglePopover"
 			>
 				<template #suffix>
 					<div
@@ -58,87 +57,80 @@
 				<Button
 					:label="firstSortLabel"
 					class="relative shrink-0 rounded-l-none [&_svg]:text-ink-gray-5 focus-visible:z-10"
-					:iconRight="isOpen ? 'lucide-chevron-up' : 'lucide-chevron-down'"
-					@click.stop="togglePopover"
+					:iconRight="open ? 'lucide-chevron-up' : 'lucide-chevron-down'"
 				/>
 			</div>
 		</template>
-		<template #body="{ close }">
-			<div
-				class="my-2 min-w-40 rounded-lg bg-surface-elevation-2 shadow-2xl ring-1 ring-black ring-opacity-5 focus:outline-none"
-			>
-				<div class="min-w-60 p-2">
-					<Draggable
-						v-if="model.length"
-						class="mb-3 flex flex-col gap-2"
-						:modelValue="model"
-						:item-key="(s) => s.fieldname"
-						handle=".sort-drag-handle"
-						tag="div"
-						@update:modelValue="reorder"
-					>
-						<template #item="{ element: sort, index: i }">
-							<div class="flex items-center gap-1">
-								<div
-									class="sort-drag-handle flex h-7 w-7 items-center justify-center"
-								>
-									<span
-										class="lucide-grip-vertical size-4 cursor-grab text-ink-gray-5"
-										aria-hidden="true"
-									/>
-								</div>
-								<div class="flex flex-1">
-									<Button
-										size="md"
-										class="relative rounded-r-none border-r focus-visible:z-10"
-										:icon="directionIcon(sort.direction)"
-										@click="toggleDirection(i)"
-									/>
-									<Combobox
-										class="relative flex-1 rounded-l-none focus-within:z-10"
-										trigger="button"
-										variant="subtle"
-										size="md"
-										:modelValue="sort.fieldname"
-										:options="optionsFor(sort.fieldname)"
-										placeholder="Select field"
-										@update:selectedOption="(o) => updateSort(o, i)"
-									/>
-								</div>
-								<Button variant="ghost" icon="lucide-x" @click="removeSort(i)" />
-							</div>
-						</template>
-					</Draggable>
-					<div v-else class="mb-3 flex h-7 items-center px-3 text-sm text-ink-gray-5">
-						Empty - Choose a field to sort by
-					</div>
-					<div class="flex items-center justify-between gap-2">
-						<!-- A custom #trigger renders the same ghost Button as "Clear Sort"
-						     beside it (gray-5, `+` icon, no chevron). The label is static, so
-						     the old per-add remount (`:key`) and the placeholder / chevron CSS
-						     hacks are no longer needed. -->
-						<Combobox
-							:options="addableOptions"
-							:modelValue="null"
-							@update:selectedOption="addSort"
-						>
-							<template #trigger>
-								<Button
-									class="!text-ink-gray-5"
-									variant="ghost"
-									label="Add Sort"
-									iconLeft="lucide-plus"
+		<template #default="{ close }">
+			<div class="min-w-60 p-2">
+				<Draggable
+					v-if="model.length"
+					class="mb-3 flex flex-col gap-2"
+					:modelValue="model"
+					:item-key="(s) => s.fieldname"
+					handle=".sort-drag-handle"
+					tag="div"
+					@update:modelValue="reorder"
+				>
+					<template #item="{ element: sort, index: i }">
+						<div class="flex items-center gap-1">
+							<div class="sort-drag-handle flex h-7 w-7 items-center justify-center">
+								<span
+									class="lucide-grip-vertical size-4 cursor-grab text-ink-gray-5"
+									aria-hidden="true"
 								/>
-							</template>
-						</Combobox>
-						<Button
-							v-if="model.length"
-							class="!text-ink-gray-5"
-							variant="ghost"
-							:label="'Clear Sort'"
-							@click="clearSort(close)"
-						/>
-					</div>
+							</div>
+							<div class="flex flex-1">
+								<Button
+									size="md"
+									class="relative rounded-r-none border-r focus-visible:z-10"
+									:icon="directionIcon(sort.direction)"
+									@click="toggleDirection(i)"
+								/>
+								<Combobox
+									class="relative flex-1 rounded-l-none focus-within:z-10"
+									trigger="button"
+									variant="subtle"
+									size="md"
+									:modelValue="sort.fieldname"
+									:options="optionsFor(sort.fieldname)"
+									placeholder="Select field"
+									@update:selectedOption="(o) => updateSort(o, i)"
+								/>
+							</div>
+							<Button variant="ghost" icon="lucide-x" @click="removeSort(i)" />
+						</div>
+					</template>
+				</Draggable>
+				<div v-else class="mb-3 flex h-7 items-center px-3 text-sm text-ink-gray-5">
+					Empty - Choose a field to sort by
+				</div>
+				<div class="flex items-center justify-between gap-2">
+					<!-- A custom #trigger renders the same ghost Button as "Clear Sort"
+					     beside it (gray-5, `+` icon, no chevron). The label is static, so
+					     the old per-add remount (`:key`) and the placeholder / chevron CSS
+					     hacks are no longer needed. -->
+					<Combobox
+						:options="addableOptions"
+						:modelValue="null"
+						@update:selectedOption="addSort"
+					>
+						<template #trigger>
+							<Button
+								class="!text-ink-gray-5"
+								variant="ghost"
+								label="Add Sort"
+								iconLeft="lucide-plus"
+							/>
+						</template>
+					</Combobox>
+					<Button
+						v-if="model.length"
+						class="!text-ink-gray-5"
+						variant="ghost"
+						:label="'Clear Sort'"
+						@click="clearSort(close)"
+					/>
 				</div>
 			</div>
 		</template>

--- a/ui/src/components/TableMultiSelect/TableMultiSelect.vue
+++ b/ui/src/components/TableMultiSelect/TableMultiSelect.vue
@@ -17,21 +17,21 @@
 				type="button"
 				:disabled="disabled"
 				:data-state="open ? 'open' : 'closed'"
-				class="flex min-h-7 w-full cursor-pointer items-center gap-1.5 rounded border border-[--surface-gray-2] bg-surface-gray-2 px-1.5 py-1 text-left text-ink-gray-7 outline-none transition-colors hover:border-outline-elevation-2 hover:bg-surface-gray-3 focus-visible:ring-2 data-[state=open]:ring-2 ring-outline-gray-3 disabled:cursor-not-allowed disabled:bg-surface-gray-1 disabled:text-ink-gray-4"
+				class="flex min-h-7 w-full cursor-pointer items-center gap-1.5 rounded-4 border border-[--surface-gray-2] bg-surface-gray-2 px-1.5 py-1 text-left text-ink-gray-7 outline-none transition-colors hover:border-outline-elevation-2 hover:bg-surface-gray-3 focus-visible:ring-2 data-[state=open]:ring-2 ring-outline-gray-3 disabled:cursor-not-allowed disabled:bg-surface-gray-1 disabled:text-ink-gray-4"
 				@click="toggleOpen"
 			>
 				<div class="flex min-w-0 flex-1 flex-wrap items-center gap-1">
 					<span
 						v-for="option in selectedOptions"
 						:key="option.value"
-						class="inline-flex h-7 items-center gap-1 rounded border border-outline-gray-1 bg-surface-base px-1.5 text-sm text-ink-gray-7 transition-colors hover:border-outline-gray-2 hover:bg-surface-gray-1"
+						class="inline-flex h-7 items-center gap-1 rounded-4 border border-outline-gray-1 bg-surface-base px-1.5 text-sm text-ink-gray-7 transition-colors hover:border-outline-gray-2 hover:bg-surface-gray-1"
 					>
 						{{ option.label }}
 						<span
 							v-if="!disabled"
 							role="button"
 							tabindex="-1"
-							class="-mr-0.5 inline-flex cursor-pointer items-center justify-center rounded-sm p-0.5 opacity-70 hover:opacity-100"
+							class="-mr-0.5 inline-flex cursor-pointer items-center justify-center rounded-1 p-0.5 opacity-70 hover:opacity-100"
 							@click.stop="removeTag(option.value)"
 							@pointerdown.stop
 						>

--- a/ui/src/components/TrialBanner/TrialBanner.vue
+++ b/ui/src/components/TrialBanner/TrialBanner.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
 		v-if="!isSidebarCollapsed && showBanner"
-		class="flex flex-col gap-3 shadow-sm rounded-lg py-2.5 px-3 bg-surface-elevation-2 text-base"
+		class="flex flex-col gap-3 shadow-sm rounded-6 py-2.5 px-3 bg-surface-elevation-2 text-base"
 	>
 		<div class="flex flex-col gap-1">
 			<div class="inline-flex text-ink-gray-9 gap-2 items-center font-medium">

--- a/ui/src/experimental/List/List.vue
+++ b/ui/src/experimental/List/List.vue
@@ -13,11 +13,11 @@
 			divider="inset"
 			:columns="tracks"
 			:rowHeight="rowHeight"
-			:style="{ '--list-row-padding-x': ROW_PADDING_X }"
+			:style="{ '--list-row-padding-x': ROW_PADDING_X, paddingInline }"
 			class="flex w-max min-w-full flex-col"
 		>
 			<ListHeader class="group sticky top-0 z-10 bg-surface-base">
-				<div class="flex items-center justify-center" role="columnheader">
+				<div class="flex items-center ps-[calc(0.5rem+1px)]" role="columnheader">
 					<Checkbox
 						:modelValue="selectAllState === 'all'"
 						:indeterminate="selectAllState === 'some'"
@@ -41,13 +41,14 @@
 						{{ column.label }}
 					</ListHeaderCellSort>
 					<ListHeaderCell v-else class="min-w-0">{{ column.label }}</ListHeaderCell>
+					<!-- The handle sits in the column gap, so a right-aligned label stays clear of it. -->
 					<span
-						class="absolute inset-y-0 -right-1 flex w-2 cursor-col-resize justify-center"
+						class="absolute inset-y-0 -right-2 flex w-2 cursor-col-resize items-center justify-center"
 						@pointerdown.stop.prevent="startResize(column, $event)"
 						@dblclick.stop.prevent="resetColumn(column)"
 					>
 						<span
-							class="border-l border-outline-gray-2 opacity-0 transition-opacity group-hover:opacity-100"
+							class="h-4 border-l border-outline-gray-2 opacity-0 transition-opacity group-hover:opacity-100"
 							:class="{ 'opacity-100': resizingFieldname === column.fieldname }"
 						/>
 					</span>
@@ -63,7 +64,7 @@
 				>
 					<!-- The molecule's own `selectable` turns a row click into a toggle; the row must stay
 						a link, so the checkbox is drawn here (frappe/frappe-ui#1131). -->
-					<ListCell class="justify-center">
+					<ListCell class="ps-[calc(0.5rem+1px)]">
 						<div
 							role="checkbox"
 							:aria-checked="isSelected(rowValue(row))"
@@ -156,6 +157,8 @@ defineSlots<{
 	empty?: () => unknown;
 }>();
 
+/** The row's own inset; the checkbox column and the last cell sit this far inside it. The checkbox
+ *  takes one pixel more, so its box reads level with text, whose ink starts inside its box. */
 const ROW_PADDING_X = "0.5rem";
 const SKELETON_ROW_COUNT = 10;
 const SKELETON_COLUMN_COUNT = 4;
@@ -167,6 +170,11 @@ defineExpose({
 		return scroller.value?.viewportElement ?? null;
 	},
 });
+
+// The gutter is where the checkbox and the last cell's text land, so the row bleeds past it.
+const paddingInline = computed(() =>
+	props.gutter ? `calc(${props.gutter} - ${ROW_PADDING_X})` : undefined
+);
 
 // Binding the sort model at mount is what makes the headers sortable, as the molecule's `active`.
 const instance = getCurrentInstance();

--- a/ui/src/experimental/List/ListFooter.vue
+++ b/ui/src/experimental/List/ListFooter.vue
@@ -10,7 +10,7 @@
 				@update:modelValue="choosePageSize"
 			/>
 			<Button
-				v-if="hasCounts && rowCount < totalCount"
+				v-if="hasNextPage ?? (hasCounts && rowCount < totalCount)"
 				variant="subtle"
 				label="Load More"
 				@click="emit('load-more')"
@@ -18,7 +18,7 @@
 		</div>
 		<div class="flex items-center gap-2">
 			<span v-if="hasCounts" class="text-sm text-ink-gray-5">
-				{{ rowCount }} of {{ totalCount }}
+				{{ rowCount }} of {{ totalCount }}{{ totalCapped ? "+" : "" }}
 			</span>
 			<Skeleton v-else class="h-3 w-16 rounded-1" />
 		</div>
@@ -35,12 +35,19 @@ const props = withDefaults(
 		totalCount?: number;
 		/** False until the first answer lands, which shows a placeholder instead of "0 of 0". */
 		hasCounts?: boolean;
+		/** The total is a floor, shown with a trailing "+". */
+		totalCapped?: boolean;
+		/** Whether Load More shows; unset, the counts decide. */
+		hasNextPage?: boolean;
 		pageSizeOptions?: number[];
 	}>(),
 	{
 		rowCount: 0,
 		totalCount: 0,
 		hasCounts: false,
+		totalCapped: false,
+		// An explicit default keeps an absent prop undefined; Vue would cast it to false otherwise.
+		hasNextPage: undefined,
 		pageSizeOptions: () => [20, 100, 500, 2500],
 	}
 );

--- a/ui/src/experimental/List/tests/list.test.ts
+++ b/ui/src/experimental/List/tests/list.test.ts
@@ -76,6 +76,19 @@ describe("List rows", () => {
   });
 });
 
+describe("List gutter", () => {
+  it("pads the table by the gutter less the row inset, and by nothing without one", async () => {
+    const bare = await mount(List, { columns, rows });
+    expect(bare.root.querySelector<HTMLElement>("[data-slot='list']")!.style.paddingInline).toBe(
+      ""
+    );
+    const padded = await mount(List, { columns, rows, gutter: "var(--page-gutter)" });
+    expect(
+      padded.root.querySelector<HTMLElement>("[data-slot='list']")!.style.paddingInline
+    ).toBe("calc(var(--page-gutter) - 0.5rem)");
+  });
+});
+
 describe("List selection", () => {
   it("a checkbox click toggles the row and does not navigate", async () => {
     const state = reactive({ selection: [] as string[] });

--- a/ui/src/experimental/List/tests/listFooter.test.ts
+++ b/ui/src/experimental/List/tests/listFooter.test.ts
@@ -40,6 +40,25 @@ describe("ListFooter counts", () => {
     await flush();
     expect(loadMore(root)).toBeUndefined();
   });
+
+  it("a capped total reads N of M+, and Load More follows hasNextPage over the counts", async () => {
+    const state = reactive({ hasNextPage: true });
+    const { root } = await mount(ListFooter, {
+      hasCounts: true,
+      rowCount: 1000,
+      totalCount: 1000,
+      totalCapped: true,
+      get hasNextPage() {
+        return state.hasNextPage;
+      },
+    });
+    expect(root.textContent).toContain("1000 of 1000+");
+    expect(loadMore(root)).toBeDefined();
+
+    state.hasNextPage = false;
+    await flush();
+    expect(loadMore(root)).toBeUndefined();
+  });
 });
 
 describe("ListFooter page size", () => {

--- a/ui/src/experimental/List/types.ts
+++ b/ui/src/experimental/List/types.ts
@@ -18,6 +18,8 @@ export interface ListProps {
   rowHeight?: number;
   /** The route a row opens; with it, every row renders as a link. */
   rowLink?: (row: ListRowData) => RouteLocationRaw;
+  /** Where the checkbox and the last cell's text land, as a CSS length; the row bleeds past it. */
+  gutter?: string;
 }
 
 /** A drag-resize result: the column and the fixed width it now has. */


### PR DESCRIPTION
Two commits, the ui half of the desk v2 list page (frappe/frappe#42673), which reaches `develop` as the same commits by the list map's ruling.

**Popover slots.** frappe-ui 1.0.0-beta.55, the version `frontend/package.base.json` pins, renamed the Popover API in its overlay refactor (frappe-ui #956): the trigger slot is `#trigger` with `open`, `close` and `toggle`; the body is the default slot; `placement` split into `side` and `align`; `bare` drops the panel chrome. `Filter`, `SortBy` and `ColumnSettings` still used the old `#target` and `#body` slots, so on the pinned version each one rendered nothing at all once its model held a value. On the desk v2 list page the header showed only the Filter button; the sort and column controls were missing.

This moves the three controls to the new slots. Props, models and emits are unchanged. The panels drop their hand-built shell for frappe-ui's `PopoverPanel`: the shell's `rounded-lg` is not in beta.55's numbered radius scale, so the popovers had square corners. The trigger opens through reka's as-child wiring, so the explicit `togglePopover` handlers go; the direction button inside the sort trigger keeps its `@click.stop`, so it still flips the direction without opening the panel.

Two more changes in `experimental/List`, for the desk v2 list page: `List` takes a `gutter`, the CSS length where the selection checkbox and the last cell's text land (the row's hover surface bleeds its 8px inset past it), and the column resize handle sits in the column gap with a 16px line instead of spanning the header. `ListFooter`'s `hasNextPage` gets an explicit undefined default: Vue cast the absent prop to `false`, which hid Load More for a host that relies on the counts. The peer floor moves to beta.55, the version these slots are verified on.

**Radius sweep.** The preset replaces Tailwind's `borderRadius` scale with numbered steps and defines no `DEFAULT`, so `rounded`, `rounded-sm`, `rounded-md` and `rounded-lg` generate no CSS: square corners on every element carrying one. The second commit renames 99 uses across `ui/src` by the map in frappe-ui's own `migrate-tokens-v2` codemod (sm 1, md 5, lg 6, xl 7, 2xl 8, bare 4). `rounded-full`, `rounded-none` and arbitrary values stay.

`Fields/AttachField.vue` also uses `#target` and `#body-main` and is left alone here; nothing on the desk reaches it yet.

Walked on the desk v2 list page (frappe/frappe#42656): before, the header had Filter and the menu only; after, Filter, the sort trigger, Columns and the menu, and each popover opens.

The frappe `frontend/` suite is green (37 files, 543 tests); the package's List tests (37) pass under the frontend's vitest, two of them new. The package's own tests do not cover templates.

>no-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)


