### PR TITLE
feat(frontend): compose the generated list page on the list components

### DIFF
--- a/frontend/src/list/defaults.ts
+++ b/frontend/src/list/defaults.ts
@@ -1,0 +1,77 @@
+// What the list shows before anyone touches it: columns from a contributed `list.js`, else from
+// meta's `in_list_view`; sort from meta's `sort_field`, else `modified desc`.
+import { getColumnAlign, getDefaultColumns, type Column } from "@framework/ui/ColumnSettings";
+import type { ListColumn } from "@framework/ui/experimental/List";
+import type { RawMetaField } from "@framework/ui/FormLayout";
+import { parseOrderBy, type Sort } from "@framework/ui/SortBy";
+import type { ListHandlers } from "@/contributions/types";
+
+/** The meta keys the list reads; `getdoctype` sends the whole doctype record. */
+export interface ListMeta {
+	title_field?: string;
+	sort_field?: string;
+	sort_order?: string;
+	fields?: RawMetaField[];
+}
+
+const GENERIC_COLUMNS: Column[] = [
+	{ fieldname: "name", label: "Name" },
+	{ fieldname: "modified", label: "Last Modified" },
+];
+
+export const DEFAULT_SORT: Sort[] = [{ fieldname: "modified", direction: "desc" }];
+
+export function defaultColumns(meta: ListMeta, contributed: ListHandlers[]): ListColumn[] {
+	const fields = meta.fields ?? [];
+	const columns = contributedColumns(fields, contributed) ?? metaColumns(fields, meta.title_field);
+	return columns.map((column) => withAlign(column, fields));
+}
+
+export function defaultSort(meta: ListMeta): Sort[] {
+	if (!meta.sort_field) return DEFAULT_SORT;
+	const orderBy = meta.sort_field.includes(" ")
+		? meta.sort_field
+		: `${meta.sort_field} ${meta.sort_order ?? "desc"}`;
+	const sort = parseOrderBy(orderBy);
+	return sort.length ? sort : DEFAULT_SORT;
+}
+
+export function sameSort(a: Sort[], b: Sort[]): boolean {
+	return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/** The fields a page of rows needs: `name` for the link, then one per column. */
+export function fetchFields(columns: Column[]): string[] {
+	return [...new Set(["name", ...columns.map((column) => column.fieldname)])];
+}
+
+/** Every contributing app's columns in run order; a fieldname named twice is shown once. */
+function contributedColumns(fields: RawMetaField[], contributed: ListHandlers[]): Column[] | null {
+	const columns: Column[] = [];
+	const seen = new Set<string>();
+	for (const handlers of contributed) {
+		for (const { fieldname, width } of handlers.columns ?? []) {
+			if (seen.has(fieldname)) continue;
+			seen.add(fieldname);
+			const column: Column = { fieldname, label: labelOf(fieldname, fields) };
+			if (width) column.width = `${width}px`;
+			columns.push(column);
+		}
+	}
+	return columns.length ? columns : null;
+}
+
+function metaColumns(fields: RawMetaField[], titleField?: string): Column[] {
+	if (!fields.some((field) => field.in_list_view)) return GENERIC_COLUMNS.map((c) => ({ ...c }));
+	return getDefaultColumns(fields, titleField);
+}
+
+function labelOf(fieldname: string, fields: RawMetaField[]): string {
+	const generic = GENERIC_COLUMNS.find((column) => column.fieldname === fieldname);
+	return fields.find((field) => field.fieldname === fieldname)?.label ?? generic?.label ?? fieldname;
+}
+
+function withAlign(column: Column, fields: RawMetaField[]): ListColumn {
+	const fieldtype = fields.find((field) => field.fieldname === column.fieldname)?.fieldtype;
+	return { ...column, align: getColumnAlign(fieldtype ?? "Data") };
+}

--- a/frontend/src/list/pageState.ts
+++ b/frontend/src/list/pageState.ts
@@ -1,0 +1,48 @@
+// What a visit keeps in its history entry: the page size and the scroll offset, so Back lands
+// where the reader left. What the session keeps per doctype: how many rows were showing and the
+// scroll offset, so a return from a record by any route, a breadcrumb too, lands there again.
+
+export interface ListMemory {
+	pageSize?: number;
+	scrollTop?: number;
+}
+
+export function readListMemory(): ListMemory {
+	const list = (history.state as { list?: unknown } | null)?.list;
+	return typeof list === "object" && list ? (list as ListMemory) : {};
+}
+
+/** Spread over the current state: vue-router keeps its own keys there. */
+export function writeListMemory(patch: ListMemory): void {
+	const list = { ...readListMemory(), ...patch };
+	history.replaceState({ ...history.state, list }, "");
+}
+
+export interface RowsMemory {
+	/** The filters and sort the rows belonged to; a different query starts fresh. */
+	query: string;
+	pageSize: number;
+	shown: number;
+	scrollTop?: number;
+}
+
+const rowsByDoctype = new Map<string, RowsMemory>();
+
+/** Patches the memory for the same query, so a Load More keeps the offset; a new query replaces it. */
+export function rememberRows(doctype: string, memory: Omit<RowsMemory, "scrollTop">): void {
+	rowsByDoctype.set(doctype, { ...recallRows(doctype, memory.query), ...memory });
+}
+
+export function rememberScroll(doctype: string, query: string, scrollTop: number): void {
+	const memory = recallRows(doctype, query);
+	if (memory) rowsByDoctype.set(doctype, { ...memory, scrollTop });
+}
+
+export function recallRows(doctype: string, query: string): RowsMemory | undefined {
+	const memory = rowsByDoctype.get(doctype);
+	return memory?.query === query ? memory : undefined;
+}
+
+export function forgetRows(doctype: string): void {
+	rowsByDoctype.delete(doctype);
+}

--- a/frontend/src/list/query.ts
+++ b/frontend/src/list/query.ts
@@ -1,0 +1,116 @@
+// The list's address: filters and sort in the URL query, one key per filtered field and the
+// sort under `_sort`, so Copy link carries them and Back restores them.
+import {
+	getFilterableFields,
+	parseFilters,
+	serializeFilters,
+	type FilterCondition,
+	type FilterField,
+	type WireFilters,
+} from "@framework/ui/Filter";
+import { parseOrderBy, serializeOrderBy, type Sort } from "@framework/ui/SortBy";
+import type { RawMetaField } from "@framework/ui/FormLayout";
+import type { LocationQuery } from "vue-router";
+
+export const SORT_KEY = "_sort";
+/** The shell's own query keys on a generated route; never read as a filter. */
+const RESERVED_KEYS = new Set([SORT_KEY, "view", "layout", "from"]);
+
+export interface ListAddress {
+	filters: FilterCondition[];
+	sort: Sort[];
+}
+
+export type Query = Record<string, string>;
+
+/** An equals filter is written bare, any other operator as a `[operator, value]` pair. */
+export function queryFromAddress(address: ListAddress): Query {
+	const query: Query = {};
+	for (const [fieldname, operator, value] of serializeFilters(completeFilters(address.filters))) {
+		query[fieldname] = operator === "=" ? bareValue(value) : JSON.stringify([operator, value]);
+	}
+	const orderBy = serializeOrderBy(address.sort);
+	if (orderBy) query[SORT_KEY] = orderBy;
+	return query;
+}
+
+/** The address a query holds; a key that names no filterable field is not ours to read. */
+export function addressFromQuery(
+	query: LocationQuery,
+	doctype: string,
+	fields: RawMetaField[]
+): Partial<ListAddress> {
+	const filterable = getFilterableFields(fields, doctype);
+	const byName = new Map(filterable.map((field) => [field.fieldname, field]));
+	const wire: WireFilters = [];
+	for (const [key, raw] of Object.entries(query)) {
+		if (RESERVED_KEYS.has(key)) continue;
+		const field = byName.get(key);
+		if (field && typeof raw === "string" && raw) wire.push([key, ...wirePair(field, raw)]);
+	}
+	const address: Partial<ListAddress> = {};
+	if (wire.length) address.filters = parseFilters(filterable, wire).map(bareLike);
+	const sort = query[SORT_KEY];
+	if (typeof sort === "string" && sort) address.sort = parseOrderBy(sort);
+	return address;
+}
+
+/** The query keys this list writes; every other key is carried through untouched. */
+export function ownedKeys(doctype: string, fields: RawMetaField[]): Set<string> {
+	const owned = new Set([SORT_KEY]);
+	for (const field of getFilterableFields(fields, doctype)) {
+		if (!RESERVED_KEYS.has(field.fieldname)) owned.add(field.fieldname);
+	}
+	return owned;
+}
+
+export function sameQuery(a: LocationQuery, b: LocationQuery): boolean {
+	return stableQuery(a) === stableQuery(b);
+}
+
+/** A condition with no value is still being typed and is not sent. */
+export function completeFilters(filters: FilterCondition[]): FilterCondition[] {
+	return filters.filter((condition) => {
+		const { value } = condition;
+		if (value === null || value === undefined || value === "") return false;
+		return !(Array.isArray(value) && !value.length);
+	});
+}
+
+function stableQuery(query: LocationQuery): string {
+	return JSON.stringify(
+		Object.keys(query)
+			.sort()
+			.map((key) => [key, query[key]])
+	);
+}
+
+function bareValue(value: unknown): string {
+	if (typeof value === "boolean") return value ? "1" : "0";
+	return String(value);
+}
+
+function wirePair(field: FilterField, raw: string): [string, unknown] {
+	const parsed = parseJson(raw);
+	if (Array.isArray(parsed) && parsed.length === 2 && typeof parsed[0] === "string") {
+		return [parsed[0], parsed[1]];
+	}
+	if (field.fieldtype === "Check") return ["=", ["1", "true", "yes"].includes(raw.toLowerCase())];
+	return ["=", raw];
+}
+
+/** The wire wraps a `like` value in `%`; the control shows the bare text. */
+function bareLike(condition: FilterCondition): FilterCondition {
+	const { operator, value } = condition;
+	if (!operator.includes("like") || typeof value !== "string") return condition;
+	if (!value.startsWith("%") || !value.endsWith("%")) return condition;
+	return { ...condition, value: value.slice(1, -1) };
+}
+
+function parseJson(raw: string): unknown {
+	try {
+		return JSON.parse(raw);
+	} catch {
+		return undefined;
+	}
+}

--- a/frontend/src/list/tests/defaults.test.ts
+++ b/frontend/src/list/tests/defaults.test.ts
@@ -1,0 +1,74 @@
+// The seeds: a contributed `list.js` above meta's `in_list_view`, and meta's sort above `modified desc`.
+import { describe, expect, it } from "vitest";
+import type { RawMetaField } from "@framework/ui/FormLayout";
+
+import { DEFAULT_SORT, defaultColumns, defaultSort, fetchFields } from "../defaults";
+
+const FIELDS: RawMetaField[] = [
+	{ fieldname: "title", label: "Title", fieldtype: "Data", in_list_view: 1 },
+	{ fieldname: "status", label: "Status", fieldtype: "Select", in_list_view: 1 },
+	{ fieldname: "amount", label: "Amount", fieldtype: "Currency", in_list_view: 1 },
+	{ fieldname: "notes", label: "Notes", fieldtype: "Text" },
+];
+
+describe("defaultColumns", () => {
+	it("puts the title field first, then every in_list_view field, aligned by fieldtype", () => {
+		const columns = defaultColumns({ title_field: "title", fields: FIELDS }, []);
+		expect(columns.map((c) => c.fieldname)).toEqual(["title", "status", "amount"]);
+		expect(columns.find((c) => c.fieldname === "amount")?.align).toBe("right");
+		expect(columns.find((c) => c.fieldname === "title")?.align).toBe("left");
+	});
+
+	it("falls back to name and modified when no field is flagged", () => {
+		const columns = defaultColumns({ fields: [FIELDS[3]] }, []);
+		expect(columns.map((c) => c.fieldname)).toEqual(["name", "modified"]);
+	});
+
+	it("takes a contributed list.js's columns over meta, in run order, each fieldname once", () => {
+		const columns = defaultColumns({ title_field: "title", fields: FIELDS }, [
+			{ columns: [{ fieldname: "status", width: 120 }, { fieldname: "notes" }] },
+			{ columns: [{ fieldname: "status" }, { fieldname: "amount" }] },
+		]);
+		expect(columns.map((c) => c.fieldname)).toEqual(["status", "notes", "amount"]);
+		expect(columns[0]).toMatchObject({ label: "Status", width: "120px" });
+		expect(columns[1].width).toBeUndefined();
+	});
+
+	it("labels a contributed column from meta, or from its fieldname", () => {
+		const columns = defaultColumns({ fields: FIELDS }, [
+			{ columns: [{ fieldname: "modified" }, { fieldname: "owner" }] },
+		]);
+		expect(columns.map((c) => c.label)).toEqual(["Last Modified", "owner"]);
+	});
+});
+
+describe("defaultSort", () => {
+	it("reads meta's sort_field and sort_order", () => {
+		expect(defaultSort({ sort_field: "amount", sort_order: "ASC" })).toEqual([
+			{ fieldname: "amount", direction: "asc" },
+		]);
+	});
+
+	it("reads a sort_field that already carries its directions", () => {
+		expect(defaultSort({ sort_field: "status asc, amount desc" })).toEqual([
+			{ fieldname: "status", direction: "asc" },
+			{ fieldname: "amount", direction: "desc" },
+		]);
+	});
+
+	it("falls back to modified desc", () => {
+		expect(defaultSort({})).toEqual(DEFAULT_SORT);
+		expect(DEFAULT_SORT).toEqual([{ fieldname: "modified", direction: "desc" }]);
+	});
+});
+
+describe("fetchFields", () => {
+	it("asks for name once, then each column", () => {
+		expect(
+			fetchFields([
+				{ fieldname: "status", label: "Status" },
+				{ fieldname: "name", label: "Name" },
+			])
+		).toEqual(["name", "status"]);
+	});
+});

--- a/frontend/src/list/tests/pageState.test.ts
+++ b/frontend/src/list/tests/pageState.test.ts
@@ -1,0 +1,54 @@
+// The history entry's memory: written over the router's own state, read back after a pop.
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+	readListMemory,
+	recallRows,
+	rememberRows,
+	rememberScroll,
+	writeListMemory,
+} from "../pageState";
+
+beforeEach(() => {
+	history.replaceState({ position: 3, current: "/lead" }, "");
+});
+
+describe("the list memory", () => {
+	it("is empty on an entry nothing wrote", () => {
+		expect(readListMemory()).toEqual({});
+	});
+
+	it("keeps the router's keys and merges its own", () => {
+		writeListMemory({ pageSize: 100 });
+		writeListMemory({ scrollTop: 240 });
+		expect(readListMemory()).toEqual({ pageSize: 100, scrollTop: 240 });
+		expect(history.state).toMatchObject({ position: 3, current: "/lead" });
+	});
+
+	it("does not follow a pushed entry", () => {
+		writeListMemory({ pageSize: 500 });
+		history.pushState({ position: 4 }, "", "/lead/LEAD-1");
+		expect(readListMemory()).toEqual({});
+	});
+});
+
+describe("the rows memory", () => {
+	it("answers for the same doctype and query only, with the last write", () => {
+		rememberRows("Lead", { query: "a", pageSize: 20, shown: 40 });
+		rememberRows("Lead", { query: "a", pageSize: 100, shown: 200 });
+		expect(recallRows("Lead", "a")).toEqual({ query: "a", pageSize: 100, shown: 200 });
+		expect(recallRows("Lead", "b")).toBeUndefined();
+		expect(recallRows("Deal", "a")).toBeUndefined();
+	});
+
+	it("keeps the scroll offset for the same query through a rows write, and drops it for a new one", () => {
+		rememberRows("Lead", { query: "a", pageSize: 20, shown: 20 });
+		rememberScroll("Lead", "a", 240);
+		rememberRows("Lead", { query: "a", pageSize: 20, shown: 40 });
+		expect(recallRows("Lead", "a")).toMatchObject({ shown: 40, scrollTop: 240 });
+		rememberScroll("Lead", "b", 999);
+		expect(recallRows("Lead", "a")?.scrollTop).toBe(240);
+		rememberRows("Lead", { query: "b", pageSize: 20, shown: 20 });
+		expect(recallRows("Lead", "b")?.scrollTop).toBeUndefined();
+	});
+});

--- a/frontend/src/list/tests/query.test.ts
+++ b/frontend/src/list/tests/query.test.ts
@@ -1,0 +1,95 @@
+// The URL encoding: an equals filter bare, any other operator as a pair, the sort under `_sort`.
+import { describe, expect, it } from "vitest";
+import type { FilterCondition } from "@framework/ui/Filter";
+
+import { addressFromQuery, ownedKeys, queryFromAddress, sameQuery } from "../query";
+
+const FIELDS = [
+	{ fieldname: "status", label: "Status", fieldtype: "Select", options: "Open\nClosed" },
+	{ fieldname: "company", label: "Company", fieldtype: "Link", options: "Company" },
+	{ fieldname: "is_active", label: "Active", fieldtype: "Check" },
+	{ fieldname: "amount", label: "Amount", fieldtype: "Currency" },
+];
+
+function condition(fieldname: string, operator: string, value: unknown): FilterCondition {
+	return { fieldname, operator, value } as FilterCondition;
+}
+
+describe("queryFromAddress", () => {
+	it("writes an equals filter bare and any other operator as a pair", () => {
+		const query = queryFromAddress({
+			filters: [condition("status", "equals", "Open"), condition("amount", ">", "100")],
+			sort: [],
+		});
+		expect(query).toEqual({ status: "Open", amount: JSON.stringify([">", "100"]) });
+	});
+
+	it("writes a Check as 1 or 0 and a like as its wire form", () => {
+		const query = queryFromAddress({
+			filters: [condition("is_active", "equals", "Yes"), condition("company", "like", "Acme")],
+			sort: [],
+		});
+		expect(query.is_active).toBe("1");
+		expect(query.company).toBe(JSON.stringify(["LIKE", "%Acme%"]));
+	});
+
+	it("writes the sort as an order_by string and drops a condition with no value", () => {
+		const query = queryFromAddress({
+			filters: [condition("status", "equals", ""), condition("company", "in", [])],
+			sort: [
+				{ fieldname: "amount", direction: "desc" },
+				{ fieldname: "status", direction: "asc" },
+			],
+		});
+		expect(query).toEqual({ _sort: "amount desc, status asc" });
+	});
+});
+
+describe("addressFromQuery", () => {
+	it("reads a bare value as equals, a pair as its operator, and a like as bare text", () => {
+		const address = addressFromQuery(
+			{ status: "Open", amount: JSON.stringify([">", "100"]), company: '["LIKE","%Acme%"]' },
+			"Lead",
+			FIELDS
+		);
+		expect(address.filters?.map((c) => [c.fieldname, c.operator, c.value])).toEqual([
+			["status", "equals", "Open"],
+			["amount", ">", "100"],
+			["company", "like", "Acme"],
+		]);
+	});
+
+	it("reads a Check from 1 or 0 as Yes or No", () => {
+		const address = addressFromQuery({ is_active: "1" }, "Lead", FIELDS);
+		expect(address.filters?.[0]).toMatchObject({ operator: "equals", value: "Yes" });
+	});
+
+	it("reads the sort and ignores a key that names no field", () => {
+		const address = addressFromQuery({ _sort: "amount desc", view: "kanban" }, "Lead", FIELDS);
+		expect(address.sort).toEqual([{ fieldname: "amount", direction: "desc" }]);
+		expect(address.filters).toBeUndefined();
+	});
+
+	it("round-trips what it wrote", () => {
+		const written = queryFromAddress({
+			filters: [condition("status", "not equals", "Closed"), condition("is_active", "equals", "No")],
+			sort: [{ fieldname: "status", direction: "asc" }],
+		});
+		const read = addressFromQuery(written, "Lead", FIELDS);
+		expect(queryFromAddress({ filters: read.filters!, sort: read.sort! })).toEqual(written);
+	});
+});
+
+describe("ownedKeys and sameQuery", () => {
+	it("owns the sort key and every filterable field, and nothing else", () => {
+		const owned = ownedKeys("Lead", FIELDS);
+		expect(owned.has("_sort")).toBe(true);
+		expect(owned.has("status")).toBe(true);
+		expect(owned.has("view")).toBe(false);
+	});
+
+	it("compares queries by content, in any key order", () => {
+		expect(sameQuery({ a: "1", b: "2" }, { b: "2", a: "1" })).toBe(true);
+		expect(sameQuery({ a: "1" }, { a: "2" })).toBe(false);
+	});
+});

--- a/frontend/src/list/tests/useListPage.test.ts
+++ b/frontend/src/list/tests/useListPage.test.ts
@@ -1,0 +1,375 @@
+// The composable as claims: what seeds it, what it writes to the URL, when it rebuilds the list,
+// and what a delete does. frappe-ui's data layer is faked; the router and history are real.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createApp, defineComponent, nextTick, reactive, type App } from "vue";
+import { createRouter, createWebHistory, type Router } from "vue-router";
+
+const fake = vi.hoisted(() => ({
+	meta: null as Record<string, unknown> | null,
+	contributed: [] as { columns?: { fieldname: string; width?: number }[] }[],
+	lists: [] as any[],
+	useList: vi.fn(),
+	call: vi.fn(),
+	remove: vi.fn(),
+}));
+
+vi.mock("frappe-ui", async (importOriginal) => ({
+	...(await importOriginal<object>()),
+	call: fake.call,
+	useList: fake.useList,
+	createResource: () => ({
+		get data() {
+			return fake.meta && { docs: [fake.meta] };
+		},
+		loading: false,
+		fetch() {},
+		reload() {},
+	}),
+}));
+
+vi.mock("@/contributions/registry", () => ({
+	listHandlersFor: () => fake.contributed.map((handlers) => ({ app: "crm", handlers })),
+}));
+
+import { Addresses } from "@/addresses";
+import type { Boot } from "@/boot";
+import { registerShell } from "@/router/routeFor";
+import { resetDoctypeMeta } from "@framework/ui/composables/useDoctypeMeta";
+import { forgetRows, readListMemory, recallRows, writeListMemory } from "../pageState";
+import { useListPage, type ListPage } from "../useListPage";
+
+const FIELDS = [
+	{ fieldname: "title", label: "Title", fieldtype: "Data", in_list_view: 1 },
+	{ fieldname: "status", label: "Status", fieldtype: "Select", options: "Open\nClosed", in_list_view: 1 },
+	{ fieldname: "amount", label: "Amount", fieldtype: "Currency", in_list_view: 1 },
+];
+
+const addresses = new Addresses({ doctypes: { Lead: ["lead", "crm"] }, modules: { crm: "CRM" } });
+const boot = { app: "crm", shell_base: "/apps/crm", prefixes: { crm: { app: "crm", modular: false } } };
+
+let router: Router;
+let app: App | null = null;
+let page: ListPage;
+
+function fakeList() {
+	const list = reactive({
+		data: null as Record<string, unknown>[] | null,
+		error: null,
+		hasNextPage: true,
+		loading: true,
+		next: vi.fn(),
+		delete: { submit: fake.remove },
+	});
+	fake.lists.push(list);
+	return list;
+}
+
+function rowsNamed(count: number, from = 0) {
+	return Array.from({ length: count }, (_, index) => ({ name: `LEAD-${from + index}` }));
+}
+
+async function mount(path: string) {
+	router = createRouter({
+		history: createWebHistory("/"),
+		routes: [
+			{ path: "/:doctype", name: "list", component: { render: () => null } },
+			{ path: "/:doctype/:name", name: "record", component: { render: () => null } },
+		],
+	});
+	registerShell({ boot: boot as unknown as Boot, addresses, router });
+	await router.replace(path);
+	const root = document.createElement("div");
+	document.body.appendChild(root);
+	app = createApp(
+		defineComponent({
+			setup() {
+				page = useListPage("Lead");
+				return () => null;
+			},
+		})
+	);
+	app.use(router);
+	app.mount(root);
+	await nextTick();
+}
+
+async function settle() {
+	for (let turn = 0; turn < 3; turn++) {
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		await nextTick();
+	}
+}
+
+/** A changed query waits out the typing debounce before it builds a list. */
+async function settleQuery() {
+	await new Promise((resolve) => setTimeout(resolve, 350));
+	await settle();
+}
+
+beforeEach(() => {
+	resetDoctypeMeta();
+	forgetRows("Lead");
+	history.replaceState(null, "");
+	fake.meta = { name: "Lead", title_field: "title", sort_field: "amount", sort_order: "ASC", fields: FIELDS };
+	fake.contributed = [];
+	fake.lists = [];
+	fake.useList.mockReset().mockImplementation(fakeList);
+	fake.call.mockReset().mockResolvedValue(42);
+	fake.remove.mockReset().mockResolvedValue("ok");
+});
+
+afterEach(() => {
+	app?.unmount();
+	app = null;
+	document.body.innerHTML = "";
+});
+
+describe("seeding", () => {
+	it("takes columns and sort from meta and reads the query it was opened with", async () => {
+		await mount("/lead?status=Open&_sort=title%20desc&view=kanban");
+		expect(page.columns.value.map((c) => c.fieldname)).toEqual(["title", "status", "amount"]);
+		expect(page.filters.value).toHaveLength(1);
+		expect(page.filters.value[0]).toMatchObject({ fieldname: "status", operator: "equals", value: "Open" });
+		expect(page.sort.value).toEqual([{ fieldname: "title", direction: "desc" }]);
+	});
+
+	it("takes a contributed list.js's columns over meta", async () => {
+		fake.contributed = [{ columns: [{ fieldname: "status" }, { fieldname: "title" }] }];
+		await mount("/lead");
+		expect(page.columns.value.map((c) => c.fieldname)).toEqual(["status", "title"]);
+		expect(page.columnsCustomized.value).toBe(false);
+	});
+
+	it("builds the list once meta is in, from offset zero, with the count beside it", async () => {
+		await mount("/lead");
+		await settle();
+		expect(page.totalCapped.value).toBe(false);
+		expect(fake.useList).toHaveBeenCalledTimes(1);
+		expect(fake.useList.mock.calls[0][0]).toMatchObject({
+			doctype: "Lead",
+			fields: ["name", "title", "status", "amount"],
+			filters: {},
+			orderBy: "amount asc",
+			start: 0,
+			limit: 20,
+			refetch: false,
+		});
+		expect(fake.call).toHaveBeenCalledWith("frappe.client.get_count", { doctype: "Lead", filters: {}, limit: 1001 });
+		expect(page.totalCount.value).toBe(42);
+		expect(page.hasCounts.value).toBe(true);
+	});
+});
+
+describe("the URL", () => {
+	it("writes a filter to the query and keeps a key it does not own", async () => {
+		await mount("/lead?view=kanban");
+		page.filters.value = [{ fieldname: "status", operator: "equals", value: "Open" } as never];
+		await settle();
+		expect(router.currentRoute.value.query).toEqual({ view: "kanban", status: "Open" });
+	});
+
+	it("writes a sort only when it is not the default", async () => {
+		await mount("/lead");
+		page.sort.value = [{ fieldname: "status", direction: "desc" }];
+		await settle();
+		expect(router.currentRoute.value.query).toEqual({ _sort: "status desc" });
+		page.sort.value = [{ fieldname: "amount", direction: "asc" }];
+		await settle();
+		expect(router.currentRoute.value.query).toEqual({});
+	});
+
+	it("reads a query it did not write, and leaves a filter still being typed alone", async () => {
+		await mount("/lead");
+		page.filters.value = [{ fieldname: "status", operator: "equals", value: "" } as never];
+		await settle();
+		expect(page.filters.value).toHaveLength(1);
+		await router.replace({ query: { status: "Closed" } });
+		await settle();
+		expect(page.filters.value).toHaveLength(1);
+		expect(page.filters.value[0]).toMatchObject({ value: "Closed" });
+	});
+});
+
+describe("the rows", () => {
+	it("keeps the selection across a load-more, minus any row that left", async () => {
+		await mount("/lead");
+		await settle();
+		fake.lists[0].data = [{ name: "LEAD-1" }, { name: "LEAD-2" }];
+		await nextTick();
+		page.selection.value = ["LEAD-1", "LEAD-2"];
+		fake.lists[0].data = [{ name: "LEAD-2" }, { name: "LEAD-3" }];
+		await nextTick();
+		expect(page.selection.value).toEqual(["LEAD-2"]);
+	});
+
+	it("rebuilds the list for a changed filter after the typing debounce, with no selection", async () => {
+		await mount("/lead");
+		await settle();
+		fake.lists[0].data = [{ name: "LEAD-1" }];
+		await nextTick();
+		page.selection.value = ["LEAD-1"];
+		page.filters.value = [{ fieldname: "status", operator: "equals", value: "Open" } as never];
+		await settle();
+		expect(fake.useList).toHaveBeenCalledTimes(1);
+		await settleQuery();
+		expect(fake.useList).toHaveBeenCalledTimes(2);
+		expect(fake.useList.mock.calls[1][0].filters).toEqual({ status: ["=", "Open"] });
+		expect(page.selection.value).toEqual([]);
+	});
+
+	it("keeps the page size in the history entry and a bigger one fetches only the missing rows", async () => {
+		await mount("/lead");
+		await settle();
+		fake.lists[0].data = rowsNamed(20);
+		await nextTick();
+		page.pageSize.value = 100;
+		await settleQuery();
+		expect((history.state as { list?: unknown }).list).toEqual({ pageSize: 100 });
+		expect(fake.useList).toHaveBeenCalledTimes(2);
+		expect(fake.useList.mock.calls[1][0]).toMatchObject({ start: 20, limit: 80 });
+		fake.lists[1].data = rowsNamed(80, 20);
+		await nextTick();
+		expect(page.rows.value).toHaveLength(100);
+		page.next();
+		expect(fake.useList.mock.calls[2][0]).toMatchObject({ start: 100, limit: 100 });
+	});
+
+	it("a bigger page size while the first page is in flight starts the list over", async () => {
+		await mount("/lead");
+		await settle();
+		page.pageSize.value = 500;
+		await settleQuery();
+		expect(fake.useList).toHaveBeenCalledTimes(2);
+		expect(fake.useList.mock.calls[1][0]).toMatchObject({ start: 0, limit: 500 });
+	});
+
+	it("a smaller page size shows fewer of the loaded rows, and next reveals them before fetching", async () => {
+		await mount("/lead");
+		await settle();
+		fake.lists[0].data = rowsNamed(100);
+		fake.lists[0].hasNextPage = false;
+		await nextTick();
+		page.pageSize.value = 20;
+		await settleQuery();
+		expect(fake.useList).toHaveBeenCalledTimes(1);
+		expect(page.rows.value).toHaveLength(20);
+		expect(page.hasNextPage.value).toBe(true);
+		page.next();
+		await nextTick();
+		expect(page.rows.value).toHaveLength(40);
+		expect(fake.useList).toHaveBeenCalledTimes(1);
+	});
+
+	it("a return to the same query shows as many rows as before, by one request", async () => {
+		await mount("/lead");
+		await settle();
+		fake.lists[0].data = rowsNamed(20);
+		await nextTick();
+		page.next();
+		await nextTick();
+		expect(fake.useList.mock.calls[1][0]).toMatchObject({ start: 20, limit: 20 });
+
+		app!.unmount();
+		app = null;
+		fake.useList.mockClear();
+		await mount("/lead");
+		await settle();
+		expect(fake.useList).toHaveBeenCalledTimes(1);
+		expect(fake.useList.mock.calls[0][0]).toMatchObject({ start: 0, limit: 40 });
+
+		app!.unmount();
+		app = null;
+		fake.useList.mockClear();
+		await mount("/lead?status=Open");
+		await settle();
+		expect(fake.useList.mock.calls[0][0]).toMatchObject({ start: 0, limit: 20 });
+	});
+
+	it("a page size changed while a filter waits is remembered under the rows' own query", async () => {
+		await mount("/lead");
+		await settle();
+		fake.lists[0].data = rowsNamed(20);
+		await nextTick();
+		const before = page.rowsKey();
+		page.filters.value = [{ fieldname: "status", operator: "equals", value: "Open" } as never];
+		await settle();
+		page.pageSize.value = 100;
+		await settle();
+		expect(page.rowsKey()).toBe(before);
+		expect(recallRows("Lead", before)).toMatchObject({ pageSize: 100, shown: 100 });
+		await settleQuery();
+		expect(page.rowsKey()).not.toBe(before);
+		expect(recallRows("Lead", page.rowsKey())).toMatchObject({ shown: 100 });
+	});
+
+	it("a new query on the same entry drops the entry's scroll offset", async () => {
+		await mount("/lead");
+		await settle();
+		writeListMemory({ scrollTop: 240 });
+		page.filters.value = [{ fieldname: "status", operator: "equals", value: "Open" } as never];
+		await settleQuery();
+		expect(readListMemory().scrollTop).toBe(0);
+	});
+
+	it("a delete's reload keeps the rows shown", async () => {
+		await mount("/lead");
+		await settle();
+		fake.lists[0].data = rowsNamed(20);
+		await nextTick();
+		page.next();
+		await nextTick();
+		fake.lists[1].data = rowsNamed(20, 20);
+		await nextTick();
+		page.selection.value = ["LEAD-0"];
+		await page.deleteSelection();
+		expect(fake.useList.mock.calls[2][0]).toMatchObject({ start: 0, limit: 40 });
+	});
+
+	it("next waits for a page in flight", async () => {
+		await mount("/lead");
+		await settle();
+		page.next();
+		expect(fake.useList).toHaveBeenCalledTimes(1);
+	});
+
+	it("links a row to its record through the shell's route", async () => {
+		await mount("/lead");
+		expect(router.resolve(page.rowLink({ name: "LEAD-1" })).path).toBe("/lead/LEAD-1");
+	});
+});
+
+describe("the count", () => {
+	it("reads a total past the bound as capped", async () => {
+		fake.call.mockResolvedValue(1001);
+		await mount("/lead");
+		await settle();
+		expect(page.totalCount.value).toBe(1000);
+		expect(page.totalCapped.value).toBe(true);
+	});
+
+	it("shows the rows as a floor when the count fails, and keeps the next page reachable", async () => {
+		fake.call.mockRejectedValue(new Error("timeout"));
+		await mount("/lead");
+		await settle();
+		fake.lists[0].data = [{ name: "LEAD-1" }];
+		await nextTick();
+		expect(page.hasCounts.value).toBe(true);
+		expect(page.totalCount.value).toBe(1);
+		expect(page.totalCapped.value).toBe(true);
+		expect(page.hasNextPage.value).toBe(true);
+	});
+});
+
+describe("deleteSelection", () => {
+	it("deletes each selected name, reports a failure, clears the selection and reloads", async () => {
+		await mount("/lead");
+		await settle();
+		fake.remove.mockResolvedValueOnce("ok").mockRejectedValueOnce(new Error("Not permitted"));
+		page.selection.value = ["LEAD-1", "LEAD-2"];
+		const outcome = await page.deleteSelection();
+		expect(fake.remove.mock.calls.map(([params]) => params)).toEqual([{ name: "LEAD-1" }, { name: "LEAD-2" }]);
+		expect(outcome).toEqual({ deleted: ["LEAD-1"], failed: [{ name: "LEAD-2", error: "Not permitted" }] });
+		expect(page.selection.value).toEqual([]);
+		expect(fake.useList).toHaveBeenCalledTimes(2);
+	});
+});

--- a/frontend/src/list/tests/useListRows.test.ts
+++ b/frontend/src/list/tests/useListRows.test.ts
@@ -1,0 +1,53 @@
+// The rows composable on its own: when the first query runs, and what a page-size change fetches.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick, reactive, ref } from "vue";
+import { useListRows, type RowsQuery } from "../useListRows";
+
+const fake = vi.hoisted(() => ({ useList: vi.fn(), call: vi.fn() }));
+
+vi.mock("frappe-ui", async (importOriginal) => ({
+	...(await importOriginal<object>()),
+	useList: fake.useList,
+	call: fake.call,
+}));
+
+function fakeList() {
+	return reactive({ data: null, error: null, hasNextPage: true, delete: { submit: vi.fn() } });
+}
+
+function queryOf(limit: number): RowsQuery {
+	return { key: "q", fields: ["name"], filters: {}, orderBy: "modified desc", limit };
+}
+
+function fetches() {
+	return fake.useList.mock.calls.map(([options]) => [options.start, options.limit]);
+}
+
+beforeEach(() => {
+	fake.useList.mockReset().mockImplementation(fakeList);
+	fake.call.mockReset().mockResolvedValue(1);
+});
+
+describe("useListRows", () => {
+	it("runs the first query at once, also when it lands after a null one", async () => {
+		const query = ref<RowsQuery | null>(null);
+		useListRows("ToDo", () => query.value);
+		await nextTick();
+		expect(fake.useList).not.toHaveBeenCalled();
+		query.value = queryOf(20);
+		await nextTick();
+		expect(fetches()).toEqual([[0, 20]]);
+	});
+
+	it("a bigger page size while a page is in flight starts over instead of stacking", async () => {
+		const limit = ref(20);
+		useListRows("ToDo", () => queryOf(limit.value));
+		await nextTick();
+		limit.value = 100;
+		await nextTick();
+		expect(fetches()).toEqual([
+			[0, 20],
+			[0, 100],
+		]);
+	});
+});

--- a/frontend/src/list/useListPage.ts
+++ b/frontend/src/list/useListPage.ts
@@ -1,0 +1,200 @@
+// One doctype's list: the state the controls edit, seeded from meta and a contributed `list.js`,
+// with filters and sort mirrored to the URL query. Every act is a model or a plain function.
+import { useDoctypeMeta } from "@framework/ui/composables/useDoctypeMeta";
+import { applyColumnWidth, clearColumnWidth } from "@framework/ui/ColumnSettings";
+import type { ListColumn } from "@framework/ui/experimental/List";
+import { serializeFilters, type FilterCondition, type FilterField } from "@framework/ui/Filter";
+import { serializeOrderBy, type Sort } from "@framework/ui/SortBy";
+import { computed, ref, watch, type ComputedRef, type Ref } from "vue";
+import { useRoute, useRouter, type RouteLocationRaw } from "vue-router";
+import { listHandlersFor } from "@/contributions/registry";
+import { routeFor } from "@/router/routeFor";
+import { defaultColumns, defaultSort, fetchFields, sameSort, type ListMeta } from "./defaults";
+import { readListMemory, recallRows, rememberRows, writeListMemory } from "./pageState";
+import { addressFromQuery, completeFilters, ownedKeys, queryFromAddress, sameQuery } from "./query";
+import { useListRows, type ListRow, type ListRows } from "./useListRows";
+
+export interface DeleteOutcome {
+	deleted: string[];
+	failed: { name: string; error: string }[];
+}
+
+export interface ListPage extends ListRows {
+	/** Written to the URL query. */
+	filters: Ref<FilterCondition[]>;
+	/** Written to the URL query; the header click edits the same list. */
+	sort: Ref<Sort[]>;
+	/** In memory for the visit. */
+	columns: Ref<ListColumn[]>;
+	quickFilterFields: Ref<FilterField[] | undefined>;
+	customizing: Ref<boolean>;
+	selection: Ref<string[]>;
+	/** Kept in the history entry. */
+	pageSize: Ref<number>;
+	/** The filters and sort the rows belong to, as one string: the session memory's key. */
+	rowsKey: () => string;
+	metaError: ComputedRef<string | null>;
+	columnsCustomized: ComputedRef<boolean>;
+	resetColumns: () => void;
+	resizeColumn: (fieldname: string, width: string) => void;
+	resetColumnWidth: (fieldname: string) => void;
+	rowLink: (row: ListRow) => RouteLocationRaw;
+	/** Deletes the selection one row at a time; the page confirms first. */
+	deleteSelection: () => Promise<DeleteOutcome>;
+}
+
+export function useListPage(doctype: string): ListPage {
+	const route = useRoute();
+	const router = useRouter();
+	const { meta, error } = useDoctypeMeta(doctype);
+	const listMeta = computed(() => meta.value as ListMeta | null);
+	const fields = computed(() => listMeta.value?.fields ?? []);
+	const contributed = listHandlersFor(doctype).map(({ handlers }) => handlers);
+
+	const filters = ref<FilterCondition[]>([]);
+	const sort = ref<Sort[]>([]);
+	const columns = ref<ListColumn[]>([]);
+	const quickFilterFields = ref<FilterField[] | undefined>();
+	const customizing = ref(false);
+	const selection = ref<string[]>([]);
+	const pageSize = ref(readListMemory().pageSize ?? 20);
+	const seeded = ref(false);
+	// Set once meta lands: the rows an earlier visit to this query showed, by Back or a breadcrumb.
+	let remembered: ReturnType<typeof recallRows>;
+
+	watch(
+		listMeta,
+		(value) => {
+			if (!value || seeded.value) return;
+			columns.value = defaultColumns(value, contributed);
+			readQuery(value);
+			remembered = recallRows(doctype, stateKey());
+			if (remembered && readListMemory().pageSize == null) pageSize.value = remembered.pageSize;
+			seeded.value = true;
+		},
+		{ immediate: true }
+	);
+
+	function readQuery(value: ListMeta) {
+		const address = addressFromQuery(route.query, doctype, value.fields ?? []);
+		filters.value = address.filters ?? [];
+		sort.value = address.sort ?? defaultSort(value);
+	}
+
+	// Only a query the page did not write itself is read back: Back, Forward, a pasted link.
+	watch(
+		() => route.query,
+		(query) => {
+			if (seeded.value && !sameQuery(query, stateQuery())) readQuery(listMeta.value!);
+		}
+	);
+
+	// A replace, so the tweak is not a step Back has to undo.
+	watch([filters, sort], writeQuery, { deep: true });
+
+	function writeQuery() {
+		if (!seeded.value || sameQuery(route.query, stateQuery())) return;
+		router.replace({ query: stateQuery(), hash: route.hash }).catch(() => {});
+	}
+
+	/** The query the state spells: foreign keys kept, the default sort left unwritten. */
+	function stateQuery() {
+		const owned = ownedKeys(doctype, fields.value);
+		const kept = Object.fromEntries(
+			Object.entries(route.query).filter(([key]) => !owned.has(key))
+		);
+		const written = sameSort(sort.value, defaultSort(listMeta.value!)) ? [] : sort.value;
+		return { ...kept, ...queryFromAddress({ filters: filters.value, sort: written }) };
+	}
+
+	function stateKey() {
+		return JSON.stringify(queryFromAddress({ filters: filters.value, sort: sort.value }));
+	}
+
+	const rows = useListRows(doctype, () => {
+		if (!seeded.value) return null;
+		return {
+			key: stateKey(),
+			fields: fetchFields(columns.value),
+			filters: filtersDict(filters.value),
+			orderBy: serializeOrderBy(sort.value.length ? sort.value : defaultSort(listMeta.value!)),
+			limit: pageSize.value,
+			restore: remembered?.shown,
+		};
+	});
+
+	watch(pageSize, (size) => writeListMemory({ pageSize: size }));
+	// The entry's offset belongs to the query it was scrolled on; a new query on the same entry
+	// starts at the top, or Back would land the old offset on the new rows.
+	watch(rows.loadedKey, (_key, previous) => {
+		if (previous != null) writeListMemory({ scrollTop: 0 });
+	});
+	// Keyed by the rows' own query: while a typed filter waits out its debounce, the state is
+	// already the new query and the rows are still the old one.
+	const rowsKey = () => rows.loadedKey.value ?? stateKey();
+	watch([pageSize, rows.shown, rows.loadedKey], ([size, shown]) => {
+		if (shown) rememberRows(doctype, { query: rowsKey(), pageSize: size, shown });
+	});
+
+	// A row that left the page leaves the selection; the rest stay selected across a load-more.
+	watch(rows.rows, (current) => {
+		const present = new Set(current.map((row) => row.name));
+		selection.value = selection.value.filter((name) => present.has(name));
+	});
+
+	const defaults = computed(() =>
+		listMeta.value ? defaultColumns(listMeta.value, contributed) : []
+	);
+
+	async function deleteSelection(): Promise<DeleteOutcome> {
+		const outcome: DeleteOutcome = { deleted: [], failed: [] };
+		for (const name of selection.value) {
+			try {
+				await rows.remove(name);
+				outcome.deleted.push(name);
+			} catch (failure) {
+				outcome.failed.push({ name, error: messageOf(failure) });
+			}
+		}
+		selection.value = [];
+		rows.reload();
+		return outcome;
+	}
+
+	return {
+		...rows,
+		filters,
+		sort,
+		columns,
+		quickFilterFields,
+		customizing,
+		selection,
+		pageSize,
+		rowsKey,
+		metaError: computed(() => (error.value ? messageOf(error.value) : null)),
+		columnsCustomized: computed(
+			() => JSON.stringify(columns.value) !== JSON.stringify(defaults.value)
+		),
+		resetColumns: () => (columns.value = defaults.value),
+		resizeColumn: (fieldname, width) =>
+			(columns.value = applyColumnWidth(columns.value, fieldname, width) as ListColumn[]),
+		resetColumnWidth: (fieldname) =>
+			(columns.value = clearColumnWidth(columns.value, fieldname) as ListColumn[]),
+		rowLink: (row) => routeFor(doctype, row.name),
+		deleteSelection,
+	};
+}
+
+/** The object form `useList` takes; it holds one condition per field, so a second one is lost. */
+function filtersDict(filters: FilterCondition[]): Record<string, unknown> {
+	const dict: Record<string, unknown> = {};
+	for (const [fieldname, operator, value] of serializeFilters(completeFilters(filters))) {
+		dict[fieldname] = [operator, value];
+	}
+	return dict;
+}
+
+function messageOf(failure: unknown): string {
+	if (failure instanceof Error) return failure.message;
+	return String(failure);
+}

--- a/frontend/src/list/useListRows.ts
+++ b/frontend/src/list/useListRows.ts
@@ -1,0 +1,196 @@
+// The rows and the total for one query: frappe-ui's `useList` per fetched page, `get_count` for
+// the total. A changed query is a new list. The pages are a buffer; the page size and Load More
+// decide how much of it shows, and only rows past its end are fetched.
+import { call, useList, type Filters, type OrderBy } from "frappe-ui";
+import {
+	computed,
+	effectScope,
+	onScopeDispose,
+	ref,
+	shallowRef,
+	watch,
+	type ComputedRef,
+	type EffectScope,
+} from "vue";
+
+export type ListRow = { name: string } & Record<string, unknown>;
+
+/** Past this many rows the count is not exact and the footer reads "1000+". */
+export const COUNT_BOUND = 1000;
+const QUERY_DEBOUNCE_MS = 300;
+
+export interface RowsQuery {
+	/** Names the filters and sort; the loaded rows carry it, so a memory is written under it. */
+	key: string;
+	fields: string[];
+	filters: Record<string, unknown>;
+	orderBy: string;
+	limit: number;
+	/** Rows to show on the first load, when an earlier visit showed more than one page. */
+	restore?: number;
+}
+
+export interface ListRows {
+	rows: ComputedRef<ListRow[]>;
+	/** True until the first page of a query lands. */
+	loading: ComputedRef<boolean>;
+	error: ComputedRef<Error | null>;
+	rowCount: ComputedRef<number>;
+	totalCount: ComputedRef<number>;
+	/** True when the total hit the bound or its query timed out. */
+	totalCapped: ComputedRef<boolean>;
+	/** False until the count has answered; the footer shows a skeleton meanwhile. */
+	hasCounts: ComputedRef<boolean>;
+	hasNextPage: ComputedRef<boolean>;
+	/** How many rows the page asked to show; the rows fall short when the query has fewer. */
+	shown: ComputedRef<number>;
+	/** The `key` of the query the rows belong to, which trails the state while a change waits. */
+	loadedKey: ComputedRef<string | null>;
+	next: () => void;
+	/** Refetches the query and shows as many rows as before. */
+	reload: () => void;
+	remove: (name: string) => Promise<unknown>;
+}
+
+type ListHandle = ReturnType<typeof useList<ListRow>>;
+
+export function useListRows(doctype: string, query: () => RowsQuery | null): ListRows {
+	const pages = shallowRef<ListHandle[]>([]);
+	const shown = ref(0);
+	const loadedKey = ref<string | null>(null);
+	const total = ref<number | null>(null);
+	const counted = ref(false);
+	let scope: EffectScope | null = null;
+	let generation = 0;
+	let timer = 0;
+
+	const loaded = computed(() => pages.value.flatMap((page) => page.data ?? []));
+	const rows = computed(() => loaded.value.slice(0, shown.value));
+	const rowCount = computed(() => rows.value.length);
+	const firstPage = computed(() => pages.value[0] ?? null);
+	const lastPage = computed(() => pages.value[pages.value.length - 1] ?? null);
+	const inFlight = computed(() => lastPage.value != null && lastPage.value.data == null);
+	const error = computed(
+		() => (pages.value.find((page) => page.error)?.error as Error | null) ?? null
+	);
+	const hasNextPage = computed(
+		() => loaded.value.length > shown.value || (lastPage.value?.hasNextPage ?? false)
+	);
+
+	// The first query runs at once; a typed filter changes it per keystroke, so the rest wait.
+	watch(
+		queryKey,
+		(key, previous) => {
+			clearTimeout(timer);
+			if (!key) return;
+			if (previous === undefined) return reload(query()!.restore);
+			timer = window.setTimeout(() => reload(query()!.limit), QUERY_DEBOUNCE_MS);
+		},
+		{ immediate: true }
+	);
+
+	// A page size is not part of the query: it is how many rows show, and a bigger one fetches
+	// only the rows still missing. While a page is in flight the offset is not known yet, so
+	// the list starts over instead.
+	watch(
+		() => query()?.limit,
+		(size, previous) => {
+			if (size == null || previous == null || !lastPage.value) return;
+			if (inFlight.value) return reload();
+			show(size);
+		}
+	);
+
+	onScopeDispose(() => {
+		clearTimeout(timer);
+		scope?.stop();
+	});
+
+	/** Undefined while there is no query yet, so the first real one still counts as the first. */
+	function queryKey(): string | undefined {
+		const current = query();
+		if (!current) return undefined;
+		const { fields, filters, orderBy } = current;
+		return JSON.stringify({ fields, filters, orderBy });
+	}
+
+	function reload(target = shown.value) {
+		const current = query();
+		scope?.stop();
+		pages.value = [];
+		shown.value = 0;
+		loadedKey.value = current?.key ?? null;
+		if (!current) return;
+		scope = effectScope();
+		show(Math.max(target ?? 0, current.limit));
+		void count(current.filters);
+	}
+
+	/** Shows `target` rows: from the buffer where it reaches, fetched past its end. */
+	function show(target: number) {
+		shown.value = target;
+		const missing = target - loaded.value.length;
+		if (missing <= 0 || lastPage.value?.hasNextPage === false) return;
+		const page = scope!.run(() => createList(doctype, query()!, loaded.value.length, missing));
+		if (page) pages.value = [...pages.value, page];
+	}
+
+	// A page still in flight has no data yet; a second Load More then would start at a stale offset.
+	function next() {
+		const current = query();
+		if (!current || !lastPage.value || inFlight.value) return;
+		show(rowCount.value + current.limit);
+	}
+
+	// `limit` caps the count and puts a one-second cap on its query; a timeout answers null.
+	async function count(filters: Record<string, unknown>) {
+		const mine = ++generation;
+		counted.value = false;
+		total.value = null;
+		const params = { doctype, filters, limit: COUNT_BOUND + 1 };
+		const answer = await call<number | null>("frappe.client.get_count", params)
+			.then((value) => value ?? COUNT_BOUND + 1)
+			.catch(() => null);
+		if (mine !== generation) return;
+		total.value = answer;
+		counted.value = true;
+	}
+
+	// A failed count shows the rows as a floor; Load More follows the list's own next page.
+	const totalCapped = computed(() =>
+		total.value == null ? hasNextPage.value : total.value > COUNT_BOUND
+	);
+
+	return {
+		rows,
+		loading: computed(
+			() => !firstPage.value || (firstPage.value.data == null && !error.value)
+		),
+		error,
+		rowCount,
+		totalCount: computed(() =>
+			total.value == null ? rowCount.value : Math.min(total.value, COUNT_BOUND)
+		),
+		totalCapped,
+		hasCounts: computed(() => counted.value),
+		hasNextPage,
+		shown: computed(() => shown.value),
+		loadedKey: computed(() => loadedKey.value),
+		next,
+		reload: () => reload(),
+		remove: (name) => firstPage.value!.delete.submit({ name }),
+	};
+}
+
+/** One page, fetched once: `refetch` is off, so a delete never refetches from a stale offset. */
+function createList(doctype: string, query: RowsQuery, start: number, limit: number): ListHandle {
+	return useList<ListRow>({
+		doctype,
+		fields: query.fields,
+		filters: query.filters as Filters,
+		orderBy: query.orderBy as OrderBy,
+		start,
+		limit,
+		refetch: false,
+	});
+}

--- a/frontend/src/list/useScrollMemory.ts
+++ b/frontend/src/list/useScrollMemory.ts
@@ -1,0 +1,62 @@
+// The list's scroll offset, kept in the history entry and in the session's memory for the
+// query, and put back once the rows are there. Back reads the entry; a breadcrumb has none and
+// reads the session.
+import { watch } from "vue";
+import { readListMemory, recallRows, rememberScroll, writeListMemory } from "./pageState";
+
+const LANDING_FRAMES = 60;
+
+export interface ScrollSession {
+	doctype: string;
+	/** The filters and sort as one string, the rows memory's key. */
+	query: () => string;
+}
+
+export function useScrollMemory(
+	viewport: () => HTMLElement | null,
+	ready: () => boolean,
+	session: ScrollSession
+): void {
+	let restored = false;
+	let landing = false;
+	let frame = 0;
+
+	watch(viewport, (element, _previous, onCleanup) => {
+		if (!element) return;
+		const remember = () => {
+			if (landing) return;
+			cancelAnimationFrame(frame);
+			frame = requestAnimationFrame(() => {
+				writeListMemory({ scrollTop: element.scrollTop });
+				rememberScroll(session.doctype, session.query(), element.scrollTop);
+			});
+		};
+		element.addEventListener("scroll", remember, { passive: true });
+		onCleanup(() => {
+			cancelAnimationFrame(frame);
+			element.removeEventListener("scroll", remember);
+		});
+	});
+
+	watch([viewport, ready], ([element, rowsLanded]) => {
+		if (restored || !element || !rowsLanded) return;
+		restored = true;
+		const top =
+			readListMemory().scrollTop ?? recallRows(session.doctype, session.query())?.scrollTop;
+		if (top) land(element, top);
+	});
+
+	// Virtual rows grow the scroll height over a few frames; the offset lands once it fits, and
+	// the clamped scrolls on the way are not remembered.
+	function land(element: HTMLElement, top: number) {
+		landing = true;
+		let frames = LANDING_FRAMES;
+		const attempt = () => {
+			const fits = element.scrollHeight - element.clientHeight >= top;
+			if (!fits && frames-- > 0) return requestAnimationFrame(attempt);
+			element.scrollTop = top;
+			landing = false;
+		};
+		attempt();
+	}
+}

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -18,7 +18,7 @@
 				<li v-for="module in modules" :key="module.slug">
 					<RouterLink
 						:to="routeForModule(module.slug)"
-						class="block rounded border border-outline-gray-2 px-3 py-2 text-sm hover:bg-surface-gray-2"
+						class="block rounded-4 border border-outline-gray-2 px-3 py-2 text-sm hover:bg-surface-gray-2"
 					>
 						{{ module.name }}
 					</RouterLink>
@@ -29,7 +29,7 @@
 				<li v-for="entry in entries" :key="entry.doctype">
 					<RouterLink
 						:to="routeFor(entry.doctype)"
-						class="block rounded border border-outline-gray-2 px-3 py-2 text-sm hover:bg-surface-gray-2"
+						class="block rounded-4 border border-outline-gray-2 px-3 py-2 text-sm hover:bg-surface-gray-2"
 					>
 						{{ entry.doctype }}
 					</RouterLink>
@@ -43,7 +43,7 @@
 					<!-- A real navigation, not a `router.push`: crossing a prefix needs a boot re-fetch. -->
 					<a
 						:href="app.route"
-						class="flex items-center gap-2 rounded border border-outline-gray-2 px-3 py-2 text-sm hover:bg-surface-gray-2"
+						class="flex items-center gap-2 rounded-4 border border-outline-gray-2 px-3 py-2 text-sm hover:bg-surface-gray-2"
 					>
 						<img v-if="app.logo" :src="app.logo" class="size-5" alt="" />
 						<span>{{ app.title }}</span>

--- a/frontend/src/pages/List.vue
+++ b/frontend/src/pages/List.vue
@@ -1,77 +1,25 @@
 <!--
-  The generated list page, a plain table for now. It owns its scroll, since the list surface that
-  replaces the table scrolls both ways under a sticky column header.
+  The generated list page every app gets at /apps/<prefix>/<slug>. The doctype is the key: a
+  new doctype is a new list, with its own state and its own controls.
 -->
 <template>
-	<PageFrame :title="doctype ?? 'Unknown'" :scroll="false">
-		<ScrollArea class="min-h-0 flex-1" :viewportClass="[pageGutter, 'py-5']">
-			<p v-if="!doctype" class="text-sm text-ink-gray-6">
-				No doctype is served at <code>{{ route.params.doctype }}</code> under this prefix.
-			</p>
-
-			<table v-else class="w-full max-w-3xl text-sm">
-				<tbody>
-					<tr v-for="row in rows" :key="row.name" class="border-b border-outline-gray-1">
-						<td class="py-1.5">
-							<!-- `routeFor`, never a template literal: under a modular prefix the hand-built form
-													resolves to the wrong page. -->
-							<RouterLink
-								:to="routeFor(doctype!, row.name)"
-								class="text-ink-blue-3 hover:underline"
-							>
-								{{ row.name }}
-							</RouterLink>
-						</td>
-						<td v-for="column in columns" :key="column" class="py-1.5 text-ink-gray-7">
-							{{ row[column] }}
-						</td>
-					</tr>
-				</tbody>
-			</table>
-		</ScrollArea>
+	<DoctypeList v-if="doctype" :key="doctype" :doctype="doctype" />
+	<PageFrame v-else title="Unknown">
+		<p class="py-5 text-sm text-ink-gray-6">
+			No doctype is served at <code>{{ route.params.doctype }}</code> under this prefix.
+		</p>
 	</PageFrame>
 </template>
 
 <script setup lang="ts">
-import { ScrollArea } from "frappe-ui";
-import { computed, inject, ref, watchEffect } from "vue";
-import { RouterLink, useRoute } from "vue-router";
+import { computed, inject } from "vue";
+import { useRoute } from "vue-router";
 import type { Addresses } from "@/addresses";
-import { routeFor } from "@/router/routeFor";
-import { listHandlersFor } from "@/contributions/registry";
-import PageFrame, { pageGutter } from "@/shell/PageFrame.vue";
+import PageFrame from "@/shell/PageFrame.vue";
+import DoctypeList from "./list/DoctypeList.vue";
 
 const addresses = inject<Addresses>("addresses")!;
 const route = useRoute();
-const rows = ref<Record<string, string>[]>([]);
 
 const doctype = computed(() => addresses.doctypeOf(String(route.params.doctype)));
-
-// A contributed `list.js` is read here and nowhere else; it shapes the view, never adds a route.
-const columns = computed(() => {
-	if (!doctype.value) return [];
-	return listHandlersFor(doctype.value).flatMap(({ handlers }) =>
-		(handlers.columns ?? []).map((column) => column.fieldname)
-	);
-});
-
-// The slower of two in-flight fetches must not repaint the list the reader left.
-let generation = 0;
-
-watchEffect(async () => {
-	if (!doctype.value) return;
-	const mine = ++generation;
-	// Cleared before the fetch: the heading switches synchronously. Writing `rows` does not
-	// re-trigger this effect, since nothing here reads it.
-	rows.value = [];
-	const params = new URLSearchParams({
-		doctype: doctype.value,
-		fields: JSON.stringify(["name", ...columns.value]),
-		limit_page_length: "20",
-	});
-	const res = await fetch(`/api/method/frappe.client.get_list?${params}`);
-	const body = res.ok ? (await res.json()).message ?? [] : [];
-	if (mine !== generation) return;
-	rows.value = body;
-});
 </script>

--- a/frontend/src/pages/Module.vue
+++ b/frontend/src/pages/Module.vue
@@ -17,7 +17,7 @@
 			<li v-for="entry in entries" :key="entry.doctype">
 				<RouterLink
 					:to="routeFor(entry.doctype)"
-					class="block rounded border border-outline-gray-2 px-3 py-2 text-sm hover:bg-surface-gray-2"
+					class="block rounded-4 border border-outline-gray-2 px-3 py-2 text-sm hover:bg-surface-gray-2"
 				>
 					{{ entry.doctype }}
 				</RouterLink>

--- a/frontend/src/pages/list/DeleteDialog.vue
+++ b/frontend/src/pages/list/DeleteDialog.vue
@@ -1,0 +1,63 @@
+<!-- The confirmation before a bulk delete; the outcome is toasted, a failure stays in the dialog. -->
+<template>
+	<Dialog v-model="open" :title="title" size="sm" :actions="actions">
+		<template #body-content>
+			<p class="text-base text-ink-gray-6">This cannot be undone.</p>
+			<p v-if="failure" class="mt-2 text-sm text-ink-red-4">{{ failure }}</p>
+		</template>
+	</Dialog>
+</template>
+
+<script setup lang="ts">
+import { Dialog, toast } from "frappe-ui";
+import { computed, ref, watch } from "vue";
+import type { DeleteOutcome } from "@/list/useListPage";
+
+const props = defineProps<{ count: number; run: () => Promise<DeleteOutcome> }>();
+const open = defineModel<boolean>({ default: false });
+
+const deleting = ref(false);
+const failure = ref("");
+const asked = ref(0);
+
+watch(open, (isOpen) => {
+	failure.value = "";
+	if (isOpen) asked.value = props.count;
+});
+
+const title = computed(() =>
+	asked.value === 1 ? "Delete 1 record?" : `Delete ${asked.value} records?`
+);
+
+const actions = computed(() =>
+	failure.value
+		? [{ label: "Close", onClick: () => (open.value = false) }]
+		: [
+				{
+					label: "Delete",
+					variant: "solid",
+					theme: "red",
+					loading: deleting.value,
+					onClick: confirm,
+				},
+		  ]
+);
+
+async function confirm() {
+	deleting.value = true;
+	try {
+		report(await props.run());
+	} finally {
+		deleting.value = false;
+	}
+}
+
+function report(outcome: DeleteOutcome) {
+	if (outcome.deleted.length) toast.success(`Deleted ${outcome.deleted.length} record(s)`);
+	if (!outcome.failed.length) {
+		open.value = false;
+		return;
+	}
+	failure.value = outcome.failed.map(({ name, error }) => `${name}: ${error}`).join("\n");
+}
+</script>

--- a/frontend/src/pages/list/DoctypeList.vue
+++ b/frontend/src/pages/list/DoctypeList.vue
@@ -1,0 +1,146 @@
+<!--
+  One doctype's list in the frame: the quick filter and the controls in one row under the title,
+  then the table with its bulk bar and footer. The composable holds the state; this lays it out.
+-->
+<template>
+	<PageFrame :scroll="false">
+		<template #header>
+			<PageHeaderTitle :title="doctype" />
+		</template>
+
+		<p v-if="metaError" :class="pageGutter" class="py-5 text-sm text-ink-red-4">
+			{{ metaError }}
+		</p>
+
+		<template v-else>
+			<div
+				:class="pageGutter"
+				class="flex shrink-0 items-start justify-between gap-2 pt-3.5"
+			>
+				<div class="flex min-w-0 flex-1 flex-col">
+					<QuickFilter
+						v-model:filters="filters"
+						v-model:fields="quickFilterFields"
+						v-model:customizing="customizing"
+						:doctype="doctype"
+					/>
+				</div>
+				<div v-if="!customizing" class="flex shrink-0 items-center gap-2">
+					<Filter v-model="filters" :doctype="doctype" />
+					<SortBy v-model="sort" :doctype="doctype" />
+					<ColumnSettings
+						v-model="columns"
+						:doctype="doctype"
+						:canReset="columnsCustomized"
+						@reset="resetColumns"
+					/>
+					<Dropdown :options="menuOptions" side="bottom" align="end">
+						<div class="flex shrink-0">
+							<Button icon="lucide-ellipsis" label="More" />
+						</div>
+					</Dropdown>
+				</div>
+			</div>
+
+			<div class="relative flex min-h-0 flex-1 flex-col pt-2">
+				<p v-if="error" :class="pageGutter" class="text-sm text-ink-red-4">
+					{{ error.message }}
+				</p>
+				<List
+					v-else
+					ref="table"
+					v-model:selection="selection"
+					v-model:sort="sort"
+					:columns="columns"
+					:rows="rows"
+					:loading="loading"
+					:rowLink="rowLink"
+					gutter="var(--page-gutter)"
+					@column-resize="resizeColumn($event.fieldname, $event.width)"
+					@column-reset="resetColumnWidth($event.fieldname)"
+				/>
+				<ListBulkBar v-model:selection="selection" :actions="bulkActions" />
+				<ListFooter
+					v-model:pageSize="pageSize"
+					:class="pageGutter"
+					:rowCount="rowCount"
+					:totalCount="totalCount"
+					:totalCapped="totalCapped"
+					:hasCounts="hasCounts"
+					:hasNextPage="hasNextPage"
+					@load-more="next"
+				/>
+			</div>
+		</template>
+
+		<DeleteDialog
+			v-model="confirmingDelete"
+			:count="selection.length"
+			:run="deleteSelection"
+		/>
+	</PageFrame>
+</template>
+
+<script setup lang="ts">
+import { Button, Dropdown, PageHeaderTitle } from "frappe-ui";
+import { ColumnSettings } from "@framework/ui/ColumnSettings";
+import { List, ListBulkBar, ListFooter, type BulkAction } from "@framework/ui/experimental/List";
+import { Filter } from "@framework/ui/Filter";
+import { QuickFilter } from "@framework/ui/QuickFilter";
+import { SortBy } from "@framework/ui/SortBy";
+import { ref } from "vue";
+import { useListPage } from "@/list/useListPage";
+import { useScrollMemory } from "@/list/useScrollMemory";
+import PageFrame, { pageGutter } from "@/shell/PageFrame.vue";
+import DeleteDialog from "./DeleteDialog.vue";
+
+const props = defineProps<{ doctype: string }>();
+
+const {
+	filters,
+	sort,
+	columns,
+	quickFilterFields,
+	customizing,
+	selection,
+	pageSize,
+	rowsKey,
+	rows,
+	loading,
+	error,
+	metaError,
+	rowCount,
+	totalCount,
+	totalCapped,
+	hasCounts,
+	hasNextPage,
+	next,
+	columnsCustomized,
+	resetColumns,
+	resizeColumn,
+	resetColumnWidth,
+	rowLink,
+	deleteSelection,
+} = useListPage(props.doctype);
+
+const table = ref<{ viewportElement: HTMLElement | null } | null>(null);
+const confirmingDelete = ref(false);
+
+useScrollMemory(
+	() => table.value?.viewportElement ?? null,
+	() => rows.value.length > 0,
+	{ doctype: props.doctype, query: rowsKey }
+);
+
+const menuOptions = [
+	{
+		label: "Customize Quick Filter",
+		icon: "lucide-sliders-horizontal",
+		onClick: () => (customizing.value = true),
+	},
+];
+
+const bulkActions: BulkAction[] = [
+	{ label: "Delete", theme: "red", onClick: () => (confirmingDelete.value = true) },
+];
+</script>

--- a/frontend/src/shell/CustomizeSidebarDialog.vue
+++ b/frontend/src/shell/CustomizeSidebarDialog.vue
@@ -14,7 +14,7 @@
 				:key="item.key"
 				:data-key="item.key"
 				:class="[
-					'flex items-center gap-1 rounded px-1 py-1',
+					'flex items-center gap-1 rounded-4 px-1 py-1',
 					item.parent_key ? 'ml-4' : '',
 					item.hidden ? 'opacity-50' : '',
 				]"
@@ -24,7 +24,7 @@
 				@drop.prevent="drop(item.key)"
 			>
 				<input
-					class="min-w-0 flex-1 rounded bg-transparent px-1 py-0.5 text-sm text-ink-gray-8 hover:bg-surface-gray-2 focus:bg-surface-gray-2"
+					class="min-w-0 flex-1 rounded-4 bg-transparent px-1 py-0.5 text-sm text-ink-gray-8 hover:bg-surface-gray-2 focus:bg-surface-gray-2"
 					:value="item.label ?? ''"
 					:placeholder="item.link_to ?? item.key"
 					:aria-label="`Name of ${item.key}`"

--- a/frontend/src/shell/PageFrame.vue
+++ b/frontend/src/shell/PageFrame.vue
@@ -5,7 +5,12 @@
 <template>
 	<!-- Read in the template, not a computed: the slots object is not reactive, and a page can
 	     supply its header after mount. Without a `PageHeader` the shell's target keeps no height. -->
-	<ScrollArea v-if="scroll" class="min-h-0 flex-1" :viewportClass="pageGutter">
+	<ScrollArea
+		v-if="scroll"
+		class="min-h-0 flex-1"
+		:class="gutterVar"
+		:viewportClass="pageGutter"
+	>
 		<PageHeader v-if="title || $slots.header">
 			<slot name="header"><PageHeaderTitle :title="title" /></slot>
 		</PageHeader>
@@ -13,7 +18,7 @@
 	</ScrollArea>
 
 	<!-- No padding here: a pane that scrolls both ways puts the gutter on its own viewport. -->
-	<div v-else class="flex min-h-0 flex-1 flex-col overflow-hidden">
+	<div v-else class="flex min-h-0 flex-1 flex-col overflow-hidden" :class="gutterVar">
 		<PageHeader v-if="title || $slots.header">
 			<slot name="header"><PageHeaderTitle :title="title" /></slot>
 		</PageHeader>
@@ -22,8 +27,9 @@
 </template>
 
 <script lang="ts">
-/** The side padding a page's content shares with the header row: `PageHeader`'s own classes. */
-export const pageGutter = "px-3 sm:px-5";
+/** The side padding a page's content shares with the header row; the frame root sets `--page-gutter`. */
+export const pageGutter = "px-[--page-gutter]";
+const gutterVar = "[--page-gutter:0.75rem] sm:[--page-gutter:1.25rem]";
 </script>
 
 <script setup lang="ts">

--- a/ui/package.json
+++ b/ui/package.json
@@ -102,7 +102,7 @@
     "@vitejs/plugin-vue": ">=4",
     "@vueuse/core": ">=10.4.1",
     "autoprefixer": "^10.4.0",
-    "frappe-ui": ">=1.0.0-beta.16",
+    "frappe-ui": ">=1.0.0-beta.55",
     "tailwindcss": "^3.4.0",
     "typescript": ">=5",
     "vite": ">=4",

--- a/ui/src/components/ActivityTimeline/AttachmentChip.vue
+++ b/ui/src/components/ActivityTimeline/AttachmentChip.vue
@@ -41,12 +41,12 @@
 				>
 					{{ textContent }}
 				</div>
-				<img v-else-if="preview === 'image'" :src="url" class="m-auto rounded border" />
+				<img v-else-if="preview === 'image'" :src="url" class="m-auto rounded-4 border" />
 				<video
 					v-else-if="preview === 'video'"
 					:src="url"
 					controls
-					class="m-auto max-h-[70vh] rounded border"
+					class="m-auto max-h-[70vh] rounded-4 border"
 				/>
 			</template>
 		</Dialog>

--- a/ui/src/components/ActivityTimeline/TimelineCard.vue
+++ b/ui/src/components/ActivityTimeline/TimelineCard.vue
@@ -1,7 +1,7 @@
 <template>
 	<!-- shared card frame for email/comment rows; the header (incl. its padding) is fully slotted -->
 	<div
-		class="timeline-card grow overflow-hidden rounded-md border border-outline-gray-2 bg-surface-base text-base leading-6 transition-all duration-300 ease-in-out"
+		class="timeline-card grow overflow-hidden rounded-5 border border-outline-gray-2 bg-surface-base text-base leading-6 transition-all duration-300 ease-in-out"
 	>
 		<slot name="header" />
 		<hr class="border-t border-outline-elevation-2" />

--- a/ui/src/components/ActivityTimeline/stories/ActivityTimeline.story.vue
+++ b/ui/src/components/ActivityTimeline/stories/ActivityTimeline.story.vue
@@ -15,7 +15,7 @@
 			<Switch v-model="withSlots" label="Slots" />
 		</div>
 
-		<div class="rounded-lg border border-outline-gray-2 p-4">
+		<div class="rounded-6 border border-outline-gray-2 p-4">
 			<ActivityTimeline
 				:activities="activities"
 				:loading="loading"
@@ -48,7 +48,7 @@
 
 				<!-- a consumer-defined type, rendered entirely through its slot -->
 				<template #item-feedback="{ activity }">
-					<div class="rounded-md bg-surface-gray-2 px-3 py-2 text-p-sm text-ink-gray-7">
+					<div class="rounded-5 bg-surface-gray-2 px-3 py-2 text-p-sm text-ink-gray-7">
 						Feedback — ★ {{ asFeedback(activity).rating }}/5 ·
 						{{ asFeedback(activity).message }}
 					</div>

--- a/ui/src/components/ColumnSettings/ColumnSettings.vue
+++ b/ui/src/components/ColumnSettings/ColumnSettings.vue
@@ -35,98 +35,91 @@
 	</Combobox>
 
 	<!-- Non-empty: the columns popover with its reorder / rename / remove rows. -->
-	<Popover v-else ref="popoverRef" placement="bottom-end">
-		<template #target="{ togglePopover }">
+	<Popover v-else ref="popoverRef" side="bottom" align="end">
+		<template #trigger>
 			<Button
 				:label="hideLabel ? undefined : 'Columns'"
 				:icon="hideLabel ? 'lucide-columns-3' : undefined"
 				:iconLeft="!hideLabel ? 'lucide-columns-3' : undefined"
-				@click="
-					confirmingReset = false;
-					togglePopover();
-				"
+				@click="confirmingReset = false"
 			/>
 		</template>
-		<template #body>
-			<div
-				class="my-2 min-w-40 rounded-lg bg-surface-elevation-2 shadow-2xl ring-1 ring-black ring-opacity-5 focus:outline-none"
-			>
-				<!-- Reorder / rename / remove the shown columns, add more. Width is
-				     not edited here — drag-resize in the table owns it (ADR-0006). -->
-				<div class="min-w-60 p-2">
-					<Draggable
-						v-if="model.length"
-						class="mb-3 flex flex-col gap-2"
-						:modelValue="model"
-						:item-key="(c) => c.fieldname"
-						handle=".column-drag-handle"
-						tag="div"
-						@update:modelValue="reorder"
-					>
-						<template #item="{ element: column, index: i }">
-							<div class="flex items-center gap-1">
-								<div
-									class="column-drag-handle flex h-7 w-7 shrink-0 items-center justify-center"
-								>
-									<span
-										class="lucide-grip-vertical size-4 cursor-grab text-ink-gray-5"
-										aria-hidden="true"
-									/>
-								</div>
-								<!-- The label is always a TextInput: read-only at rest, click to
-								     rename. Editing writes a local `draft` (so Esc reverts and
-								     typing doesn't churn the dragged list); commit on Enter/blur. -->
-								<TextInput
-									:ref="editIndex === i ? focusInput : undefined"
-									size="sm"
-									class="min-w-44 flex-1"
-									:readonly="editIndex !== i"
-									:modelValue="editIndex === i ? draft : column.label"
-									@click="editColumn(i)"
-									@update:modelValue="(value: string) => (draft = value)"
-									@keydown.enter.prevent="commitEdit"
-									@keydown.esc.prevent="cancelEdit"
-									@blur="commitEdit"
+		<template #default>
+			<!-- Reorder / rename / remove the shown columns, add more. Width is
+			     not edited here — drag-resize in the table owns it (ADR-0006). -->
+			<div class="min-w-60 p-2">
+				<Draggable
+					v-if="model.length"
+					class="mb-3 flex flex-col gap-2"
+					:modelValue="model"
+					:item-key="(c) => c.fieldname"
+					handle=".column-drag-handle"
+					tag="div"
+					@update:modelValue="reorder"
+				>
+					<template #item="{ element: column, index: i }">
+						<div class="flex items-center gap-1">
+							<div
+								class="column-drag-handle flex h-7 w-7 shrink-0 items-center justify-center"
+							>
+								<span
+									class="lucide-grip-vertical size-4 cursor-grab text-ink-gray-5"
+									aria-hidden="true"
 								/>
-								<Button variant="ghost" icon="lucide-x" @click="removeColumn(i)" />
 							</div>
+							<!-- The label is always a TextInput: read-only at rest, click to
+							     rename. Editing writes a local `draft` (so Esc reverts and
+							     typing doesn't churn the dragged list); commit on Enter/blur. -->
+							<TextInput
+								:ref="editIndex === i ? focusInput : undefined"
+								size="sm"
+								class="min-w-44 flex-1"
+								:readonly="editIndex !== i"
+								:modelValue="editIndex === i ? draft : column.label"
+								@click="editColumn(i)"
+								@update:modelValue="(value: string) => (draft = value)"
+								@keydown.enter.prevent="commitEdit"
+								@keydown.esc.prevent="cancelEdit"
+								@blur="commitEdit"
+							/>
+							<Button variant="ghost" icon="lucide-x" @click="removeColumn(i)" />
+						</div>
+					</template>
+				</Draggable>
+				<div class="flex items-center justify-between gap-2">
+					<!-- A custom #trigger renders the same ghost Button as "Reset" beside
+					     it (gray-5, `+` icon, no chevron). The label is static, so the old
+					     per-add remount (`:key`) and placeholder hacks are gone. When
+					     Reset is hidden, `!flex-1` fills the row and `!justify-start`
+					     left-aligns the icon/label (Button defaults to justify-center). -->
+					<Combobox
+						:options="addableOptions"
+						:modelValue="null"
+						@update:selectedOption="addColumn"
+					>
+						<template #trigger>
+							<Button
+								variant="ghost"
+								label="Add Column"
+								iconLeft="lucide-plus"
+								:class="[
+									'!text-ink-gray-5',
+									canReset ? undefined : '!flex-1 !justify-start',
+								]"
+							/>
 						</template>
-					</Draggable>
-					<div class="flex items-center justify-between gap-2">
-						<!-- A custom #trigger renders the same ghost Button as "Reset" beside
-						     it (gray-5, `+` icon, no chevron). The label is static, so the old
-						     per-add remount (`:key`) and placeholder hacks are gone. When
-						     Reset is hidden, `!flex-1` fills the row and `!justify-start`
-						     left-aligns the icon/label (Button defaults to justify-center). -->
-						<Combobox
-							:options="addableOptions"
-							:modelValue="null"
-							@update:selectedOption="addColumn"
-						>
-							<template #trigger>
-								<Button
-									variant="ghost"
-									label="Add Column"
-									iconLeft="lucide-plus"
-									:class="[
-										'!text-ink-gray-5',
-										canReset ? undefined : '!flex-1 !justify-start',
-									]"
-								/>
-							</template>
-						</Combobox>
-						<!-- Reset to the Meta defaults. The host owns the defaults (ADR-0006),
-						     so this only emits; `canReset` hides it when nothing to undo. The
-						     first click arms an inline confirm, the second emits. -->
-						<Button
-							v-if="canReset"
-							:class="confirmingReset ? undefined : '!text-ink-gray-5'"
-							:variant="confirmingReset ? 'subtle' : 'ghost'"
-							:theme="confirmingReset ? 'red' : 'gray'"
-							:label="confirmingReset ? 'Confirm Reset' : 'Reset'"
-							@click="onResetClick"
-						/>
-					</div>
+					</Combobox>
+					<!-- Reset to the Meta defaults. The host owns the defaults (ADR-0006),
+					     so this only emits; `canReset` hides it when nothing to undo. The
+					     first click arms an inline confirm, the second emits. -->
+					<Button
+						v-if="canReset"
+						:class="confirmingReset ? undefined : '!text-ink-gray-5'"
+						:variant="confirmingReset ? 'subtle' : 'ghost'"
+						:theme="confirmingReset ? 'red' : 'gray'"
+						:label="confirmingReset ? 'Confirm Reset' : 'Reset'"
+						@click="onResetClick"
+					/>
 				</div>
 			</div>
 		</template>

--- a/ui/src/components/Composer/ComposerEditor.vue
+++ b/ui/src/components/Composer/ComposerEditor.vue
@@ -42,7 +42,7 @@
 							@toggle="onQuoteToggle"
 						>
 							<summary
-								class="w-fit cursor-pointer select-none rounded px-1 text-sm font-bold leading-[1.15] text-ink-gray-5 bg-surface-gray-2 list-none [&::-webkit-details-marker]:hidden"
+								class="w-fit cursor-pointer select-none rounded-4 px-1 text-sm font-bold leading-[1.15] text-ink-gray-5 bg-surface-gray-2 list-none [&::-webkit-details-marker]:hidden"
 							>
 								•••
 							</summary>

--- a/ui/src/components/Composer/EmailComposer/RecipientSelect.vue
+++ b/ui/src/components/Composer/EmailComposer/RecipientSelect.vue
@@ -14,7 +14,7 @@
 				<Avatar size="xs" :image="option?.image" :label="option?.label || value" />
 				<span class="mb-0.5 leading-4 truncate">{{ option?.label || value }}</span>
 				<button
-					class="grid size-4 place-items-center rounded-sm text-ink-gray-5 hover:bg-surface-gray-4"
+					class="grid size-4 place-items-center rounded-1 text-ink-gray-5 hover:bg-surface-gray-4"
 					@click.stop="removeTag"
 				>
 					<FeatherIcon name="x" class="size-3" />

--- a/ui/src/components/Composer/stories/CommentThread.vue
+++ b/ui/src/components/Composer/stories/CommentThread.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="rounded-md border border-outline-gray-2 bg-surface-base p-4">
+	<div class="rounded-5 border border-outline-gray-2 bg-surface-base p-4">
 		<div class="flex flex-col gap-4">
 			<div v-for="comment in comments" :key="comment.id" class="flex gap-3">
 				<Avatar size="md" :label="comment.author" />
@@ -19,7 +19,7 @@
 
 		<div class="mt-4 flex gap-3 border-t border-outline-gray-1 pt-4">
 			<Avatar size="md" label="Sydney" />
-			<div class="min-w-0 flex-1 rounded-md border border-outline-gray-2">
+			<div class="min-w-0 flex-1 rounded-5 border border-outline-gray-2">
 				<CommentComposer
 					ref="composerRef"
 					v-model="draft"

--- a/ui/src/components/Composer/stories/Composer.story.vue
+++ b/ui/src/components/Composer/stories/Composer.story.vue
@@ -23,7 +23,7 @@
 			</p>
 			<TicketReply />
 			<pre
-				class="mt-3 overflow-auto rounded-lg bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
+				class="mt-3 overflow-auto rounded-6 bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
 			><code>{{ ticketSnippet }}</code></pre>
 		</section>
 
@@ -37,7 +37,7 @@
 			</p>
 			<DockedCompose />
 			<pre
-				class="mt-3 overflow-auto rounded-lg bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
+				class="mt-3 overflow-auto rounded-6 bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
 			><code>{{ dockedSnippet }}</code></pre>
 		</section>
 
@@ -50,7 +50,7 @@
 			</p>
 			<CommentThread />
 			<pre
-				class="mt-3 overflow-auto rounded-lg bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
+				class="mt-3 overflow-auto rounded-6 bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
 			><code>{{ commentSnippet }}</code></pre>
 		</section>
 
@@ -63,7 +63,7 @@
 			</p>
 			<QuickReply />
 			<pre
-				class="mt-3 overflow-auto rounded-lg bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
+				class="mt-3 overflow-auto rounded-6 bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
 			><code>{{ quickSnippet }}</code></pre>
 		</section>
 
@@ -75,7 +75,7 @@
 			</p>
 			<CustomUtility />
 			<pre
-				class="mt-3 overflow-auto rounded-lg bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
+				class="mt-3 overflow-auto rounded-6 bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
 			><code>{{ utilitySnippet }}</code></pre>
 		</section>
 	</div>

--- a/ui/src/components/Composer/stories/CustomUtility.vue
+++ b/ui/src/components/Composer/stories/CustomUtility.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="rounded-md border border-outline-gray-2 bg-surface-base p-2">
+	<div class="rounded-5 border border-outline-gray-2 bg-surface-base p-2">
 		<EmailComposer
 			ref="composerRef"
 			v-model="body"

--- a/ui/src/components/Composer/stories/DockedCompose.vue
+++ b/ui/src/components/Composer/stories/DockedCompose.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="rounded-md border border-outline-gray-2 p-4">
+	<div class="rounded-5 border border-outline-gray-2 p-4">
 		<p v-if="lastSent" class="mb-3 text-p-sm text-ink-gray-5">Sent “{{ lastSent }}” ✓</p>
 		<!-- FloatingWindow brings dock, float, and minimize; the draft rides along. -->
 		<FloatingWindow title="New message">

--- a/ui/src/components/Composer/stories/QuickReply.vue
+++ b/ui/src/components/Composer/stories/QuickReply.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="rounded-md border border-outline-gray-2 bg-surface-base">
+	<div class="rounded-5 border border-outline-gray-2 bg-surface-base">
 		<div class="flex gap-3 border-b border-outline-gray-2 px-4 py-3">
 			<Avatar size="md" label="Grace Hopper" />
 			<div class="min-w-0">

--- a/ui/src/components/Composer/stories/TicketReply.vue
+++ b/ui/src/components/Composer/stories/TicketReply.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="rounded-md border border-outline-gray-2 bg-surface-base">
+	<div class="rounded-5 border border-outline-gray-2 bg-surface-base">
 		<div class="flex items-center justify-between border-b border-outline-gray-2 px-4 py-3">
 			<div>
 				<div class="text-base font-medium text-ink-gray-9">

--- a/ui/src/components/ConditionBuilder/ConditionBuilder.vue
+++ b/ui/src/components/ConditionBuilder/ConditionBuilder.vue
@@ -34,7 +34,7 @@
 		<div
 			v-if="fieldsError"
 			data-slot="condition-fields-error"
-			class="mb-4 flex items-center gap-2 rounded-md bg-surface-red-2 p-2 text-p-sm text-ink-red-6"
+			class="mb-4 flex items-center gap-2 rounded-5 bg-surface-red-2 p-2 text-p-sm text-ink-red-6"
 		>
 			<span :id="fieldsErrorId" class="min-w-0 flex-1">{{ labels.fieldsError }}</span>
 			<Button
@@ -54,7 +54,7 @@
 			data-slot="condition-empty"
 			:type="readonly ? undefined : 'button'"
 			:tabindex="readonly ? -1 : undefined"
-			class="flex w-full items-center justify-center gap-2 rounded-md border border-outline-gray-2 p-4 text-p-sm text-ink-gray-5"
+			class="flex w-full items-center justify-center gap-2 rounded-5 border border-outline-gray-2 p-4 text-p-sm text-ink-gray-5"
 			:class="!readonly && 'cursor-pointer'"
 			@click="onEmptyClick"
 		>
@@ -67,7 +67,7 @@
 		<div
 			v-else
 			class="flex w-full flex-col gap-4"
-			:class="bordered !== 'none' && 'rounded-lg border border-outline-gray-2 p-3'"
+			:class="bordered !== 'none' && 'rounded-6 border border-outline-gray-2 p-3'"
 		>
 			<ConditionGroup :group="tree" :path="[]">
 				<template v-if="$slots.condition" #condition="slotProps">

--- a/ui/src/components/ConditionBuilder/ConditionGroup.vue
+++ b/ui/src/components/ConditionBuilder/ConditionGroup.vue
@@ -15,7 +15,7 @@
 		:aria-describedby="describedBy || undefined"
 		:aria-invalid="invalid || undefined"
 		class="flex w-full min-w-0 flex-col gap-4"
-		:class="hasCard && 'rounded-lg border border-outline-gray-2 bg-surface-base p-3'"
+		:class="hasCard && 'rounded-6 border border-outline-gray-2 bg-surface-base p-3'"
 	>
 		<legend v-if="rootTag === 'fieldset'" :id="legendId" class="sr-only">
 			{{ groupName }}
@@ -42,7 +42,7 @@
 			role="list"
 			:data-group-path="path.join('.')"
 			:data-condition-builder="builderId"
-			class="flex w-full min-w-0 list-none flex-col gap-4 rounded-md"
+			class="flex w-full min-w-0 list-none flex-col gap-4 rounded-5"
 			:class="canTakeDrag && 'bg-surface-gray-2'"
 			ghost-class="opacity-40"
 			chosen-class="cursor-grabbing"

--- a/ui/src/components/DataImport/MappingStep.vue
+++ b/ui/src/components/DataImport/MappingStep.vue
@@ -19,7 +19,7 @@
 			</div>
 		</div>
 
-		<div v-if="Object.keys(columnMappings).length" class="border rounded-md space-y-8">
+		<div v-if="Object.keys(columnMappings).length" class="border rounded-5 space-y-8">
 			<div class="grid grid-cols-2 text-ink-gray-5 border-b py-2 px-4">
 				<div>Fields in File</div>
 				<div>Fields in System</div>

--- a/ui/src/components/DataImport/PreviewStep.vue
+++ b/ui/src/components/DataImport/PreviewStep.vue
@@ -24,7 +24,7 @@
 
 		<div v-if="mapping.length" class="space-y-2">
 			<div class="text-ink-gray-5 text-sm">Column Mapping</div>
-			<div class="border rounded-md bg-surface-gray-2 p-4 space-y-4 text-sm text-ink-gray-7">
+			<div class="border rounded-5 bg-surface-gray-2 p-4 space-y-4 text-sm text-ink-gray-7">
 				<div
 					v-for="map in mapping"
 					class="grid grid-cols-[40%,10%,40%] lg:grid-cols-3 space-x-3 items-center"
@@ -44,7 +44,7 @@
 
 		<div v-if="warnings.length" class="space-y-2">
 			<div class="text-ink-gray-5 text-sm">Warnings</div>
-			<div class="rounded-md bg-surface-amber-2 p-2 space-y-2 text-xs">
+			<div class="rounded-5 bg-surface-amber-2 p-2 space-y-2 text-xs">
 				<div v-for="warning in warnings" class="flex items-center space-x-2">
 					<FeatherIcon name="alert-circle" class="size-3 text-ink-amber-6" />
 					<div v-html="warning.message" class="text-ink-amber-6"></div>
@@ -52,9 +52,9 @@
 			</div>
 		</div>
 
-		<div v-if="preview?.data?.length" class="border rounded-md overflow-x-auto">
+		<div v-if="preview?.data?.length" class="border rounded-5 overflow-x-auto">
 			<table class="divide-y">
-				<thead class="rounded-t-md">
+				<thead class="rounded-t-5">
 					<tr>
 						<th
 							v-for="column in previewColumns"
@@ -96,7 +96,7 @@
 		<div v-if="data.status != 'Pending' && importLogs.length" class="space-y-4">
 			<div class="font-semibold text-ink-gray-9">Import Logs</div>
 
-			<div class="rounded-md p-2" :class="importBannerClass">
+			<div class="rounded-5 p-2" :class="importBannerClass">
 				{{ importSuccessCount }} {{ importSuccessCount == 1 ? "row" : "rows" }} imported
 				successfully, {{ importErrorCount }}
 				{{ importErrorCount == 1 ? "row" : "rows" }} failed.
@@ -104,9 +104,9 @@
 
 			<TabButtons :buttons="tabButtons" v-model="activeTab" class="w-fit" />
 
-			<div v-if="filteredLogs.length" class="border rounded-md overflow-x-auto">
+			<div v-if="filteredLogs.length" class="border rounded-5 overflow-x-auto">
 				<table class="table-fixed w-full divide-y">
-					<thead class="rounded-t-md">
+					<thead class="rounded-t-5">
 						<tr>
 							<th
 								class="p-2 text-left text-sm text-ink-gray-5 w-20 border-r text-center"
@@ -122,9 +122,9 @@
 								<div class="flex items-center justify-center space-x-2">
 									<div
 										v-if="row.success"
-										class="size-1.5 bg-surface-green-3 rounded"
+										class="size-1.5 bg-surface-green-3 rounded-4"
 									></div>
-									<div v-else class="size-1.5 bg-surface-red-7 rounded"></div>
+									<div v-else class="size-1.5 bg-surface-red-7 rounded-4"></div>
 									<div>
 										{{ JSON.parse(row["row_indexes"])[0] - 1 }}
 									</div>

--- a/ui/src/components/DataImport/UploadStep.vue
+++ b/ui/src/components/DataImport/UploadStep.vue
@@ -22,7 +22,7 @@
 				v-if="showFileSelector && !importFile"
 				@dragover.prevent
 				@drop.prevent="(e) => uploadFile(e)"
-				class="h-[300px] flex items-center justify-center bg-surface-gray-1 border border-dashed border-outline-gray-3 rounded-md"
+				class="h-[300px] flex items-center justify-center bg-surface-gray-1 border border-dashed border-outline-gray-3 rounded-5"
 			>
 				<div v-if="showFileSelector && !uploading" class="w-4/5 lg:w-2/5 text-center">
 					<FeatherIcon
@@ -54,7 +54,7 @@
 				</div>
 				<div
 					v-else-if="showFileSelector && uploading"
-					class="w-4/5 lg:w-2/5 bg-surface-base border rounded-md p-2"
+					class="w-4/5 lg:w-2/5 bg-surface-base border rounded-5 p-2"
 				>
 					<div class="space-y-2">
 						<div class="font-medium">
@@ -74,10 +74,10 @@
 			</div>
 			<div
 				v-else-if="importFile"
-				class="h-[300px] flex items-center justify-center bg-surface-gray-1 border border-dashed border-outline-gray-3 rounded-md"
+				class="h-[300px] flex items-center justify-center bg-surface-gray-1 border border-dashed border-outline-gray-3 rounded-5"
 			>
 				<div
-					class="w-4/5 lg:w-2/5 bg-surface-base border rounded-md p-2 flex items-center justify-between items-center"
+					class="w-4/5 lg:w-2/5 bg-surface-base border rounded-5 p-2 flex items-center justify-between items-center"
 				>
 					<div class="space-y-2">
 						<div class="font-medium leading-5 text-ink-gray-9">
@@ -97,7 +97,7 @@
 
 			<div
 				v-else-if="showSheetSelector"
-				class="flex flex-col h-[300px] p-4 border border-dashed border-outline-gray-3 rounded-md"
+				class="flex flex-col h-[300px] p-4 border border-dashed border-outline-gray-3 rounded-5"
 			>
 				<div class="flex items-center space-x-2 text-ink-gray-7">
 					<FeatherIcon
@@ -113,7 +113,7 @@
 					<input
 						v-model="googleSheet"
 						type="text"
-						class="w-full border border-outline-gray-2 rounded-md px-2.5 text-base"
+						class="w-full border border-outline-gray-2 rounded-5 px-2.5 text-base"
 						placeholder="Add Google Sheets Link"
 					/>
 					<div class="text-ink-gray-5">

--- a/ui/src/components/Fields/AttachField.vue
+++ b/ui/src/components/Fields/AttachField.vue
@@ -43,14 +43,14 @@
 						<img
 							:src="modelValue"
 							alt=""
-							class="size-4 shrink-0 rounded object-cover"
+							class="size-4 shrink-0 rounded-4 object-cover"
 						/>
 					</template>
 					<template #body-main>
 						<img
 							:src="modelValue"
 							alt=""
-							class="max-h-64 max-w-72 rounded-md object-contain p-1"
+							class="max-h-64 max-w-72 rounded-5 object-contain p-1"
 						/>
 					</template>
 				</Popover>
@@ -73,7 +73,7 @@
 					<button
 						type="button"
 						aria-label="Replace"
-						class="grid size-4 shrink-0 place-items-center rounded-sm text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+						class="grid size-4 shrink-0 place-items-center rounded-1 text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
 						@click.stop="openDialog"
 						@pointerdown.stop
 					>
@@ -83,7 +83,7 @@
 						type="button"
 						aria-label="Clear"
 						data-slot="clear"
-						class="grid size-4 shrink-0 place-items-center rounded-sm text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+						class="grid size-4 shrink-0 place-items-center rounded-1 text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
 						@click.stop="clear"
 						@pointerdown.stop
 					>

--- a/ui/src/components/Fields/CodeEditorField.vue
+++ b/ui/src/components/Fields/CodeEditorField.vue
@@ -83,7 +83,7 @@
 					v-show="previewOpen"
 					:modelValue="value"
 					:language="language"
-					class="mt-1 min-h-[4.5rem] rounded-md border border-outline-gray-1 p-3"
+					class="mt-1 min-h-[4.5rem] rounded-5 border border-outline-gray-1 p-3"
 				/>
 			</div>
 		</div>
@@ -103,7 +103,7 @@
 			<CodePreview
 				:modelValue="value"
 				:language="language"
-				class="min-h-[4.5rem] rounded-md border border-outline-gray-1 p-3"
+				class="min-h-[4.5rem] rounded-5 border border-outline-gray-1 p-3"
 			/>
 		</div>
 	</div>

--- a/ui/src/components/Fields/GeolocationField.vue
+++ b/ui/src/components/Fields/GeolocationField.vue
@@ -30,7 +30,7 @@
 					type="button"
 					aria-label="Clear"
 					data-slot="clear"
-					class="group-hover:grid group-focus:grid group-focus-within:grid hidden size-4 place-items-center rounded-sm text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+					class="group-hover:grid group-focus:grid group-focus-within:grid hidden size-4 place-items-center rounded-1 text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
 					@click.stop="clearLocation"
 					@pointerdown.stop
 				>
@@ -49,11 +49,11 @@
 			     empty map (see loadError). -->
 			<div
 				v-if="loadError"
-				class="flex h-[500px] w-full items-center justify-center rounded border border-dashed border-outline-gray-2 p-6 text-center text-p-sm text-ink-gray-6"
+				class="flex h-[500px] w-full items-center justify-center rounded-4 border border-dashed border-outline-gray-2 p-6 text-center text-p-sm text-ink-gray-6"
 			>
 				{{ loadError }}
 			</div>
-			<div v-else :id="mapId" class="h-[500px] w-full rounded" />
+			<div v-else :id="mapId" class="h-[500px] w-full rounded-4" />
 			<template #actions>
 				<div class="flex items-center justify-end gap-2">
 					<Button

--- a/ui/src/components/Fields/ImageField.vue
+++ b/ui/src/components/Fields/ImageField.vue
@@ -16,7 +16,7 @@
 			role="group"
 			:aria-labelledby="labelledBy"
 			:aria-describedby="describedBy"
-			class="flex items-center justify-center overflow-hidden rounded-lg border border-outline-gray-1 bg-surface-gray-1"
+			class="flex items-center justify-center overflow-hidden rounded-6 border border-outline-gray-1 bg-surface-gray-1"
 			:class="url ? 'min-h-32' : 'min-h-24'"
 		>
 			<img

--- a/ui/src/components/FileUpload/AttachmentsList.vue
+++ b/ui/src/components/FileUpload/AttachmentsList.vue
@@ -2,7 +2,7 @@
 	<div class="flex flex-col gap-2">
 		<div
 			v-if="modelValue.length"
-			class="flex flex-col divide-y divide-outline-gray-1 rounded-lg border border-outline-gray-1"
+			class="flex flex-col divide-y divide-outline-gray-1 rounded-6 border border-outline-gray-1"
 		>
 			<a
 				v-for="(attachment, index) in modelValue"
@@ -13,7 +13,7 @@
 				class="group flex items-center gap-3 px-3 py-2 hover:bg-surface-gray-1"
 			>
 				<span
-					class="grid size-9 shrink-0 place-items-center overflow-hidden rounded border border-outline-gray-1 bg-surface-gray-1"
+					class="grid size-9 shrink-0 place-items-center overflow-hidden rounded-4 border border-outline-gray-1 bg-surface-gray-1"
 				>
 					<img
 						v-if="isImage(attachment.file_url)"
@@ -34,7 +34,7 @@
 				<button
 					type="button"
 					aria-label="Remove"
-					class="grid size-5 shrink-0 place-items-center rounded text-ink-gray-5 opacity-0 hover:bg-surface-gray-3 group-hover:opacity-100"
+					class="grid size-5 shrink-0 place-items-center rounded-4 text-ink-gray-5 opacity-0 hover:bg-surface-gray-3 group-hover:opacity-100"
 					@click.prevent="remove(index)"
 				>
 					<span class="lucide-x size-3.5" />
@@ -43,7 +43,7 @@
 		</div>
 		<div
 			v-else
-			class="rounded-lg border border-dashed border-outline-gray-2 p-4 text-center text-p-sm text-ink-gray-5"
+			class="rounded-6 border border-dashed border-outline-gray-2 p-4 text-center text-p-sm text-ink-gray-5"
 		>
 			No attachments yet.
 		</div>

--- a/ui/src/components/FileUpload/FileUploadDialog.vue
+++ b/ui/src/components/FileUpload/FileUploadDialog.vue
@@ -14,7 +14,7 @@
 			     distinct zone from the add-menu below (same row styling otherwise). -->
 			<div
 				v-if="uploader.items.length && !composing"
-				class="mb-1.5 rounded-lg border border-outline-gray-1 bg-surface-gray-2 p-1"
+				class="mb-1.5 rounded-6 border border-outline-gray-1 bg-surface-gray-2 p-1"
 			>
 				<!-- mini-header: count + bulk Set-all privacy. Optimize is image-only,
 				     so it lives on each image row (below), not here. -->
@@ -23,7 +23,7 @@
 					<Dropdown :options="bulkPrivacyOptions">
 						<button
 							type="button"
-							class="flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-ink-gray-6 hover:bg-surface-gray-3"
+							class="flex items-center gap-1 rounded-4 px-1.5 py-0.5 text-xs text-ink-gray-6 hover:bg-surface-gray-3"
 						>
 							<span :class="[bulkPrivacyIcon, 'size-3']" />
 							{{ bulkPrivacyLabel }}
@@ -35,11 +35,11 @@
 				<div
 					v-for="item in uploader.items"
 					:key="item.id"
-					class="group flex items-center gap-2.5 rounded-md px-2 py-1.5 hover:bg-surface-gray-3"
+					class="group flex items-center gap-2.5 rounded-5 px-2 py-1.5 hover:bg-surface-gray-3"
 				>
 					<!-- thumbnail / kind icon -->
 					<div
-						class="flex size-8 flex-shrink-0 items-center justify-center overflow-hidden rounded bg-surface-gray-2"
+						class="flex size-8 flex-shrink-0 items-center justify-center overflow-hidden rounded-4 bg-surface-gray-2"
 					>
 						<img
 							v-if="thumbUrl(item)"
@@ -211,7 +211,7 @@
 						v-for="option in menu"
 						:key="option.key"
 						type="button"
-						class="flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-left hover:bg-surface-gray-2"
+						class="flex w-full items-center gap-2.5 rounded-5 px-2 py-1.5 text-left hover:bg-surface-gray-2"
 						@click="onMenu(option.key)"
 					>
 						<span :class="[option.icon, 'size-4 text-ink-gray-6']" />
@@ -255,7 +255,7 @@
 			<!-- drop overlay — only while dragging files over this popover -->
 			<div
 				v-if="dragging"
-				class="absolute inset-1 z-10 flex flex-col items-center justify-center gap-1.5 rounded-lg border-2 border-dashed border-outline-gray-4 bg-surface-gray-1/90 text-ink-gray-7"
+				class="absolute inset-1 z-10 flex flex-col items-center justify-center gap-1.5 rounded-6 border-2 border-dashed border-outline-gray-4 bg-surface-gray-1/90 text-ink-gray-7"
 			>
 				<span class="lucide-cloud-upload size-7" />
 				<p class="text-p-sm font-medium">Drop files here</p>

--- a/ui/src/components/FileUpload/ImageCropper.vue
+++ b/ui/src/components/FileUpload/ImageCropper.vue
@@ -2,11 +2,11 @@
 	<div class="flex flex-col gap-3">
 		<div
 			v-if="loadError"
-			class="flex h-80 items-center justify-center rounded-lg border border-dashed border-outline-gray-2 p-6 text-center text-p-sm text-ink-gray-6"
+			class="flex h-80 items-center justify-center rounded-6 border border-dashed border-outline-gray-2 p-6 text-center text-p-sm text-ink-gray-6"
 		>
 			{{ loadError }}
 		</div>
-		<div v-show="!loadError" class="h-[60vh] overflow-hidden rounded-lg bg-surface-gray-10">
+		<div v-show="!loadError" class="h-[60vh] overflow-hidden rounded-6 bg-surface-gray-10">
 			<!-- cropperjs v2 replaces this <img> with a <cropper-canvas> tree. -->
 			<img ref="image" :src="objectUrl" alt="" class="block max-w-full" />
 		</div>

--- a/ui/src/components/FileUpload/UploadTray.vue
+++ b/ui/src/components/FileUpload/UploadTray.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
 		v-if="batches.length"
-		class="fixed z-50 w-80 overflow-hidden rounded-lg border border-outline-gray-2 bg-surface-base shadow-lg"
+		class="fixed z-50 w-80 overflow-hidden rounded-6 border border-outline-gray-2 bg-surface-base shadow-lg"
 		:class="positionClass"
 		@mouseenter="onEnter"
 	>
@@ -28,7 +28,7 @@
 			<button
 				type="button"
 				aria-label="Toggle"
-				class="grid size-5 place-items-center rounded text-ink-gray-5 hover:bg-surface-gray-2"
+				class="grid size-5 place-items-center rounded-4 text-ink-gray-5 hover:bg-surface-gray-2"
 				@click="expanded = !expanded"
 			>
 				<span
@@ -39,7 +39,7 @@
 			<button
 				type="button"
 				aria-label="Close"
-				class="grid size-5 place-items-center rounded text-ink-gray-5 hover:bg-surface-gray-2"
+				class="grid size-5 place-items-center rounded-4 text-ink-gray-5 hover:bg-surface-gray-2"
 				@click="dismiss"
 			>
 				<span class="lucide-x size-4" />
@@ -73,7 +73,7 @@
 						v-if="item.status === 'uploading' && batch.cancel"
 						type="button"
 						aria-label="Cancel"
-						class="grid size-4 place-items-center rounded text-ink-gray-5 hover:bg-surface-gray-2"
+						class="grid size-4 place-items-center rounded-4 text-ink-gray-5 hover:bg-surface-gray-2"
 						@click="batch.cancel(item.id)"
 					>
 						<span class="lucide-x size-3" />
@@ -82,7 +82,7 @@
 						v-if="item.status === 'error' && batch.retry"
 						type="button"
 						aria-label="Retry"
-						class="grid size-4 place-items-center rounded text-ink-gray-5 hover:bg-surface-gray-2"
+						class="grid size-4 place-items-center rounded-4 text-ink-gray-5 hover:bg-surface-gray-2"
 						@click="batch.retry(item.id)"
 					>
 						<span class="lucide-rotate-cw size-3" />

--- a/ui/src/components/FileUpload/sources/CameraSource.vue
+++ b/ui/src/components/FileUpload/sources/CameraSource.vue
@@ -2,7 +2,7 @@
 	<div class="flex flex-col items-center gap-3">
 		<div
 			v-if="error"
-			class="flex min-h-64 w-full items-center justify-center rounded-lg border border-dashed border-outline-gray-2 p-6 text-center text-p-sm text-ink-gray-6"
+			class="flex min-h-64 w-full items-center justify-center rounded-6 border border-dashed border-outline-gray-2 p-6 text-center text-p-sm text-ink-gray-6"
 		>
 			{{ error }}
 		</div>
@@ -10,11 +10,11 @@
 			<video
 				v-show="!snapshot"
 				ref="video"
-				class="max-h-80 w-full rounded-lg bg-surface-gray-10"
+				class="max-h-80 w-full rounded-6 bg-surface-gray-10"
 				autoplay
 				playsinline
 			/>
-			<canvas v-show="snapshot" ref="canvas" class="max-h-80 w-full rounded-lg" />
+			<canvas v-show="snapshot" ref="canvas" class="max-h-80 w-full rounded-6" />
 			<div class="flex w-full items-center justify-end gap-2">
 				<template v-if="!snapshot">
 					<Button

--- a/ui/src/components/Filter/Filter.vue
+++ b/ui/src/components/Filter/Filter.vue
@@ -32,14 +32,13 @@
 	</Combobox>
 
 	<!-- Non-empty: the filter popover with its condition rows. -->
-	<Popover v-else ref="popoverRef" placement="bottom-end">
-		<template #target="{ togglePopover, close }">
+	<Popover v-else ref="popoverRef" side="bottom" align="end">
+		<template #trigger="{ close }">
 			<div class="flex items-center">
 				<Button
 					label="Filter"
 					class="relative rounded-r-none focus-visible:z-10"
 					iconLeft="lucide-list-filter"
-					@click="togglePopover"
 				>
 					<template #suffix>
 						<div
@@ -57,91 +56,87 @@
 				/>
 			</div>
 		</template>
-		<template #body="{ close }">
-			<div
-				class="my-2 min-w-40 rounded-lg bg-surface-elevation-2 shadow-2xl ring-1 ring-black ring-opacity-5 focus:outline-none"
-			>
-				<div class="min-w-72 p-2 sm:min-w-[400px]">
-					<!-- One grid for all rows so the field / operator / value columns
-					     line up across rows instead of each row sizing to its own
-					     content. Columns auto-size to the widest cell; the controls
-					     fill their column (`w-full`) so every box shares a width. -->
-					<div
-						v-if="model.length"
-						class="mb-3 grid grid-cols-[auto_auto_auto_auto_auto] items-center gap-x-2 gap-y-3"
+		<template #default="{ close }">
+			<div class="min-w-72 p-2 sm:min-w-[400px]">
+				<!-- One grid for all rows so the field / operator / value columns
+				     line up across rows instead of each row sizing to its own
+				     content. Columns auto-size to the widest cell; the controls
+				     fill their column (`w-full`) so every box shares a width. -->
+				<div
+					v-if="model.length"
+					class="mb-3 grid grid-cols-[auto_auto_auto_auto_auto] items-center gap-x-2 gap-y-3"
+				>
+					<template v-for="(f, i) in model" :key="i">
+						<div class="w-13 pl-2 text-end text-base text-ink-gray-5">
+							{{ i == 0 ? "Where" : "And" }}
+						</div>
+						<div class="min-w-[140px]">
+							<Combobox
+								class="w-full"
+								trigger="button"
+								variant="subtle"
+								size="md"
+								:modelValue="f.fieldname"
+								:options="allFields"
+								placeholder="Select field"
+								@update:selectedOption="(o) => updateField(o, i)"
+							/>
+						</div>
+						<div>
+							<Select
+								class="w-full"
+								:modelValue="f.operator"
+								:options="getOperators(f.field?.fieldtype ?? '', f.fieldname)"
+								placeholder="Equals"
+								@update:modelValue="(v) => updateOperator(v, i)"
+							/>
+						</div>
+						<div class="w-[180px]">
+							<component
+								:is="VALUE_CONTROLS[valueControl(f).control]"
+								v-bind="valueControl(f).props"
+								class="w-full"
+								:modelValue="f.value"
+								@update:modelValue="(v) => updateValue(v, i)"
+							/>
+						</div>
+						<Button
+							class="flex"
+							variant="ghost"
+							icon="lucide-x"
+							@click="removeFilter(i)"
+						/>
+					</template>
+				</div>
+				<div v-else class="mb-3 flex h-7 items-center px-3 text-sm text-ink-gray-5">
+					Empty - Choose a field to filter by
+				</div>
+				<div class="flex items-center justify-between gap-2">
+					<!-- A custom #trigger renders the same ghost Button as "Clear All
+					     Filters" beside it (gray-5, `+` icon, no chevron). The label is
+					     static, so the old per-add remount (`:key`) and the placeholder /
+					     chevron CSS hacks are no longer needed. -->
+					<Combobox
+						:options="allFields"
+						:modelValue="null"
+						@update:selectedOption="addFilter"
 					>
-						<template v-for="(f, i) in model" :key="i">
-							<div class="w-13 pl-2 text-end text-base text-ink-gray-5">
-								{{ i == 0 ? "Where" : "And" }}
-							</div>
-							<div class="min-w-[140px]">
-								<Combobox
-									class="w-full"
-									trigger="button"
-									variant="subtle"
-									size="md"
-									:modelValue="f.fieldname"
-									:options="allFields"
-									placeholder="Select field"
-									@update:selectedOption="(o) => updateField(o, i)"
-								/>
-							</div>
-							<div>
-								<Select
-									class="w-full"
-									:modelValue="f.operator"
-									:options="getOperators(f.field?.fieldtype ?? '', f.fieldname)"
-									placeholder="Equals"
-									@update:modelValue="(v) => updateOperator(v, i)"
-								/>
-							</div>
-							<div class="w-[180px]">
-								<component
-									:is="VALUE_CONTROLS[valueControl(f).control]"
-									v-bind="valueControl(f).props"
-									class="w-full"
-									:modelValue="f.value"
-									@update:modelValue="(v) => updateValue(v, i)"
-								/>
-							</div>
+						<template #trigger>
 							<Button
-								class="flex"
+								class="!text-ink-gray-5"
 								variant="ghost"
-								icon="lucide-x"
-								@click="removeFilter(i)"
+								label="Add Filter"
+								iconLeft="lucide-plus"
 							/>
 						</template>
-					</div>
-					<div v-else class="mb-3 flex h-7 items-center px-3 text-sm text-ink-gray-5">
-						Empty - Choose a field to filter by
-					</div>
-					<div class="flex items-center justify-between gap-2">
-						<!-- A custom #trigger renders the same ghost Button as "Clear All
-						     Filters" beside it (gray-5, `+` icon, no chevron). The label is
-						     static, so the old per-add remount (`:key`) and the placeholder /
-						     chevron CSS hacks are no longer needed. -->
-						<Combobox
-							:options="allFields"
-							:modelValue="null"
-							@update:selectedOption="addFilter"
-						>
-							<template #trigger>
-								<Button
-									class="!text-ink-gray-5"
-									variant="ghost"
-									label="Add Filter"
-									iconLeft="lucide-plus"
-								/>
-							</template>
-						</Combobox>
-						<Button
-							v-if="model.length"
-							class="!text-ink-gray-5"
-							variant="ghost"
-							label="Clear All Filters"
-							@click="clearAll(close)"
-						/>
-					</div>
+					</Combobox>
+					<Button
+						v-if="model.length"
+						class="!text-ink-gray-5"
+						variant="ghost"
+						label="Clear All Filters"
+						@click="clearAll(close)"
+					/>
 				</div>
 			</div>
 		</template>

--- a/ui/src/components/FormLayout/FormLayout.vue
+++ b/ui/src/components/FormLayout/FormLayout.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
 		class="flex flex-col"
-		:class="{ 'border border-outline-gray-1 border-outline-elevation-2 rounded-lg': hasTabs }"
+		:class="{ 'border border-outline-gray-1 border-outline-elevation-2 rounded-6': hasTabs }"
 	>
 		<Tabs
 			:model-value="activeIndex"

--- a/ui/src/components/Grid/Grid.vue
+++ b/ui/src/components/Grid/Grid.vue
@@ -27,7 +27,7 @@
 
 		<div
 			v-if="columns.length"
-			class="relative isolate overflow-hidden rounded border border-outline-gray-2"
+			class="relative isolate overflow-hidden rounded-4 border border-outline-gray-2"
 			:class="{ 'grid-disabled': disabled }"
 		>
 			<!-- Scroller + shadows share a `relative` box so the shadows clamp to the

--- a/ui/src/components/InviteUser/stories/InviteUser.story.vue
+++ b/ui/src/components/InviteUser/stories/InviteUser.story.vue
@@ -12,7 +12,7 @@
 			<Switch v-model="showResultToasts" label="Result toasts" />
 		</div>
 
-		<div class="rounded-lg border border-outline-gray-2 p-4">
+		<div class="rounded-6 border border-outline-gray-2 p-4">
 			<InviteUser
 				v-bind="controller"
 				:show-result-toasts="showResultToasts"
@@ -28,7 +28,7 @@
 		     owned by the panel. Use a field slot only when you need to replace the
 		     rendered field wholesale. -->
 		<h4 class="mb-2 mt-8 text-lg-semibold text-ink-gray-9">emailProps / rolesProps</h4>
-		<div class="rounded-lg border border-outline-gray-2 p-4">
+		<div class="rounded-6 border border-outline-gray-2 p-4">
 			<InviteUser
 				v-bind="controller"
 				:show-result-toasts="showResultToasts"

--- a/ui/src/components/Link/Link.vue
+++ b/ui/src/components/Link/Link.vue
@@ -28,7 +28,7 @@
 				type="button"
 				aria-label="Clear"
 				data-slot="clear"
-				class="group-hover:grid group-focus:grid group-focus-within:grid hidden size-4 place-items-center rounded-sm text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+				class="group-hover:grid group-focus:grid group-focus-within:grid hidden size-4 place-items-center rounded-1 text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
 				@click.stop="clearValue"
 				@pointerdown.stop
 			>
@@ -39,7 +39,7 @@
 				type="button"
 				aria-label="Edit linked record"
 				data-slot="edit"
-				class="group-hover:grid group-focus:grid group-focus-within:grid hidden size-4 place-items-center rounded-sm text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+				class="group-hover:grid group-focus:grid group-focus-within:grid hidden size-4 place-items-center rounded-1 text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
 				@click.stop="emit('edit', model!)"
 				@pointerdown.stop
 			>
@@ -50,7 +50,7 @@
 				type="button"
 				aria-label="Open linked record"
 				data-slot="redirect"
-				class="group-hover:grid group-focus:grid group-focus-within:grid hidden size-4 place-items-center rounded-sm text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+				class="group-hover:grid group-focus:grid group-focus-within:grid hidden size-4 place-items-center rounded-1 text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
 				@click.stop="emit('redirect', model!)"
 				@pointerdown.stop
 			>

--- a/ui/src/components/ListView/ListViewShell.vue
+++ b/ui/src/components/ListView/ListViewShell.vue
@@ -18,7 +18,7 @@
 -->
 <template>
 	<div
-		class="flex min-h-0 flex-col overflow-hidden rounded-lg border border-outline-gray-1 bg-surface-base"
+		class="flex min-h-0 flex-col overflow-hidden rounded-6 border border-outline-gray-1 bg-surface-base"
 	>
 		<!-- Toolbar region: the home of the list-view controls. The slotted content
 		     owns its own alignment (quick filters left, Filter/Sort right). -->

--- a/ui/src/components/Notifications/stories/Notifications.story.vue
+++ b/ui/src/components/Notifications/stories/Notifications.story.vue
@@ -14,7 +14,7 @@
 			<Switch v-model="errored" label="Error" />
 		</div>
 
-		<div class="h-[480px] rounded-lg border border-outline-gray-2 overflow-hidden">
+		<div class="h-[480px] rounded-6 border border-outline-gray-2 overflow-hidden">
 			<NotificationPanel
 				v-bind="controller"
 				:tabs="withTabs ? tabs : undefined"

--- a/ui/src/components/Onboarding/GettingStartedBanner.vue
+++ b/ui/src/components/Onboarding/GettingStartedBanner.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
 		v-if="!isSidebarCollapsed"
-		class="flex flex-col gap-3 shadow-sm rounded-lg py-2.5 px-3 bg-surface-elevation-2 text-base"
+		class="flex flex-col gap-3 shadow-sm rounded-6 py-2.5 px-3 bg-surface-elevation-2 text-base"
 	>
 		<div v-if="stepsCompleted != totalSteps" class="inline-flex text-ink-gray-9 gap-2">
 			<StepsIcon class="h-4 my-0.5 shrink-0" />

--- a/ui/src/components/Onboarding/HelpCenter.vue
+++ b/ui/src/components/Onboarding/HelpCenter.vue
@@ -21,7 +21,7 @@
 		<div class="flex flex-col gap-1.5 overflow-y-auto">
 			<div v-for="a in parsedArticles" :key="a.title" class="flex flex-col gap-1.5">
 				<div
-					class="flex items-center justify-between p-1.5 hover:bg-surface-gray-1 rounded cursor-pointer"
+					class="flex items-center justify-between p-1.5 hover:bg-surface-gray-1 rounded-4 cursor-pointer"
 					@click="a.opened = !a.opened"
 				>
 					<div class="flex items-center gap-2">
@@ -36,7 +36,7 @@
 					<div
 						v-for="subArticle in a.subArticles"
 						:key="subArticle.name"
-						class="group flex items-center justify-between gap-2 p-1.5 hover:bg-surface-gray-1 rounded cursor-pointer"
+						class="group flex items-center justify-between gap-2 p-1.5 hover:bg-surface-gray-1 rounded-4 cursor-pointer"
 						@click="() => openDoc(subArticle.name)"
 					>
 						<div class="flex items-center gap-2">

--- a/ui/src/components/Onboarding/HelpModal.vue
+++ b/ui/src/components/Onboarding/HelpModal.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
 		v-show="show"
-		class="fixed z-50 right-0 w-80 h-[calc(100%_-_80px)] text-ink-gray-9 m-5 mt-[62px] p-3 flex gap-2 flex-col justify-between rounded-lg bg-surface-elevation-2 shadow-2xl"
+		class="fixed z-50 right-0 w-80 h-[calc(100%_-_80px)] text-ink-gray-9 m-5 mt-[62px] p-3 flex gap-2 flex-col justify-between rounded-6 bg-surface-elevation-2 shadow-2xl"
 		:class="{ 'top-[calc(100%_-_120px)] border': minimize }"
 		@click.stop
 	>
@@ -36,7 +36,7 @@
 		</div>
 		<div v-for="item in footerItems" class="flex flex-col gap-1.5">
 			<div
-				class="w-full flex gap-2 items-center hover:bg-surface-gray-1 text-ink-gray-8 rounded px-2 py-1.5 cursor-pointer"
+				class="w-full flex gap-2 items-center hover:bg-surface-gray-1 text-ink-gray-8 rounded-4 px-2 py-1.5 cursor-pointer"
 				@click="item.onClick"
 			>
 				<component :is="item.icon" class="h-4" />

--- a/ui/src/components/Onboarding/IntermediateStepModal.vue
+++ b/ui/src/components/Onboarding/IntermediateStepModal.vue
@@ -9,7 +9,7 @@
 					<div v-if="currentStep.message">{{ currentStep.message }}</div>
 					<video
 						v-if="currentStep.videoURL"
-						class="w-full rounded"
+						class="w-full rounded-4"
 						controls
 						autoplay
 						muted

--- a/ui/src/components/Onboarding/OnboardingSteps.vue
+++ b/ui/src/components/Onboarding/OnboardingSteps.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="flex flex-col justify-center items-center gap-1 mt-4 mb-7">
-		<component :is="logo" class="size-10 shrink-0 rounded mb-4" />
+		<component :is="logo" class="size-10 shrink-0 rounded-4 mb-4" />
 		<div class="text-base font-medium">
 			{{ "Welcome to " + title }}
 		</div>
@@ -34,7 +34,7 @@
 			<div
 				v-for="step in steps"
 				:key="step.title"
-				class="group w-full flex gap-2 justify-between items-center hover:bg-surface-gray-1 rounded px-2 py-1.5 cursor-pointer"
+				class="group w-full flex gap-2 justify-between items-center hover:bg-surface-gray-1 rounded-4 px-2 py-1.5 cursor-pointer"
 				@click.stop="() => !step.completed && !isDependent(step) && step.onClick?.()"
 			>
 				<component

--- a/ui/src/components/Phone/Phone.vue
+++ b/ui/src/components/Phone/Phone.vue
@@ -33,7 +33,7 @@
 					type="button"
 					data-slot="country"
 					:data-state="open ? 'open' : 'closed'"
-					class="flex min-w-[50px] items-center justify-center gap-1 self-stretch rounded-l px-2 focus:outline-none"
+					class="flex min-w-[50px] items-center justify-center gap-1 self-stretch rounded-l-4 px-2 focus:outline-none"
 					:class="disabled && 'cursor-not-allowed'"
 					:disabled="disabled"
 					:aria-label="
@@ -48,7 +48,7 @@
 						v-if="phoneDetails.country"
 						:src="getFlagUrl(phoneDetails.country)"
 						:alt="phoneDetails.country.name"
-						class="h-3 w-4 rounded-sm object-cover"
+						class="h-3 w-4 rounded-1 object-cover"
 					/>
 					<!-- Same-size placeholder so the chevron never shifts. -->
 					<span v-else class="lucide-globe size-4 shrink-0 text-ink-gray-6" />
@@ -110,7 +110,7 @@
 						<img
 							:src="getFlagUrl(item.country)"
 							alt=""
-							class="h-3 w-4 rounded-sm object-cover"
+							class="h-3 w-4 rounded-1 object-cover"
 							loading="lazy"
 							decoding="async"
 						/>
@@ -218,10 +218,10 @@ const numberInputClasses = computed(() => [
 
 const inputClasses = computed(() => {
 	const sizeClasses = {
-		sm: "h-7 rounded",
-		md: "h-8 rounded",
-		lg: "h-10 rounded-md",
-		xl: "h-10 rounded-md",
+		sm: "h-7 rounded-4",
+		md: "h-8 rounded-4",
+		lg: "h-10 rounded-5",
+		xl: "h-10 rounded-5",
 	}[props.size];
 
 	const variantClasses = props.disabled

--- a/ui/src/components/QuickFilter/QuickFilterInputs.vue
+++ b/ui/src/components/QuickFilter/QuickFilterInputs.vue
@@ -34,29 +34,37 @@
 				@update:modelValue="(v: boolean) => setValue(field, v)"
 			/>
 			<!-- The fieldtype's value control. Free-text fields (and name) carry a
-			     ≈/= operator toggle as a prefix inside the input; clicking it flips
-			     like ↔ equals in place (and, for name, swaps text box ↔ Link pick). -->
-			<component
-				v-else
-				:is="valueControl(field).is"
-				v-bind="valueControl(field).props"
-				class="w-full"
-				:modelValue="displayValue(field)"
-				@update:modelValue="(v: FilterValue) => setValue(field, v)"
-			>
-				<template v-if="hasOperatorToggle(field)" #prefix>
+			     ≈/= operator toggle over the input's start; clicking it flips
+			     like ↔ equals in place (and, for name, swaps text box ↔ Link pick).
+			     The toggle sits outside the control, so the swap neither moves nor
+			     remounts it; the control gets a spacer where the toggle shows. -->
+			<div v-else class="relative flex">
+				<component
+					:is="valueControl(field).is"
+					v-bind="valueControl(field).props"
+					class="w-full"
+					:modelValue="displayValue(field)"
+					@update:modelValue="(v: FilterValue) => setValue(field, v)"
+				>
+					<template v-if="hasOperatorToggle(field)" #prefix>
+						<span class="block w-3.5 shrink-0" aria-hidden="true" />
+					</template>
+				</component>
+				<Tooltip
+					v-if="hasOperatorToggle(field)"
+					:text="operatorLabel(activeOperator(field))"
+				>
 					<button
 						type="button"
-						class="grid size-5 place-items-center rounded text-xs font-medium text-ink-gray-5 hover:bg-surface-gray-4 hover:text-ink-gray-8"
-						:title="operatorLabel(activeOperator(field))"
+						class="absolute start-1 top-1/2 grid size-5 -translate-y-1/2 place-items-center rounded-3 text-xs font-medium text-ink-gray-5 hover:bg-surface-gray-4 hover:text-ink-gray-8"
 						:aria-label="operatorLabel(activeOperator(field))"
 						@pointerdown.stop
 						@click.stop="toggleOperator(field)"
 					>
 						{{ operatorSymbol(activeOperator(field)) }}
 					</button>
-				</template>
-			</component>
+				</Tooltip>
+			</div>
 		</div>
 		<!-- Overflow affordance: collapsed inputs hide behind a count; expanding
 		     shows all and lets them wrap. A `subtle` pill (not bare ghost text) so it
@@ -82,7 +90,7 @@
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from "vue";
-import { Button, Checkbox, TextInput, debounce } from "frappe-ui";
+import { Button, Checkbox, TextInput, Tooltip, debounce } from "frappe-ui";
 import {
 	applyQuick,
 	hasOperatorToggle,
@@ -301,9 +309,14 @@ function bareField(field: FilterField, overrides: Partial<FieldMeta> = {}): Fiel
 function valueControl(field: FilterField): ValueControl {
 	const fieldtype = field.fieldtype;
 	if (isNameField(field)) {
+		// The picker's input fills its trigger, so its text centres like the text box's and the
+		// placeholder stays still when the toggle swaps them.
 		return activeOperator(field) === "equals"
-			? { is: LinkField, props: { field: bareField(field) } }
-			: { is: TextInput, props: { type: "text", placeholder: field.label } };
+			? {
+					is: LinkField,
+					props: { field: bareField(field), class: "[&_input]:h-full" },
+			  }
+			: textControl(field);
 	}
 	if (fieldtype === "Link") {
 		return { is: LinkField, props: { field: bareField(field) } };
@@ -318,6 +331,12 @@ function valueControl(field: FilterField): ValueControl {
 	if (fieldtype === "Date") return { is: DateField, props: { field: bareField(field) } };
 	if (fieldtype === "Datetime") return { is: DatetimeField, props: { field: bareField(field) } };
 	if (fieldtype === "Duration") return { is: DurationField, props: { field: bareField(field) } };
-	return { is: TextInput, props: { type: "text", placeholder: field.label } };
+	return textControl(field);
+}
+
+/** With the toggle over its start, the text box keeps 2px between the toggle and the text. */
+function textControl(field: FilterField): ValueControl {
+	const inset = hasOperatorToggle(field) ? "[&_input]:ps-[26px]" : undefined;
+	return { is: TextInput, props: { type: "text", placeholder: field.label, class: inset } };
 }
 </script>

--- a/ui/src/components/SignupBanner/SignupBanner.vue
+++ b/ui/src/components/SignupBanner/SignupBanner.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
 		v-if="!isSidebarCollapsed"
-		class="flex flex-col gap-3 shadow-sm rounded-lg py-2.5 px-3 bg-surface-base text-base"
+		class="flex flex-col gap-3 shadow-sm rounded-6 py-2.5 px-3 bg-surface-base text-base"
 	>
 		<div class="flex flex-col gap-1">
 			<slot>

--- a/ui/src/components/SortBy/SortBy.vue
+++ b/ui/src/components/SortBy/SortBy.vue
@@ -32,14 +32,13 @@
 	</Combobox>
 
 	<!-- Non-empty: the sort popover (single-sort compact / multi-sort badge). -->
-	<Popover v-else placement="bottom-end">
-		<template #target="{ isOpen, togglePopover }">
+	<Popover v-else side="bottom" align="end">
+		<template #trigger="{ open }">
 			<Button
 				v-if="model.length > 1"
 				:label="'Sort'"
 				:icon="hideLabel ? 'lucide-arrow-up-down' : undefined"
 				:iconLeft="!hideLabel ? 'lucide-arrow-up-down' : undefined"
-				@click="togglePopover"
 			>
 				<template #suffix>
 					<div
@@ -58,87 +57,80 @@
 				<Button
 					:label="firstSortLabel"
 					class="relative shrink-0 rounded-l-none [&_svg]:text-ink-gray-5 focus-visible:z-10"
-					:iconRight="isOpen ? 'lucide-chevron-up' : 'lucide-chevron-down'"
-					@click.stop="togglePopover"
+					:iconRight="open ? 'lucide-chevron-up' : 'lucide-chevron-down'"
 				/>
 			</div>
 		</template>
-		<template #body="{ close }">
-			<div
-				class="my-2 min-w-40 rounded-lg bg-surface-elevation-2 shadow-2xl ring-1 ring-black ring-opacity-5 focus:outline-none"
-			>
-				<div class="min-w-60 p-2">
-					<Draggable
-						v-if="model.length"
-						class="mb-3 flex flex-col gap-2"
-						:modelValue="model"
-						:item-key="(s) => s.fieldname"
-						handle=".sort-drag-handle"
-						tag="div"
-						@update:modelValue="reorder"
-					>
-						<template #item="{ element: sort, index: i }">
-							<div class="flex items-center gap-1">
-								<div
-									class="sort-drag-handle flex h-7 w-7 items-center justify-center"
-								>
-									<span
-										class="lucide-grip-vertical size-4 cursor-grab text-ink-gray-5"
-										aria-hidden="true"
-									/>
-								</div>
-								<div class="flex flex-1">
-									<Button
-										size="md"
-										class="relative rounded-r-none border-r focus-visible:z-10"
-										:icon="directionIcon(sort.direction)"
-										@click="toggleDirection(i)"
-									/>
-									<Combobox
-										class="relative flex-1 rounded-l-none focus-within:z-10"
-										trigger="button"
-										variant="subtle"
-										size="md"
-										:modelValue="sort.fieldname"
-										:options="optionsFor(sort.fieldname)"
-										placeholder="Select field"
-										@update:selectedOption="(o) => updateSort(o, i)"
-									/>
-								</div>
-								<Button variant="ghost" icon="lucide-x" @click="removeSort(i)" />
-							</div>
-						</template>
-					</Draggable>
-					<div v-else class="mb-3 flex h-7 items-center px-3 text-sm text-ink-gray-5">
-						Empty - Choose a field to sort by
-					</div>
-					<div class="flex items-center justify-between gap-2">
-						<!-- A custom #trigger renders the same ghost Button as "Clear Sort"
-						     beside it (gray-5, `+` icon, no chevron). The label is static, so
-						     the old per-add remount (`:key`) and the placeholder / chevron CSS
-						     hacks are no longer needed. -->
-						<Combobox
-							:options="addableOptions"
-							:modelValue="null"
-							@update:selectedOption="addSort"
-						>
-							<template #trigger>
-								<Button
-									class="!text-ink-gray-5"
-									variant="ghost"
-									label="Add Sort"
-									iconLeft="lucide-plus"
+		<template #default="{ close }">
+			<div class="min-w-60 p-2">
+				<Draggable
+					v-if="model.length"
+					class="mb-3 flex flex-col gap-2"
+					:modelValue="model"
+					:item-key="(s) => s.fieldname"
+					handle=".sort-drag-handle"
+					tag="div"
+					@update:modelValue="reorder"
+				>
+					<template #item="{ element: sort, index: i }">
+						<div class="flex items-center gap-1">
+							<div class="sort-drag-handle flex h-7 w-7 items-center justify-center">
+								<span
+									class="lucide-grip-vertical size-4 cursor-grab text-ink-gray-5"
+									aria-hidden="true"
 								/>
-							</template>
-						</Combobox>
-						<Button
-							v-if="model.length"
-							class="!text-ink-gray-5"
-							variant="ghost"
-							:label="'Clear Sort'"
-							@click="clearSort(close)"
-						/>
-					</div>
+							</div>
+							<div class="flex flex-1">
+								<Button
+									size="md"
+									class="relative rounded-r-none border-r focus-visible:z-10"
+									:icon="directionIcon(sort.direction)"
+									@click="toggleDirection(i)"
+								/>
+								<Combobox
+									class="relative flex-1 rounded-l-none focus-within:z-10"
+									trigger="button"
+									variant="subtle"
+									size="md"
+									:modelValue="sort.fieldname"
+									:options="optionsFor(sort.fieldname)"
+									placeholder="Select field"
+									@update:selectedOption="(o) => updateSort(o, i)"
+								/>
+							</div>
+							<Button variant="ghost" icon="lucide-x" @click="removeSort(i)" />
+						</div>
+					</template>
+				</Draggable>
+				<div v-else class="mb-3 flex h-7 items-center px-3 text-sm text-ink-gray-5">
+					Empty - Choose a field to sort by
+				</div>
+				<div class="flex items-center justify-between gap-2">
+					<!-- A custom #trigger renders the same ghost Button as "Clear Sort"
+					     beside it (gray-5, `+` icon, no chevron). The label is static, so
+					     the old per-add remount (`:key`) and the placeholder / chevron CSS
+					     hacks are no longer needed. -->
+					<Combobox
+						:options="addableOptions"
+						:modelValue="null"
+						@update:selectedOption="addSort"
+					>
+						<template #trigger>
+							<Button
+								class="!text-ink-gray-5"
+								variant="ghost"
+								label="Add Sort"
+								iconLeft="lucide-plus"
+							/>
+						</template>
+					</Combobox>
+					<Button
+						v-if="model.length"
+						class="!text-ink-gray-5"
+						variant="ghost"
+						:label="'Clear Sort'"
+						@click="clearSort(close)"
+					/>
 				</div>
 			</div>
 		</template>

--- a/ui/src/components/TableMultiSelect/TableMultiSelect.vue
+++ b/ui/src/components/TableMultiSelect/TableMultiSelect.vue
@@ -17,21 +17,21 @@
 				type="button"
 				:disabled="disabled"
 				:data-state="open ? 'open' : 'closed'"
-				class="flex min-h-7 w-full cursor-pointer items-center gap-1.5 rounded border border-[--surface-gray-2] bg-surface-gray-2 px-1.5 py-1 text-left text-ink-gray-7 outline-none transition-colors hover:border-outline-elevation-2 hover:bg-surface-gray-3 focus-visible:ring-2 data-[state=open]:ring-2 ring-outline-gray-3 disabled:cursor-not-allowed disabled:bg-surface-gray-1 disabled:text-ink-gray-4"
+				class="flex min-h-7 w-full cursor-pointer items-center gap-1.5 rounded-4 border border-[--surface-gray-2] bg-surface-gray-2 px-1.5 py-1 text-left text-ink-gray-7 outline-none transition-colors hover:border-outline-elevation-2 hover:bg-surface-gray-3 focus-visible:ring-2 data-[state=open]:ring-2 ring-outline-gray-3 disabled:cursor-not-allowed disabled:bg-surface-gray-1 disabled:text-ink-gray-4"
 				@click="toggleOpen"
 			>
 				<div class="flex min-w-0 flex-1 flex-wrap items-center gap-1">
 					<span
 						v-for="option in selectedOptions"
 						:key="option.value"
-						class="inline-flex h-7 items-center gap-1 rounded border border-outline-gray-1 bg-surface-base px-1.5 text-sm text-ink-gray-7 transition-colors hover:border-outline-gray-2 hover:bg-surface-gray-1"
+						class="inline-flex h-7 items-center gap-1 rounded-4 border border-outline-gray-1 bg-surface-base px-1.5 text-sm text-ink-gray-7 transition-colors hover:border-outline-gray-2 hover:bg-surface-gray-1"
 					>
 						{{ option.label }}
 						<span
 							v-if="!disabled"
 							role="button"
 							tabindex="-1"
-							class="-mr-0.5 inline-flex cursor-pointer items-center justify-center rounded-sm p-0.5 opacity-70 hover:opacity-100"
+							class="-mr-0.5 inline-flex cursor-pointer items-center justify-center rounded-1 p-0.5 opacity-70 hover:opacity-100"
 							@click.stop="removeTag(option.value)"
 							@pointerdown.stop
 						>

--- a/ui/src/components/TrialBanner/TrialBanner.vue
+++ b/ui/src/components/TrialBanner/TrialBanner.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
 		v-if="!isSidebarCollapsed && showBanner"
-		class="flex flex-col gap-3 shadow-sm rounded-lg py-2.5 px-3 bg-surface-elevation-2 text-base"
+		class="flex flex-col gap-3 shadow-sm rounded-6 py-2.5 px-3 bg-surface-elevation-2 text-base"
 	>
 		<div class="flex flex-col gap-1">
 			<div class="inline-flex text-ink-gray-9 gap-2 items-center font-medium">

--- a/ui/src/experimental/List/List.vue
+++ b/ui/src/experimental/List/List.vue
@@ -13,11 +13,11 @@
 			divider="inset"
 			:columns="tracks"
 			:rowHeight="rowHeight"
-			:style="{ '--list-row-padding-x': ROW_PADDING_X }"
+			:style="{ '--list-row-padding-x': ROW_PADDING_X, paddingInline }"
 			class="flex w-max min-w-full flex-col"
 		>
 			<ListHeader class="group sticky top-0 z-10 bg-surface-base">
-				<div class="flex items-center justify-center" role="columnheader">
+				<div class="flex items-center ps-[calc(0.5rem+1px)]" role="columnheader">
 					<Checkbox
 						:modelValue="selectAllState === 'all'"
 						:indeterminate="selectAllState === 'some'"
@@ -41,13 +41,14 @@
 						{{ column.label }}
 					</ListHeaderCellSort>
 					<ListHeaderCell v-else class="min-w-0">{{ column.label }}</ListHeaderCell>
+					<!-- The handle sits in the column gap, so a right-aligned label stays clear of it. -->
 					<span
-						class="absolute inset-y-0 -right-1 flex w-2 cursor-col-resize justify-center"
+						class="absolute inset-y-0 -right-2 flex w-2 cursor-col-resize items-center justify-center"
 						@pointerdown.stop.prevent="startResize(column, $event)"
 						@dblclick.stop.prevent="resetColumn(column)"
 					>
 						<span
-							class="border-l border-outline-gray-2 opacity-0 transition-opacity group-hover:opacity-100"
+							class="h-4 border-l border-outline-gray-2 opacity-0 transition-opacity group-hover:opacity-100"
 							:class="{ 'opacity-100': resizingFieldname === column.fieldname }"
 						/>
 					</span>
@@ -63,7 +64,7 @@
 				>
 					<!-- The molecule's own `selectable` turns a row click into a toggle; the row must stay
 						a link, so the checkbox is drawn here (frappe/frappe-ui#1131). -->
-					<ListCell class="justify-center">
+					<ListCell class="ps-[calc(0.5rem+1px)]">
 						<div
 							role="checkbox"
 							:aria-checked="isSelected(rowValue(row))"
@@ -156,6 +157,8 @@ defineSlots<{
 	empty?: () => unknown;
 }>();
 
+/** The row's own inset; the checkbox column and the last cell sit this far inside it. The checkbox
+ *  takes one pixel more, so its box reads level with text, whose ink starts inside its box. */
 const ROW_PADDING_X = "0.5rem";
 const SKELETON_ROW_COUNT = 10;
 const SKELETON_COLUMN_COUNT = 4;
@@ -167,6 +170,11 @@ defineExpose({
 		return scroller.value?.viewportElement ?? null;
 	},
 });
+
+// The gutter is where the checkbox and the last cell's text land, so the row bleeds past it.
+const paddingInline = computed(() =>
+	props.gutter ? `calc(${props.gutter} - ${ROW_PADDING_X})` : undefined
+);
 
 // Binding the sort model at mount is what makes the headers sortable, as the molecule's `active`.
 const instance = getCurrentInstance();

--- a/ui/src/experimental/List/ListFooter.vue
+++ b/ui/src/experimental/List/ListFooter.vue
@@ -10,7 +10,7 @@
 				@update:modelValue="choosePageSize"
 			/>
 			<Button
-				v-if="hasCounts && rowCount < totalCount"
+				v-if="hasNextPage ?? (hasCounts && rowCount < totalCount)"
 				variant="subtle"
 				label="Load More"
 				@click="emit('load-more')"
@@ -18,7 +18,7 @@
 		</div>
 		<div class="flex items-center gap-2">
 			<span v-if="hasCounts" class="text-sm text-ink-gray-5">
-				{{ rowCount }} of {{ totalCount }}
+				{{ rowCount }} of {{ totalCount }}{{ totalCapped ? "+" : "" }}
 			</span>
 			<Skeleton v-else class="h-3 w-16 rounded-1" />
 		</div>
@@ -35,12 +35,19 @@ const props = withDefaults(
 		totalCount?: number;
 		/** False until the first answer lands, which shows a placeholder instead of "0 of 0". */
 		hasCounts?: boolean;
+		/** The total is a floor, shown with a trailing "+". */
+		totalCapped?: boolean;
+		/** Whether Load More shows; unset, the counts decide. */
+		hasNextPage?: boolean;
 		pageSizeOptions?: number[];
 	}>(),
 	{
 		rowCount: 0,
 		totalCount: 0,
 		hasCounts: false,
+		totalCapped: false,
+		// An explicit default keeps an absent prop undefined; Vue would cast it to false otherwise.
+		hasNextPage: undefined,
 		pageSizeOptions: () => [20, 100, 500, 2500],
 	}
 );

--- a/ui/src/experimental/List/tests/list.test.ts
+++ b/ui/src/experimental/List/tests/list.test.ts
@@ -76,6 +76,19 @@ describe("List rows", () => {
   });
 });
 
+describe("List gutter", () => {
+  it("pads the table by the gutter less the row inset, and by nothing without one", async () => {
+    const bare = await mount(List, { columns, rows });
+    expect(bare.root.querySelector<HTMLElement>("[data-slot='list']")!.style.paddingInline).toBe(
+      ""
+    );
+    const padded = await mount(List, { columns, rows, gutter: "var(--page-gutter)" });
+    expect(
+      padded.root.querySelector<HTMLElement>("[data-slot='list']")!.style.paddingInline
+    ).toBe("calc(var(--page-gutter) - 0.5rem)");
+  });
+});
+
 describe("List selection", () => {
   it("a checkbox click toggles the row and does not navigate", async () => {
     const state = reactive({ selection: [] as string[] });

--- a/ui/src/experimental/List/tests/listFooter.test.ts
+++ b/ui/src/experimental/List/tests/listFooter.test.ts
@@ -40,6 +40,25 @@ describe("ListFooter counts", () => {
     await flush();
     expect(loadMore(root)).toBeUndefined();
   });
+
+  it("a capped total reads N of M+, and Load More follows hasNextPage over the counts", async () => {
+    const state = reactive({ hasNextPage: true });
+    const { root } = await mount(ListFooter, {
+      hasCounts: true,
+      rowCount: 1000,
+      totalCount: 1000,
+      totalCapped: true,
+      get hasNextPage() {
+        return state.hasNextPage;
+      },
+    });
+    expect(root.textContent).toContain("1000 of 1000+");
+    expect(loadMore(root)).toBeDefined();
+
+    state.hasNextPage = false;
+    await flush();
+    expect(loadMore(root)).toBeUndefined();
+  });
 });
 
 describe("ListFooter page size", () => {

--- a/ui/src/experimental/List/types.ts
+++ b/ui/src/experimental/List/types.ts
@@ -18,6 +18,8 @@ export interface ListProps {
   rowHeight?: number;
   /** The route a row opens; with it, every row renders as a link. */
   rowLink?: (row: ListRowData) => RouteLocationRaw;
+  /** Where the checkbox and the last cell's text land, as a CSS length; the row bleeds past it. */
+  gutter?: string;
 }
 
 /** A drag-resize result: the column and the fixed width it now has. */


### PR DESCRIPTION
Resolves the page build on the shell-and-list map: the generated list page now composes the list controls and the experimental List module instead of drawing its own table. Ticket: frappe/frappe#42656 (child of #42569). Four commits: the ui Popover fix and the ui radius sweep (both also on #42672 for `develop`), the page, and the frontend radius sweep.

## What a person sees

Open a doctype from the rail and the frame's header row shows the doctype's title. Below it one row: the quick-filter inputs left, `Filter`, `SortBy`, `ColumnSettings` and a `⋯` menu right (they hide while the quick filter is being customized). Then the table with a sticky header, drag-resize, select-all and rows that are links; a floating bulk bar with Delete; and the footer with page sizes, Load More and "N of M".

Before: a plain table of `name` plus contributed columns, twenty rows, no controls (the page as merged in #42619).

After, ToDo on a bench site:

![the list](https://raw.githubusercontent.com/shariquerik/frappe/assets/list-page-42656/v7-list.png)

Two rows selected, with the bulk bar:

![selection](https://raw.githubusercontent.com/shariquerik/frappe/assets/list-page-42656/v7-selected.png)

The delete confirmation, the columns and sort popovers, the quick filter's customize mode and the 100-row page: [dialog](https://raw.githubusercontent.com/shariquerik/frappe/assets/list-page-42656/v7-delete-dialog.png), [columns](https://raw.githubusercontent.com/shariquerik/frappe/assets/list-page-42656/v7-columns-popover.png), [sort](https://raw.githubusercontent.com/shariquerik/frappe/assets/list-page-42656/v7-sort-popover.png), [customize](https://raw.githubusercontent.com/shariquerik/frappe/assets/list-page-42656/v7-customize.png), [100 rows](https://raw.githubusercontent.com/shariquerik/frappe/assets/list-page-42656/v7-rows-100.png).

## What is built

**`frontend/src/list/`** is the desk composable and its helpers:

- `useListPage(doctype)` holds `filters`, `sort`, `columns`, `quickFilterFields`, `customizing`, `selection` and `pageSize`, seeds them once meta lands, mirrors filters and sort to the URL query, and exposes `next`, `reload`, `deleteSelection`, `resetColumns`, `resizeColumn`, `resetColumnWidth` and `rowLink`. No global, no root object.
- `useListRows` fetches through frappe-ui's `useList` with `refetch` off, one `useList` per fetched page: a changed query is a new list from offset zero, `next()` adds a page, the pages are a buffer and the page size is how much of it shows: a bigger size fetches only the rows still missing (20 to 100 is one request for 80), a smaller one shows fewer of the loaded rows with no request, Load More reveals from the buffer before it fetches, and the total is one `frappe.client.get_count`.
- `query.ts` is the URL encoding, `defaults.ts` the seeds, `pageState.ts` the history-entry memory, `useScrollMemory.ts` the scroll offset.

**`frontend/src/pages/List.vue`** keys `pages/list/DoctypeList.vue` by doctype, so a new doctype is a new list. `DeleteDialog.vue` confirms the bulk delete.

**`ui/`** (first commit, also PR #42672 on `develop`): `Filter`, `SortBy` and `ColumnSettings` move to frappe-ui beta.55's Popover slots; on the pinned version they drew nothing once their model had a value. Their panels now take frappe-ui's `PopoverPanel` shell instead of a hand-built one. `List` takes a `gutter`: the CSS length where the checkbox and the last cell's text land, so the row's hover surface bleeds the row inset (8px) past it on both sides. Its resize handle sits in the column gap. Props and models are otherwise unchanged. That commit drops out of this PR at the next develop sync.

## Fixes after the first walk

Six UI issues found on the first build, all in this PR:

| Issue | Fix |
|---|---|
| The Sort, Filter and Columns popovers had square corners | the hand-built shell used `rounded-lg`, which is not in frappe-ui beta.55's numbered radius scale and painted nothing; the panels take `PopoverPanel` ([after](https://raw.githubusercontent.com/shariquerik/frappe/assets/list-page-42656/v7-filter-popover.png)) |
| The table did not line up with the title, the page-size tabs or the footer count | `PageFrame` sets `--page-gutter` on its root and `pageGutter` reads it; the `List` takes `gutter="var(--page-gutter)"` and puts the selection checkbox and the last cell's text on it, with the hover surface bleeding past ([crop](https://raw.githubusercontent.com/shariquerik/frappe/assets/list-page-42656/v7-gutter.png)) |
| A page size of 100 refetched all 100 rows | `useListRows` keeps one `useList` per page as a buffer; growing the size fetches `start=20 limit=80`, Load More then `start=100 limit=100`, and 20 again shows the first 20 with no request |
| Opening a record and coming back reset the list to 20 rows, and the breadcrumb lost the scroll | the page remembers per doctype how many rows showed for which query and the scroll offset, for the session; Back and the breadcrumb both restore them in one request |
| Square corners everywhere, not only the popovers | frappe-ui's preset has no `rounded`, `rounded-sm`, `rounded-md` or `rounded-lg`; two sweep commits rename 105 uses in `ui/` and `frontend/` to the numbered steps by frappe-ui's own codemod map |
| The resize handle was full header height and a right-aligned label touched it | the handle sits in the column gap (`-right-2`) with a 16px line ([after](https://raw.githubusercontent.com/shariquerik/frappe/assets/list-page-42656/v7-resize-handle.png)) |
| The quick filter showed one field plus "3 more" with room to spare | its wrapper was a flex child sized to its content, so it measured only itself; it is `min-w-0 flex-1` now ([CRM Deal](https://raw.githubusercontent.com/shariquerik/frappe/assets/list-page-42656/v7-crm-deal-quick-filter.png)) |
| The controls sat in the header row | they sit right of the quick filter, as CRM's frontend2 places them; this reverses the header-row placement from #42572 on the maintainer's call |

## Named acts

| Act | Channel |
|---|---|
| Apply a filter | `filters` model, written to the URL query |
| Sort by a column | `sort` model, written to the URL query; the header click edits the same list |
| Set the columns | `columns` model, in memory; `resetColumns`, `resizeColumn`, `resetColumnWidth` |
| Select rows, clear the selection | `selection` model |
| Open the quick filter, customize it | `customizing` model; `quickFilterFields` model in memory |
| Change the page size, load more | `pageSize` model on the history entry; `next()` |
| Delete the selection | `deleteSelection()`, the page confirms in a `Dialog` first |
| Open a row | the row's link, `rowLink(row)` = `routeFor(doctype, name)` |

## Rulings kept

- Defaults: columns from a contributed `list.js` (every contributing app in run order, each fieldname once, `width` as px), else meta's `in_list_view` through `getDefaultColumns`, else `name` + `modified`; sort from meta's `sort_field` + `sort_order`, else `modified desc`.
- URL: an equals filter is written bare (`?status=Open`, a Check as `1`/`0`), any other operator as `["op", value]`; the sort under `_sort` only when it is not the default; keys the list does not own (`view`) are carried through. A query the page did not write itself (Back, Forward, a pasted link) is read back; a filter row still being typed is left alone.
- History entry: `pageSize` and `scrollTop` under `history.state.list`, spread over vue-router's keys; a push does not inherit them, Back brings them back.
- Session memory per doctype: the filters and sort, the page size, how many rows were showing and the scroll offset. A return to the same query, by Back or by a breadcrumb, fetches that many rows in one request (`start=0 limit=40` after a Load More) and lands at the offset; the history entry's offset wins when it has one. A different query starts at the page size and the top. A delete's reload keeps the rows shown too.
- Delete: one `DELETE /api/v2/document/<doctype>/<name>` per selected row after a `Dialog`; each failure is reported in the dialog by name, the rest are deleted and toasted; then the list reloads.
- No New button.

## Cold load, ToDo on a bench site (365 rows, 6 fields)

| request | bytes |
|---|---|
| `getdoctype` (meta, `with_parent`) | 26,519 |
| `get_count` | 15 |
| `/api/v2/document/ToDo` (20 rows) | 2,611 |

Boot, translations and the address table are unchanged (22,257 / 1,905 / 10,844).

## Cache and invalidation

- Meta: `useDoctypeMeta` memoises one entry per doctype for the session; only `reload()` refetches it.
- Rows: `useList` is created without a `cacheKey`, so nothing is cached client-side; every query change is a fresh request, and a delete reloads.
- Count: one call per query change and per reload, guarded by a generation counter so a slow answer cannot overwrite a newer one. It is sent with `limit: 1001`, which puts a one-second statement cap on the query and caps the answer; past 1,000 rows the footer reads `1000+` (Error Log on the bench site does).
- A typed filter changes the query per keystroke; the rows query waits 300 ms after the last change, so five characters are one count and one rows request.
- A failed count shows the loaded rows as a floor (`20+` while the list reports a next page), and Load More follows the list's own `hasNextPage`, not the count.

## Permissions

- Rows: `/api/v2/document/<doctype>` runs through `frappe.qb.get_query(..., ignore_permissions=False)`, so doctype read permission, user permissions and permlevel column filtering are applied server-side.
- Count: `frappe.client.get_count` → `reportview.get_count` → `DatabaseQuery`, read permission.
- Delete: `DELETE /api/v2/document/<doctype>/<name>` → `frappe.client.delete_doc` → `frappe.delete_doc` → `check_permission("delete")` per row.
- Nothing here hides anything from the server.

## Tests

`frontend/`: 37 files, 549 tests (44 new under `src/list/tests/`). `ui/src/experimental/List/tests`: 37 (two new: the capped total with Load More on `hasNextPage`, and the gutter): the URL encoding round-trips, the seeds, the history memory, and the composable driven through a real web-history router with frappe-ui's data layer faked.

## Not in this PR

- A live screenshot next to CRM's frontend2 list: that line is not served on the bench I built on (its Vite host dies on a duplicated editor dependency). The layout follows its `pages/List.vue` and `ListSurface.vue` classes.
- Value formatting per fieldtype (dates, links, currency) is the raw value, as `List`'s default cell.
- `Fields/AttachField.vue` still uses the old Popover slots; nothing on the desk reaches it.
- Two conditions on one field (`amount > 100` and `amount < 500`): frappe-ui's `useList` takes filters only as a field-keyed object, so the page holds one condition per field, the same as the URL. Feature request: frappe/frappe-ui#1134.

>no-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)










