### PR TITLE
feat: add has_role to check if user has any of the given roles

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -711,24 +711,38 @@ def only_for(roles: list[str] | tuple[str] | str, message=False):
 
 	:param roles: Permitted role(s)
 	"""
-
-	if local.session.user == "Administrator":
+	if has_role(roles):
 		return
+
+	if not message:
+		raise PermissionError
 
 	if isinstance(roles, str):
 		roles = (roles,)
 
-	if set(roles).isdisjoint(get_roles()):
-		if not message:
-			raise PermissionError
+	throw(
+		_("This action is only allowed for {}").format(
+			", ".join(bold(_(role)) for role in roles),
+		),
+		PermissionError,
+		_("Not Permitted"),
+	)
 
-		throw(
-			_("This action is only allowed for {}").format(
-				", ".join(bold(_(role)) for role in roles),
-			),
-			PermissionError,
-			_("Not Permitted"),
-		)
+
+def has_role(roles: list[str] | tuple[str] | str) -> bool:
+	"""
+	Returns True if the user has any of the permitted roles.
+
+	:param roles: Permitted role(s)
+	"""
+
+	if local.session.user == "Administrator":
+		return True
+
+	if isinstance(roles, str):
+		roles = (roles,)
+
+	return not set(roles).isdisjoint(get_roles())
 
 
 def get_domain_data(module):


### PR DESCRIPTION
### Problem

`frappe.only_for()` answers by raising — right for guarding an endpoint, wrong for branching on a role. So call sites hand-roll `"Role" in frappe.get_roles()` instead: 28 such checks in `frappe` today, only 4 of which handle `Administrator`.

That gap matters because `get_roles("Administrator")` returns every role in the Role table, so a hand-rolled check works right up until the role isn't a Role document on that site — app not installed, fixture not run, typo. Then Administrator silently fails it.

### Change

`frappe.has_role(roles)` — the same check `only_for()` performs, returning a bool. Takes a role or a list.

```python
if frappe.has_role("System Manager"):
	...
```

`only_for()` now calls it, so there is one definition of the check.

Named to match the existing client-side `frappe.user.has_role()`, which takes the same argument shape and has the same any-of semantics. No behaviour change to `only_for()`. Additive — no call sites migrated.
