### PR TITLE
fix(grid): correct the child table row form backdrop and remove its duplicate button

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -1441,7 +1441,7 @@ export default class GridRow {
 			.find(".grid-delete-row")
 			.toggle(!(this.grid.df && this.grid.df.cannot_delete_rows));
 
-		frappe.dom.freeze("", "dark grid-form");
+		frappe.dom.freeze("", "grid-form");
 		if (cur_frm) cur_frm.cur_grid = this;
 		this.wrapper.addClass("grid-row-open");
 		if (

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -1432,9 +1432,7 @@ export default class GridRow {
 		let cannot_add_rows =
 			this.grid.cannot_add_rows || (this.grid.df && this.grid.df.cannot_add_rows);
 		this.wrapper
-			.find(
-				".grid-insert-row-below, .grid-insert-row, .grid-duplicate-row, .grid-append-row"
-			)
+			.find(".grid-insert-row-below, .grid-insert-row, .grid-duplicate-row")
 			.toggle(!cannot_add_rows);
 
 		this.wrapper

--- a/frappe/public/js/frappe/form/grid_row_form.js
+++ b/frappe/public/js/frappe/form/grid_row_form.js
@@ -84,12 +84,6 @@ export default class GridRowForm {
 						<span class="text-medium"> ${__("Shortcuts")}: </span>
 						<kbd>${__("Ctrl + Up")}</kbd> . <kbd>${__("Ctrl + Down")}</kbd> . <kbd>${__("ESC")}</kbd>
 					</div>
-					<span class="row-actions">
-						${frappe.ui.button.html({
-							label: __("Insert Below"),
-							css_class: "pull-right grid-append-row",
-						})}
-					</span>
 				</div>
 			</div>`;
 
@@ -121,18 +115,13 @@ export default class GridRowForm {
 			me.row.move();
 			return false;
 		});
-		this.wrapper.find(".grid-append-row").on("click", function () {
-			me.row.toggle_view(false);
-			me.row.grid.add_new_row(me.row.doc.idx + 1, null, true);
-			return false;
-		});
 		this.wrapper.find(".grid-form-heading, .grid-footer-toolbar").on("click", function () {
 			me.row.toggle_view();
 			return false;
 		});
 	}
 	toggle_add_delete_button_display($parent) {
-		$parent.find(".row-actions, .grid-append-row").toggle(this.row.grid.is_editable());
+		$parent.find(".row-actions").toggle(this.row.grid.is_editable());
 	}
 	refresh_field(fieldname) {
 		const field = this.fields_dict[fieldname];

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -602,6 +602,11 @@
 
 #freeze.grid-form {
 	z-index: 1020;
+	background-color: var(--gray-800);
+
+	.freeze-message-container {
+		background-color: transparent;
+	}
 }
 
 .recorder-form-in-grid {

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -594,10 +594,6 @@
 			padding-left: 0;
 		}
 	}
-
-	.grid-append-row {
-		margin-top: calc(-1 * var(--margin-xs));
-	}
 }
 
 #freeze.grid-form {


### PR DESCRIPTION
## Description
Two fixes to the child table row editing form.

The backdrop rendered near white instead of dimmed (dark). It now uses the same scrim as global search and other Dialogs do. Scoped to the row form - other freeze overlays are unchanged (this felt more like a global design change, so did not touch it).

The row form showed two "Insert Below" buttons, one in the header and one in the footer, doing the same thing. The footer one is removed.

Before:
<img width="1511" height="827" alt="Screenshot 2026-09-09 at 8 03 27 PM" src="https://github.com/user-attachments/assets/c6224384-08b3-405a-8358-5efdf5c199fc" />

After:
<img width="1510" height="825" alt="Screenshot 2026-09-09 at 8 05 09 PM" src="https://github.com/user-attachments/assets/740f67fb-f0bd-4215-af13-7031730ff40e" />
