### PR TITLE
fix(automation): check reference permission on every auto repeat save

### DIFF
--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -131,12 +131,7 @@ class AutoRepeat(Document):
 	def validate_reference_permission(self):
 		if frappe.flags.in_patch or self.flags.ignore_permissions:
 			return
-		if (
-			self.is_new()
-			or self.has_value_changed("reference_doctype")
-			or self.has_value_changed("reference_document")
-		):
-			frappe.has_permission(self.reference_doctype, "write", self.reference_document, throw=True)
+		frappe.has_permission(self.reference_doctype, "write", self.reference_document, throw=True)
 
 	def validate_submit_on_creation(self):
 		if self.submit_on_creation and not frappe.get_meta(self.reference_doctype).is_submittable:

--- a/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
@@ -273,6 +273,22 @@ class TestAutoRepeat(IntegrationTestCase):
 
 		self.assertFalse(frappe.db.get_value("ToDo", todo.name, "auto_repeat"))
 
+	def test_reference_document_write_permission_on_update(self):
+		todo = frappe.get_doc(
+			doctype="ToDo", description="test reference permission", assigned_by="Administrator"
+		).insert()
+		user = create_user_without_reference_access()
+		doc = make_auto_repeat(reference_document=todo.name)
+
+		self.assertTrue(frappe.has_permission("Auto Repeat", "write", doc.name, user=user))
+
+		with set_user(user):
+			doc = frappe.get_doc("Auto Repeat", doc.name)
+			doc.append("assignee", {"user": user})
+			self.assertRaises(frappe.PermissionError, doc.save)
+
+		self.assertFalse(frappe.db.exists("Auto Repeat User", {"parent": doc.name}))
+
 	def test_deleted_reference_does_not_stop_the_scheduler(self):
 		todo = frappe.get_doc(
 			doctype="ToDo", description="test reference permission", assigned_by="Administrator"


### PR DESCRIPTION
Auto Repeat checks the acting user's permission on the referenced document only when the reference itself is set or changed. Every other field is unguarded, and the DocType grants write to roles that are not restricted to their own records, so a user who cannot read the referenced document can still edit an Auto Repeat that points at it. The runtime check is made against the owner, so it passes for a record the attacker did not create.

The check now runs on every save. A gate keyed on which fields changed has to enumerate every field that affects what gets generated and who receives it, and misses the next one that gets added.

The gate was there so that an Auto Repeat whose reference went out of reach could still be disabled. Generation already stops on its own in that case, so nothing runs away without it.

---

Ref: https://support.frappe.io/helpdesk/tickets/77878?view=VIEW-HD+Ticket-1252
