### PR TITLE
fix(dashboard): don't prefill child table when link is on the parent

### DIFF
--- a/cypress/fixtures/doctype_to_link.js
+++ b/cypress/fixtures/doctype_to_link.js
@@ -22,11 +22,6 @@ export default {
 			link_doctype: "Doctype With Child Table",
 			link_fieldname: "title",
 		},
-		{
-			group: "Child Doctype",
-			link_doctype: "Doctype With Link And Child Table",
-			link_fieldname: "doctype_to_link",
-		},
 	],
 	modified: "2022-02-10 12:03:12.603763",
 	modified_by: "Administrator",

--- a/cypress/fixtures/doctype_with_link_and_child_table.js
+++ b/cypress/fixtures/doctype_with_link_and_child_table.js
@@ -1,8 +1,7 @@
 export default {
-	name: "Doctype to Link",
+	name: "Doctype With Link And Child Table",
 	actions: [],
 	custom: 1,
-	naming_rule: "By fieldname",
 	autoname: "field:title",
 	creation: "2022-02-09 20:15:21.242213",
 	doctype: "DocType",
@@ -15,22 +14,25 @@ export default {
 			label: "Title",
 			unique: 1,
 		},
-	],
-	links: [
 		{
-			group: "Child Doctype",
-			link_doctype: "Doctype With Child Table",
-			link_fieldname: "title",
+			fieldname: "doctype_to_link",
+			fieldtype: "Link",
+			label: "Doctype to Link",
+			options: "Doctype to Link",
 		},
 		{
-			group: "Child Doctype",
-			link_doctype: "Doctype With Link And Child Table",
-			link_fieldname: "doctype_to_link",
+			fieldname: "child_table",
+			fieldtype: "Table",
+			label: "Child Table",
+			options: "Child Table Doctype",
+			reqd: 1,
 		},
 	],
+	links: [],
 	modified: "2022-02-10 12:03:12.603763",
 	modified_by: "Administrator",
 	module: "Custom",
+	naming_rule: "By fieldname",
 	owner: "Administrator",
 	permissions: [
 		{

--- a/cypress/fixtures/doctype_with_link_and_child_table.js
+++ b/cypress/fixtures/doctype_with_link_and_child_table.js
@@ -15,12 +15,6 @@ export default {
 			unique: 1,
 		},
 		{
-			fieldname: "doctype_to_link",
-			fieldtype: "Link",
-			label: "Doctype to Link",
-			options: "Doctype to Link",
-		},
-		{
 			fieldname: "child_table",
 			fieldtype: "Table",
 			label: "Child Table",

--- a/cypress/integration/dashboard_links.js
+++ b/cypress/integration/dashboard_links.js
@@ -1,4 +1,5 @@
 import doctype_with_child_table from "../fixtures/doctype_with_child_table";
+import doctype_with_link_and_child_table from "../fixtures/doctype_with_link_and_child_table";
 import child_table_doctype from "../fixtures/child_table_doctype";
 import child_table_doctype_1 from "../fixtures/child_table_doctype_1";
 import doctype_to_link from "../fixtures/doctype_to_link";
@@ -12,6 +13,7 @@ context("Dashboard links", () => {
 		cy.insert_doc("DocType", child_table_doctype, true);
 		cy.insert_doc("DocType", child_table_doctype_1, true);
 		cy.insert_doc("DocType", doctype_with_child_table, true);
+		cy.insert_doc("DocType", doctype_with_link_and_child_table, true);
 		cy.insert_doc("DocType", doctype_to_link, true);
 		return cy
 			.window()
@@ -84,9 +86,22 @@ context("Dashboard links", () => {
 		cy.fill_field("title", "Test Linking");
 		cy.findByRole("button", { name: "Save" }).click();
 
-		cy.get(".document-link .btn-new").click();
+		cy.get('.btn-new[data-doctype="Doctype With Child Table"]').click();
 		cy.get(
 			'.frappe-control[data-fieldname="child_table"] .rows .data-row .col[data-fieldname="doctype_to_link"]'
 		).should("contain.text", "Test Linking");
+	});
+
+	it("check if child table is left empty when the link field is on the parent", () => {
+		cy.new_form(doctype_to_link_name);
+		cy.fill_field("title", "Test Parent Linking");
+		cy.findByRole("button", { name: "Save" }).click();
+
+		cy.get('.btn-new[data-doctype="Doctype With Link And Child Table"]').click();
+
+		cy.get_field("doctype_to_link", "Link").should("have.value", "Test Parent Linking");
+		cy.get(
+			'.frappe-control[data-fieldname="child_table"] .rows .data-row .col[data-fieldname="doctype_to_link"]'
+		).should("not.contain.text", "Test Parent Linking");
 	});
 });

--- a/cypress/integration/dashboard_links.js
+++ b/cypress/integration/dashboard_links.js
@@ -5,6 +5,7 @@ import child_table_doctype_1 from "../fixtures/child_table_doctype_1";
 import doctype_to_link from "../fixtures/doctype_to_link";
 const doctype_to_link_name = doctype_to_link.name;
 const child_table_doctype_name = child_table_doctype.name;
+const doctype_with_link_name = doctype_with_link_and_child_table.name;
 
 context("Dashboard links", () => {
 	before(() => {
@@ -18,11 +19,18 @@ context("Dashboard links", () => {
 		return cy
 			.window()
 			.its("frappe")
-			.then((frappe) => {
-				frappe.call("frappe.tests.ui_test_helpers.update_child_table", {
-					name: child_table_doctype_name,
-				});
-			});
+			.then((frappe) =>
+				frappe
+					.call("frappe.tests.ui_test_helpers.update_child_table", {
+						name: child_table_doctype_name,
+					})
+					.then(() =>
+						frappe.call(
+							"frappe.tests.ui_test_helpers.add_link_field_and_dashboard_link",
+							{ name: doctype_with_link_name }
+						)
+					)
+			);
 	});
 
 	it("Adding a new contact, checking for the counter on the dashboard and deleting the created contact", () => {
@@ -97,11 +105,12 @@ context("Dashboard links", () => {
 		cy.fill_field("title", "Test Parent Linking");
 		cy.findByRole("button", { name: "Save" }).click();
 
-		cy.get('.btn-new[data-doctype="Doctype With Link And Child Table"]').click();
+		cy.get(`.btn-new[data-doctype="${doctype_with_link_name}"]`).click();
 
-		cy.get_field("doctype_to_link", "Link").should("have.value", "Test Parent Linking");
-		cy.get(
-			'.frappe-control[data-fieldname="child_table"] .rows .data-row .col[data-fieldname="doctype_to_link"]'
-		).should("not.contain.text", "Test Parent Linking");
+		cy.url().should("include", "doctype-with-link-and-child-table/new");
+		cy.window().then((win) => {
+			expect(win.cur_frm.doc.doctype_to_link).to.eq("Test Parent Linking");
+			expect(win.cur_frm.doc.child_table[0].doctype_to_link).to.be.undefined;
+		});
 	});
 });

--- a/cypress/integration/dashboard_links.js
+++ b/cypress/integration/dashboard_links.js
@@ -107,10 +107,11 @@ context("Dashboard links", () => {
 
 		cy.get(`.btn-new[data-doctype="${doctype_with_link_name}"]`).click();
 
-		cy.url().should("include", "doctype-with-link-and-child-table/new");
-		cy.window().then((win) => {
-			expect(win.cur_frm.doc.doctype_to_link).to.eq("Test Parent Linking");
-			expect(win.cur_frm.doc.child_table[0].doctype_to_link).to.be.undefined;
+		cy.window().should((win) => {
+			const doc = win.cur_frm.doc;
+			expect(doc.doctype).to.eq(doctype_with_link_name);
+			expect(doc.doctype_to_link).to.eq("Test Parent Linking");
+			expect(doc.child_table[0].doctype_to_link).to.not.eq("Test Parent Linking");
 		});
 	});
 });

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -2391,26 +2391,29 @@ frappe.ui.form.Form = class FrappeForm {
 	}
 
 	set_link_field(doctype, new_doc, fieldname) {
-		let me = this;
-		frappe.get_meta(doctype).fields.forEach(function (df) {
-			const isLinkToParent = df.fieldtype === "Link" && df.options === me.doctype;
+		const fields = frappe.get_meta(doctype).fields;
+		const links_to_parent = (df) => df.fieldtype === "Link" && df.options === this.doctype;
 
-			if (fieldname) {
-				if (df.fieldname === fieldname && isLinkToParent) {
-					new_doc[df.fieldname] = me.doc.name;
-				}
-				if (df.fieldtype === "Table" && df.options && df.reqd) {
-					me.set_link_field(df.options, new_doc[df.fieldname][0]);
-				}
+		if (fieldname) {
+			if (fields.some((df) => df.fieldname === fieldname && links_to_parent(df))) {
+				new_doc[fieldname] = this.doc.name;
 				return;
 			}
 
-			if (isLinkToParent) {
-				new_doc[df.fieldname] = me.doc.name;
-			} else if (["Link", "Dynamic Link"].includes(df.fieldtype) && me.doc[df.fieldname]) {
-				new_doc[df.fieldname] = me.doc[df.fieldname];
+			// link is not on the parent, look for it in a mandatory child table
+			fields
+				.filter((df) => df.fieldtype === "Table" && df.options && df.reqd)
+				.forEach((df) => this.set_link_field(df.options, new_doc[df.fieldname][0]));
+			return;
+		}
+
+		fields.forEach((df) => {
+			if (links_to_parent(df)) {
+				new_doc[df.fieldname] = this.doc.name;
+			} else if (["Link", "Dynamic Link"].includes(df.fieldtype) && this.doc[df.fieldname]) {
+				new_doc[df.fieldname] = this.doc[df.fieldname];
 			} else if (df.fieldtype === "Table" && df.options && df.reqd) {
-				me.set_link_field(df.options, new_doc[df.fieldname][0]);
+				this.set_link_field(df.options, new_doc[df.fieldname][0]);
 			}
 		});
 	}

--- a/frappe/tests/ui_test_helpers.py
+++ b/frappe/tests/ui_test_helpers.py
@@ -354,22 +354,54 @@ def update_webform_to_multistep():
 		_doc.save()
 
 
+def _append_doctype_to_link_field(doc) -> bool:
+	if any(field.fieldname == "doctype_to_link" for field in doc.fields):
+		return False
+
+	doc.append(
+		"fields",
+		{
+			"fieldname": "doctype_to_link",
+			"fieldtype": "Link",
+			"in_list_view": 1,
+			"label": "Doctype to Link",
+			"options": "Doctype to Link",
+		},
+	)
+	return True
+
+
 @whitelist_for_tests()
 def update_child_table(name: str | int):
 	doc = frappe.get_doc("DocType", name)
-	if len(doc.fields) == 1:
-		doc.append(
-			"fields",
-			{
-				"fieldname": "doctype_to_link",
-				"fieldtype": "Link",
-				"in_list_view": 1,
-				"label": "Doctype to Link",
-				"options": "Doctype to Link",
-			},
-		)
-
+	if _append_doctype_to_link_field(doc):
 		doc.save()
+
+
+@whitelist_for_tests()
+def add_link_field_and_dashboard_link(name: str | int):
+	"""Show `name` in the Connections tab of `Doctype to Link`, linked through a field on `name`.
+
+	Wired up here instead of in the fixtures because the two doctypes reference each other: the
+	Link field needs `Doctype to Link` to exist, and the Document Link row needs the field.
+	"""
+	doc = frappe.get_doc("DocType", name)
+	if _append_doctype_to_link_field(doc):
+		doc.save()
+
+	parent = frappe.get_doc("DocType", "Doctype to Link")
+	if any(link.link_doctype == name for link in parent.links):
+		return
+
+	parent.append(
+		"links",
+		{
+			"group": "Child Doctype",
+			"link_doctype": name,
+			"link_fieldname": "doctype_to_link",
+		},
+	)
+	parent.save()
 
 
 @whitelist_for_tests()


### PR DESCRIPTION
Creating a document from the Connections tab fills the first row of every mandatory child table, even when the dashboard link fieldname already matches a Link field on the parent. Making a BOM from an Item sets `BOM.item` and then adds that same item as its own raw material ([forum report](https://discuss.frappe.io/t/creating-a-bom-from-the-item-connections/164131)).

The child recursion was added in d4338a1cd9 for links that exist *only* in a child table (Item → Sales Order is `Sales Order Item.item_code`). That case still works; it just no longer runs when the parent already carries the link.