### PR TITLE
fix(ui): align form builder selector icons with their input

### DIFF
--- a/frappe/public/js/form_builder/components/controls/DataControl.vue
+++ b/frappe/public/js/form_builder/components/controls/DataControl.vue
@@ -32,22 +32,40 @@ if (props.df.fieldtype === "Icon") {
 		<div v-else class="control-label label" :class="{ reqd: df.reqd }">{{ __(df.label) }}</div>
 
 		<!-- data input -->
-		<input
-			v-if="slots.label"
-			class="form-control"
-			type="text"
-			:style="{ height: df.fieldtype == 'Table MultiSelect' ? '42px' : '' }"
-			:placeholder="__(placeholder)"
-			readonly
-		/>
-		<input
-			v-else
-			class="form-control"
-			type="text"
-			:value="value"
-			:disabled="read_only || df.read_only"
-			@input="(event) => $emit('update:modelValue', event.target.value)"
-		/>
+		<div class="control-input">
+			<input
+				v-if="slots.label"
+				class="form-control"
+				type="text"
+				:style="{ height: df.fieldtype == 'Table MultiSelect' ? '42px' : '' }"
+				:placeholder="__(placeholder)"
+				readonly
+			/>
+			<input
+				v-else
+				class="form-control"
+				type="text"
+				:value="value"
+				:disabled="read_only || df.read_only"
+				@input="(event) => $emit('update:modelValue', event.target.value)"
+			/>
+
+			<!-- color selector icon -->
+			<div class="selected-color no-value" />
+
+			<!-- icon selector icon -->
+			<div
+				v-if="df.fieldtype == 'Icon'"
+				class="selected-icon no-value"
+				v-html="frappe.utils.icon('folder', 'sm')"
+			/>
+			<!-- phone selector icon -->
+			<div
+				v-if="df.fieldtype == 'Phone'"
+				class="selected-phone no-value"
+				v-html="frappe.utils.icon('chevron-down', 'sm')"
+			/>
+		</div>
 		<input
 			v-if="slots.label && df.fieldtype === 'Barcode'"
 			class="mt-2 form-control"
@@ -65,32 +83,5 @@ if (props.df.fieldtype === "Icon") {
 			:class="['time-zone', !df.description ? 'mt-2' : '']"
 			v-html="time_zone"
 		/>
-
-		<!-- color selector icon -->
-		<div class="selected-color no-value" />
-
-		<!-- icon selector icon -->
-		<div
-			v-if="df.fieldtype == 'Icon'"
-			class="selected-icon no-value"
-			v-html="frappe.utils.icon('folder', 'md')"
-		/>
-		<!-- phone selector icon -->
-		<div
-			v-if="df.fieldtype == 'Phone'"
-			class="selected-phone no-value"
-			v-html="frappe.utils.icon('chevron-down', 'sm')"
-		/>
 	</div>
 </template>
-
-<style lang="scss" scoped>
-.selected-color {
-	background-color: transparent;
-	top: 30px !important;
-}
-
-.selected-phone {
-	top: 32px !important;
-}
-</style>


### PR DESCRIPTION
Fixes #42578

## Description

In the form builder, the selector icons on Icon, Color and Phone fields sat outside their input container instead of inside it. Worst on Icon, where the folder icon floated above the field entirely.

The desk form rendered these correctly, only the Form Builder preview was affected.

## Changes
Icon, Color and Phone field types in the form builder now match the desk form, at any position in a column.

Before:
<img width="1512" height="826" alt="Screenshot 2026-09-10 at 1 56 01 AM" src="https://github.com/user-attachments/assets/efb6b95d-706a-431d-898a-1b49745fe433" />

After:
<img width="1512" height="825" alt="Screenshot 2026-09-10 at 1 57 57 AM" src="https://github.com/user-attachments/assets/f596451e-60d4-45f5-8e66-891e280a1311" />


