### PR TITLE
fix(workflow): clear doctype cache when a workflow is deleted

### DIFF
--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -9,6 +9,7 @@ from frappe.model.workflow import (
 	WorkflowTransitionError,
 	apply_workflow,
 	get_common_transition_actions,
+	get_workflow_name,
 )
 from frappe.tests import IntegrationTestCase
 from frappe.tests.utils import make_test_records
@@ -71,6 +72,15 @@ class TestWorkflow(IntegrationTestCase):
 
 		self.workflow.transitions[0].condition = ""
 		self.workflow.save()
+
+	def test_deleting_workflow_clears_cached_name(self):
+		"""A deleted workflow must not stay cached against its document type"""
+		self.assertEqual(get_workflow_name("ToDo"), "Test ToDo")
+
+		frappe.delete_doc("Workflow", "Test ToDo")
+
+		self.assertFalse(get_workflow_name("ToDo"))
+		create_new_todo()
 
 	def test_get_common_transition_actions(self):
 		todo1 = create_new_todo()

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -42,6 +42,9 @@ class Workflow(Document):
 		self.create_custom_field_for_workflow_state()
 		self.update_default_workflow_status()
 
+	def on_trash(self):
+		frappe.clear_cache(doctype=self.document_type)
+
 	def create_custom_field_for_workflow_state(self):
 		frappe.clear_cache(doctype=self.document_type)
 		meta = frappe.get_meta(self.document_type)


### PR DESCRIPTION
Deleting a Workflow left its name in the `workflow` cache hash, so every subsequent save of the target doctype raised `DoesNotExistError: Workflow <name> not found`. The doctype stayed unsaveable until the cache was cleared by hand.

`get_workflow_name` memoises the doctype -> workflow name mapping. The controller only invalidated it from `on_update`, never on delete — `delete_doc` clears the Workflow's own document cache, not the entry keyed on the target doctype.

Adds `on_trash`, mirroring what `on_update` already does.

Reproduced on Sales Order before the fix:

```
after insert, cached name: 'ZZ Repro SO Workflow'
workflow row exists: None
after delete,   cached name: 'ZZ Repro SO Workflow'
RESULT: DoesNotExistError Workflow ZZ Repro SO Workflow not found
```

Deactivating a workflow (`is_active = 0`) was never affected — that goes through `on_update`.