### PR TITLE
feat(workflow): scope a workflow to documents with conditions

### DIFF
--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -78,7 +78,7 @@ user_cache_keys = (
 doctype_cache_keys = (
 	"last_modified",
 	"linked_doctypes",
-	"workflow",
+	"workflows",
 	"data_import_column_header_map",
 )
 

--- a/frappe/core/doctype/deleted_document/deleted_document.py
+++ b/frappe/core/doctype/deleted_document/deleted_document.py
@@ -68,7 +68,7 @@ def restore(name: str | int, alert: bool = True):
 	except frappe.DocstatusTransitionError:
 		frappe.msgprint(_("Cancelled Document restored as Draft"))
 		doc.docstatus = 0
-		active_workflow = get_workflow_name(doc.doctype)
+		active_workflow = get_workflow_name(doc.doctype, doc)
 		if active_workflow:
 			workflow_state_fieldname = frappe.get_value("Workflow", active_workflow, "workflow_state_field")
 			if doc.get(workflow_state_fieldname):

--- a/frappe/desk/form/meta.py
+++ b/frappe/desk/form/meta.py
@@ -216,22 +216,10 @@ class FormMeta(Meta):
 
 	def load_workflows(self):
 		"""Ship every active workflow of the doctype; the desk picks the one that fits each document."""
-		workflow_docs = []
-		seen_states = set()
+		workflows = [frappe.get_doc("Workflow", name) for name in get_workflow_names(self.name)]
+		states = {state.state for workflow in workflows for state in workflow.get("states")}
 
-		for workflow_name in get_workflow_names(self.name):
-			if not frappe.db.exists("Workflow", workflow_name):
-				continue
-
-			workflow = frappe.get_doc("Workflow", workflow_name)
-			workflow_docs.append(workflow)
-
-			for state in workflow.get("states"):
-				if state.state not in seen_states:
-					seen_states.add(state.state)
-					workflow_docs.append(frappe.get_doc("Workflow State", state.state))
-
-		self.set("__workflow_docs", workflow_docs)
+		self.set("__workflow_docs", [*workflows, *get_workflow_state_docs(states)])
 
 	def load_templates(self):
 		if not self.custom:
@@ -262,6 +250,18 @@ class FormMeta(Meta):
 		except frappe.PermissionError:
 			# no access to kanban board
 			pass
+
+
+def get_workflow_state_docs(states: set[str]) -> list[dict]:
+	"""The Workflow State masters the desk needs to colour the states it was given."""
+	if not states:
+		return []
+
+	docs = frappe.get_all("Workflow State", filters={"name": ("in", sorted(states))}, fields=["*"])
+	for doc in docs:
+		doc["doctype"] = "Workflow State"
+
+	return docs
 
 
 def get_code_files_via_hooks(hook, name):

--- a/frappe/desk/form/meta.py
+++ b/frappe/desk/form/meta.py
@@ -7,6 +7,7 @@ from frappe import _
 from frappe.app_state import get_disabled_modules
 from frappe.model.meta import Meta
 from frappe.model.utils import render_include
+from frappe.model.workflow import get_workflow_names
 from frappe.modules import get_module_path, load_doctype_module, scrub
 from frappe.utils import get_bench_path, get_html_format
 from frappe.utils.data import get_link_to_form
@@ -214,15 +215,22 @@ class FormMeta(Meta):
 		self.set("__print_formats", print_formats)
 
 	def load_workflows(self):
-		# get active workflow
-		workflow_name = self.get_workflow()
+		"""Ship every active workflow of the doctype; the desk picks the one that fits each document."""
 		workflow_docs = []
+		seen_states = set()
 
-		if workflow_name and frappe.db.exists("Workflow", workflow_name):
+		for workflow_name in get_workflow_names(self.name):
+			if not frappe.db.exists("Workflow", workflow_name):
+				continue
+
 			workflow = frappe.get_doc("Workflow", workflow_name)
 			workflow_docs.append(workflow)
 
-			workflow_docs.extend(frappe.get_doc("Workflow State", d.state) for d in workflow.get("states"))
+			for state in workflow.get("states"):
+				if state.state not in seen_states:
+					seen_states.add(state.state)
+					workflow_docs.append(frappe.get_doc("Workflow State", state.state))
+
 		self.set("__workflow_docs", workflow_docs)
 
 	def load_templates(self):

--- a/frappe/desk/form/meta.py
+++ b/frappe/desk/form/meta.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 import os
+from typing import TYPE_CHECKING
 
 import frappe
 from frappe import _
@@ -11,6 +12,9 @@ from frappe.model.workflow import get_workflow_names
 from frappe.modules import get_module_path, load_doctype_module, scrub
 from frappe.utils import get_bench_path, get_html_format
 from frappe.utils.data import get_link_to_form
+
+if TYPE_CHECKING:
+	from frappe.model.document import Document
 
 ASSET_KEYS = (
 	"__js",
@@ -252,16 +256,17 @@ class FormMeta(Meta):
 			pass
 
 
-def get_workflow_state_docs(states: set[str]) -> list[dict]:
-	"""The Workflow State masters the desk needs to colour the states it was given."""
+def get_workflow_state_docs(states: set[str]) -> list["Document"]:
+	"""The Workflow State masters the desk needs to colour the states it was given.
+
+	Read in one query but returned as Documents: the meta bundle is serialized through
+	Meta.as_dict, which walks __dict__ and cannot handle a plain dict.
+	"""
 	if not states:
 		return []
 
-	docs = frappe.get_all("Workflow State", filters={"name": ("in", sorted(states))}, fields=["*"])
-	for doc in docs:
-		doc["doctype"] = "Workflow State"
-
-	return docs
+	rows = frappe.get_all("Workflow State", filters={"name": ("in", sorted(states))}, fields=["*"])
+	return [frappe.get_doc({"doctype": "Workflow State", **row}) for row in rows]
 
 
 def get_code_files_via_hooks(hook, name):

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1187,7 +1187,7 @@ class Document(BaseDocument):
 		"""Validate if the workflow transition is valid"""
 		if frappe.flags.in_install == "frappe":
 			return
-		workflow = self.meta.get_workflow()
+		workflow = self.meta.get_workflow(self)
 		if workflow:
 			validate_workflow(self)
 			if self._action != "save":

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -393,8 +393,8 @@ class Meta(Document):
 		if field := self.get_field(fieldname):
 			return field.translatable
 
-	def get_workflow(self):
-		return get_workflow_name(self.name)
+	def get_workflow(self, doc=None):
+		return get_workflow_name(self.name, doc)
 
 	def get_naming_series_options(self) -> list[str]:
 		"""Get list naming series options."""

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -269,7 +269,13 @@ def apply_workflow(doc: Document | str | dict, action: str):
 
 @frappe.whitelist()
 def can_cancel_document(doctype: str, docname: str | None = None):
-	doc = frappe.get_doc(doctype, docname) if docname else None
+	doc = None
+	if docname:
+		# doctype level first, so a caller without read access cannot probe for names
+		frappe.has_permission(doctype=doctype, ptype="read", throw=True)
+		doc = frappe.get_doc(doctype, docname)
+		doc.check_permission("read")
+
 	workflow = get_workflow(doctype, doc)
 	if not workflow:
 		return True

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -284,6 +284,15 @@ def can_cancel_document(doctype: str, docname: str | None = None):
 	return True
 
 
+def get_state_for_docstatus(workflow: "Workflow", docstatus) -> str:
+	"""The state a document of this docstatus enters the workflow at."""
+	for state in workflow.states:
+		if cint(state.doc_status) == cint(docstatus):
+			return state.state
+
+	return workflow.states[0].state
+
+
 def validate_workflow(doc):
 	"""Validate Workflow State and Transition for the current user.
 
@@ -295,6 +304,11 @@ def validate_workflow(doc):
 	current_state = None
 	if getattr(doc, "_doc_before_save", None):
 		current_state = doc._doc_before_save.get(workflow.workflow_state_field)
+
+	if current_state and not any(d.state == current_state for d in workflow.states):
+		current_state = get_state_for_docstatus(workflow, doc.docstatus)
+		doc.set(workflow.workflow_state_field, current_state)
+
 	next_state = doc.get(workflow.workflow_state_field)
 
 	if not next_state:

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -31,13 +31,44 @@ class WorkflowPermissionError(frappe.ValidationError):
 	pass
 
 
-def get_workflow_name(doctype):
-	workflow_name = frappe.cache.hget("workflow", doctype)
-	if workflow_name is None:
-		workflow_name = frappe.db.get_value("Workflow", {"document_type": doctype, "is_active": 1}, "name")
-		frappe.cache.hset("workflow", doctype, workflow_name or "")
+def get_workflow_names(doctype: str) -> list[str]:
+	"""Return every active workflow of a doctype, highest priority first.
 
-	return workflow_name
+	Priority is read off the cached doc rather than the query, because a site part way through a
+	migrate has the row but not yet the column, and every document save comes through here.
+	"""
+	names = frappe.cache.hget("workflows", doctype)
+	if names is None:
+		names = frappe.get_all(
+			"Workflow",
+			filters={"document_type": doctype, "is_active": 1},
+			order_by="modified desc",
+			pluck="name",
+		)
+		names.sort(key=lambda name: -cint(frappe.get_cached_doc("Workflow", name).get("priority")))
+		frappe.cache.hset("workflows", doctype, names)
+
+	return names
+
+
+def get_workflow_name(doctype: str, doc: "Document | dict | None" = None) -> str | None:
+	"""Return the workflow governing `doc`.
+
+	Without a doc, return the highest priority workflow of the doctype. A doc that matches no
+	workflow's conditions is not governed by any workflow and behaves as if none were configured.
+	"""
+	names = get_workflow_names(doctype)
+	if not names:
+		return None
+
+	if doc is None:
+		return names[0]
+
+	for name in names:
+		if frappe.get_cached_doc("Workflow", name).applies_to(doc):
+			return name
+
+	return None
 
 
 @frappe.whitelist()
@@ -56,7 +87,10 @@ def get_transitions(
 
 	doc.check_permission("read")
 
-	workflow = workflow or get_workflow(doc.doctype)
+	workflow = workflow or get_workflow(doc.doctype, doc)
+	if not workflow:
+		return []
+
 	current_state = doc.get(workflow.workflow_state_field)
 
 	if not current_state:
@@ -120,7 +154,10 @@ def apply_workflow(doc: Document | str | dict, action: str):
 	"""Allow workflow action on the current doc"""
 	doc = frappe.get_doc(frappe.parse_json(doc))
 	doc.load_from_db()
-	workflow = get_workflow(doc.doctype)
+	workflow = get_workflow(doc.doctype, doc)
+	if not workflow:
+		frappe.throw(_("No Workflow applies to this document"), WorkflowTransitionError)
+
 	transitions = get_transitions(doc, workflow)
 	user = frappe.session.user
 
@@ -231,8 +268,12 @@ def apply_workflow(doc: Document | str | dict, action: str):
 
 
 @frappe.whitelist()
-def can_cancel_document(doctype: str):
-	workflow = get_workflow(doctype)
+def can_cancel_document(doctype: str, docname: str | None = None):
+	doc = frappe.get_doc(doctype, docname) if docname else None
+	workflow = get_workflow(doctype, doc)
+	if not workflow:
+		return True
+
 	cancelling_states = [s.state for s in workflow.states if s.doc_status == "2"]
 	if not cancelling_states:
 		return True
@@ -249,7 +290,7 @@ def validate_workflow(doc):
 	- Check if user is allowed to edit in current state
 	- Check if user is allowed to transition to the next state (if changed)
 	"""
-	workflow = get_workflow(doc.doctype)
+	workflow = get_workflow(doc.doctype, doc)
 
 	current_state = None
 	if getattr(doc, "_doc_before_save", None):
@@ -294,8 +335,9 @@ def validate_workflow(doc):
 			)
 
 
-def get_workflow(doctype) -> "Workflow":
-	return frappe.get_cached_doc("Workflow", get_workflow_name(doctype))
+def get_workflow(doctype, doc: "Document | dict | None" = None) -> "Workflow | None":
+	name = get_workflow_name(doctype, doc)
+	return frappe.get_cached_doc("Workflow", name) if name else None
 
 
 def has_approval_access(user, doc, transition):

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1561,7 +1561,7 @@ frappe.ui.form.Form = class FrappeForm {
 			this.perm[0].submit &&
 			!this.is_dirty() &&
 			!this.is_new() &&
-			!frappe.model.has_workflow(this.doctype) && // show only if no workflow
+			!frappe.workflow.has_workflow(this.doc) && // show only if no workflow
 			this.doc.docstatus === 0
 		) {
 			this.dashboard.add_comment(__("Submit this document to confirm"), "blue", true);

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -724,9 +724,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 		return this.get_docstatus() === 2 && this.frm.perm[0].amend && !this.read_only;
 	}
 	has_workflow() {
-		if (this._has_workflow === undefined)
-			this._has_workflow = frappe.model.has_workflow(this.frm.doctype);
-		return this._has_workflow;
+		return frappe.workflow.has_workflow(this.frm.doc);
 	}
 	get_docstatus() {
 		return cint(this.frm.doc.docstatus);
@@ -835,6 +833,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 				frappe
 					.xcall("frappe.model.workflow.can_cancel_document", {
 						doctype: this.frm.doc.doctype,
+						docname: this.frm.doc.name,
 					})
 					.then((can_cancel) => {
 						if (can_cancel) {

--- a/frappe/public/js/frappe/form/workflow.js
+++ b/frappe/public/js/frappe/form/workflow.js
@@ -22,10 +22,9 @@ frappe.ui.form.States = class FormStates {
 		this.frm.page.add_action_item(
 			__("Help"),
 			function () {
-				frappe.workflow.setup(me.frm.doctype);
 				var state = me.get_state();
 				var d = new frappe.ui.Dialog({
-					title: "Workflow: " + frappe.workflow.workflows[me.frm.doctype].name,
+					title: "Workflow: " + frappe.workflow.get_workflow(me.frm.doc).name,
 				});
 
 				frappe.workflow.get_transitions(me.frm.doc).then((transitions) => {
@@ -36,7 +35,7 @@ frappe.ui.form.States = class FormStates {
 						).join(", ") || __("None: End of Workflow").bold();
 
 					const document_editable_by = frappe.workflow
-						.get_document_state_roles(me.frm.doctype, state)
+						.get_document_state_roles(me.frm.doc, state)
 						.map((role) => frappe.utils.bold(role))
 						.join(", ");
 
@@ -63,6 +62,8 @@ frappe.ui.form.States = class FormStates {
 		// workflow_state (it predates the workflow) never reaches
 		// show_actions, and would otherwise keep showing them
 		this.frm.page.clear_actions_menu();
+
+		if (!frappe.workflow.has_workflow(this.frm.doc)) return;
 
 		// hide if its not yet saved
 		if (this.frm.doc.__islocal) {
@@ -110,10 +111,7 @@ frappe.ui.form.States = class FormStates {
 				if (frappe.user_roles.includes(d.allowed) && has_approval_access(d)) {
 					added = true;
 					me.frm.page.add_action_item(__(d.action), function () {
-						if (
-							frappe.workflow?.workflows?.[me.frm.doctype]
-								?.enable_action_confirmation
-						) {
+						if (frappe.workflow.get_workflow(me.frm.doc)?.enable_action_confirmation) {
 							frappe.confirm(__("Are you sure you want to {0}?", [d.action]), () =>
 								me.handle_workflow_action(d)
 							);
@@ -162,7 +160,7 @@ frappe.ui.form.States = class FormStates {
 
 	set_default_state() {
 		var default_state = frappe.workflow.get_default_state(
-			this.frm.doctype,
+			this.frm.doc,
 			this.frm.doc.docstatus
 		);
 		if (default_state) {

--- a/frappe/public/js/frappe/model/indicator.js
+++ b/frappe/public/js/frappe/model/indicator.js
@@ -31,7 +31,7 @@ frappe.get_indicator = function (doc, doctype, show_workflow_state) {
 	if (!doctype) doctype = doc.doctype;
 
 	let meta = frappe.get_meta(doctype);
-	var workflow = frappe.workflow.get_workflow(doc);
+	var workflow = frappe.workflow.get_workflow(doc, doctype);
 	var without_workflow = workflow ? workflow["override_status"] : true;
 
 	var settings = frappe.listview_settings[doctype] || {};

--- a/frappe/public/js/frappe/model/indicator.js
+++ b/frappe/public/js/frappe/model/indicator.js
@@ -31,7 +31,7 @@ frappe.get_indicator = function (doc, doctype, show_workflow_state) {
 	if (!doctype) doctype = doc.doctype;
 
 	let meta = frappe.get_meta(doctype);
-	var workflow = frappe.workflow.workflows[doctype];
+	var workflow = frappe.workflow.get_workflow(doc);
 	var without_workflow = workflow ? workflow["override_status"] : true;
 
 	var settings = frappe.listview_settings[doctype] || {};

--- a/frappe/public/js/frappe/model/workflow.js
+++ b/frappe/public/js/frappe/model/workflow.js
@@ -110,7 +110,7 @@ frappe.workflow = {
 		const states = (frappe.workflow.candidates[doctype] || []).flatMap(
 			(workflow) => workflow.states || []
 		);
-		return $.unique(states.map((d) => d.update_field));
+		return [...new Set(states.map((d) => d.update_field).filter(Boolean))];
 	},
 	get_state(doc) {
 		const state_field = this.get_state_fieldname(doc.doctype);

--- a/frappe/public/js/frappe/model/workflow.js
+++ b/frappe/public/js/frappe/model/workflow.js
@@ -22,13 +22,12 @@ frappe.workflow = {
 			.get_list("Workflow", { document_type: doctype })
 			.sort((a, b) => cint(b.priority) - cint(a.priority));
 
-		frappe.workflow.candidates[doctype] = workflows;
-
 		if (!workflows.length) {
 			frappe.workflow.state_fields[doctype] = null;
 			return;
 		}
 
+		frappe.workflow.candidates[doctype] = workflows;
 		frappe.workflow.workflows[doctype] = workflows[0];
 		frappe.workflow.state_fields[doctype] = workflows[0].workflow_state_field;
 		frappe.workflow.avoid_status_override[doctype] = workflows.flatMap((workflow) =>

--- a/frappe/public/js/frappe/model/workflow.js
+++ b/frappe/public/js/frappe/model/workflow.js
@@ -3,21 +3,54 @@
 
 frappe.provide("frappe.workflow");
 
+const CONDITION_OPERATORS = {
+	"=": (a, b) => a === b,
+	"!=": (a, b) => a !== b,
+	">": (a, b) => a > b,
+	"<": (a, b) => a < b,
+	">=": (a, b) => a >= b,
+	"<=": (a, b) => a <= b,
+};
+
 frappe.workflow = {
 	state_fields: {},
 	workflows: {},
+	candidates: {},
 	avoid_status_override: {},
 	setup: function (doctype) {
-		var wf = frappe.get_list("Workflow", { document_type: doctype });
-		if (wf.length) {
-			frappe.workflow.workflows[doctype] = wf[0];
-			frappe.workflow.state_fields[doctype] = wf[0].workflow_state_field;
-			frappe.workflow.avoid_status_override[doctype] = wf[0].states
-				.filter((row) => row.avoid_status_override)
-				.map((d) => d.state);
-		} else {
+		const workflows = frappe
+			.get_list("Workflow", { document_type: doctype })
+			.sort((a, b) => cint(b.priority) - cint(a.priority));
+
+		frappe.workflow.candidates[doctype] = workflows;
+
+		if (!workflows.length) {
 			frappe.workflow.state_fields[doctype] = null;
+			return;
 		}
+
+		frappe.workflow.workflows[doctype] = workflows[0];
+		frappe.workflow.state_fields[doctype] = workflows[0].workflow_state_field;
+		frappe.workflow.avoid_status_override[doctype] = workflows.flatMap((workflow) =>
+			(workflow.states || []).filter((row) => row.avoid_status_override).map((d) => d.state)
+		);
+	},
+	applies_to: function (workflow, doc) {
+		return (workflow.conditions || []).every(({ field, condition, value }) =>
+			CONDITION_OPERATORS[condition](doc[field], value)
+		);
+	},
+	get_workflow: function (doc) {
+		if (!doc) return null;
+		frappe.workflow.setup(doc.doctype);
+		return (
+			(frappe.workflow.candidates[doc.doctype] || []).find((workflow) =>
+				frappe.workflow.applies_to(workflow, doc)
+			) || null
+		);
+	},
+	has_workflow: function (doc) {
+		return Boolean(frappe.workflow.get_workflow(doc));
 	},
 	get_state_fieldname: function (doctype) {
 		if (frappe.workflow.state_fields[doctype] === undefined) {
@@ -25,73 +58,63 @@ frappe.workflow = {
 		}
 		return frappe.workflow.state_fields[doctype];
 	},
-	get_default_state: function (doctype, docstatus) {
-		frappe.workflow.setup(doctype);
-		var value = null;
-		$.each(frappe.workflow.workflows[doctype].states, function (i, workflow_state) {
-			if (cint(workflow_state.doc_status) === cint(docstatus)) {
-				value = workflow_state.state;
-				return false;
-			}
-		});
-		return value;
+	get_default_state: function (doc, docstatus) {
+		const workflow = frappe.workflow.get_workflow(doc);
+		if (!workflow) return null;
+
+		const default_state = (workflow.states || []).find(
+			(state) => cint(state.doc_status) === cint(docstatus)
+		);
+		return default_state ? default_state.state : null;
 	},
 	get_transitions: function (doc) {
 		frappe.workflow.setup(doc.doctype);
 		return frappe.xcall("frappe.model.workflow.get_transitions", { doc: doc });
 	},
-	get_document_state_roles: function (doctype, state) {
-		frappe.workflow.setup(doctype);
-		let workflow_states =
-			frappe.get_children(frappe.workflow.workflows[doctype], "states", { state: state }) ||
-			[];
-		return workflow_states.map((d) => d.allow_edit);
+	get_document_state_roles: function (doc, state) {
+		const workflow = frappe.workflow.get_workflow(doc);
+		if (!workflow) return [];
+
+		return (frappe.get_children(workflow, "states", { state: state }) || []).map(
+			(d) => d.allow_edit
+		);
 	},
-	is_self_approval_enabled: function (doctype) {
-		return frappe.workflow.workflows[doctype].allow_self_approval;
+	is_self_approval_enabled: function (doc) {
+		return frappe.workflow.get_workflow(doc)?.allow_self_approval;
 	},
 	is_read_only: function (doctype, name) {
 		var state_fieldname = frappe.workflow.get_state_fieldname(doctype);
-		if (state_fieldname) {
-			var doc = locals[doctype][name];
-			if (!doc) return false;
-			if (doc.__islocal) return false;
+		if (!state_fieldname) return false;
 
-			var state =
-				doc[state_fieldname] || frappe.workflow.get_default_state(doctype, doc.docstatus);
-			if (!state) return false;
+		var doc = locals[doctype][name];
+		if (!doc) return false;
+		if (doc.__islocal) return false;
+		if (!frappe.workflow.has_workflow(doc)) return false;
 
-			let allow_edit_roles = frappe.workflow.get_document_state_roles(doctype, state);
-			let has_common_role = frappe.user_roles.some((role) =>
-				allow_edit_roles.includes(role)
-			);
-			return !has_common_role;
-		}
-		return false;
+		var state = doc[state_fieldname] || frappe.workflow.get_default_state(doc, doc.docstatus);
+		if (!state) return false;
+
+		let allow_edit_roles = frappe.workflow.get_document_state_roles(doc, state);
+		return !frappe.user_roles.some((role) => allow_edit_roles.includes(role));
 	},
 	get_update_fields: function (doctype) {
-		var update_fields = $.unique(
-			$.map(frappe.workflow.workflows[doctype].states || [], function (d) {
-				return d.update_field;
-			})
+		frappe.workflow.setup(doctype);
+		const states = (frappe.workflow.candidates[doctype] || []).flatMap(
+			(workflow) => workflow.states || []
 		);
-		return update_fields;
+		return $.unique(states.map((d) => d.update_field));
 	},
 	get_state(doc) {
 		const state_field = this.get_state_fieldname(doc.doctype);
-		let state = doc[state_field];
-		if (!state) {
-			state = this.get_default_state(doc.doctype, doc.docstatus);
-		}
-		return state;
+		return doc[state_field] || this.get_default_state(doc, doc.docstatus);
 	},
 	get_all_transitions(doctype) {
-		return frappe.workflow.workflows[doctype].transitions || [];
+		frappe.workflow.setup(doctype);
+		return (frappe.workflow.candidates[doctype] || []).flatMap(
+			(workflow) => workflow.transitions || []
+		);
 	},
 	get_all_transition_actions(doctype) {
-		const transitions = this.get_all_transitions(doctype);
-		return transitions.map((transition) => {
-			return transition.action;
-		});
+		return this.get_all_transitions(doctype).map((transition) => transition.action);
 	},
 };

--- a/frappe/public/js/frappe/model/workflow.js
+++ b/frappe/public/js/frappe/model/workflow.js
@@ -3,6 +3,15 @@
 
 frappe.provide("frappe.workflow");
 
+const NUMERIC_FIELDTYPES = ["Int", "Float", "Currency", "Percent"];
+
+function cast_condition_value(value, fieldtype) {
+	if (fieldtype === "Check") return cint(value);
+	if (NUMERIC_FIELDTYPES.includes(fieldtype)) return flt(value);
+
+	return value;
+}
+
 const CONDITION_OPERATORS = {
 	"=": (a, b) => a === b,
 	"!=": (a, b) => a !== b,
@@ -44,9 +53,13 @@ frappe.workflow = {
 		);
 	},
 	applies_to: function (workflow, doc) {
-		return (workflow.conditions || []).every(({ field, condition, value }) =>
-			CONDITION_OPERATORS[condition](doc[field], value)
-		);
+		return (workflow.conditions || []).every(({ field, condition, value }) => {
+			const fieldtype = frappe.meta.get_docfield(workflow.document_type, field)?.fieldtype;
+			return CONDITION_OPERATORS[condition](
+				cast_condition_value(doc[field], fieldtype),
+				cast_condition_value(value, fieldtype)
+			);
+		});
 	},
 	get_workflow: function (doc) {
 		if (!doc) return null;

--- a/frappe/public/js/frappe/model/workflow.js
+++ b/frappe/public/js/frappe/model/workflow.js
@@ -61,11 +61,13 @@ frappe.workflow = {
 			);
 		});
 	},
-	get_workflow: function (doc) {
-		if (!doc) return null;
-		frappe.workflow.setup(doc.doctype);
+	get_workflow: function (doc, doctype) {
+		doctype = doctype || doc?.doctype;
+		if (!doc || !doctype) return null;
+
+		frappe.workflow.setup(doctype);
 		return (
-			(frappe.workflow.candidates[doc.doctype] || []).find((workflow) =>
+			(frappe.workflow.candidates[doctype] || []).find((workflow) =>
 				frappe.workflow.applies_to(workflow, doc)
 			) || null
 		);

--- a/frappe/public/js/frappe/model/workflow.js
+++ b/frappe/public/js/frappe/model/workflow.js
@@ -42,6 +42,8 @@ frappe.workflow = {
 
 		if (!workflows.length) {
 			frappe.workflow.state_fields[doctype] = null;
+			delete frappe.workflow.candidates[doctype];
+			delete frappe.workflow.workflows[doctype];
 			return;
 		}
 

--- a/frappe/public/js/frappe/model/workflow.js
+++ b/frappe/public/js/frappe/model/workflow.js
@@ -12,6 +12,15 @@ const CONDITION_OPERATORS = {
 	"<=": (a, b) => a <= b,
 };
 
+function resolve_workflow(doc) {
+	if (typeof doc === "string") {
+		frappe.workflow.setup(doc);
+		return frappe.workflow.workflows[doc] || null;
+	}
+
+	return frappe.workflow.get_workflow(doc);
+}
+
 frappe.workflow = {
 	state_fields: {},
 	workflows: {},
@@ -58,7 +67,7 @@ frappe.workflow = {
 		return frappe.workflow.state_fields[doctype];
 	},
 	get_default_state: function (doc, docstatus) {
-		const workflow = frappe.workflow.get_workflow(doc);
+		const workflow = resolve_workflow(doc);
 		if (!workflow) return null;
 
 		const default_state = (workflow.states || []).find(
@@ -71,7 +80,7 @@ frappe.workflow = {
 		return frappe.xcall("frappe.model.workflow.get_transitions", { doc: doc });
 	},
 	get_document_state_roles: function (doc, state) {
-		const workflow = frappe.workflow.get_workflow(doc);
+		const workflow = resolve_workflow(doc);
 		if (!workflow) return [];
 
 		return (frappe.get_children(workflow, "states", { state: state }) || []).map(
@@ -79,7 +88,7 @@ frappe.workflow = {
 		);
 	},
 	is_self_approval_enabled: function (doc) {
-		return frappe.workflow.get_workflow(doc)?.allow_self_approval;
+		return resolve_workflow(doc)?.allow_self_approval;
 	},
 	is_read_only: function (doctype, name) {
 		var state_fieldname = frappe.workflow.get_state_fieldname(doctype);

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -11,6 +11,7 @@ from frappe.model.workflow import (
 	get_common_transition_actions,
 	get_transitions,
 	get_workflow_name,
+	get_workflow_names,
 )
 from frappe.tests import IntegrationTestCase
 from frappe.tests.utils import make_test_records
@@ -593,6 +594,17 @@ class TestConditionalWorkflow(IntegrationTestCase):
 		todo.reload()
 		self.assertEqual(get_workflow_name("ToDo", todo), "Test High ToDo")
 		self.assertEqual(todo.workflow_state, "Pending")
+
+	def test_deleting_a_workflow_drops_it_from_the_cache(self):
+		from frappe.desk.form.meta import get_meta
+
+		create_conditional_todo_workflow("Test Any ToDo")
+		self.assertEqual(get_workflow_names("ToDo"), ["Test Any ToDo"])
+
+		frappe.delete_doc("Workflow", "Test Any ToDo")
+
+		self.assertEqual(get_workflow_names("ToDo"), [])
+		self.assertEqual(get_meta("ToDo").get("__workflow_docs"), [])
 
 	def test_conditions_must_name_a_real_field(self):
 		workflow = build_todo_workflow("Test High ToDo")

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -583,6 +583,17 @@ class TestConditionalWorkflow(IntegrationTestCase):
 		todo.reload()
 		self.assertEqual(todo.workflow_state, "Pending")
 
+	def test_seeding_respects_the_tie_break_between_equal_priorities(self):
+		todo = create_new_todo(priority="High")
+		self.assertIsNone(todo.workflow_state)
+
+		create_conditional_todo_workflow("Test Any ToDo", states=("Rejected", "Approved"))
+		create_conditional_todo_workflow("Test High ToDo", priority="High")
+
+		todo.reload()
+		self.assertEqual(get_workflow_name("ToDo", todo), "Test High ToDo")
+		self.assertEqual(todo.workflow_state, "Pending")
+
 	def test_conditions_must_name_a_real_field(self):
 		workflow = build_todo_workflow("Test High ToDo")
 		workflow.append("conditions", dict(field="not_a_field", condition="=", value="High"))

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -533,7 +533,8 @@ class TestConditionalWorkflow(IntegrationTestCase):
 		"""Leave the doctype exactly as it was found.
 
 		Creating a Workflow writes a Custom Field, which commits, so a workflow made here outlives
-		the transaction rollback and would otherwise resolve for the tests that follow.
+		the transaction rollback. The cleanup has to be committed for the same reason, or it is
+		rolled back with the test and the workflow resolves for everything that follows.
 		"""
 		for name in frappe.get_all("Workflow", {"document_type": "ToDo"}, pluck="name"):
 			if name not in self.pre_existing:
@@ -542,6 +543,7 @@ class TestConditionalWorkflow(IntegrationTestCase):
 		for name in self.suspended:
 			frappe.db.set_value("Workflow", name, "is_active", 1)
 
+		frappe.db.commit()
 		frappe.clear_cache(doctype="ToDo")
 
 	def test_conditional_workflow_skips_documents_it_does_not_match(self):

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -9,6 +9,8 @@ from frappe.model.workflow import (
 	WorkflowTransitionError,
 	apply_workflow,
 	get_common_transition_actions,
+	get_transitions,
+	get_workflow_name,
 )
 from frappe.tests import IntegrationTestCase
 from frappe.tests.utils import make_test_records
@@ -414,8 +416,12 @@ def create_domain_workflow():
 	return workflow
 
 
-def create_new_todo():
-	return frappe.get_doc(doctype="ToDo", description="workflow " + random_string(10)).insert()
+def create_new_todo(priority=None):
+	todo = frappe.get_doc(doctype="ToDo", description="workflow " + random_string(10))
+	if priority:
+		todo.priority = priority
+
+	return todo.insert()
 
 
 def create_new_submittable_doctype():
@@ -501,3 +507,94 @@ def create_new_webhook():
 	webhook.save()
 
 	return webhook
+
+
+class TestConditionalWorkflow(IntegrationTestCase):
+	WORKFLOW_NAMES = ("Test High ToDo", "Test Low ToDo", "Test Old ToDo", "Test Any ToDo")
+
+	def setUp(self):
+		frappe.db.delete("Workflow Action")
+		self.suspended = frappe.get_all("Workflow", {"document_type": "ToDo", "is_active": 1}, pluck="name")
+		for name in self.suspended:
+			frappe.db.set_value("Workflow", name, "is_active", 0)
+		frappe.clear_cache(doctype="ToDo")
+
+	def tearDown(self):
+		for name in self.WORKFLOW_NAMES:
+			frappe.delete_doc("Workflow", name, force=True, ignore_missing=True)
+		for name in self.suspended:
+			frappe.db.set_value("Workflow", name, "is_active", 1)
+		frappe.clear_cache(doctype="ToDo")
+
+	def test_conditional_workflow_skips_documents_it_does_not_match(self):
+		create_conditional_todo_workflow("Test High ToDo", priority="High")
+
+		high = create_new_todo(priority="High")
+		self.assertEqual(get_workflow_name("ToDo", high), "Test High ToDo")
+		self.assertEqual(high.workflow_state, "Pending")
+
+		low = create_new_todo(priority="Low")
+		self.assertIsNone(get_workflow_name("ToDo", low))
+		self.assertIsNone(low.workflow_state)
+		self.assertEqual(get_transitions(low), [])
+
+	def test_unconditional_workflow_governs_every_document(self):
+		create_conditional_todo_workflow("Test Any ToDo")
+
+		for priority in ("High", "Low"):
+			todo = create_new_todo(priority=priority)
+			self.assertEqual(get_workflow_name("ToDo", todo), "Test Any ToDo")
+
+	def test_highest_priority_matching_workflow_wins(self):
+		create_conditional_todo_workflow("Test Any ToDo", workflow_priority=0)
+		create_conditional_todo_workflow("Test High ToDo", priority="High", workflow_priority=10)
+
+		self.assertEqual(get_workflow_name("ToDo", create_new_todo(priority="High")), "Test High ToDo")
+		self.assertEqual(get_workflow_name("ToDo", create_new_todo(priority="Low")), "Test Any ToDo")
+
+	def test_catch_all_workflow_retires_only_the_other_catch_all(self):
+		create_conditional_todo_workflow("Test High ToDo", priority="High")
+		create_conditional_todo_workflow("Test Old ToDo")
+		create_conditional_todo_workflow("Test Any ToDo")
+
+		self.assertEqual(frappe.db.get_value("Workflow", "Test Old ToDo", "is_active"), 0)
+		self.assertEqual(frappe.db.get_value("Workflow", "Test High ToDo", "is_active"), 1)
+
+	def test_conditions_must_name_a_real_field(self):
+		workflow = build_todo_workflow("Test High ToDo")
+		workflow.append("conditions", dict(field="not_a_field", condition="=", value="High"))
+
+		self.assertRaises(frappe.ValidationError, workflow.insert)
+
+	def test_active_workflows_must_share_a_state_field(self):
+		create_conditional_todo_workflow("Test High ToDo", priority="High")
+
+		workflow = build_todo_workflow("Test Low ToDo")
+		workflow.workflow_state_field = "custom_state"
+		workflow.append("conditions", dict(field="priority", condition="=", value="Low"))
+
+		self.assertRaises(frappe.ValidationError, workflow.insert)
+
+
+def build_todo_workflow(name):
+	workflow = frappe.new_doc("Workflow")
+	workflow.workflow_name = name
+	workflow.document_type = "ToDo"
+	workflow.workflow_state_field = "workflow_state"
+	workflow.is_active = 1
+	workflow.append("states", dict(state="Pending", allow_edit="All"))
+	workflow.append("states", dict(state="Approved", allow_edit="All"))
+	workflow.append(
+		"transitions",
+		dict(state="Pending", action="Approve", next_state="Approved", allowed="All"),
+	)
+	return workflow
+
+
+def create_conditional_todo_workflow(name, priority=None, workflow_priority=0):
+	workflow = build_todo_workflow(name)
+	workflow.priority = workflow_priority
+	if priority:
+		workflow.append("conditions", dict(field="priority", condition="=", value=priority))
+
+	return workflow.insert()

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -606,6 +606,14 @@ class TestConditionalWorkflow(IntegrationTestCase):
 		self.assertEqual(get_workflow_names("ToDo"), [])
 		self.assertEqual(get_meta("ToDo").get("__workflow_docs"), [])
 
+	def test_desk_metadata_serializes_with_a_workflow(self):
+		from frappe.desk.form.load import get_meta_bundle
+
+		create_conditional_todo_workflow("Test Any ToDo")
+
+		workflow_docs = get_meta_bundle("ToDo")[0]["__workflow_docs"]
+		self.assertIn("Workflow State", [doc.doctype for doc in workflow_docs])
+
 	def test_conditions_must_name_a_real_field(self):
 		workflow = build_todo_workflow("Test High ToDo")
 		workflow.append("conditions", dict(field="not_a_field", condition="=", value="High"))

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -307,8 +307,9 @@ def create_todo_workflow():
 
 	if not frappe.db.exists("Role", TEST_ROLE):
 		frappe.get_doc(doctype="Role", role_name=TEST_ROLE).insert(ignore_if_duplicate=True)
-		if frappe.db.exists("User", UI_TEST_USER):
-			frappe.get_doc("User", UI_TEST_USER).add_roles(TEST_ROLE)
+
+	if frappe.db.exists("User", UI_TEST_USER):
+		frappe.get_doc("User", UI_TEST_USER).add_roles(TEST_ROLE)
 
 	workflow = frappe.new_doc("Workflow")
 	workflow.workflow_name = "Test ToDo"

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -656,6 +656,53 @@ class TestConditionalWorkflow(IntegrationTestCase):
 
 		self.assertRaises(frappe.ValidationError, workflow.insert)
 
+	def test_repeated_conditions_on_one_field_must_all_hold(self):
+		build_conditional_todo_workflow([("priority", "=", "High"), ("priority", "=", "Low")]).insert()
+
+		for priority in ("High", "Medium", "Low"):
+			self.assertIsNone(get_workflow_name("ToDo", create_new_todo(priority=priority)))
+
+	def test_adjacent_strict_bounds_on_a_discrete_field_coexist(self):
+		build_conditional_todo_workflow([("date", ">", "2026-01-01")]).insert()
+		build_conditional_todo_workflow([("date", "<", "2026-01-02")]).insert()
+
+		self.assertEqual(len(get_workflow_names("ToDo")), 2)
+
+	def test_bounds_that_pin_a_value_contradict_an_exclusion(self):
+		build_conditional_todo_workflow([("date", ">=", "2026-01-01"), ("date", "<=", "2026-01-01")]).insert()
+		build_conditional_todo_workflow([("date", "!=", "2026-01-01")]).insert()
+
+		self.assertEqual(len(get_workflow_names("ToDo")), 2)
+
+	def test_touching_inclusive_bounds_are_rejected(self):
+		build_conditional_todo_workflow([("date", ">=", "2026-01-01")]).insert()
+		workflow = build_conditional_todo_workflow([("date", "<=", "2026-01-01")])
+
+		self.assertRaises(frappe.ValidationError, workflow.insert)
+
+	def test_every_peer_is_checked_not_only_the_first(self):
+		create_conditional_todo_workflow(priority="High")
+		create_conditional_todo_workflow(priority="Low")
+		workflow = build_conditional_todo_workflow([("priority", "=", "Low")])
+
+		self.assertRaises(frappe.ValidationError, workflow.insert)
+
+	def test_inactive_peers_do_not_block_a_workflow(self):
+		dormant = build_conditional_todo_workflow([("priority", "=", "High")])
+		dormant.is_active = 0
+		dormant.insert()
+
+		self.assertIsNotNone(create_conditional_todo_workflow(priority="High"))
+
+	def test_reactivating_a_workflow_rechecks_its_peers(self):
+		create_conditional_todo_workflow(priority="High")
+		dormant = build_conditional_todo_workflow([("priority", "=", "High")])
+		dormant.is_active = 0
+		dormant.insert()
+
+		dormant.is_active = 1
+		self.assertRaises(frappe.ValidationError, dormant.save)
+
 	def test_conditions_must_name_a_real_field(self):
 		workflow = build_todo_workflow()
 		workflow.append("conditions", dict(field="not_a_field", condition="=", value="High"))

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -8,6 +8,7 @@ import frappe
 from frappe.model.workflow import (
 	WorkflowTransitionError,
 	apply_workflow,
+	can_cancel_document,
 	get_common_transition_actions,
 	get_transitions,
 	get_workflow_name,
@@ -703,6 +704,15 @@ class TestConditionalWorkflow(IntegrationTestCase):
 		dormant.is_active = 1
 		self.assertRaises(frappe.ValidationError, dormant.save)
 
+	def test_can_cancel_document_needs_read_access(self):
+		"""A missing name and a readable one have to fail alike, or the endpoint tells callers which exist."""
+		workflow = create_conditional_todo_workflow()
+		user = create_user_without_roles()
+
+		with self.set_user(user):
+			self.assertRaises(frappe.PermissionError, can_cancel_document, "Workflow", workflow.name)
+			self.assertRaises(frappe.PermissionError, can_cancel_document, "Workflow", "no-such-workflow")
+
 	def test_conditions_must_name_a_real_field(self):
 		workflow = build_todo_workflow()
 		workflow.append("conditions", dict(field="not_a_field", condition="=", value="High"))
@@ -742,6 +752,18 @@ def create_workflow_state_field(doctype):
 			"allow_on_submit": 1,
 		}
 	).insert(ignore_if_duplicate=True)
+
+
+def create_user_without_roles() -> str:
+	user = frappe.get_doc(
+		doctype="User",
+		email=f"workflow-{frappe.generate_hash(length=8)}@example.com",
+		first_name="Workflow Test",
+	)
+	user.insert(ignore_permissions=True)
+	user.remove_roles(*[d.role for d in user.roles])
+
+	return user.name
 
 
 def build_todo_workflow(states=("Pending", "Approved")):

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -510,7 +510,7 @@ def create_new_webhook():
 
 
 class TestConditionalWorkflow(IntegrationTestCase):
-	WORKFLOW_NAMES = ("Test High ToDo", "Test Low ToDo", "Test Old ToDo", "Test Any ToDo")
+	WORKFLOW_NAMES = ("Test Any ToDo", "Test High ToDo", "Test Low ToDo", "Test Old ToDo")
 
 	def setUp(self):
 		frappe.db.delete("Workflow Action")
@@ -560,6 +560,29 @@ class TestConditionalWorkflow(IntegrationTestCase):
 		self.assertEqual(frappe.db.get_value("Workflow", "Test Old ToDo", "is_active"), 0)
 		self.assertEqual(frappe.db.get_value("Workflow", "Test High ToDo", "is_active"), 1)
 
+	def test_moving_between_workflows_re_enters_the_new_one(self):
+		create_conditional_todo_workflow("Test High ToDo", priority="High")
+		create_conditional_todo_workflow("Test Low ToDo", priority="Low", states=("Rejected", "Approved"))
+
+		todo = create_new_todo(priority="High")
+		self.assertEqual(todo.workflow_state, "Pending")
+
+		todo.priority = "Low"
+		todo.save()
+
+		self.assertEqual(get_workflow_name("ToDo", todo), "Test Low ToDo")
+		self.assertEqual(todo.workflow_state, "Rejected")
+
+	def test_seeding_skips_documents_a_higher_priority_workflow_claims(self):
+		todo = create_new_todo(priority="High")
+		self.assertIsNone(todo.workflow_state)
+
+		create_conditional_todo_workflow("Test High ToDo", priority="High", workflow_priority=10)
+		create_conditional_todo_workflow("Test Any ToDo", workflow_priority=0)
+
+		todo.reload()
+		self.assertEqual(todo.workflow_state, "Pending")
+
 	def test_conditions_must_name_a_real_field(self):
 		workflow = build_todo_workflow("Test High ToDo")
 		workflow.append("conditions", dict(field="not_a_field", condition="=", value="High"))
@@ -576,23 +599,26 @@ class TestConditionalWorkflow(IntegrationTestCase):
 		self.assertRaises(frappe.ValidationError, workflow.insert)
 
 
-def build_todo_workflow(name):
+def build_todo_workflow(name, states=("Pending", "Approved")):
 	workflow = frappe.new_doc("Workflow")
 	workflow.workflow_name = name
 	workflow.document_type = "ToDo"
 	workflow.workflow_state_field = "workflow_state"
 	workflow.is_active = 1
-	workflow.append("states", dict(state="Pending", allow_edit="All"))
-	workflow.append("states", dict(state="Approved", allow_edit="All"))
+	for state in states:
+		workflow.append("states", dict(state=state, allow_edit="All"))
+
 	workflow.append(
 		"transitions",
-		dict(state="Pending", action="Approve", next_state="Approved", allowed="All"),
+		dict(state=states[0], action="Approve", next_state=states[1], allowed="All"),
 	)
 	return workflow
 
 
-def create_conditional_todo_workflow(name, priority=None, workflow_priority=0):
-	workflow = build_todo_workflow(name)
+def create_conditional_todo_workflow(
+	name, priority=None, workflow_priority=0, states=("Pending", "Approved")
+):
+	workflow = build_todo_workflow(name, states)
 	workflow.priority = workflow_priority
 	if priority:
 		workflow.append("conditions", dict(field="priority", condition="=", value=priority))

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -625,6 +625,37 @@ class TestConditionalWorkflow(IntegrationTestCase):
 		workflow_docs = get_meta_bundle("ToDo")[0]["__workflow_docs"]
 		self.assertIn("Workflow State", [doc.doctype for doc in workflow_docs])
 
+	def test_exclusive_conditions_coexist_at_the_same_priority(self):
+		high = create_conditional_todo_workflow(priority="High")
+		low = create_conditional_todo_workflow(priority="Low")
+
+		self.assertEqual(get_workflow_name("ToDo", create_new_todo(priority="High")), high.name)
+		self.assertEqual(get_workflow_name("ToDo", create_new_todo(priority="Low")), low.name)
+
+	def test_exclusive_ranges_coexist_at_the_same_priority(self):
+		build_conditional_todo_workflow([("date", ">=", "2026-01-01")]).insert()
+		build_conditional_todo_workflow([("date", "<", "2026-01-01")]).insert()
+
+		self.assertEqual(len(get_workflow_names("ToDo")), 2)
+
+	def test_overlapping_conditions_are_rejected_at_the_same_priority(self):
+		create_conditional_todo_workflow(priority="High")
+		workflow = build_conditional_todo_workflow([("priority", "=", "High")])
+
+		self.assertRaises(frappe.ValidationError, workflow.insert)
+
+	def test_conditions_on_different_fields_are_rejected_at_the_same_priority(self):
+		create_conditional_todo_workflow(priority="High")
+		workflow = build_conditional_todo_workflow([("status", "=", "Open")])
+
+		self.assertRaises(frappe.ValidationError, workflow.insert)
+
+	def test_catch_all_is_rejected_beside_a_conditional_workflow_of_equal_priority(self):
+		create_conditional_todo_workflow(priority="High")
+		workflow = build_conditional_todo_workflow([])
+
+		self.assertRaises(frappe.ValidationError, workflow.insert)
+
 	def test_conditions_must_name_a_real_field(self):
 		workflow = build_todo_workflow()
 		workflow.append("conditions", dict(field="not_a_field", condition="=", value="High"))
@@ -682,10 +713,15 @@ def build_todo_workflow(states=("Pending", "Approved")):
 	return workflow
 
 
-def create_conditional_todo_workflow(priority=None, workflow_priority=0, states=("Pending", "Approved")):
+def build_conditional_todo_workflow(conditions, workflow_priority=0, states=("Pending", "Approved")):
 	workflow = build_todo_workflow(states)
 	workflow.priority = workflow_priority
-	if priority:
-		workflow.append("conditions", dict(field="priority", condition="=", value=priority))
+	for field, condition, value in conditions:
+		workflow.append("conditions", dict(field=field, condition=condition, value=value))
 
-	return workflow.insert()
+	return workflow
+
+
+def create_conditional_todo_workflow(priority=None, workflow_priority=0, states=("Pending", "Approved")):
+	conditions = [("priority", "=", priority)] if priority else []
+	return build_conditional_todo_workflow(conditions, workflow_priority, states).insert()

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -521,20 +521,27 @@ def create_new_webhook():
 
 
 class TestConditionalWorkflow(IntegrationTestCase):
-	WORKFLOW_NAMES = ("Test Any ToDo", "Test High ToDo", "Test Low ToDo", "Test Old ToDo")
-
 	def setUp(self):
 		frappe.db.delete("Workflow Action")
+		self.pre_existing = frappe.get_all("Workflow", {"document_type": "ToDo"}, pluck="name")
 		self.suspended = frappe.get_all("Workflow", {"document_type": "ToDo", "is_active": 1}, pluck="name")
 		for name in self.suspended:
 			frappe.db.set_value("Workflow", name, "is_active", 0)
 		frappe.clear_cache(doctype="ToDo")
 
 	def tearDown(self):
-		for name in self.WORKFLOW_NAMES:
-			frappe.delete_doc("Workflow", name, force=True, ignore_missing=True)
+		"""Leave the doctype exactly as it was found.
+
+		Creating a Workflow writes a Custom Field, which commits, so a workflow made here outlives
+		the transaction rollback and would otherwise resolve for the tests that follow.
+		"""
+		for name in frappe.get_all("Workflow", {"document_type": "ToDo"}, pluck="name"):
+			if name not in self.pre_existing:
+				frappe.delete_doc("Workflow", name, force=True, ignore_missing=True)
+
 		for name in self.suspended:
 			frappe.db.set_value("Workflow", name, "is_active", 1)
+
 		frappe.clear_cache(doctype="ToDo")
 
 	def test_conditional_workflow_skips_documents_it_does_not_match(self):

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -565,7 +565,7 @@ class TestConditionalWorkflow(IntegrationTestCase):
 		self.assertEqual(get_workflow_name("ToDo", create_new_todo(priority="Low")), catch_all.name)
 
 	def test_catch_all_workflow_retires_only_the_other_catch_all(self):
-		conditional = create_conditional_todo_workflow(priority="High")
+		conditional = create_conditional_todo_workflow(priority="High", workflow_priority=10)
 		retired = create_conditional_todo_workflow()
 		create_conditional_todo_workflow()
 
@@ -595,11 +595,11 @@ class TestConditionalWorkflow(IntegrationTestCase):
 		todo.reload()
 		self.assertEqual(todo.workflow_state, "Pending")
 
-	def test_seeding_respects_the_tie_break_between_equal_priorities(self):
+	def test_seeding_at_equal_priority_stays_within_conditions(self):
 		todo = create_new_todo(priority="High")
 		self.assertIsNone(todo.workflow_state)
 
-		create_conditional_todo_workflow(states=("Rejected", "Approved"))
+		create_conditional_todo_workflow(priority="Low", states=("Rejected", "Approved"))
 		high = create_conditional_todo_workflow(priority="High")
 
 		todo.reload()

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -521,36 +521,28 @@ def create_new_webhook():
 
 
 class TestConditionalWorkflow(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		create_workflow_state_field("ToDo")
+
 	def setUp(self):
-		frappe.db.delete("Workflow Action")
-		self.pre_existing = frappe.get_all("Workflow", {"document_type": "ToDo"}, pluck="name")
-		self.suspended = frappe.get_all("Workflow", {"document_type": "ToDo", "is_active": 1}, pluck="name")
-		for name in self.suspended:
-			frappe.db.set_value("Workflow", name, "is_active", 0)
-		frappe.clear_cache(doctype="ToDo")
+		"""Start from a doctype no workflow governs.
 
-	def tearDown(self):
-		"""Leave the doctype exactly as it was found.
-
-		Creating a Workflow writes a Custom Field, which commits, so a workflow made here outlives
-		the transaction rollback. The cleanup has to be committed for the same reason, or it is
-		rolled back with the test and the workflow resolves for everything that follows.
+		IntegrationTestCase rolls back once the class is done, not between tests, so a workflow
+		made by an earlier test is still around. Retiring them here is enough: every workflow gets
+		a name of its own, so nothing collides.
 		"""
-		for name in frappe.get_all("Workflow", {"document_type": "ToDo"}, pluck="name"):
-			if name not in self.pre_existing:
-				frappe.delete_doc("Workflow", name, force=True, ignore_missing=True)
+		for name in frappe.get_all("Workflow", {"document_type": "ToDo", "is_active": 1}, pluck="name"):
+			frappe.db.set_value("Workflow", name, "is_active", 0)
 
-		for name in self.suspended:
-			frappe.db.set_value("Workflow", name, "is_active", 1)
-
-		frappe.db.commit()
 		frappe.clear_cache(doctype="ToDo")
 
 	def test_conditional_workflow_skips_documents_it_does_not_match(self):
-		create_conditional_todo_workflow("Test High ToDo", priority="High")
+		workflow = create_conditional_todo_workflow(priority="High")
 
 		high = create_new_todo(priority="High")
-		self.assertEqual(get_workflow_name("ToDo", high), "Test High ToDo")
+		self.assertEqual(get_workflow_name("ToDo", high), workflow.name)
 		self.assertEqual(high.workflow_state, "Pending")
 
 		low = create_new_todo(priority="Low")
@@ -559,30 +551,30 @@ class TestConditionalWorkflow(IntegrationTestCase):
 		self.assertEqual(get_transitions(low), [])
 
 	def test_unconditional_workflow_governs_every_document(self):
-		create_conditional_todo_workflow("Test Any ToDo")
+		workflow = create_conditional_todo_workflow()
 
 		for priority in ("High", "Low"):
 			todo = create_new_todo(priority=priority)
-			self.assertEqual(get_workflow_name("ToDo", todo), "Test Any ToDo")
+			self.assertEqual(get_workflow_name("ToDo", todo), workflow.name)
 
 	def test_highest_priority_matching_workflow_wins(self):
-		create_conditional_todo_workflow("Test Any ToDo", workflow_priority=0)
-		create_conditional_todo_workflow("Test High ToDo", priority="High", workflow_priority=10)
+		catch_all = create_conditional_todo_workflow(workflow_priority=0)
+		high = create_conditional_todo_workflow(priority="High", workflow_priority=10)
 
-		self.assertEqual(get_workflow_name("ToDo", create_new_todo(priority="High")), "Test High ToDo")
-		self.assertEqual(get_workflow_name("ToDo", create_new_todo(priority="Low")), "Test Any ToDo")
+		self.assertEqual(get_workflow_name("ToDo", create_new_todo(priority="High")), high.name)
+		self.assertEqual(get_workflow_name("ToDo", create_new_todo(priority="Low")), catch_all.name)
 
 	def test_catch_all_workflow_retires_only_the_other_catch_all(self):
-		create_conditional_todo_workflow("Test High ToDo", priority="High")
-		create_conditional_todo_workflow("Test Old ToDo")
-		create_conditional_todo_workflow("Test Any ToDo")
+		conditional = create_conditional_todo_workflow(priority="High")
+		retired = create_conditional_todo_workflow()
+		create_conditional_todo_workflow()
 
-		self.assertEqual(frappe.db.get_value("Workflow", "Test Old ToDo", "is_active"), 0)
-		self.assertEqual(frappe.db.get_value("Workflow", "Test High ToDo", "is_active"), 1)
+		self.assertEqual(frappe.db.get_value("Workflow", retired.name, "is_active"), 0)
+		self.assertEqual(frappe.db.get_value("Workflow", conditional.name, "is_active"), 1)
 
 	def test_moving_between_workflows_re_enters_the_new_one(self):
-		create_conditional_todo_workflow("Test High ToDo", priority="High")
-		create_conditional_todo_workflow("Test Low ToDo", priority="Low", states=("Rejected", "Approved"))
+		create_conditional_todo_workflow(priority="High")
+		low = create_conditional_todo_workflow(priority="Low", states=("Rejected", "Approved"))
 
 		todo = create_new_todo(priority="High")
 		self.assertEqual(todo.workflow_state, "Pending")
@@ -590,15 +582,15 @@ class TestConditionalWorkflow(IntegrationTestCase):
 		todo.priority = "Low"
 		todo.save()
 
-		self.assertEqual(get_workflow_name("ToDo", todo), "Test Low ToDo")
+		self.assertEqual(get_workflow_name("ToDo", todo), low.name)
 		self.assertEqual(todo.workflow_state, "Rejected")
 
 	def test_seeding_skips_documents_a_higher_priority_workflow_claims(self):
 		todo = create_new_todo(priority="High")
 		self.assertIsNone(todo.workflow_state)
 
-		create_conditional_todo_workflow("Test High ToDo", priority="High", workflow_priority=10)
-		create_conditional_todo_workflow("Test Any ToDo", workflow_priority=0)
+		create_conditional_todo_workflow(priority="High", workflow_priority=10)
+		create_conditional_todo_workflow(workflow_priority=0)
 
 		todo.reload()
 		self.assertEqual(todo.workflow_state, "Pending")
@@ -607,20 +599,20 @@ class TestConditionalWorkflow(IntegrationTestCase):
 		todo = create_new_todo(priority="High")
 		self.assertIsNone(todo.workflow_state)
 
-		create_conditional_todo_workflow("Test Any ToDo", states=("Rejected", "Approved"))
-		create_conditional_todo_workflow("Test High ToDo", priority="High")
+		create_conditional_todo_workflow(states=("Rejected", "Approved"))
+		high = create_conditional_todo_workflow(priority="High")
 
 		todo.reload()
-		self.assertEqual(get_workflow_name("ToDo", todo), "Test High ToDo")
+		self.assertEqual(get_workflow_name("ToDo", todo), high.name)
 		self.assertEqual(todo.workflow_state, "Pending")
 
 	def test_deleting_a_workflow_drops_it_from_the_cache(self):
 		from frappe.desk.form.meta import get_meta
 
-		create_conditional_todo_workflow("Test Any ToDo")
-		self.assertEqual(get_workflow_names("ToDo"), ["Test Any ToDo"])
+		workflow = create_conditional_todo_workflow()
+		self.assertEqual(get_workflow_names("ToDo"), [workflow.name])
 
-		frappe.delete_doc("Workflow", "Test Any ToDo")
+		frappe.delete_doc("Workflow", workflow.name)
 
 		self.assertEqual(get_workflow_names("ToDo"), [])
 		self.assertEqual(get_meta("ToDo").get("__workflow_docs"), [])
@@ -628,30 +620,55 @@ class TestConditionalWorkflow(IntegrationTestCase):
 	def test_desk_metadata_serializes_with_a_workflow(self):
 		from frappe.desk.form.load import get_meta_bundle
 
-		create_conditional_todo_workflow("Test Any ToDo")
+		create_conditional_todo_workflow()
 
 		workflow_docs = get_meta_bundle("ToDo")[0]["__workflow_docs"]
 		self.assertIn("Workflow State", [doc.doctype for doc in workflow_docs])
 
 	def test_conditions_must_name_a_real_field(self):
-		workflow = build_todo_workflow("Test High ToDo")
+		workflow = build_todo_workflow()
 		workflow.append("conditions", dict(field="not_a_field", condition="=", value="High"))
 
 		self.assertRaises(frappe.ValidationError, workflow.insert)
 
 	def test_active_workflows_must_share_a_state_field(self):
-		create_conditional_todo_workflow("Test High ToDo", priority="High")
+		create_conditional_todo_workflow(priority="High")
 
-		workflow = build_todo_workflow("Test Low ToDo")
+		workflow = build_todo_workflow()
 		workflow.workflow_state_field = "custom_state"
 		workflow.append("conditions", dict(field="priority", condition="=", value="Low"))
 
 		self.assertRaises(frappe.ValidationError, workflow.insert)
 
 
-def build_todo_workflow(name, states=("Pending", "Approved")):
+def create_workflow_state_field(doctype):
+	"""Give the doctype its workflow state field before any test makes a workflow.
+
+	Saving a Workflow creates this field when it is missing, and creating a field is DDL, which
+	commits. The workflow saved alongside it would then outlive the test's rollback and resolve
+	for every test that follows.
+	"""
+	if frappe.get_meta(doctype).get_field("workflow_state"):
+		return
+
+	frappe.get_doc(
+		{
+			"doctype": "Custom Field",
+			"dt": doctype,
+			"fieldname": "workflow_state",
+			"label": "Workflow State",
+			"fieldtype": "Link",
+			"options": "Workflow State",
+			"hidden": 1,
+			"no_copy": 1,
+			"allow_on_submit": 1,
+		}
+	).insert(ignore_if_duplicate=True)
+
+
+def build_todo_workflow(states=("Pending", "Approved")):
 	workflow = frappe.new_doc("Workflow")
-	workflow.workflow_name = name
+	workflow.workflow_name = f"Test ToDo {frappe.generate_hash(length=8)}"
 	workflow.document_type = "ToDo"
 	workflow.workflow_state_field = "workflow_state"
 	workflow.is_active = 1
@@ -665,10 +682,8 @@ def build_todo_workflow(name, states=("Pending", "Approved")):
 	return workflow
 
 
-def create_conditional_todo_workflow(
-	name, priority=None, workflow_priority=0, states=("Pending", "Approved")
-):
-	workflow = build_todo_workflow(name, states)
+def create_conditional_todo_workflow(priority=None, workflow_priority=0, states=("Pending", "Approved")):
+	workflow = build_todo_workflow(states)
 	workflow.priority = workflow_priority
 	if priority:
 		workflow.append("conditions", dict(field="priority", condition="=", value=priority))

--- a/frappe/workflow/doctype/workflow/workflow.js
+++ b/frappe/workflow/doctype/workflow/workflow.js
@@ -111,20 +111,23 @@ frappe.ui.form.on("Workflow", {
 		frappe.model.with_doctype(doc.document_type, () => {
 			const meta = frappe.get_meta(doc.document_type);
 			const is_submittable = meta.is_submittable;
-			const fieldnames = meta.fields
-				.filter((field) => !frappe.model.no_value_type.includes(field.fieldtype))
-				.map((field) => field.fieldname);
+			const value_fields = meta.fields.filter(
+				(field) => !frappe.model.no_value_type.includes(field.fieldtype)
+			);
 
 			frm.fields_dict.states.grid.update_docfield_property(
 				"update_field",
 				"options",
-				[""].concat(fieldnames)
+				[""].concat(value_fields.map((field) => field.fieldname))
 			);
 
 			frm.fields_dict.conditions.grid.update_docfield_property(
 				"field",
 				"options",
-				fieldnames
+				value_fields.map((field) => ({
+					label: `${field.label} (${field.fieldname})`,
+					value: field.fieldname,
+				}))
 			);
 
 			frm.fields_dict.states.grid.update_docfield_property(

--- a/frappe/workflow/doctype/workflow/workflow.js
+++ b/frappe/workflow/doctype/workflow/workflow.js
@@ -121,6 +121,12 @@ frappe.ui.form.on("Workflow", {
 				[""].concat(fieldnames)
 			);
 
+			frm.fields_dict.conditions.grid.update_docfield_property(
+				"field",
+				"options",
+				fieldnames
+			);
+
 			frm.fields_dict.states.grid.update_docfield_property(
 				"doc_status",
 				"read_only",

--- a/frappe/workflow/doctype/workflow/workflow.json
+++ b/frappe/workflow/doctype/workflow/workflow.json
@@ -14,6 +14,10 @@
   "override_status",
   "send_email_alert",
   "enable_action_confirmation",
+  "applicability_section",
+  "conditions",
+  "column_break_conditions",
+  "priority",
   "states_head",
   "states",
   "transition_rules",
@@ -62,11 +66,34 @@
    "label": "Send Email Alert"
   },
   {
-    "default": "0",
-    "description": "If checked, a confirmation will be required before performing workflow actions.",
-    "fieldname": "enable_action_confirmation",
-    "fieldtype": "Check",
-    "label": "Enable Action Confirmation"
+   "default": "0",
+   "description": "If checked, a confirmation will be required before performing workflow actions.",
+   "fieldname": "enable_action_confirmation",
+   "fieldtype": "Check",
+   "label": "Enable Action Confirmation"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "applicability_section",
+   "fieldtype": "Section Break",
+   "label": "Applicability"
+  },
+  {
+   "description": "Restrict this workflow to documents matching all of these conditions. Leave empty to apply it to every document of this type.",
+   "fieldname": "conditions",
+   "fieldtype": "Table",
+   "label": "Conditions",
+   "options": "Workflow Condition"
+  },
+  {
+   "fieldname": "column_break_conditions",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "Workflows with a higher priority are matched first.",
+   "fieldname": "priority",
+   "fieldtype": "Int",
+   "label": "Priority"
   },
   {
    "description": "Different \"States\" this document can exist in. Like \"Open\", \"Pending Approval\" etc.",
@@ -112,7 +139,7 @@
  "icon": "fa fa-random",
  "idx": 1,
  "links": [],
- "modified": "2024-03-23 16:04:04.849665",
+ "modified": "2026-09-10 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Workflow",
  "name": "Workflow",

--- a/frappe/workflow/doctype/workflow/workflow.json
+++ b/frappe/workflow/doctype/workflow/workflow.json
@@ -14,7 +14,7 @@
   "override_status",
   "send_email_alert",
   "enable_action_confirmation",
-  "applicability_section",
+  "conditions_section",
   "priority",
   "conditions",
   "states_head",
@@ -73,9 +73,9 @@
   },
   {
    "collapsible": 1,
-   "fieldname": "applicability_section",
+   "fieldname": "conditions_section",
    "fieldtype": "Section Break",
-   "label": "Applicability"
+   "label": "Conditions"
   },
   {
    "description": "Workflows with a higher priority are matched first.",
@@ -87,7 +87,6 @@
    "description": "Restrict this workflow to documents matching all of these conditions. Leave empty to apply it to every document of this type.",
    "fieldname": "conditions",
    "fieldtype": "Table",
-   "label": "Conditions",
    "options": "Workflow Condition"
   },
   {
@@ -134,7 +133,7 @@
  "icon": "fa fa-random",
  "idx": 1,
  "links": [],
- "modified": "2026-09-10 14:30:00.000000",
+ "modified": "2026-09-10 16:00:00.000000",
  "modified_by": "Administrator",
  "module": "Workflow",
  "name": "Workflow",

--- a/frappe/workflow/doctype/workflow/workflow.json
+++ b/frappe/workflow/doctype/workflow/workflow.json
@@ -15,9 +15,8 @@
   "send_email_alert",
   "enable_action_confirmation",
   "applicability_section",
-  "conditions",
-  "column_break_conditions",
   "priority",
+  "conditions",
   "states_head",
   "states",
   "transition_rules",
@@ -79,21 +78,17 @@
    "label": "Applicability"
   },
   {
+   "description": "Workflows with a higher priority are matched first.",
+   "fieldname": "priority",
+   "fieldtype": "Int",
+   "label": "Priority"
+  },
+  {
    "description": "Restrict this workflow to documents matching all of these conditions. Leave empty to apply it to every document of this type.",
    "fieldname": "conditions",
    "fieldtype": "Table",
    "label": "Conditions",
    "options": "Workflow Condition"
-  },
-  {
-   "fieldname": "column_break_conditions",
-   "fieldtype": "Column Break"
-  },
-  {
-   "description": "Workflows with a higher priority are matched first.",
-   "fieldname": "priority",
-   "fieldtype": "Int",
-   "label": "Priority"
   },
   {
    "description": "Different \"States\" this document can exist in. Like \"Open\", \"Pending Approval\" etc.",
@@ -139,7 +134,7 @@
  "icon": "fa fa-random",
  "idx": 1,
  "links": [],
- "modified": "2026-09-10 10:00:00.000000",
+ "modified": "2026-09-10 14:30:00.000000",
  "modified_by": "Administrator",
  "module": "Workflow",
  "name": "Workflow",

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -78,7 +78,12 @@ class Workflow(Document):
 			)
 
 	def update_default_workflow_status(self):
-		"""Seed the state field of documents this workflow governs, leaving the rest untouched."""
+		"""Seed the state field of documents this workflow governs, leaving the rest untouched.
+
+		A state this workflow does not define is treated as unset. A workflow that outranks a
+		peer has to correct what the peer seeded before it existed, the same way validate_workflow
+		re-enters a document whose stored state is foreign to the workflow that governs it.
+		"""
 		outranking = self.get_higher_priority_workflows()
 		if any(not workflow.conditions for workflow in outranking):
 			return
@@ -91,6 +96,8 @@ class Workflow(Document):
 			Not(Criterion.all(workflow.get_condition_criteria(TargetDocType))) for workflow in outranking
 		]
 
+		own_states = [d.state for d in self.states]
+
 		for d in self.get("states"):
 			if d.doc_status in docstatus_map:
 				continue
@@ -98,7 +105,7 @@ class Workflow(Document):
 			query = (
 				frappe.qb.update(TargetDocType)
 				.set(state_field, d.state)
-				.where(state_field.isnull() | (state_field == ""))
+				.where(state_field.isnull() | (state_field == "") | state_field.notin(own_states))
 				.where(TargetDocType.docstatus == d.doc_status)
 			)
 			for criterion in criteria:
@@ -108,17 +115,16 @@ class Workflow(Document):
 			docstatus_map[d.doc_status] = d.state
 
 	def get_higher_priority_workflows(self) -> list["Workflow"]:
-		"""Active workflows of this doctype that claim a document before this one gets to."""
-		workflows = []
-		for name in get_workflow_names(self.document_type):
-			if name == self.name:
-				continue
+		"""Active workflows of this doctype that resolve before this one.
 
-			other = frappe.get_cached_doc("Workflow", name)
-			if cint(other.priority) > cint(self.priority):
-				workflows.append(other)
+		Position, not priority: get_workflow_names breaks a tie by modification time, so comparing
+		priority alone would let an older peer seed the documents its newer peer governs.
+		"""
+		names = get_workflow_names(self.document_type)
+		if self.name not in names:
+			return []
 
-		return workflows
+		return [frappe.get_cached_doc("Workflow", name) for name in names[: names.index(self.name)]]
 
 	def get_condition_criteria(self, table) -> list:
 		comparators = {

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -2,6 +2,8 @@
 # License: MIT. See LICENSE
 
 import operator
+from collections import defaultdict
+from datetime import timedelta
 
 from pypika.terms import Criterion, Not
 
@@ -10,7 +12,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.model.workflow import DEFAULT_WORKFLOW_TASKS, get_workflow_names
 from frappe.utils import cint
-from frappe.utils.data import compare, evaluate_filters
+from frappe.utils.data import cast, compare, evaluate_filters
 
 CONDITION_COMPARATORS = {
 	"=": operator.eq,
@@ -22,6 +24,7 @@ CONDITION_COMPARATORS = {
 }
 LOWER_BOUND_CONDITIONS = {">", ">="}
 UPPER_BOUND_CONDITIONS = {"<", "<="}
+DISCRETE_STEPS = {"Int": 1, "Check": 1, "Date": timedelta(days=1)}
 
 
 class Workflow(Document):
@@ -254,26 +257,28 @@ class Workflow(Document):
 				)
 
 	def is_disjoint_from(self, other: "Workflow") -> bool:
-		"""True when a field the two workflows share proves no document can match both."""
+		"""True when a field both workflows constrain proves no document can match both."""
+		own = group_conditions_by_field(self.conditions)
+		their = group_conditions_by_field(other.conditions)
+
 		return any(
-			self.is_contradictory(own, their)
-			for own in self.conditions
-			for their in other.conditions
-			if own.field == their.field
+			self.is_contradictory(own[field], their[field], field) for field in own.keys() & their.keys()
 		)
 
-	def is_contradictory(self, first, second) -> bool:
-		"""True when no value of the field the two conditions share can satisfy both."""
-		docfield = frappe.get_meta(self.document_type).get_field(first.field)
+	def is_contradictory(self, own, their, field) -> bool:
+		"""True when the two sets of conditions on one field cannot hold for the same document."""
+		docfield = frappe.get_meta(self.document_type).get_field(field)
 		fieldtype = docfield.fieldtype if docfield else None
 
-		if first.condition == "=":
-			return not compare(first.value, second.condition, second.value, fieldtype)
+		own_value = get_pinned_value(own, fieldtype)
+		if own_value is not None:
+			return not is_allowed_by(own_value, their, fieldtype)
 
-		if second.condition == "=":
-			return not compare(second.value, first.condition, first.value, fieldtype)
+		their_value = get_pinned_value(their, fieldtype)
+		if their_value is not None:
+			return not is_allowed_by(their_value, own, fieldtype)
 
-		return is_empty_range(first, second, fieldtype)
+		return any(is_empty_range(a, b, fieldtype) for a in own for b in their)
 
 	def set_active(self):
 		"""Retire the other catch-all workflow of this doctype; conditional ones can coexist."""
@@ -313,6 +318,39 @@ class Workflow(Document):
 		)
 
 
+def group_conditions_by_field(conditions) -> dict[str, list]:
+	grouped = defaultdict(list)
+	for condition in conditions:
+		grouped[condition.field].append(condition)
+
+	return grouped
+
+
+def is_allowed_by(value, conditions, fieldtype) -> bool:
+	"""True when the value satisfies every one of the conditions."""
+	return all(compare(value, d.condition, d.value, fieldtype) for d in conditions)
+
+
+def get_pinned_value(conditions, fieldtype):
+	"""The single value these conditions force the field to, if they force one."""
+	values = {cast(fieldtype, d.value) for d in conditions if d.condition == "="}
+	bounds = {d.condition: cast(fieldtype, d.value) for d in conditions if d.condition in ("<=", ">=")}
+	if ">=" in bounds and bounds[">="] == bounds.get("<="):
+		values.add(bounds[">="])
+
+	return values.pop() if len(values) == 1 else None
+
+
+def to_inclusive_bound(condition, fieldtype) -> tuple[str, object]:
+	"""A strict bound on a field with discrete values is the inclusive bound one step in."""
+	value = cast(fieldtype, condition.value)
+	step = DISCRETE_STEPS.get(fieldtype)
+	if not step or condition.condition in ("<=", ">="):
+		return condition.condition, value
+
+	return (">=", value + step) if condition.condition == ">" else ("<=", value - step)
+
+
 def is_empty_range(first, second, fieldtype) -> bool:
 	"""True when a lower bound and an upper bound on the same field leave no value between them."""
 	lower, upper = first, second
@@ -322,8 +360,11 @@ def is_empty_range(first, second, fieldtype) -> bool:
 	if lower.condition not in LOWER_BOUND_CONDITIONS or upper.condition not in UPPER_BOUND_CONDITIONS:
 		return False
 
-	both_inclusive = lower.condition == ">=" and upper.condition == "<="
-	return compare(lower.value, ">" if both_inclusive else ">=", upper.value, fieldtype)
+	low_condition, low_value = to_inclusive_bound(lower, fieldtype)
+	high_condition, high_value = to_inclusive_bound(upper, fieldtype)
+	both_inclusive = low_condition == ">=" and high_condition == "<="
+
+	return compare(low_value, ">" if both_inclusive else ">=", high_value, fieldtype)
 
 
 @frappe.whitelist()

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -188,12 +188,14 @@ class Workflow(Document):
 				frappe.throw(frappe._("Cannot cancel before submitting. See Transition {0}").format(t.idx))
 
 	def applies_to(self, doc) -> bool:
-		"""Return True if this workflow governs `doc`. A workflow without conditions governs all."""
-		if not self.conditions:
-			return True
+		"""Return True if this workflow governs `doc`. A workflow without conditions governs all.
 
-		return evaluate_filters(
-			doc, [(self.document_type, d.field, d.condition, d.value) for d in self.conditions]
+		Conditions are evaluated one at a time: Filters.optimize collapses repeated equalities on a
+		field into an `in`, which would read the rows as alternatives rather than requirements.
+		"""
+		return all(
+			evaluate_filters(doc, [(self.document_type, d.field, d.condition, d.value)])
+			for d in self.conditions
 		)
 
 	def validate_fields_in_conditions(self):

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -10,7 +10,18 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.model.workflow import DEFAULT_WORKFLOW_TASKS, get_workflow_names
 from frappe.utils import cint
-from frappe.utils.data import evaluate_filters
+from frappe.utils.data import compare, evaluate_filters
+
+CONDITION_COMPARATORS = {
+	"=": operator.eq,
+	"!=": operator.ne,
+	">": operator.gt,
+	"<": operator.lt,
+	">=": operator.ge,
+	"<=": operator.le,
+}
+LOWER_BOUND_CONDITIONS = {">", ">="}
+UPPER_BOUND_CONDITIONS = {"<", "<="}
 
 
 class Workflow(Document):
@@ -46,6 +57,7 @@ class Workflow(Document):
 		self.validate_fields_in_conditions()
 		self.validate_shared_state_field()
 		self.set_active()
+		self.validate_no_ambiguous_peer()
 		self.validate_docstatus()
 
 	def on_update(self):
@@ -131,15 +143,7 @@ class Workflow(Document):
 		return [frappe.get_cached_doc("Workflow", name) for name in names[: names.index(self.name)]]
 
 	def get_condition_criteria(self, table) -> list:
-		comparators = {
-			"=": operator.eq,
-			"!=": operator.ne,
-			">": operator.gt,
-			"<": operator.lt,
-			">=": operator.ge,
-			"<=": operator.le,
-		}
-		return [comparators[d.condition](getattr(table, d.field), d.value) for d in self.conditions]
+		return [CONDITION_COMPARATORS[d.condition](getattr(table, d.field), d.value) for d in self.conditions]
 
 	def validate_docstatus(self):
 		def get_state(state):
@@ -227,6 +231,48 @@ class Workflow(Document):
 					)
 				)
 
+	def validate_no_ambiguous_peer(self):
+		"""Active workflows sharing a priority must not both be able to match one document.
+
+		Resolution takes the first match in priority order, so a tie is settled by modification
+		time, and the losing workflow is never reached.
+		"""
+		if not cint(self.is_active):
+			return
+
+		for peer in self.get_other_active_workflows(["name", "priority"]):
+			if cint(peer.priority) != cint(self.priority):
+				continue
+
+			if not self.is_disjoint_from(frappe.get_cached_doc("Workflow", peer.name)):
+				frappe.throw(
+					_(
+						"Workflow {0} has the same priority and can govern the same {1}. Narrow the conditions of either workflow, or give them different priorities."
+					).format(frappe.bold(peer.name), frappe.bold(self.document_type))
+				)
+
+	def is_disjoint_from(self, other: "Workflow") -> bool:
+		"""True when a field the two workflows share proves no document can match both."""
+		return any(
+			self.is_contradictory(own, their)
+			for own in self.conditions
+			for their in other.conditions
+			if own.field == their.field
+		)
+
+	def is_contradictory(self, first, second) -> bool:
+		"""True when no value of the field the two conditions share can satisfy both."""
+		docfield = frappe.get_meta(self.document_type).get_field(first.field)
+		fieldtype = docfield.fieldtype if docfield else None
+
+		if first.condition == "=":
+			return not compare(first.value, second.condition, second.value, fieldtype)
+
+		if second.condition == "=":
+			return not compare(second.value, first.condition, first.value, fieldtype)
+
+		return is_empty_range(first, second, fieldtype)
+
 	def set_active(self):
 		"""Retire the other catch-all workflow of this doctype; conditional ones can coexist."""
 		if not cint(self.is_active) or self.conditions:
@@ -263,6 +309,19 @@ class Workflow(Document):
 			},
 			fields=fields,
 		)
+
+
+def is_empty_range(first, second, fieldtype) -> bool:
+	"""True when a lower bound and an upper bound on the same field leave no value between them."""
+	lower, upper = first, second
+	if lower.condition in UPPER_BOUND_CONDITIONS:
+		lower, upper = upper, lower
+
+	if lower.condition not in LOWER_BOUND_CONDITIONS or upper.condition not in UPPER_BOUND_CONDITIONS:
+		return False
+
+	both_inclusive = lower.condition == ">=" and upper.condition == "<="
+	return compare(lower.value, ">" if both_inclusive else ">=", upper.value, fieldtype)
 
 
 @frappe.whitelist()

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -52,6 +52,10 @@ class Workflow(Document):
 		self.create_custom_field_for_workflow_state()
 		self.update_default_workflow_status()
 
+	def on_trash(self):
+		"""Drop this workflow's name from the doctype cache, which resolution reads without rechecking."""
+		frappe.clear_cache(doctype=self.document_type)
+
 	def create_custom_field_for_workflow_state(self):
 		frappe.clear_cache(doctype=self.document_type)
 		meta = frappe.get_meta(self.document_type)

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -214,16 +214,23 @@ class Workflow(Document):
 		if not cint(self.is_active):
 			return
 
-		for name in get_workflow_names(self.document_type):
-			if name == self.name:
-				continue
+		names = [name for name in get_workflow_names(self.document_type) if name != self.name]
+		if not names:
+			return
 
-			state_field = frappe.db.get_value("Workflow", name, "workflow_state_field")
-			if state_field != self.workflow_state_field:
+		others = frappe.get_all(
+			"Workflow", filters={"name": ("in", names)}, fields=["name", "workflow_state_field"]
+		)
+		for other in others:
+			if other.workflow_state_field != self.workflow_state_field:
 				frappe.throw(
 					_(
 						"Workflow {0} on {1} uses the state field {2}. Every active workflow of a doctype must use the same field."
-					).format(frappe.bold(name), frappe.bold(self.document_type), frappe.bold(state_field))
+					).format(
+						frappe.bold(other.name),
+						frappe.bold(self.document_type),
+						frappe.bold(other.workflow_state_field),
+					)
 				)
 
 	def set_active(self):

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -3,6 +3,8 @@
 
 import operator
 
+from pypika.terms import Criterion, Not
+
 import frappe
 from frappe import _
 from frappe.model.document import Document
@@ -77,10 +79,17 @@ class Workflow(Document):
 
 	def update_default_workflow_status(self):
 		"""Seed the state field of documents this workflow governs, leaving the rest untouched."""
+		outranking = self.get_higher_priority_workflows()
+		if any(not workflow.conditions for workflow in outranking):
+			return
+
 		docstatus_map = {}
 		TargetDocType = frappe.qb.DocType(self.document_type)
 		state_field = getattr(TargetDocType, self.workflow_state_field)
 		criteria = self.get_condition_criteria(TargetDocType)
+		criteria += [
+			Not(Criterion.all(workflow.get_condition_criteria(TargetDocType))) for workflow in outranking
+		]
 
 		for d in self.get("states"):
 			if d.doc_status in docstatus_map:
@@ -97,6 +106,19 @@ class Workflow(Document):
 
 			query.run()
 			docstatus_map[d.doc_status] = d.state
+
+	def get_higher_priority_workflows(self) -> list["Workflow"]:
+		"""Active workflows of this doctype that claim a document before this one gets to."""
+		workflows = []
+		for name in get_workflow_names(self.document_type):
+			if name == self.name:
+				continue
+
+			other = frappe.get_cached_doc("Workflow", name)
+			if cint(other.priority) > cint(self.priority):
+				workflows.append(other)
+
+		return workflows
 
 	def get_condition_criteria(self, table) -> list:
 		comparators = {

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -214,13 +214,7 @@ class Workflow(Document):
 		if not cint(self.is_active):
 			return
 
-		names = [name for name in get_workflow_names(self.document_type) if name != self.name]
-		if not names:
-			return
-
-		others = frappe.get_all(
-			"Workflow", filters={"name": ("in", names)}, fields=["name", "workflow_state_field"]
-		)
+		others = self.get_other_active_workflows(["name", "workflow_state_field"])
 		for other in others:
 			if other.workflow_state_field != self.workflow_state_field:
 				frappe.throw(
@@ -238,9 +232,37 @@ class Workflow(Document):
 		if not cint(self.is_active) or self.conditions:
 			return
 
-		for name in get_workflow_names(self.document_type):
-			if name != self.name and not frappe.get_cached_doc("Workflow", name).conditions:
+		names = [other.name for other in self.get_other_active_workflows(["name"])]
+		if not names:
+			return
+
+		conditional = set(
+			frappe.get_all(
+				"Workflow Condition",
+				filters={"parenttype": "Workflow", "parent": ("in", names)},
+				pluck="parent",
+			)
+		)
+		for name in names:
+			if name not in conditional:
 				frappe.db.set_value("Workflow", name, "is_active", 0)
+
+	def get_other_active_workflows(self, fields: list[str]) -> list:
+		"""Read the peers straight from the table.
+
+		This runs during validate, before this workflow's own row exists. Going through the
+		cached name list would store an answer taken from that gap and hand it to every document
+		saved afterwards.
+		"""
+		return frappe.get_all(
+			"Workflow",
+			filters={
+				"document_type": self.document_type,
+				"is_active": 1,
+				"name": ("!=", self.name),
+			},
+			fields=fields,
+		)
 
 
 @frappe.whitelist()

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -1,11 +1,14 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
+import operator
+
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.model.workflow import DEFAULT_WORKFLOW_TASKS
+from frappe.model.workflow import DEFAULT_WORKFLOW_TASKS, get_workflow_names
 from frappe.utils import cint
+from frappe.utils.data import evaluate_filters
 
 
 class Workflow(Document):
@@ -18,14 +21,17 @@ class Workflow(Document):
 
 	if TYPE_CHECKING:
 		from frappe.types import DF
+		from frappe.workflow.doctype.workflow_condition.workflow_condition import WorkflowCondition
 		from frappe.workflow.doctype.workflow_document_state.workflow_document_state import (
 			WorkflowDocumentState,
 		)
 		from frappe.workflow.doctype.workflow_transition.workflow_transition import WorkflowTransition
 
+		conditions: DF.Table[WorkflowCondition]
 		document_type: DF.Link
 		is_active: DF.Check
 		override_status: DF.Check
+		priority: DF.Int
 		send_email_alert: DF.Check
 		states: DF.Table[WorkflowDocumentState]
 		transitions: DF.Table[WorkflowTransition]
@@ -35,6 +41,8 @@ class Workflow(Document):
 	# end: auto-generated types
 
 	def validate(self):
+		self.validate_fields_in_conditions()
+		self.validate_shared_state_field()
 		self.set_active()
 		self.validate_docstatus()
 
@@ -68,22 +76,38 @@ class Workflow(Document):
 			)
 
 	def update_default_workflow_status(self):
+		"""Seed the state field of documents this workflow governs, leaving the rest untouched."""
 		docstatus_map = {}
-		states = self.get("states")
-
 		TargetDocType = frappe.qb.DocType(self.document_type)
 		state_field = getattr(TargetDocType, self.workflow_state_field)
+		criteria = self.get_condition_criteria(TargetDocType)
 
-		for d in states:
-			if d.doc_status not in docstatus_map:
-				(
-					frappe.qb.update(TargetDocType)
-					.set(state_field, d.state)
-					.where(state_field.isnull() | (state_field == ""))
-					.where(TargetDocType.docstatus == d.doc_status)
-				).run()
+		for d in self.get("states"):
+			if d.doc_status in docstatus_map:
+				continue
 
-				docstatus_map[d.doc_status] = d.state
+			query = (
+				frappe.qb.update(TargetDocType)
+				.set(state_field, d.state)
+				.where(state_field.isnull() | (state_field == ""))
+				.where(TargetDocType.docstatus == d.doc_status)
+			)
+			for criterion in criteria:
+				query = query.where(criterion)
+
+			query.run()
+			docstatus_map[d.doc_status] = d.state
+
+	def get_condition_criteria(self, table) -> list:
+		comparators = {
+			"=": operator.eq,
+			"!=": operator.ne,
+			">": operator.gt,
+			"<": operator.lt,
+			">=": operator.ge,
+			"<=": operator.le,
+		}
+		return [comparators[d.condition](getattr(table, d.field), d.value) for d in self.conditions]
 
 	def validate_docstatus(self):
 		def get_state(state):
@@ -127,14 +151,57 @@ class Workflow(Document):
 			if state_docstatus == 0 and next_state_docstatus == 2:
 				frappe.throw(frappe._("Cannot cancel before submitting. See Transition {0}").format(t.idx))
 
+	def applies_to(self, doc) -> bool:
+		"""Return True if this workflow governs `doc`. A workflow without conditions governs all."""
+		if not self.conditions:
+			return True
+
+		return evaluate_filters(
+			doc, [(self.document_type, d.field, d.condition, d.value) for d in self.conditions]
+		)
+
+	def validate_fields_in_conditions(self):
+		if not self.conditions:
+			return
+
+		docfields = {df.fieldname for df in frappe.get_meta(self.document_type).fields}
+		for condition in self.conditions:
+			if condition.field not in docfields:
+				frappe.throw(
+					_("{0} is not a field of doctype {1}").format(
+						frappe.bold(condition.field), frappe.bold(self.document_type)
+					)
+				)
+
+	def validate_shared_state_field(self):
+		"""Every workflow of a doctype has to read its state from the same field.
+
+		The desk resolves the state field per doctype, so two active workflows disagreeing on it
+		would leave documents rendering against the wrong field.
+		"""
+		if not cint(self.is_active):
+			return
+
+		for name in get_workflow_names(self.document_type):
+			if name == self.name:
+				continue
+
+			state_field = frappe.db.get_value("Workflow", name, "workflow_state_field")
+			if state_field != self.workflow_state_field:
+				frappe.throw(
+					_(
+						"Workflow {0} on {1} uses the state field {2}. Every active workflow of a doctype must use the same field."
+					).format(frappe.bold(name), frappe.bold(self.document_type), frappe.bold(state_field))
+				)
+
 	def set_active(self):
-		if cint(self.is_active):
-			Workflow = frappe.qb.DocType("Workflow")
-			(
-				frappe.qb.update(Workflow)
-				.set(Workflow.is_active, 0)
-				.where(Workflow.document_type == self.document_type)
-			).run()
+		"""Retire the other catch-all workflow of this doctype; conditional ones can coexist."""
+		if not cint(self.is_active) or self.conditions:
+			return
+
+		for name in get_workflow_names(self.document_type):
+			if name != self.name and not frappe.get_cached_doc("Workflow", name).conditions:
+				frappe.db.set_value("Workflow", name, "is_active", 0)
 
 
 @frappe.whitelist()

--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -92,7 +92,7 @@ def has_permission(doc, user):
 
 
 def process_workflow_actions(doc, state):
-	workflow = get_workflow_name(doc.get("doctype"))
+	workflow = get_workflow_name(doc.get("doctype"), doc)
 	if not workflow:
 		return
 
@@ -222,7 +222,7 @@ def get_user_who_set_workflow_state(doc, doc_workflow_state):
 	"""Get the full name of the user who triggered the workflow action that set the document to the given state.
 	Falls back to None if no completed Workflow Action is found (e.g. state was set without workflow).
 	"""
-	workflow_name = get_workflow_name(doc.get("doctype"))
+	workflow_name = get_workflow_name(doc.get("doctype"), doc)
 	if not workflow_name:
 		return None
 
@@ -478,7 +478,7 @@ def clear_workflow_actions(doctype, name):
 
 
 def get_doc_workflow_state(doc):
-	workflow_name = get_workflow_name(doc.get("doctype"))
+	workflow_name = get_workflow_name(doc.get("doctype"), doc)
 	workflow_state_field = get_workflow_state_field(workflow_name)
 	return doc.get(workflow_state_field)
 
@@ -522,7 +522,7 @@ def get_common_email_args(doc):
 
 def get_email_template_from_workflow(doc):
 	"""Return next_action_email_template for workflow state (if available) based on doc current workflow state."""
-	workflow_name = get_workflow_name(doc.get("doctype"))
+	workflow_name = get_workflow_name(doc.get("doctype"), doc)
 	doc_state = get_doc_workflow_state(doc)
 	template_name = frappe.db.get_value(
 		"Workflow Document State",

--- a/frappe/workflow/doctype/workflow_condition/workflow_condition.json
+++ b/frappe/workflow/doctype/workflow_condition/workflow_condition.json
@@ -1,0 +1,49 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-09-10 10:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "field",
+  "condition",
+  "value"
+ ],
+ "fields": [
+  {
+   "fieldname": "field",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Field",
+   "reqd": 1
+  },
+  {
+   "fieldname": "condition",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Condition",
+   "options": "=\n!=\n>\n<\n>=\n<=",
+   "reqd": 1
+  },
+  {
+   "fieldname": "value",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Value",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-09-10 10:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Workflow",
+ "name": "Workflow Condition",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/frappe/workflow/doctype/workflow_condition/workflow_condition.py
+++ b/frappe/workflow/doctype/workflow_condition/workflow_condition.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2026, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class WorkflowCondition(Document):
+	_DOCTYPE_NAME = "Workflow Condition"
+
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		condition: DF.Literal["=", "!=", ">", "<", ">=", "<="]
+		field: DF.Literal[None]
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		value: DF.Data
+	# end: auto-generated types
+
+	pass


### PR DESCRIPTION
A doctype can have exactly one active workflow, and it governs every document of that type. There is no way to say "this workflow applies to these documents only" — a document the workflow was never meant to cover still loses its Submit and Cancel buttons, because applicability is resolved from the doctype alone and never looks at the document.

Transition conditions do not help: they gate edges, so a document that matches none is stuck rather than free.

## What changes

`Workflow` gets a **Conditions** table and a **Priority**. Active workflows of a doctype are resolved per document, highest priority first, and the first one whose conditions match governs it. A document that matches none is governed by no workflow and behaves as if none were configured — normal Submit and Cancel.

Conditions on one workflow all have to hold, on any field and however many there are. A workflow with no conditions still matches everything, so existing setups are unchanged. Activating a catch-all workflow retires the other catch-all, as before, but leaves conditional ones alone.

Constraint: every active workflow of a doctype must read its state from the same field. The desk resolves that field per doctype, so letting them disagree would render documents against the wrong field.

Constraint: two active workflows of the same priority must not both be able to match one document. A priority tie falls back to modification time, so an unresolved one hands the document to whichever workflow was edited last and never reaches the other. A catch-all beside a conditional workflow is such a tie: layer those by priority.

Known limitation: the disjointness proof is made when a workflow is saved and rests on the fieldtype of the fields it compares. Changing that fieldtype afterwards, Int to Float say, can leave two active workflows overlapping at one priority, where resolution falls back to modification time. Nothing revalidates a workflow when its doctype changes, though the next save of either one throws.

## Notes

- `update_default_workflow_status` now seeds only the documents the workflow governs, so activating a conditional workflow no longer stamps a state on everything.
- `get_workflow_names` sorts by priority off the cached doc rather than in the query. A site part way through a migrate has the row but not the column, and every document save comes through here.
- The tie check weighs a workflow's rows for a field against the peer's rows for that field. Rows that force a single value are tested against every one of the peer's rows; otherwise it looks for a lower and an upper bound with nothing between them, counting a strict bound on a discrete field (Int, Check, Date) as the inclusive bound one step in. It compares through the same `frappe.utils.data.compare` that evaluates conditions at resolution, and anything left unproven throws.
- The desk ships every active workflow of a doctype and picks per document. Doctype-wide callers with no single document — list view bulk actions, indicators, the fields a workflow keeps read only — read the union, which is what they showed before.



