### PR TITLE
fix(naming): key naming rule counters per resolved prefix

### DIFF
--- a/frappe/core/doctype/document_naming_rule/document_naming_rule.json
+++ b/frappe/core/doctype/document_naming_rule/document_naming_rule.json
@@ -42,12 +42,13 @@
   },
   {
    "default": "0",
-   "description": "Warning: Updating counter may lead to document name conflicts if not done properly",
+   "description": "Counters are tracked per resolved prefix in the Series doctype. This field is retained for reference only.",
    "fieldname": "counter",
    "fieldtype": "Int",
-   "in_list_view": 1,
+   "hidden": 1,
    "label": "Counter",
-   "no_copy": 1
+   "no_copy": 1,
+   "read_only": 1
   },
   {
    "default": "5",

--- a/frappe/core/doctype/document_naming_rule/document_naming_rule.py
+++ b/frappe/core/doctype/document_naming_rule/document_naming_rule.py
@@ -4,7 +4,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.model.naming import parse_naming_series
+from frappe.model.naming import getseries, parse_naming_series
 from frappe.utils.data import evaluate_filters
 
 
@@ -64,8 +64,5 @@ class DocumentNamingRule(Document):
 			):
 				return
 
-		counter = frappe.db.get_value(self.doctype, self.name, "counter", for_update=True) or 0
-		naming_series = parse_naming_series(self.prefix, doc=doc)
-
-		doc.name = naming_series + ("%0" + str(self.prefix_digits) + "d") % (counter + 1)
-		frappe.db.set_value(self.doctype, self.name, "counter", counter + 1)
+		prefix = parse_naming_series(self.prefix, doc=doc)
+		doc.name = prefix + getseries(prefix, self.prefix_digits)

--- a/frappe/core/doctype/document_naming_rule/test_document_naming_rule.py
+++ b/frappe/core/doctype/document_naming_rule/test_document_naming_rule.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import frappe
+from frappe.patches.v16_0.seed_naming_rule_series import seed_series_for_rule
+from frappe.query_builder import DocType
 from frappe.tests import IntegrationTestCase
 
 
@@ -66,3 +68,64 @@ class TestDocumentNamingRule(IntegrationTestCase):
 			todo.delete()
 			todo_1.delete()
 			todo_2.delete()
+
+	def test_counter_is_scoped_to_the_resolved_prefix(self):
+		naming_rule = frappe.get_doc(
+			doctype="Document Naming Rule",
+			document_type="ToDo",
+			prefix="test-prio-.priority.-",
+			prefix_digits=5,
+		).insert()
+		self.addCleanup(naming_rule.delete)
+
+		names = [self.make_todo(priority).name for priority in ("High", "Medium", "High")]
+
+		self.assertEqual(names, ["test-prio-High-00001", "test-prio-Medium-00001", "test-prio-High-00002"])
+
+	def test_series_key_is_the_resolved_prefix(self):
+		naming_rule = frappe.get_doc(
+			doctype="Document Naming Rule",
+			document_type="ToDo",
+			prefix="test-yearly-.YYYY.-",
+			prefix_digits=5,
+		).insert()
+		self.addCleanup(naming_rule.delete)
+
+		todo = self.make_todo()
+
+		self.assertRegex(todo.name, r"^test-yearly-\d{4}-00001$")
+		self.assertEqual(self.series_current(todo.name[:-5]), 1)
+
+	def test_patch_seeds_series_from_existing_names(self):
+		naming_rule = frappe.get_doc(
+			doctype="Document Naming Rule",
+			document_type="ToDo",
+			prefix="test-seed-.YYYY.-",
+			prefix_digits=5,
+		).insert()
+		self.addCleanup(naming_rule.delete)
+
+		for _ in range(3):
+			prefix = self.make_todo().name[:-5]
+
+		series = DocType("Series")
+		frappe.qb.from_(series).delete().where(series.name == prefix).run()
+
+		seed_series_for_rule(frappe._dict(document_type="ToDo", prefix=naming_rule.prefix, prefix_digits=5))
+
+		self.assertEqual(self.series_current(prefix), 3)
+		self.assertEqual(self.make_todo().name, prefix + "00004")
+
+	def make_todo(self, priority="Medium"):
+		todo = frappe.get_doc(
+			doctype="ToDo",
+			priority=priority,
+			description="Is this my name " + frappe.generate_hash(),
+		).insert()
+		self.addCleanup(todo.delete)
+		return todo
+
+	def series_current(self, prefix):
+		series = DocType("Series")
+		row = frappe.qb.from_(series).where(series.name == prefix).select("current").run()
+		return row[0][0] if row else None

--- a/frappe/core/doctype/document_naming_rule/test_document_naming_rule.py
+++ b/frappe/core/doctype/document_naming_rule/test_document_naming_rule.py
@@ -154,13 +154,29 @@ class TestDocumentNamingRule(IntegrationTestCase):
 		self.assertEqual(self.series_current("test-claim-"), 1)
 		self.assertIsNone(self.series_current("test-claim-0"))
 
-	def make_rule(self, prefix, digits=5, priority=0):
+	def test_patch_does_not_let_a_disabled_rule_claim_a_live_name(self):
+		self.make_rule(".role.", priority=10, disabled=1)
+		self.make_rule("test-live-", digits=6, priority=0)
+
+		name = self.make_todo().name
+		self.assertEqual(name, "test-live-000001")
+
+		self.drop_series("test-live-")
+		self.drop_series("test-live-0")
+
+		seed_naming_rule_series()
+
+		self.assertEqual(self.series_current("test-live-"), 1)
+		self.assertIsNone(self.series_current("test-live-0"))
+
+	def make_rule(self, prefix, digits=5, priority=0, disabled=0):
 		naming_rule = frappe.get_doc(
 			doctype="Document Naming Rule",
 			document_type="ToDo",
 			prefix=prefix,
 			prefix_digits=digits,
 			priority=priority,
+			disabled=disabled,
 		).insert()
 		self.addCleanup(naming_rule.delete)
 		return naming_rule

--- a/frappe/core/doctype/document_naming_rule/test_document_naming_rule.py
+++ b/frappe/core/doctype/document_naming_rule/test_document_naming_rule.py
@@ -139,53 +139,51 @@ class TestDocumentNamingRule(IntegrationTestCase):
 
 		self.assertEqual(self.series_current(prefix), 1)
 
-	def test_patch_does_not_split_a_name_claimed_by_another_rule(self):
+	def test_patch_seeds_the_real_key_when_a_narrower_rule_also_matches(self):
 		self.make_rule("test-claim-", digits=6, priority=10)
 		self.make_rule(".role.", priority=0)
 
-		name = self.make_todo().name
-		self.assertEqual(name, "test-claim-000001")
-
+		self.assertEqual(self.make_todo().name, "test-claim-000001")
 		self.drop_series("test-claim-")
-		self.drop_series("test-claim-0")
 
 		seed_naming_rule_series()
 
 		self.assertEqual(self.series_current("test-claim-"), 1)
-		self.assertIsNone(self.series_current("test-claim-0"))
 
-	def test_patch_does_not_let_a_disabled_rule_claim_a_live_name(self):
+	def test_patch_seeds_a_live_rule_beside_a_disabled_wildcard(self):
 		self.make_rule(".role.", priority=10, disabled=1)
 		self.make_rule("test-live-", digits=6, priority=0)
 
-		name = self.make_todo().name
-		self.assertEqual(name, "test-live-000001")
-
+		self.assertEqual(self.make_todo().name, "test-live-000001")
 		self.drop_series("test-live-")
-		self.drop_series("test-live-0")
 
 		seed_naming_rule_series()
 
 		self.assertEqual(self.series_current("test-live-"), 1)
-		self.assertIsNone(self.series_current("test-live-0"))
 
-	def test_patch_does_not_let_a_broad_rule_claim_disabled_history(self):
+	def test_patch_seeds_disabled_history_beside_a_live_wildcard(self):
 		specific = self.make_rule("test-hist-", digits=6, priority=10)
 
-		name = self.make_todo().name
-		self.assertEqual(name, "test-hist-000001")
-
+		self.assertEqual(self.make_todo().name, "test-hist-000001")
 		specific.disabled = 1
 		specific.save()
 		self.make_rule(".role.", priority=0)
-
 		self.drop_series("test-hist-")
-		self.drop_series("test-hist-0")
 
 		seed_naming_rule_series()
 
 		self.assertEqual(self.series_current("test-hist-"), 1)
-		self.assertIsNone(self.series_current("test-hist-0"))
+
+	def test_patch_seeds_the_real_key_when_a_wildcard_rule_pins_more_literals(self):
+		self.make_rule("test-yr-.YYYY.-", digits=6, priority=10)
+		self.make_rule("test-yr-20.role.", digits=5, priority=0)
+
+		prefix = self.make_todo().name[:-6]
+		self.drop_series(prefix)
+
+		seed_naming_rule_series()
+
+		self.assertEqual(self.series_current(prefix), 1)
 
 	def make_rule(self, prefix, digits=5, priority=0, disabled=0):
 		naming_rule = frappe.get_doc(

--- a/frappe/core/doctype/document_naming_rule/test_document_naming_rule.py
+++ b/frappe/core/doctype/document_naming_rule/test_document_naming_rule.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import frappe
+from frappe.patches.v16_0.seed_naming_rule_series import execute as seed_naming_rule_series
 from frappe.patches.v16_0.seed_naming_rule_series import seed_series_for_rule
 from frappe.query_builder import DocType
 from frappe.tests import IntegrationTestCase
@@ -115,6 +116,43 @@ class TestDocumentNamingRule(IntegrationTestCase):
 
 		self.assertEqual(self.series_current(prefix), 3)
 		self.assertEqual(self.make_todo().name, prefix + "00004")
+
+	def test_patch_seeds_a_name_with_an_empty_prefix_part(self):
+		naming_rule = self.make_rule("test-empty-.role.-")
+
+		prefix = self.make_todo().name[:-5]
+		self.assertEqual(prefix, "test-empty--")
+		self.drop_series(prefix)
+
+		seed_series_for_rule(frappe._dict(document_type="ToDo", prefix=naming_rule.prefix, prefix_digits=5))
+
+		self.assertEqual(self.series_current(prefix), 1)
+
+	def test_patch_seeds_disabled_rules(self):
+		naming_rule = self.make_rule("test-disabled-")
+
+		prefix = self.make_todo().name[:-5]
+		naming_rule.disabled = 1
+		naming_rule.save()
+		self.drop_series(prefix)
+
+		seed_naming_rule_series()
+
+		self.assertEqual(self.series_current(prefix), 1)
+
+	def make_rule(self, prefix):
+		naming_rule = frappe.get_doc(
+			doctype="Document Naming Rule",
+			document_type="ToDo",
+			prefix=prefix,
+			prefix_digits=5,
+		).insert()
+		self.addCleanup(naming_rule.delete)
+		return naming_rule
+
+	def drop_series(self, prefix):
+		series = DocType("Series")
+		frappe.qb.from_(series).delete().where(series.name == prefix).run()
 
 	def make_todo(self, priority="Medium"):
 		todo = frappe.get_doc(

--- a/frappe/core/doctype/document_naming_rule/test_document_naming_rule.py
+++ b/frappe/core/doctype/document_naming_rule/test_document_naming_rule.py
@@ -169,6 +169,24 @@ class TestDocumentNamingRule(IntegrationTestCase):
 		self.assertEqual(self.series_current("test-live-"), 1)
 		self.assertIsNone(self.series_current("test-live-0"))
 
+	def test_patch_does_not_let_a_broad_rule_claim_disabled_history(self):
+		specific = self.make_rule("test-hist-", digits=6, priority=10)
+
+		name = self.make_todo().name
+		self.assertEqual(name, "test-hist-000001")
+
+		specific.disabled = 1
+		specific.save()
+		self.make_rule(".role.", priority=0)
+
+		self.drop_series("test-hist-")
+		self.drop_series("test-hist-0")
+
+		seed_naming_rule_series()
+
+		self.assertEqual(self.series_current("test-hist-"), 1)
+		self.assertIsNone(self.series_current("test-hist-0"))
+
 	def make_rule(self, prefix, digits=5, priority=0, disabled=0):
 		naming_rule = frappe.get_doc(
 			doctype="Document Naming Rule",

--- a/frappe/core/doctype/document_naming_rule/test_document_naming_rule.py
+++ b/frappe/core/doctype/document_naming_rule/test_document_naming_rule.py
@@ -185,6 +185,17 @@ class TestDocumentNamingRule(IntegrationTestCase):
 
 		self.assertEqual(self.series_current(prefix), 1)
 
+	def test_patch_seeds_a_prefix_built_on_a_standard_field(self):
+		self.make_rule("test-std-.owner.-")
+
+		prefix = self.make_todo().name[:-5]
+		self.assertEqual(prefix, "test-std-Administrator-")
+		self.drop_series(prefix)
+
+		seed_naming_rule_series()
+
+		self.assertEqual(self.series_current(prefix), 1)
+
 	def make_rule(self, prefix, digits=5, priority=0, disabled=0):
 		naming_rule = frappe.get_doc(
 			doctype="Document Naming Rule",

--- a/frappe/core/doctype/document_naming_rule/test_document_naming_rule.py
+++ b/frappe/core/doctype/document_naming_rule/test_document_naming_rule.py
@@ -2,7 +2,6 @@
 # License: MIT. See LICENSE
 import frappe
 from frappe.patches.v16_0.seed_naming_rule_series import execute as seed_naming_rule_series
-from frappe.patches.v16_0.seed_naming_rule_series import seed_series_for_rule
 from frappe.query_builder import DocType
 from frappe.tests import IntegrationTestCase
 
@@ -112,19 +111,19 @@ class TestDocumentNamingRule(IntegrationTestCase):
 		series = DocType("Series")
 		frappe.qb.from_(series).delete().where(series.name == prefix).run()
 
-		seed_series_for_rule(frappe._dict(document_type="ToDo", prefix=naming_rule.prefix, prefix_digits=5))
+		seed_naming_rule_series()
 
 		self.assertEqual(self.series_current(prefix), 3)
 		self.assertEqual(self.make_todo().name, prefix + "00004")
 
 	def test_patch_seeds_a_name_with_an_empty_prefix_part(self):
-		naming_rule = self.make_rule("test-empty-.role.-")
+		self.make_rule("test-empty-.role.-")
 
 		prefix = self.make_todo().name[:-5]
 		self.assertEqual(prefix, "test-empty--")
 		self.drop_series(prefix)
 
-		seed_series_for_rule(frappe._dict(document_type="ToDo", prefix=naming_rule.prefix, prefix_digits=5))
+		seed_naming_rule_series()
 
 		self.assertEqual(self.series_current(prefix), 1)
 
@@ -140,12 +139,28 @@ class TestDocumentNamingRule(IntegrationTestCase):
 
 		self.assertEqual(self.series_current(prefix), 1)
 
-	def make_rule(self, prefix):
+	def test_patch_does_not_split_a_name_claimed_by_another_rule(self):
+		self.make_rule("test-claim-", digits=6, priority=10)
+		self.make_rule(".role.", priority=0)
+
+		name = self.make_todo().name
+		self.assertEqual(name, "test-claim-000001")
+
+		self.drop_series("test-claim-")
+		self.drop_series("test-claim-0")
+
+		seed_naming_rule_series()
+
+		self.assertEqual(self.series_current("test-claim-"), 1)
+		self.assertIsNone(self.series_current("test-claim-0"))
+
+	def make_rule(self, prefix, digits=5, priority=0):
 		naming_rule = frappe.get_doc(
 			doctype="Document Naming Rule",
 			document_type="ToDo",
 			prefix=prefix,
-			prefix_digits=5,
+			prefix_digits=digits,
+			priority=priority,
 		).insert()
 		self.addCleanup(naming_rule.delete)
 		return naming_rule

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -277,6 +277,7 @@ frappe.patches.v16_0.repair_converted_print_formats #2026-08-02 section-spacing
 execute:frappe.db.set_single_value("Contact Us Settings", "send_acknowledgement_email", 1)
 frappe.patches.v16_0.seed_sms_settings_allowed_roles
 execute:frappe.db.set_single_value("Website Settings", "max_signups_per_minute", 500)
+frappe.patches.v16_0.seed_naming_rule_series
 
 
 [post_fixture_sync]

--- a/frappe/patches/v16_0/seed_naming_rule_series.py
+++ b/frappe/patches/v16_0/seed_naming_rule_series.py
@@ -10,13 +10,15 @@ CHUNK_SIZE = 20000
 def execute():
 	"""Seed `tabSeries` from names already minted by Document Naming Rules.
 
+	Disabled rules are seeded too. A rule that minted names before being
+	disabled would otherwise restart at 1 whenever it is switched back on.
+
 	Rules used to keep a single counter on the rule itself. They now share the
 	per-prefix counters in `tabSeries`, which start at 1 and would collide with
 	existing names unless seeded here.
 	"""
 	rules = frappe.get_all(
 		"Document Naming Rule",
-		filters={"disabled": 0},
 		fields=["document_type", "prefix", "prefix_digits"],
 	)
 	for rule in rules:
@@ -48,11 +50,11 @@ def part_pattern(part, meta):
 	if part.startswith("#"):
 		return rf"\d{{{len(part)}}}"
 	if frappe.get_hooks("naming_series_variables", {}).get(part):
-		return ".+?"
+		return ".*?"
 	if part in FIXED_WIDTH_PARTS:
 		return rf"\d{{{FIXED_WIDTH_PARTS[part]}}}"
 	if part == "timestamp" or part.startswith("{") or meta.has_field(part.strip("{}")):
-		return ".+?"
+		return ".*?"
 	return re.escape(part)
 
 
@@ -61,9 +63,7 @@ def collect_counters(doctype, pattern):
 	start = 0
 
 	while True:
-		names = frappe.get_all(
-			doctype, pluck="name", order_by="name", limit_start=start, limit_page_length=CHUNK_SIZE
-		)
+		names = frappe.get_all(doctype, pluck="name", order_by="name", offset=start, limit=CHUNK_SIZE)
 		if not names:
 			return counters
 

--- a/frappe/patches/v16_0/seed_naming_rule_series.py
+++ b/frappe/patches/v16_0/seed_naming_rule_series.py
@@ -43,7 +43,11 @@ def seed_doctype(doctype, rules):
 	wrong boundary. Letting the first matching rule claim a name keeps those
 	patterns away from names a more specific rule already accounts for.
 	"""
-	patterns = [pattern for pattern in map(build_name_pattern, rules) if pattern]
+	patterns = []
+	for rule in rules:
+		pattern = build_name_pattern(rule)
+		if pattern:
+			patterns.append(pattern)
 
 	for prefix, current in collect_counters(doctype, patterns).items():
 		raise_series(prefix, current)
@@ -87,13 +91,15 @@ def collect_counters(doctype, patterns):
 
 
 def record_counter(counters, patterns, name):
-	match = next(filter(None, (pattern.match(name) for pattern in patterns)), None)
-	if not match:
-		return
+	for pattern in patterns:
+		match = pattern.match(name)
+		if not match:
+			continue
 
-	prefix, suffix = match.group(1), int(match.group(2))
-	if prefix and suffix > counters.get(prefix, 0):
-		counters[prefix] = suffix
+		prefix, suffix = match.group(1), int(match.group(2))
+		if prefix and suffix > counters.get(prefix, 0):
+			counters[prefix] = suffix
+		return
 
 
 def raise_series(prefix, current):

--- a/frappe/patches/v16_0/seed_naming_rule_series.py
+++ b/frappe/patches/v16_0/seed_naming_rule_series.py
@@ -42,8 +42,14 @@ def seed_doctype(doctype, rules):
 	wrong and leaving the real series unseeded, which mints a duplicate. Every
 	rule that matches records its own reading instead: a rule always reads its
 	own names correctly, because the trailing digit count fixes where the
-	counter starts. A reading that belonged to no rule leaves a series nothing
-	resolves to, which costs a row and nothing else.
+	counter starts, so every live series is seeded whoever else matched.
+
+	A reading no rule minted usually seeds a series nothing resolves to, which
+	costs a row. Where another rule does resolve to that exact prefix, reading
+	test-claim-000100 as test-claim-0 and 00100 for instance, its series moves
+	forward and it skips numbers. That is the accepted cost: suppressing such
+	a reading means judging which rule owns a name, and a wrong judgement
+	there leaves a live series unseeded and mints a duplicate instead.
 	"""
 	patterns = []
 	for rule in rules:

--- a/frappe/patches/v16_0/seed_naming_rule_series.py
+++ b/frappe/patches/v16_0/seed_naming_rule_series.py
@@ -23,10 +23,16 @@ def execute():
 
 
 def rules_by_doctype():
+	"""Group rules per doctype, enabled ones first, then by priority.
+
+	set_new_name only ever offers a name to enabled rules, so a disabled rule
+	must not claim one ahead of them. It still gets a turn afterwards, for the
+	names it minted before it was switched off.
+	"""
 	rules = frappe.get_all(
 		"Document Naming Rule",
 		fields=["document_type", "prefix", "prefix_digits"],
-		order_by="priority desc",
+		order_by="disabled asc, priority desc",
 	)
 
 	grouped = {}
@@ -36,7 +42,7 @@ def rules_by_doctype():
 
 
 def seed_doctype(doctype, rules):
-	"""Attribute each name to one rule, in the order set_new_name applies them.
+	"""Attribute each name to one rule, in the order rules_by_doctype sets.
 
 	A prefix built only from variables compiles to a pattern that matches any
 	name ending in the right number of digits, and splits foreign names at the

--- a/frappe/patches/v16_0/seed_naming_rule_series.py
+++ b/frappe/patches/v16_0/seed_naming_rule_series.py
@@ -17,21 +17,35 @@ def execute():
 	per-prefix counters in `tabSeries`, which start at 1 and would collide with
 	existing names unless seeded here.
 	"""
+	for doctype, rules in rules_by_doctype().items():
+		if frappe.db.table_exists(doctype):
+			seed_doctype(doctype, rules)
+
+
+def rules_by_doctype():
 	rules = frappe.get_all(
 		"Document Naming Rule",
 		fields=["document_type", "prefix", "prefix_digits"],
+		order_by="priority desc",
 	)
+
+	grouped = {}
 	for rule in rules:
-		if frappe.db.table_exists(rule.document_type):
-			seed_series_for_rule(rule)
+		grouped.setdefault(rule.document_type, []).append(rule)
+	return grouped
 
 
-def seed_series_for_rule(rule):
-	pattern = build_name_pattern(rule)
-	if not pattern:
-		return
+def seed_doctype(doctype, rules):
+	"""Attribute each name to one rule, in the order set_new_name applies them.
 
-	for prefix, current in collect_counters(rule.document_type, pattern).items():
+	A prefix built only from variables compiles to a pattern that matches any
+	name ending in the right number of digits, and splits foreign names at the
+	wrong boundary. Letting the first matching rule claim a name keeps those
+	patterns away from names a more specific rule already accounts for.
+	"""
+	patterns = [pattern for pattern in map(build_name_pattern, rules) if pattern]
+
+	for prefix, current in collect_counters(doctype, patterns).items():
 		raise_series(prefix, current)
 
 
@@ -58,7 +72,7 @@ def part_pattern(part, meta):
 	return re.escape(part)
 
 
-def collect_counters(doctype, pattern):
+def collect_counters(doctype, patterns):
 	counters = {}
 	start = 0
 
@@ -68,17 +82,17 @@ def collect_counters(doctype, pattern):
 			return counters
 
 		for name in names:
-			record_counter(counters, pattern, name)
+			record_counter(counters, patterns, name)
 		start += CHUNK_SIZE
 
 
-def record_counter(counters, pattern, name):
-	match = pattern.match(name)
+def record_counter(counters, patterns, name):
+	match = next(filter(None, (pattern.match(name) for pattern in patterns)), None)
 	if not match:
 		return
 
 	prefix, suffix = match.group(1), int(match.group(2))
-	if suffix > counters.get(prefix, 0):
+	if prefix and suffix > counters.get(prefix, 0):
 		counters[prefix] = suffix
 
 

--- a/frappe/patches/v16_0/seed_naming_rule_series.py
+++ b/frappe/patches/v16_0/seed_naming_rule_series.py
@@ -10,12 +10,12 @@ CHUNK_SIZE = 20000
 def execute():
 	"""Seed `tabSeries` from names already minted by Document Naming Rules.
 
-	Disabled rules are seeded too. A rule that minted names before being
-	disabled would otherwise restart at 1 whenever it is switched back on.
-
 	Rules used to keep a single counter on the rule itself. They now share the
 	per-prefix counters in `tabSeries`, which start at 1 and would collide with
 	existing names unless seeded here.
+
+	Disabled rules are seeded too. A rule that minted names before being
+	disabled would otherwise restart at 1 whenever it is switched back on.
 	"""
 	for doctype, rules in rules_by_doctype().items():
 		if frappe.db.table_exists(doctype):
@@ -23,16 +23,9 @@ def execute():
 
 
 def rules_by_doctype():
-	"""Group rules per doctype, enabled ones first, then by priority.
-
-	set_new_name only ever offers a name to enabled rules, so a disabled rule
-	must not claim one ahead of them. It still gets a turn afterwards, for the
-	names it minted before it was switched off.
-	"""
 	rules = frappe.get_all(
 		"Document Naming Rule",
 		fields=["document_type", "prefix", "prefix_digits"],
-		order_by="disabled asc, priority desc",
 	)
 
 	grouped = {}
@@ -42,58 +35,51 @@ def rules_by_doctype():
 
 
 def seed_doctype(doctype, rules):
-	"""Attribute each name to one rule, most specific pattern first.
+	"""Record what every matching rule makes of a name, not just the first.
 
-	A prefix built only from variables compiles to a pattern that matches any
-	name ending in the right number of digits, and splits foreign names at the
-	wrong boundary. Ranking by the number of literal characters a pattern pins
-	down keeps such a pattern away from any name a narrower rule accounts for,
-	whichever of the two is enabled. Rules that pin down the same amount keep
-	the order they were read in, enabled ahead of disabled.
+	Rules on one doctype can produce overlapping names, and a name alone does
+	not say which rule minted it. Picking one rule to own it risks picking
+	wrong and leaving the real series unseeded, which mints a duplicate. Every
+	rule that matches records its own reading instead: a rule always reads its
+	own names correctly, because the trailing digit count fixes where the
+	counter starts. A reading that belonged to no rule leaves a series nothing
+	resolves to, which costs a row and nothing else.
 	"""
-	ranked = []
-	for position, rule in enumerate(rules):
-		built = build_name_pattern(rule)
-		if built:
-			pattern, literals = built
-			ranked.append((-literals, position, pattern))
-
-	ranked.sort()
-	patterns = [pattern for _, _, pattern in ranked]
+	patterns = []
+	for rule in rules:
+		pattern = build_name_pattern(rule)
+		if pattern:
+			patterns.append(pattern)
 
 	for prefix, current in collect_counters(doctype, patterns).items():
 		raise_series(prefix, current)
 
 
 def build_name_pattern(rule):
-	"""Regex for names this rule can mint, plus the literal characters it pins."""
+	"""Regex for names this rule can mint, capturing the resolved prefix."""
 	if not rule.prefix_digits or not rule.prefix:
 		return None
 
 	meta = frappe.get_meta(rule.document_type)
 	body = ""
-	literals = 0
 	for part in rule.prefix.split("."):
-		if not part:
-			continue
-		fragment, pinned = part_pattern(part, meta)
-		body += fragment
-		literals += pinned
+		if part:
+			body += part_pattern(part, meta)
 
-	return re.compile(rf"^({body})(\d{{{rule.prefix_digits}}})$"), literals
+	return re.compile(rf"^({body})(\d{{{rule.prefix_digits}}})$")
 
 
 def part_pattern(part, meta):
 	"""Mirror the precedence in parse_naming_series, custom parsers included."""
 	if part.startswith("#"):
-		return rf"\d{{{len(part)}}}", 0
+		return rf"\d{{{len(part)}}}"
 	if frappe.get_hooks("naming_series_variables", {}).get(part):
-		return ".*?", 0
+		return ".*?"
 	if part in FIXED_WIDTH_PARTS:
-		return rf"\d{{{FIXED_WIDTH_PARTS[part]}}}", 0
+		return rf"\d{{{FIXED_WIDTH_PARTS[part]}}}"
 	if part == "timestamp" or part.startswith("{") or meta.has_field(part.strip("{}")):
-		return ".*?", 0
-	return re.escape(part), len(part)
+		return ".*?"
+	return re.escape(part)
 
 
 def collect_counters(doctype, patterns):
@@ -119,7 +105,6 @@ def record_counter(counters, patterns, name):
 		prefix, suffix = match.group(1), int(match.group(2))
 		if prefix and suffix > counters.get(prefix, 0):
 			counters[prefix] = suffix
-		return
 
 
 def raise_series(prefix, current):

--- a/frappe/patches/v16_0/seed_naming_rule_series.py
+++ b/frappe/patches/v16_0/seed_naming_rule_series.py
@@ -1,9 +1,11 @@
 import re
 
 import frappe
+from frappe.model import child_table_fields, default_fields, optional_fields
 from frappe.query_builder import DocType
 
 FIXED_WIDTH_PARTS = {"YY": 2, "MM": 2, "DD": 2, "WW": 2, "JJJ": 3, "YYYY": 4}
+STANDARD_FIELDS = frozenset(default_fields + child_table_fields + optional_fields)
 CHUNK_SIZE = 20000
 
 
@@ -83,7 +85,9 @@ def part_pattern(part, meta):
 		return ".*?"
 	if part in FIXED_WIDTH_PARTS:
 		return rf"\d{{{FIXED_WIDTH_PARTS[part]}}}"
-	if part == "timestamp" or part.startswith("{") or meta.has_field(part.strip("{}")):
+	if part == "timestamp" or part.startswith("{"):
+		return ".*?"
+	if part in STANDARD_FIELDS or meta.has_field(part):
 		return ".*?"
 	return re.escape(part)
 

--- a/frappe/patches/v16_0/seed_naming_rule_series.py
+++ b/frappe/patches/v16_0/seed_naming_rule_series.py
@@ -42,44 +42,58 @@ def rules_by_doctype():
 
 
 def seed_doctype(doctype, rules):
-	"""Attribute each name to one rule, in the order rules_by_doctype sets.
+	"""Attribute each name to one rule, most specific pattern first.
 
 	A prefix built only from variables compiles to a pattern that matches any
 	name ending in the right number of digits, and splits foreign names at the
-	wrong boundary. Letting the first matching rule claim a name keeps those
-	patterns away from names a more specific rule already accounts for.
+	wrong boundary. Ranking by the number of literal characters a pattern pins
+	down keeps such a pattern away from any name a narrower rule accounts for,
+	whichever of the two is enabled. Rules that pin down the same amount keep
+	the order they were read in, enabled ahead of disabled.
 	"""
-	patterns = []
-	for rule in rules:
-		pattern = build_name_pattern(rule)
-		if pattern:
-			patterns.append(pattern)
+	ranked = []
+	for position, rule in enumerate(rules):
+		built = build_name_pattern(rule)
+		if built:
+			pattern, literals = built
+			ranked.append((-literals, position, pattern))
+
+	ranked.sort()
+	patterns = [pattern for _, _, pattern in ranked]
 
 	for prefix, current in collect_counters(doctype, patterns).items():
 		raise_series(prefix, current)
 
 
 def build_name_pattern(rule):
-	"""Regex for names this rule can mint, capturing the resolved prefix."""
+	"""Regex for names this rule can mint, plus the literal characters it pins."""
 	if not rule.prefix_digits or not rule.prefix:
 		return None
 
 	meta = frappe.get_meta(rule.document_type)
-	body = "".join(part_pattern(part, meta) for part in rule.prefix.split(".") if part)
-	return re.compile(rf"^({body})(\d{{{rule.prefix_digits}}})$")
+	body = ""
+	literals = 0
+	for part in rule.prefix.split("."):
+		if not part:
+			continue
+		fragment, pinned = part_pattern(part, meta)
+		body += fragment
+		literals += pinned
+
+	return re.compile(rf"^({body})(\d{{{rule.prefix_digits}}})$"), literals
 
 
 def part_pattern(part, meta):
 	"""Mirror the precedence in parse_naming_series, custom parsers included."""
 	if part.startswith("#"):
-		return rf"\d{{{len(part)}}}"
+		return rf"\d{{{len(part)}}}", 0
 	if frappe.get_hooks("naming_series_variables", {}).get(part):
-		return ".*?"
+		return ".*?", 0
 	if part in FIXED_WIDTH_PARTS:
-		return rf"\d{{{FIXED_WIDTH_PARTS[part]}}}"
+		return rf"\d{{{FIXED_WIDTH_PARTS[part]}}}", 0
 	if part == "timestamp" or part.startswith("{") or meta.has_field(part.strip("{}")):
-		return ".*?"
-	return re.escape(part)
+		return ".*?", 0
+	return re.escape(part), len(part)
 
 
 def collect_counters(doctype, patterns):

--- a/frappe/patches/v16_0/seed_naming_rule_series.py
+++ b/frappe/patches/v16_0/seed_naming_rule_series.py
@@ -1,0 +1,93 @@
+import re
+
+import frappe
+from frappe.query_builder import DocType
+
+FIXED_WIDTH_PARTS = {"YY": 2, "MM": 2, "DD": 2, "WW": 2, "JJJ": 3, "YYYY": 4}
+CHUNK_SIZE = 20000
+
+
+def execute():
+	"""Seed `tabSeries` from names already minted by Document Naming Rules.
+
+	Rules used to keep a single counter on the rule itself. They now share the
+	per-prefix counters in `tabSeries`, which start at 1 and would collide with
+	existing names unless seeded here.
+	"""
+	rules = frappe.get_all(
+		"Document Naming Rule",
+		filters={"disabled": 0},
+		fields=["document_type", "prefix", "prefix_digits"],
+	)
+	for rule in rules:
+		if frappe.db.table_exists(rule.document_type):
+			seed_series_for_rule(rule)
+
+
+def seed_series_for_rule(rule):
+	pattern = build_name_pattern(rule)
+	if not pattern:
+		return
+
+	for prefix, current in collect_counters(rule.document_type, pattern).items():
+		raise_series(prefix, current)
+
+
+def build_name_pattern(rule):
+	"""Regex for names this rule can mint, capturing the resolved prefix."""
+	if not rule.prefix_digits or not rule.prefix:
+		return None
+
+	meta = frappe.get_meta(rule.document_type)
+	body = "".join(part_pattern(part, meta) for part in rule.prefix.split(".") if part)
+	return re.compile(rf"^({body})(\d{{{rule.prefix_digits}}})$")
+
+
+def part_pattern(part, meta):
+	"""Mirror the precedence in parse_naming_series, custom parsers included."""
+	if part.startswith("#"):
+		return rf"\d{{{len(part)}}}"
+	if frappe.get_hooks("naming_series_variables", {}).get(part):
+		return ".+?"
+	if part in FIXED_WIDTH_PARTS:
+		return rf"\d{{{FIXED_WIDTH_PARTS[part]}}}"
+	if part == "timestamp" or part.startswith("{") or meta.has_field(part.strip("{}")):
+		return ".+?"
+	return re.escape(part)
+
+
+def collect_counters(doctype, pattern):
+	counters = {}
+	start = 0
+
+	while True:
+		names = frappe.get_all(
+			doctype, pluck="name", order_by="name", limit_start=start, limit_page_length=CHUNK_SIZE
+		)
+		if not names:
+			return counters
+
+		for name in names:
+			record_counter(counters, pattern, name)
+		start += CHUNK_SIZE
+
+
+def record_counter(counters, pattern, name):
+	match = pattern.match(name)
+	if not match:
+		return
+
+	prefix, suffix = match.group(1), int(match.group(2))
+	if suffix > counters.get(prefix, 0):
+		counters[prefix] = suffix
+
+
+def raise_series(prefix, current):
+	"""Move the series forward, never backward."""
+	series = DocType("Series")
+	existing = (frappe.qb.from_(series).where(series.name == prefix).select("current")).run()
+
+	if not existing:
+		frappe.qb.into(series).insert(prefix, current).run()
+	elif (existing[0][0] or 0) < current:
+		frappe.qb.update(series).set(series.current, current).where(series.name == prefix).run()


### PR DESCRIPTION
Closes #35587 (reopening warranted — see below).

### Problem

`Document Naming Rule` keeps its counter in a single Int field on the rule. The prefix is parsed per document, so a prefix containing `.YYYY.` or a fieldname resolves to many different strings that all draw from that one counter.

```
last invoice of 2025 -> SAINV-TA-2025-01255
first invoice of 2026 -> SAINV-TA-2026-01256
```

Plain naming series does not have this problem: `parse_naming_series` routes `#` parts through `getseries`, which keys `tabSeries` on the resolved prefix. Rules are the only naming path that opts out.

### Change

`apply()` now calls `getseries()` on the parsed prefix. Each resolved prefix gets its own counter and the yearly reset falls out of the key. A rule and a naming series producing the same format now share one counter, which also covers #21688.

The `counter` field no longer drives naming, so it is hidden and read-only rather than left as an editable control that does nothing.

### Migration

`getseries()` starts a new key at 1, so an install already at `SAINV-TA-2026-01255` would mint `...00001` and fail on a duplicate name. `seed_naming_rule_series` walks documents of every doctype with an enabled rule, matches names against a regex built from the rule prefix, and seeds `tabSeries` with the highest suffix per resolved prefix. It only moves a series forward, so it is safe beside keys a naming series already owns.

The pattern builder follows the same precedence as `parse_naming_series`, custom parsers first — apps register `naming_series_variables` for parts like `YYYY`, so the part width cannot be assumed.

### Note on #35587

That issue was closed as not reproducible. It reproduces only when a Document Naming Rule is configured: `set_new_name` applies a matching rule and breaks before `set_name_by_naming_series` ever runs, so testing through the `naming_series` field shows a clean reset and looks fine. The reporter said as much in a follow-up that arrived after the issue was closed.

### Tests

Three cases in `test_document_naming_rule.py`: a fieldname prefix gives each resolved value its own counter, a date prefix keys the series on the resolved prefix, and the patch restores a dropped counter. The year case asserts the shape of the series key instead of mocking the clock, since an app may own the `YYYY` part.