### PR TITLE
fix(social_login_key): backfill the social login key configs.

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -277,6 +277,7 @@ frappe.patches.v16_0.repair_converted_print_formats #2026-08-02 section-spacing
 execute:frappe.db.set_single_value("Contact Us Settings", "send_acknowledgement_email", 1)
 frappe.patches.v16_0.seed_sms_settings_allowed_roles
 execute:frappe.db.set_single_value("Website Settings", "max_signups_per_minute", 500)
+frappe.patches.v16_0.backfill_social_login_key_trust_flags
 
 
 [post_fixture_sync]

--- a/frappe/patches/v16_0/backfill_social_login_key_trust_flags.py
+++ b/frappe/patches/v16_0/backfill_social_login_key_trust_flags.py
@@ -1,0 +1,18 @@
+import frappe
+
+
+def execute():
+	"""Preserve existing Social Login Key behavior."""
+	frappe.reload_doctype("Social Login Key")
+
+	social_login_key = frappe.qb.DocType("Social Login Key")
+
+	frappe.qb.update(social_login_key).set(social_login_key.trust_email_without_verified_claim, 1).where(
+		social_login_key.trust_email_without_verified_claim == 0
+	).run()
+
+	frappe.qb.update(social_login_key).set(social_login_key.trust_any_tenant, 1).where(
+		(social_login_key.social_login_provider == "Office 365")
+		& (social_login_key.trust_any_tenant == 0)
+		& (social_login_key.tenant_id.isnull() | (social_login_key.tenant_id == ""))
+	).run()


### PR DESCRIPTION
Backfilling the social login key configs. to minimize breakages on exisiting Social Login Keys. Can be re-configured by Sys. Man.

related to #42402