### PR TITLE
fix(oauth): remove ROPC

### DIFF
--- a/frappe/oauth.py
+++ b/frappe/oauth.py
@@ -1,6 +1,7 @@
 import base64
 import datetime
 import hashlib
+import hmac
 import re
 from urllib.parse import urljoin, urlparse
 
@@ -8,7 +9,6 @@ from oauthlib.common import Request
 from oauthlib.openid import RequestValidator
 
 import frappe
-from frappe.auth import LoginManager
 from frappe.integrations.doctype.oauth_bearer_token.oauth_bearer_token import get_oauth_token_hash
 from frappe.integrations.doctype.oauth_client.oauth_client import OAuthClient
 from frappe.utils.data import cstr, get_system_timezone, now_datetime
@@ -96,8 +96,9 @@ class OAuthWebRequestValidator(RequestValidator):
 
 	def authenticate_client(self, request: Request, *args, **kwargs) -> bool | None:
 		"""
-		Loads the client based on request parameters and sets in oauth request.
-		Returns True on success, None on error.
+		Loads the client based on request parameters, verifies its client_secret
+		for confidential clients, and sets it in the oauth request.
+		Returns True on success, False/None on error.
 		"""
 		# Get ClientID in URL
 		if request.client_id:
@@ -114,13 +115,36 @@ class OAuthWebRequestValidator(RequestValidator):
 
 			client_name = frappe.db.get_value("OAuth Bearer Token", filters=token_filters, fieldname="client")
 
-		oc: OAuthClient = frappe.get_cached_doc("OAuth Client", client_name)
+		try:
+			oc: OAuthClient = frappe.get_cached_doc("OAuth Client", client_name)
+		except frappe.DoesNotExistError:
+			return False
+
+		if not oc.is_public_client() and not self.verify_client_secret(oc, request):
+			return False
+
 		try:
 			request.client = request.client or oc.as_dict()
 		except Exception as e:
 			return generate_json_error_response(e)
 
 		return True
+
+	def verify_client_secret(self, oc: OAuthClient, request: Request) -> bool:
+		"""Verify the client_secret of a confidential client.
+
+		Only client_secret_post (a client_secret body/query param) is
+		supported: an Authorization: Basic header never reaches this code,
+		since frappe.auth.validate_auth_via_api_keys() intercepts any Basic
+		auth header at the request level and treats it as a Frappe User API
+		key/secret, before this whitelisted method ever runs.
+		"""
+		client_secret = request.client_secret
+
+		if not isinstance(client_secret, str) or not oc.client_secret:
+			return False
+
+		return hmac.compare_digest(client_secret, oc.client_secret)
 
 	def authenticate_client_id(self, client_id, request, *args, **kwargs):
 		try:
@@ -186,7 +210,17 @@ class OAuthWebRequestValidator(RequestValidator):
 	def validate_grant_type(self, client_id, grant_type, client, request, *args, **kwargs):
 		# Clients should only be allowed to use one type of grant.
 		# In this case, it must be "authorization_code" or "refresh_token"
-		return grant_type in ["authorization_code", "refresh_token", "password"]
+		return grant_type in ["authorization_code", "refresh_token"]
+
+	def validate_user(self, username, password, client, request, *args, **kwargs):
+		"""Resource Owner Password Credentials Grant is not supported.
+
+		oauthlib's ResourceOwnerPasswordCredentialsGrant handler calls this
+		unconditionally regardless of validate_grant_type, so this must
+		exist and reject cleanly rather than fall through to the base
+		RequestValidator's NotImplementedError.
+		"""
+		return False
 
 	def save_bearer_token(self, token, request, *args, **kwargs):
 		# Remember to associate it with request.scopes, request.user and
@@ -521,21 +555,6 @@ class OAuthWebRequestValidator(RequestValidator):
 			return True
 
 		return False
-
-	def validate_user(self, username, password, client, request, *args, **kwargs):
-		"""Ensure the username and password is valid.
-
-		Method is used by:
-		- Resource Owner Password Credentials Grant
-		"""
-		login_manager = LoginManager()
-		login_manager.authenticate(username, password)
-
-		if login_manager.user == "Guest":
-			return False
-
-		request.user = login_manager.user
-		return True
 
 
 def calculate_at_hash(access_token, hash_alg):

--- a/frappe/tests/test_oauth20.py
+++ b/frappe/tests/test_oauth20.py
@@ -215,6 +215,7 @@ class TestOAuth20(FrappeRequestTestCase):
 				"code": auth_code,
 				"redirect_uri": self.redirect_uri,
 				"client_id": self.client_id,
+				"client_secret": self.client_secret,
 				"scope": self.scope,
 			},
 		)
@@ -266,6 +267,7 @@ class TestOAuth20(FrappeRequestTestCase):
 				"code": auth_code,
 				"redirect_uri": self.redirect_uri,
 				"client_id": self.client_id,
+				"client_secret": self.client_secret,
 				"scope": self.scope,
 				"code_verifier": "420",
 			},
@@ -313,6 +315,7 @@ class TestOAuth20(FrappeRequestTestCase):
 				"code": auth_code,
 				"redirect_uri": self.redirect_uri,
 				"client_id": self.client_id,
+				"client_secret": self.client_secret,
 			},
 		)
 
@@ -323,7 +326,11 @@ class TestOAuth20(FrappeRequestTestCase):
 		revoke_token_response = self.post(
 			"/api/method/frappe.integrations.oauth2.revoke_token",
 			headers=self.form_header,
-			data={"token": bearer_token.get("access_token")},
+			data={
+				"token": bearer_token.get("access_token"),
+				"client_id": self.client_id,
+				"client_secret": self.client_secret,
+			},
 		)
 
 		self.assertTrue(revoke_token_response.status_code == 200)
@@ -333,14 +340,14 @@ class TestOAuth20(FrappeRequestTestCase):
 			check_valid_openid_response(access_token=bearer_token.get("access_token"), client=self)
 		)
 
-	def test_resource_owner_password_credentials_grant(self):
+	def test_resource_owner_password_credentials_grant_is_rejected(self):
 		client = frappe.get_doc("OAuth Client", self.client_id)
 		client.grant_type = "Authorization Code"
 		client.response_type = "Code"
 		client.save()
 		frappe.db.commit()
 
-		# Request for bearer token
+		# Request for bearer token, no client_secret: rejected at client authentication
 		token_response = self.post(
 			"/api/method/frappe.integrations.oauth2.get_token",
 			data={
@@ -353,13 +360,25 @@ class TestOAuth20(FrappeRequestTestCase):
 			headers=self.form_header,
 		)
 
-		# Parse bearer token json
-		bearer_token = token_response.json
+		self.assertEqual(token_response.status_code, 400)
+		self.assertEqual(token_response.json.get("error"), "invalid_client")
 
-		# Check token for valid response
-		self.assertTrue(
-			check_valid_openid_response(access_token=bearer_token.get("access_token"), client=self)
+		# Even with a valid client_secret, credentials are never checked and no token is issued
+		token_response = self.post(
+			"/api/method/frappe.integrations.oauth2.get_token",
+			data={
+				"grant_type": "password",
+				"username": "test@example.com",
+				"password": "Eastern_43A1W",
+				"client_id": self.client_id,
+				"client_secret": self.client_secret,
+				"scope": self.scope,
+			},
+			headers=self.form_header,
 		)
+
+		self.assertEqual(token_response.status_code, 400)
+		self.assertEqual(token_response.json.get("error"), "invalid_grant")
 
 	@requires_test_service(TestService.WEB_SERVER)
 	def test_login_using_implicit_token(self):
@@ -434,6 +453,7 @@ class TestOAuth20(FrappeRequestTestCase):
 					"code": auth_code,
 					"redirect_uri": self.redirect_uri,
 					"client_id": self.client_id,
+					"client_secret": self.client_secret,
 					"scope": self.scope,
 				}
 			),


### PR DESCRIPTION
Reverts frappe/frappe#42662 and brings back the original fix.

Update: removing ROPC instead, rest of the fix has been done in #41546

> [!IMPORTANT]
> Resource Owner Password Credentials Grant (RFC 6749 §4.3) is formally deprecated by RFC 9700 §2.4 ("MUST NOT be used"). This patch removes the grant type entirely rather than attempting to fix it in place, consistent with current IETF guidance. (ref: https://www.rfc-editor.org/info/rfc9700/#name-resource-owner-password-cre)
