### PR TITLE
feat(ui): composer submitting state, footer slot, toolbar start and body fade

### DIFF
--- a/ui/src/components/Composer/CommentComposer/CommentComposer.vue
+++ b/ui/src/components/Composer/CommentComposer/CommentComposer.vue
@@ -6,6 +6,7 @@
 		:upload-function="uploadFunction"
 		:extensions="extensions"
 		:max-attachments="maxAttachments"
+		:submitting="submitting"
 		:mentions="mentions"
 		v-model:body="body"
 		@submit="emit('submit', $event)"

--- a/ui/src/components/Composer/CommentComposer/CommentComposer.vue
+++ b/ui/src/components/Composer/CommentComposer/CommentComposer.vue
@@ -15,6 +15,9 @@
 		<template v-if="$slots.actions" #actions="actionProps">
 			<slot name="actions" v-bind="actionProps" />
 		</template>
+		<template v-if="$slots.footer" #footer>
+			<slot name="footer" />
+		</template>
 	</ComposerEditor>
 </template>
 

--- a/ui/src/components/Composer/ComposerEditor.vue
+++ b/ui/src/components/Composer/ComposerEditor.vue
@@ -434,8 +434,10 @@ function focus() {
 	setTimeout(() => editor.value?.commands?.focus("start"), 0);
 }
 
+// The shortcut reaches here directly, so the in-flight guard has to live here
+// too, not only on the button.
 function submit() {
-	if (isDisabled.value) return;
+	if (isDisabled.value || props.submitting) return;
 	emit("submit", { body: buildMessage(), attachments: attachments.value });
 }
 

--- a/ui/src/components/Composer/ComposerEditor.vue
+++ b/ui/src/components/Composer/ComposerEditor.vue
@@ -101,9 +101,8 @@
 										:icon="LucidePaperclip"
 										aria-label="Attach file"
 										class="shrink-0"
-										:disabled="
-											isUploading || attachments.length >= maxAttachments
-										"
+										:loading="isUploading"
+										:disabled="attachments.length >= maxAttachments"
 										@click="attachInput?.click()"
 									/>
 									<input

--- a/ui/src/components/Composer/ComposerEditor.vue
+++ b/ui/src/components/Composer/ComposerEditor.vue
@@ -81,6 +81,9 @@
 							</Button>
 						</div>
 
+						<!-- Host content pinned above the utilities row, e.g. actions staged for send. -->
+						<slot name="footer" />
+
 						<div class="flex items-center justify-between gap-2 px-2.5 pb-2.5">
 							<!-- Starts 8px into the gutter: 6px is the sm icon inset, which puts
 							     the first glyph's box on the body text edge, and 2px absorb the

--- a/ui/src/components/Composer/ComposerEditor.vue
+++ b/ui/src/components/Composer/ComposerEditor.vue
@@ -24,7 +24,7 @@
 					<EditorTableMenu />
 
 					<div
-						class="flex max-h-[50vh] min-h-0 flex-1 flex-col overflow-y-auto px-2.5 pb-2.5"
+						class="composer-body flex max-h-[50vh] min-h-0 flex-1 flex-col overflow-y-auto px-2.5 pb-2.5"
 					>
 						<EditorContent
 							class="prose-sm max-w-full flex-1 pb-8 pt-4 [&_p.reply-to-content]:hidden"
@@ -82,7 +82,10 @@
 						</div>
 
 						<div class="flex items-center justify-between gap-2 px-2.5 pb-2.5">
-							<div class="relative -ml-1.5 overflow-hidden" style="max-width: 70%">
+							<!-- Starts 8px into the gutter: 6px is the sm icon inset, which puts
+							     the first glyph's box on the body text edge, and 2px absorb the
+							     glyph's own side bearing so its ink lines up with the text ink. -->
+							<div class="relative -ml-3.5 overflow-hidden" style="max-width: 70%">
 								<!-- p-0.5 keeps button focus rings from being clipped by overflow-x-auto. -->
 								<div
 									ref="toolbarScroller"
@@ -451,3 +454,13 @@ function reset() {
 
 defineExpose({ editor, focus, reset, submit });
 </script>
+
+<style scoped>
+/* The body scrolls straight into the toolbar with no separator, so a scrolled
+   line would be sliced at the toolbar edge. Fade the bottom 18px instead; the
+   body's own bottom padding keeps the last line clear of it at the scroll end. */
+.composer-body {
+	-webkit-mask-image: linear-gradient(to bottom, #000 calc(100% - 18px), transparent);
+	mask-image: linear-gradient(to bottom, #000 calc(100% - 18px), transparent);
+}
+</style>

--- a/ui/src/components/Composer/ComposerEditor.vue
+++ b/ui/src/components/Composer/ComposerEditor.vue
@@ -147,6 +147,7 @@
 									variant="solid"
 									:label="submitLabel"
 									:disabled="isDisabled"
+									:loading="submitting"
 									@click="submit"
 								/>
 							</div>

--- a/ui/src/components/Composer/EmailComposer/EmailComposer.vue
+++ b/ui/src/components/Composer/EmailComposer/EmailComposer.vue
@@ -35,6 +35,9 @@
 		<template v-if="$slots.actions" #actions="actionProps">
 			<slot name="actions" v-bind="actionProps" />
 		</template>
+		<template v-if="$slots.footer" #footer>
+			<slot name="footer" />
+		</template>
 	</ComposerEditor>
 </template>
 

--- a/ui/src/components/Composer/EmailComposer/EmailComposer.vue
+++ b/ui/src/components/Composer/EmailComposer/EmailComposer.vue
@@ -6,6 +6,7 @@
 		:upload-function="uploadFunction"
 		:extensions="extensions"
 		:max-attachments="maxAttachments"
+		:submitting="submitting"
 		v-model:body="body"
 		v-model:quoted="quoted"
 		@submit="handleSubmit"

--- a/ui/src/components/Composer/types.ts
+++ b/ui/src/components/Composer/types.ts
@@ -43,6 +43,8 @@ interface BaseComposerProps {
   extensions?: Extension[];
   /** Maximum number of attachments. Defaults to 10. */
   maxAttachments?: number;
+  /** Host is performing the send: the submit button shows a spinner and ignores clicks. */
+  submitting?: boolean;
 }
 
 export interface ComposerEditorProps extends BaseComposerProps {

--- a/ui/src/components/Composer/types.ts
+++ b/ui/src/components/Composer/types.ts
@@ -98,6 +98,8 @@ export interface EmailComposerSlots {
   header?: () => any;
   /** Extra footer actions, beside the built-in attach button. */
   actions?: (props: ComposerActionsSlotProps) => any;
+  /** Pinned between the body (and attachments) and the utilities row, for notices such as staged actions. */
+  footer?: () => any;
 }
 
 // --- CommentComposer ---------------------------------------------------------
@@ -111,4 +113,6 @@ export type CommentComposerEmits = BaseComposerEmits<CommentPayload>;
 export interface CommentComposerSlots {
   /** Extra footer actions, beside the built-in attach button. */
   actions?: (props: ComposerActionsSlotProps) => any;
+  /** Pinned between the body (and attachments) and the utilities row, for notices such as staged actions. */
+  footer?: () => any;
 }


### PR DESCRIPTION
Follow-ups to #42119.

## API

- `submitting` on `EmailComposer` and `CommentComposer`. The host performs the send, so the submit button had no way to show it and consumers fell back to a "Sending..." label. While set, the Send button shows a spinner after its label, sets `aria-busy`, and ignores clicks and the submit shortcut until the host resets the composer. Pair it with a shorter label; helpdesk passes "Sending".

- `#footer` slot on both composers, rendered between the body (after any attachments) and the utilities row. The composer had no hook there, so anything a host wanted pinned above the toolbar, such as actions staged to run after the send, had to sit outside it under the Send button. Helpdesk moves its saved reply actions panel in.

## UI

| | Before | After |
|---|---|---|
| Toolbar start | first button box on the body text edge, so its glyph sat 6px inside it | toolbar starts one small-icon inset into the gutter; the paperclip sits on the text edge like the body does |
| Attach button while uploading | disabled, so it only dimmed | `loading`: the paperclip becomes a spinner in place, still non-interactive; the attachment cap still disables it |
| Recipient chips | a recipient the host seeded with a label showed its bare address until a search happened to return it | the model's recipients feed the input's option cache alongside search results, so seeded names and avatars show from the first render |
| Body bottom edge | body scrolled straight into the toolbar, a scrolled line was sliced at the edge | bottom 18px fade, the same mask `EmailContent` uses for clipped mail; the body's own bottom padding keeps the last line clear at the scroll end |

## Screenshots

Body edge at the same scroll offset, before and after:

![body edge before](https://raw.githubusercontent.com/aerodeval/frappe/composer-pr-assets/body-fade-before.png)
![body edge after](https://raw.githubusercontent.com/aerodeval/frappe/composer-pr-assets/body-fade-after.png)

Toolbar start and submitting spinner shots to follow.

no-docs
