### PR TITLE
fix(oauth): bind social-login state to the initiating browser

### DIFF
--- a/frappe/integrations/doctype/social_login_key/test_social_login_key.py
+++ b/frappe/integrations/doctype/social_login_key/test_social_login_key.py
@@ -139,6 +139,26 @@ class TestSocialLoginKey(IntegrationTestCase):
 		simulate_new_request(None if browser_dropped_cookie else issued_secret)
 		self.assertEqual(consume_oauth_state(flow_b), "/app/flow-b")
 
+	def test_completed_login_leaves_other_pending_states_usable(self):
+		"""Completing one attempt must not retire the browser's binding cookie either: the
+		cookie is shared by every attempt that browser has in flight, so doing so would
+		break the ones still pending."""
+		github_social_login_setup()
+
+		simulate_new_request()
+		flow_a = create_oauth_state("/app/flow-a")
+		flow_b = create_oauth_state("/app/flow-b")
+		issued_secret = current_binding_secret()
+
+		# Flow A completes successfully.
+		simulate_new_request(issued_secret)
+		self.assertEqual(consume_oauth_state(flow_a), "/app/flow-a")
+		browser_dropped_cookie = OAUTH_LOGIN_BINDING_COOKIE in frappe.local.cookie_manager.to_delete
+
+		# Flow B, still pending in that same browser, must remain redeemable.
+		simulate_new_request(None if browser_dropped_cookie else issued_secret)
+		self.assertEqual(consume_oauth_state(flow_b), "/app/flow-b")
+
 	def test_forged_oauth_state_is_rejected_end_to_end(self):
 		"""A state value that wasn't issued via create_oauth_state() must not log anyone in
 		or produce a redirect, regardless of what it contains."""

--- a/frappe/integrations/doctype/social_login_key/test_social_login_key.py
+++ b/frappe/integrations/doctype/social_login_key/test_social_login_key.py
@@ -14,6 +14,7 @@ from frappe.integrations.doctype.social_login_key.social_login_key import BaseUr
 from frappe.tests import IntegrationTestCase
 from frappe.utils import set_request
 from frappe.utils.oauth import (
+	OAUTH_LOGIN_BINDING_COOKIE,
 	consume_oauth_state,
 	create_oauth_state,
 	enforce_office_365_tenant,
@@ -46,8 +47,10 @@ class TestSocialLoginKey(IntegrationTestCase):
 		mock_session = MagicMock()
 		mock_session.get.side_effect = github_response_for_private_email
 
+		state = create_oauth_state(None)  # Dummy code, real state token
+		simulate_oauth_browser_roundtrip()
 		with patch.object(OAuth2Service, "get_auth_session", return_value=mock_session):
-			login_via_oauth2("github", "iwriu", create_oauth_state(None))  # Dummy code, real state token
+			login_via_oauth2("github", "iwriu", state)
 
 	def test_github_login_with_public_email(self):
 		github_social_login_setup()
@@ -55,8 +58,10 @@ class TestSocialLoginKey(IntegrationTestCase):
 		mock_session = MagicMock()
 		mock_session.get.side_effect = github_response_for_public_email
 
+		state = create_oauth_state(None)  # Dummy code, real state token
+		simulate_oauth_browser_roundtrip()
 		with patch.object(OAuth2Service, "get_auth_session", return_value=mock_session):
-			login_via_oauth2("github", "iwriu", create_oauth_state(None))  # Dummy code, real state token
+			login_via_oauth2("github", "iwriu", state)
 
 	def test_normal_signup_and_github_login(self):
 		github_social_login_setup()
@@ -68,18 +73,34 @@ class TestSocialLoginKey(IntegrationTestCase):
 		mock_session = MagicMock()
 		mock_session.get.side_effect = github_response_for_login
 
+		state = create_oauth_state(None)
+		simulate_oauth_browser_roundtrip()
 		with patch.object(OAuth2Service, "get_auth_session", return_value=mock_session):
-			login_via_oauth2("github", "iwriu", create_oauth_state(None))
+			login_via_oauth2("github", "iwriu", state)
 		self.assertEqual(frappe.session.user, TEST_GITHUB_USER)
 
 	def test_oauth_state_helpers_reject_unknown_and_reused_tokens(self):
 		"""consume_oauth_state must only resolve tokens it minted itself, and only once."""
+		github_social_login_setup()
 		self.assertIsNone(consume_oauth_state("attacker-forged-token"))
 		self.assertIsNone(consume_oauth_state(""))
 
 		state = create_oauth_state("/app/some-page")
+		simulate_oauth_browser_roundtrip()
 		self.assertEqual(consume_oauth_state(state), "/app/some-page")
 		# same token can't be redeemed twice
+		self.assertIsNone(consume_oauth_state(state))
+
+	def test_oauth_state_without_binding_cookie_is_rejected(self):
+		"""A `state` that is valid and unused must still be rejected if the request
+		completing the callback doesn't carry the cookie set when the flow started -
+		i.e. it isn't the same browser."""
+		github_social_login_setup()
+
+		state = create_oauth_state("/app/some-page")
+		# NOTE: no simulate_oauth_browser_roundtrip() here - the callback arrives
+		# without the binding cookie, as it would from a browser that never started
+		# this login attempt.
 		self.assertIsNone(consume_oauth_state(state))
 
 	def test_forged_oauth_state_is_rejected_end_to_end(self):
@@ -105,6 +126,7 @@ class TestSocialLoginKey(IntegrationTestCase):
 		mock_session.get.side_effect = github_response_for_login
 
 		state = create_oauth_state("/app/some-legit-page")
+		simulate_oauth_browser_roundtrip()
 
 		with patch.object(OAuth2Service, "get_auth_session", return_value=mock_session):
 			login_via_oauth2("github", "iwriu", state)
@@ -128,8 +150,10 @@ class TestSocialLoginKey(IntegrationTestCase):
 		mock_session = MagicMock()
 		mock_session.get.side_effect = github_response_for_login
 
+		state = create_oauth_state(None)
+		simulate_oauth_browser_roundtrip()
 		with patch.object(OAuth2Service, "get_auth_session", return_value=mock_session):
-			login_via_oauth2("github", "iwriu", create_oauth_state(None))
+			login_via_oauth2("github", "iwriu", state)
 		self.assertEqual(frappe.session.user, "Guest")
 
 	@IntegrationTestCase.change_settings("Website Settings", disable_signup=1)
@@ -142,8 +166,10 @@ class TestSocialLoginKey(IntegrationTestCase):
 		mock_session = MagicMock()
 		mock_session.get.side_effect = github_response_for_login
 
+		state = create_oauth_state(None)
+		simulate_oauth_browser_roundtrip()
 		with patch.object(OAuth2Service, "get_auth_session", return_value=mock_session):
-			login_via_oauth2("github", "iwriu", create_oauth_state(None))
+			login_via_oauth2("github", "iwriu", state)
 
 		self.assertEqual(frappe.session.user, TEST_GITHUB_USER)
 
@@ -453,3 +479,10 @@ def github_social_login_setup():
 	frappe.local.login_manager = LoginManager()
 
 	return create_github_social_login_key()
+
+
+def simulate_oauth_browser_roundtrip():
+	"""Re-issue the current request carrying the binding cookie `create_oauth_state`
+	just set on `frappe.local.cookie_manager`, as a real browser would on callback."""
+	binding_secret = frappe.local.cookie_manager.cookies[OAUTH_LOGIN_BINDING_COOKIE]["value"]
+	set_request(path="/random", headers=[("Cookie", f"{OAUTH_LOGIN_BINDING_COOKIE}={binding_secret}")])

--- a/frappe/integrations/doctype/social_login_key/test_social_login_key.py
+++ b/frappe/integrations/doctype/social_login_key/test_social_login_key.py
@@ -103,6 +103,42 @@ class TestSocialLoginKey(IntegrationTestCase):
 		# this login attempt.
 		self.assertIsNone(consume_oauth_state(state))
 
+	def test_states_survive_a_second_login_render(self):
+		"""Re-rendering /login (a refresh, a second tab) must reuse the binding cookie the
+		browser already holds, or it orphans every state minted by the earlier render."""
+		github_social_login_setup()
+
+		simulate_new_request()
+		first_tab_state = create_oauth_state("/app/first-tab")
+		issued_secret = current_binding_secret()
+
+		# The browser loads /login again, sending the cookie it already holds.
+		simulate_new_request(issued_secret)
+		create_oauth_state("/app/second-tab")
+
+		# Whatever cookie that render left the browser with is what the callback carries.
+		simulate_new_request(current_binding_secret() or issued_secret)
+		self.assertEqual(consume_oauth_state(first_tab_state), "/app/first-tab")
+
+	def test_rejected_callback_leaves_other_pending_states_usable(self):
+		"""A callback that fails binding validation must not retire the browser's cookie,
+		which would take its other in-flight login attempts down with it."""
+		github_social_login_setup()
+
+		simulate_new_request()
+		flow_a = create_oauth_state("/app/flow-a")
+		flow_b = create_oauth_state("/app/flow-b")
+		issued_secret = current_binding_secret()
+
+		# A callback for flow A arrives without the binding cookie, and is rejected.
+		simulate_new_request()
+		self.assertIsNone(consume_oauth_state(flow_a))
+		browser_dropped_cookie = OAUTH_LOGIN_BINDING_COOKIE in frappe.local.cookie_manager.to_delete
+
+		# Flow B is still pending in that same browser and must remain redeemable.
+		simulate_new_request(None if browser_dropped_cookie else issued_secret)
+		self.assertEqual(consume_oauth_state(flow_b), "/app/flow-b")
+
 	def test_forged_oauth_state_is_rejected_end_to_end(self):
 		"""A state value that wasn't issued via create_oauth_state() must not log anyone in
 		or produce a redirect, regardless of what it contains."""
@@ -486,3 +522,17 @@ def simulate_oauth_browser_roundtrip():
 	just set on `frappe.local.cookie_manager`, as a real browser would on callback."""
 	binding_secret = frappe.local.cookie_manager.cookies[OAUTH_LOGIN_BINDING_COOKIE]["value"]
 	set_request(path="/random", headers=[("Cookie", f"{OAUTH_LOGIN_BINDING_COOKIE}={binding_secret}")])
+
+
+def simulate_new_request(binding_secret=None):
+	"""A fresh HTTP request, optionally carrying the binding cookie. Each request gets its
+	own CookieManager, so a cookie set on a previous response is not visible to this one."""
+	headers = [("Cookie", f"{OAUTH_LOGIN_BINDING_COOKIE}={binding_secret}")] if binding_secret else []
+	set_request(path="/random", headers=headers)
+	frappe.local.cookie_manager = CookieManager()
+
+
+def current_binding_secret():
+	"""The binding cookie this request's response would hand back, if any."""
+	cookie = frappe.local.cookie_manager.cookies.get(OAUTH_LOGIN_BINDING_COOKIE)
+	return cookie["value"] if cookie else None

--- a/frappe/utils/oauth.py
+++ b/frappe/utils/oauth.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
+import hashlib
+import hmac
 import json
 from collections.abc import Callable
 from functools import lru_cache
@@ -149,29 +151,76 @@ def get_oauth_keys(provider: str) -> dict[str, str]:
 
 
 OAUTH_LOGIN_FLOW_CACHE_PREFIX = "frappe_oauth_login"
+OAUTH_LOGIN_BINDING_COOKIE = "oauth_login_binding"
+
+
+def _get_or_create_oauth_binding_secret() -> str:
+	"""Return this request's browser-binding secret, minting and cookie-ing it on first use.
+
+	`/login` renders a button per enabled Social Login Key, each calling `create_oauth_state`
+	in the same request. They must all share one secret/cookie - if each call minted and
+	cookied its own, only the last one rendered would actually reach the browser, breaking
+	every other provider's button.
+	"""
+	if existing := frappe.local.cookie_manager.cookies.get(OAUTH_LOGIN_BINDING_COOKIE):
+		return existing["value"]
+
+	binding_secret = frappe.generate_hash(length=32)
+	frappe.local.cookie_manager.set_cookie(
+		OAUTH_LOGIN_BINDING_COOKIE,
+		binding_secret,
+		max_age=600,
+		httponly=True,
+		samesite="Lax",
+	)
+	return binding_secret
 
 
 def create_oauth_state(redirect_to: str | None) -> str:
 	"""Create a single-use token referencing this login attempt's `redirect_to`.
 
-	The returned token is what gets sent to the OAuth provider as `state`.
+	The returned token is what gets sent to the OAuth provider as `state`. This request's
+	browser-binding secret is handed to the browser as an HttpOnly cookie and only its hash
+	is kept server-side, so `consume_oauth_state` can later tell whether the browser
+	completing the callback is the same one that started this login attempt.
 	"""
 	state = frappe.generate_hash(length=32)
-	frappe.cache.set_value(f"{OAUTH_LOGIN_FLOW_CACHE_PREFIX}:{state}", redirect_to or "", expires_in_sec=600)
+	binding_hash = hashlib.sha256(_get_or_create_oauth_binding_secret().encode()).hexdigest()
+
+	frappe.cache.set_value(
+		f"{OAUTH_LOGIN_FLOW_CACHE_PREFIX}:{state}",
+		{"redirect_to": redirect_to or "", "binding_hash": binding_hash},
+		expires_in_sec=600,
+	)
 	return state
 
 
 def consume_oauth_state(state: str) -> str | None:
 	"""Look up and invalidate the redirect_to stored for this login attempt.
 
-	Returns None if `state` doesn't reference a known, unused login attempt.
+	Returns None if `state` doesn't reference a known, unused login attempt, or if the
+	request completing the callback doesn't carry the binding cookie set for it -
+	i.e. it isn't the browser that started this login attempt.
 	"""
 	if not state:
 		return None
 	key = f"{OAUTH_LOGIN_FLOW_CACHE_PREFIX}:{state}"
-	redirect_to = frappe.cache.get_value(key)
+	data = frappe.cache.get_value(key)
 	frappe.cache.delete_value(key)
-	return redirect_to
+	frappe.local.cookie_manager.delete_cookie(OAUTH_LOGIN_BINDING_COOKIE)
+
+	# A state minted before this binding shipped is a plain `redirect_to` string, and can
+	# still be in flight for its 600s lifetime across an upgrade. Treat it as expired
+	# rather than indexing a string and raising.
+	if not isinstance(data, dict):
+		return None
+
+	presented_secret = frappe.local.request.cookies.get(OAUTH_LOGIN_BINDING_COOKIE, "")
+	presented_hash = hashlib.sha256(presented_secret.encode()).hexdigest()
+	if not presented_secret or not hmac.compare_digest(presented_hash, data.get("binding_hash") or ""):
+		return None
+
+	return data.get("redirect_to")
 
 
 def get_oauth2_authorize_url(provider: str, redirect_to: str) -> str:

--- a/frappe/utils/oauth.py
+++ b/frappe/utils/oauth.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import hashlib
 import hmac
 import json
 from collections.abc import Callable
@@ -154,18 +153,7 @@ OAUTH_LOGIN_FLOW_CACHE_PREFIX = "frappe_oauth_login"
 OAUTH_LOGIN_BINDING_COOKIE = "oauth_login_binding"
 
 
-def _get_or_create_oauth_binding_secret() -> str:
-	"""Return this request's browser-binding secret, minting and cookie-ing it on first use.
-
-	`/login` renders a button per enabled Social Login Key, each calling `create_oauth_state`
-	in the same request. They must all share one secret/cookie - if each call minted and
-	cookied its own, only the last one rendered would actually reach the browser, breaking
-	every other provider's button.
-	"""
-	if existing := frappe.local.cookie_manager.cookies.get(OAUTH_LOGIN_BINDING_COOKIE):
-		return existing["value"]
-
-	binding_secret = frappe.generate_hash(length=32)
+def _set_oauth_binding_cookie(binding_secret: str) -> None:
 	frappe.local.cookie_manager.set_cookie(
 		OAUTH_LOGIN_BINDING_COOKIE,
 		binding_secret,
@@ -173,6 +161,30 @@ def _get_or_create_oauth_binding_secret() -> str:
 		httponly=True,
 		samesite="Lax",
 	)
+
+
+def _get_or_create_oauth_binding_secret() -> str:
+	"""Return the browser-binding secret for this login attempt, minting one if needed.
+
+	Reuses an already-issued secret rather than replacing it, so that concurrent login
+	attempts from one browser stay redeemable:
+
+	- one already set earlier in this request: `/login` renders a button per enabled
+	  Social Login Key and each calls `create_oauth_state`, so minting per call would
+	  leave only the last provider's button working;
+	- one the browser already holds: re-rendering `/login` (a refresh, a second tab)
+	  would otherwise orphan the states from the earlier render.
+	"""
+	if pending := frappe.local.cookie_manager.cookies.get(OAUTH_LOGIN_BINDING_COOKIE):
+		return pending["value"]
+
+	if existing := frappe.local.request.cookies.get(OAUTH_LOGIN_BINDING_COOKIE):
+		# Re-set it so the cookie keeps outliving the states minted against it.
+		_set_oauth_binding_cookie(existing)
+		return existing
+
+	binding_secret = frappe.generate_hash(length=32)
+	_set_oauth_binding_cookie(binding_secret)
 	return binding_secret
 
 
@@ -185,7 +197,7 @@ def create_oauth_state(redirect_to: str | None) -> str:
 	completing the callback is the same one that started this login attempt.
 	"""
 	state = frappe.generate_hash(length=32)
-	binding_hash = hashlib.sha256(_get_or_create_oauth_binding_secret().encode()).hexdigest()
+	binding_hash = frappe.utils.sha256_hash(_get_or_create_oauth_binding_secret())
 
 	frappe.cache.set_value(
 		f"{OAUTH_LOGIN_FLOW_CACHE_PREFIX}:{state}",
@@ -207,7 +219,6 @@ def consume_oauth_state(state: str) -> str | None:
 	key = f"{OAUTH_LOGIN_FLOW_CACHE_PREFIX}:{state}"
 	data = frappe.cache.get_value(key)
 	frappe.cache.delete_value(key)
-	frappe.local.cookie_manager.delete_cookie(OAUTH_LOGIN_BINDING_COOKIE)
 
 	# A state minted before this binding shipped is a plain `redirect_to` string, and can
 	# still be in flight for its 600s lifetime across an upgrade. Treat it as expired
@@ -216,9 +227,15 @@ def consume_oauth_state(state: str) -> str | None:
 		return None
 
 	presented_secret = frappe.local.request.cookies.get(OAUTH_LOGIN_BINDING_COOKIE, "")
-	presented_hash = hashlib.sha256(presented_secret.encode()).hexdigest()
-	if not presented_secret or not hmac.compare_digest(presented_hash, data.get("binding_hash") or ""):
+	if not presented_secret or not hmac.compare_digest(
+		frappe.utils.sha256_hash(presented_secret), data.get("binding_hash") or ""
+	):
 		return None
+
+	# Retire the binding only now that this browser is confirmed as the one that started
+	# the attempt. Clearing it any earlier would let a callback that fails validation take
+	# down the browser's other pending login attempts along with it.
+	frappe.local.cookie_manager.delete_cookie(OAUTH_LOGIN_BINDING_COOKIE)
 
 	return data.get("redirect_to")
 

--- a/frappe/utils/oauth.py
+++ b/frappe/utils/oauth.py
@@ -213,6 +213,10 @@ def consume_oauth_state(state: str) -> str | None:
 	Returns None if `state` doesn't reference a known, unused login attempt, or if the
 	request completing the callback doesn't carry the binding cookie set for it -
 	i.e. it isn't the browser that started this login attempt.
+
+	Single use belongs to the state, which is deleted here. The binding cookie is
+	deliberately not: it identifies the browser rather than one attempt, is shared by
+	every attempt that browser has in flight, and expires on its own.
 	"""
 	if not state:
 		return None
@@ -231,11 +235,6 @@ def consume_oauth_state(state: str) -> str | None:
 		frappe.utils.sha256_hash(presented_secret), data.get("binding_hash") or ""
 	):
 		return None
-
-	# Retire the binding only now that this browser is confirmed as the one that started
-	# the attempt. Clearing it any earlier would let a callback that fails validation take
-	# down the browser's other pending login attempts along with it.
-	frappe.local.cookie_manager.delete_cookie(OAUTH_LOGIN_BINDING_COOKIE)
 
 	return data.get("redirect_to")
 


### PR DESCRIPTION
The state token issued for a social login is now tied to the browser that started the flow. `create_oauth_state` hands that browser a short-lived `HttpOnly` cookie and stores only its hash alongside `redirect_to`; `consume_oauth_state` requires the matching cookie before resolving a state.

One secret is minted per request rather than per call, since /login renders a button per enabled Social Login Key and each one calls `create_oauth_state`. Minting a cookie per call would leave only the last provider's button working.

Cache entries written before this change are plain strings and can still be in flight for their 600s lifetime across an upgrade, so a non-dict entry is treated as expired rather than indexed.

>[!IMPORTANT]
Logins where the flow starts and finishes in different browser contexts (an embedded webview handing off to the system browser, or a callback replayed server-side) will now be rejected. Ordinary browser logins are unaffected.