### PR TITLE
fix: allow deleting queued submission documents

### DIFF
--- a/frappe/core/doctype/submission_queue/test_submission_queue.py
+++ b/frappe/core/doctype/submission_queue/test_submission_queue.py
@@ -43,6 +43,8 @@ class TestSubmissionQueue(IntegrationTestCase):
 
 		frappe.db.commit()
 		queue_submission(d, "submit")
+		with self.assertRaises(frappe.LinkExistsError):
+			d.delete()
 		frappe.db.commit()
 
 		# Waiting for execution
@@ -53,6 +55,11 @@ class TestSubmissionQueue(IntegrationTestCase):
 		job = self.queue.fetch_job(submission_queue.job_id)
 		# Test completion
 		self.check_status(job, status="finished")
+
+		d.reload()
+		d.cancel()
+		d.delete()
+		self.assertFalse(frappe.db.exists("Submission Queue", submission_queue.name))
 
 	def test_cancel_operation(self):
 		from frappe.core.doctype.doctype.test_doctype import new_doctype

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -461,6 +461,8 @@ def get_dynamic_linked_docs(doc, method="Delete", limit: int | None = None) -> l
 			# filter before limiting, or irrelevant rows could fill the limit
 			if method == "Delete":
 				query = query.where(RefDoc.docstatus != DocStatus.cancelled())
+				if df.parent == "Submission Queue":
+					query = query.where(RefDoc.status == "Queued")
 			elif method == "Cancel":
 				query = query.where(RefDoc.docstatus == DocStatus.submitted())
 			if limit:
@@ -525,6 +527,10 @@ def raise_link_exists_exception(doc, reference_doctype, reference_docname, row="
 
 
 def delete_dynamic_links(doctype, name):
+	frappe.db.delete(
+		"Submission Queue",
+		{"ref_doctype": doctype, "ref_docname": name, "status": ("in", ("Finished", "Failed"))},
+	)
 	delete_references("ToDo", doctype, name, "reference_type")
 	delete_references("Email Unsubscribe", doctype, name)
 	delete_references("DocShare", doctype, name, "share_doctype", "share_name")


### PR DESCRIPTION
Cancelled documents submitted through the background queue remain blocked by completed Submission Queue records.

This permits deletion only after processing, keeps queued submissions protected, and removes completed queue rows with the deleted document.