### PR TITLE
feat(desk-v2): persist the list's columns, sort and quick filters per person and per site

### DIFF
--- a/frappe/desk/doctype/doctype_view/api.py
+++ b/frappe/desk/doctype/doctype_view/api.py
@@ -1,11 +1,9 @@
 # The three calls a view's settings go through: read both scopes, patch keys, clear one key.
 
-import json
-
 import frappe
 from frappe import _
 
-from .doctype_view import PLAIN_VIEW, SITE_ROW, VIEW_TYPES, is_site_administrator
+from .doctype_view import PLAIN_VIEW, SITE_ROW, VIEW_TYPES, DuplicateViewError, is_site_administrator
 
 SCOPES = ("user", "site")
 
@@ -19,14 +17,13 @@ def get(doctype: str, type: str = "List") -> dict:
 
 
 @frappe.whitelist()
-def save(doctype: str, type: str, scope: str, settings: str | dict) -> dict:
+def save(doctype: str, type: str, scope: str, settings: dict) -> dict:
 	"""Patch the keys given onto one scope's row, creating it, and hand back both scopes."""
 	_check(doctype, type, scope)
-	patch = _as_settings(settings)
+	if not isinstance(settings, dict):
+		frappe.throw(_("The settings of a view are one object."), title=_("Not Settings"))
 
-	address = _address(doctype, type, scope)
-	name, stored = _locked(address)
-	_write(address, name, {**stored, **patch})
+	_apply(_address(doctype, type, scope), lambda stored: {**stored, **settings})
 
 	return _rows(doctype, type)
 
@@ -38,10 +35,7 @@ def reset(doctype: str, type: str, scope: str, key: str) -> dict:
 	if not isinstance(key, str):
 		frappe.throw(_("A settings key is one name."))
 
-	address = _address(doctype, type, scope)
-	name, stored = _locked(address)
-	stored.pop(key, None)
-	_write(address, name, stored)
+	_apply(_address(doctype, type, scope), lambda stored: {k: v for k, v in stored.items() if k != key})
 
 	return _rows(doctype, type)
 
@@ -97,6 +91,16 @@ def _rows(doctype: str, type: str) -> dict:
 	return {"site": by_user.get(SITE_ROW), "user": by_user.get(frappe.session.user)}
 
 
+def _apply(address: dict, change):
+	"""Read, change and write under the row lock; a first write that loses the race to a twin runs again on the twin's row."""
+	frappe.db.savepoint("doctype_view_write")
+	try:
+		_write(address, change)
+	except (frappe.UniqueValidationError, DuplicateViewError):
+		frappe.db.rollback(save_point="doctype_view_write")
+		_write(address, change)
+
+
 def _locked(address: dict) -> tuple[str | None, dict]:
 	"""The row at this address, locked until the write lands so two tabs cannot drop each other's key."""
 	row = frappe.db.get_value("Doctype View", address, ["name", "settings"], as_dict=True, for_update=True)
@@ -110,23 +114,12 @@ def _parsed(settings) -> dict | None:
 	return parsed if isinstance(parsed, dict) else None
 
 
-def _as_settings(settings: str | dict) -> dict:
-	"""The caller's patch, whether the request carried it as an object or as a JSON string."""
-	if isinstance(settings, str):
-		try:
-			settings = json.loads(settings)
-		except ValueError:
-			settings = None
-
-	if not isinstance(settings, dict):
-		frappe.throw(_("The settings of a view are one object."), title=_("Not Settings"))
-
-	return settings
-
-
-def _write(address: dict, existing: str | None, settings: dict):
-	"""Put these settings at this address, and delete the row when there are none."""
+def _write(address: dict, change):
+	"""Put the changed settings at this address, and delete the row when there are none."""
 	# `ignore_permissions`: the gate is `_check`'s; a Desk User has no write on the doctype.
+	existing, stored = _locked(address)
+	settings = change(stored)
+
 	if not settings:
 		if existing:
 			frappe.delete_doc("Doctype View", existing, ignore_permissions=True, delete_permanently=True)

--- a/frappe/desk/doctype/doctype_view/api.py
+++ b/frappe/desk/doctype/doctype_view/api.py
@@ -1,0 +1,141 @@
+# The three calls a view's settings go through: read both scopes, patch keys, clear one key.
+
+import json
+
+import frappe
+from frappe import _
+
+from .doctype_view import PLAIN_VIEW, SITE_ROW, VIEW_TYPES, is_site_administrator
+
+SCOPES = ("user", "site")
+
+
+@frappe.whitelist()
+def get(doctype: str, type: str = "List") -> dict:
+	"""The site row's and the caller's own `settings` for this view, either `None` when absent."""
+	_check(doctype, type)
+
+	return _rows(doctype, type)
+
+
+@frappe.whitelist()
+def save(doctype: str, type: str, scope: str, settings: str | dict) -> dict:
+	"""Patch the keys given onto one scope's row, creating it, and hand back both scopes."""
+	_check(doctype, type, scope)
+	patch = _as_settings(settings)
+
+	address = _address(doctype, type, scope)
+	name, stored = _locked(address)
+	_write(address, name, {**stored, **patch})
+
+	return _rows(doctype, type)
+
+
+@frappe.whitelist()
+def reset(doctype: str, type: str, scope: str, key: str) -> dict:
+	"""Clear one key on one scope's row, deleting the row when nothing is left."""
+	_check(doctype, type, scope)
+	if not isinstance(key, str):
+		frappe.throw(_("A settings key is one name."))
+
+	address = _address(doctype, type, scope)
+	name, stored = _locked(address)
+	stored.pop(key, None)
+	_write(address, name, stored)
+
+	return _rows(doctype, type)
+
+
+def _check(doctype: str, type: str, scope: str = "user"):
+	"""Refuse an argument the caller cannot use, and the site scope for anyone but a System Manager."""
+	# Explicit: `validate_argument_types` only runs in a request, and `doctype` goes into a filter.
+	if not all(isinstance(argument, str) for argument in (doctype, type, scope)):
+		frappe.throw(_("A doctype, a view type and a scope are each one name."))
+
+	if not frappe.db.exists("DocType", doctype):
+		frappe.throw(_("{0} is not a doctype.").format(frappe.bold(doctype)))
+
+	if not frappe.has_permission(doctype, "read"):
+		frappe.throw(_("You are not permitted to read {0}.").format(doctype), frappe.PermissionError)
+
+	if type not in VIEW_TYPES:
+		frappe.throw(_("{0} is not a view type.").format(frappe.bold(type)))
+
+	if scope not in SCOPES:
+		frappe.throw(_("{0} is not a settings scope.").format(scope))
+
+	if scope == "site" and not is_site_administrator():
+		frappe.throw(
+			_("Only a System Manager may change what everyone on this site sees."),
+			frappe.PermissionError,
+		)
+
+
+def _address(doctype: str, type: str, scope: str) -> dict:
+	# No `user` argument anywhere here: the user scope is the session user and nothing else.
+	return {
+		"reference_doctype": doctype,
+		"type": type,
+		"user": frappe.session.user if scope == "user" else SITE_ROW,
+		"label": PLAIN_VIEW,
+	}
+
+
+def _rows(doctype: str, type: str) -> dict:
+	rows = frappe.get_all(
+		"Doctype View",
+		filters={
+			"reference_doctype": doctype,
+			"type": type,
+			"label": PLAIN_VIEW,
+			"user": ("in", (SITE_ROW, frappe.session.user)),
+		},
+		fields=["user", "settings"],
+	)
+	by_user = {row.user: _parsed(row.settings) for row in rows}
+
+	return {"site": by_user.get(SITE_ROW), "user": by_user.get(frappe.session.user)}
+
+
+def _locked(address: dict) -> tuple[str | None, dict]:
+	"""The row at this address, locked until the write lands so two tabs cannot drop each other's key."""
+	row = frappe.db.get_value("Doctype View", address, ["name", "settings"], as_dict=True, for_update=True)
+
+	return (row.name, _parsed(row.settings) or {}) if row else (None, {})
+
+
+def _parsed(settings) -> dict | None:
+	parsed = frappe.parse_json(settings) if settings else None
+
+	return parsed if isinstance(parsed, dict) else None
+
+
+def _as_settings(settings: str | dict) -> dict:
+	"""The caller's patch, whether the request carried it as an object or as a JSON string."""
+	if isinstance(settings, str):
+		try:
+			settings = json.loads(settings)
+		except ValueError:
+			settings = None
+
+	if not isinstance(settings, dict):
+		frappe.throw(_("The settings of a view are one object."), title=_("Not Settings"))
+
+	return settings
+
+
+def _write(address: dict, existing: str | None, settings: dict):
+	"""Put these settings at this address, and delete the row when there are none."""
+	# `ignore_permissions`: the gate is `_check`'s; a Desk User has no write on the doctype.
+	if not settings:
+		if existing:
+			frappe.delete_doc("Doctype View", existing, ignore_permissions=True, delete_permanently=True)
+		return
+
+	doc = (
+		frappe.get_doc("Doctype View", existing)
+		if existing
+		else frappe.get_doc({"doctype": "Doctype View", **address})
+	)
+	doc.settings = settings
+	doc.save(ignore_permissions=True)

--- a/frappe/desk/doctype/doctype_view/doctype_view.json
+++ b/frappe/desk/doctype/doctype_view/doctype_view.json
@@ -1,0 +1,96 @@
+{
+ "actions": [],
+ "autoname": "hash",
+ "creation": "2026-09-10 10:00:00.000000",
+ "description": "One view of one doctype: the site's or one person's, holding whatever shape the view type needs.",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "reference_doctype",
+  "type",
+  "user",
+  "label",
+  "settings_section",
+  "settings"
+ ],
+ "fields": [
+  {
+   "description": "The doctype this is a view of.",
+   "fieldname": "reference_doctype",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Doctype",
+   "options": "DocType",
+   "reqd": 1
+  },
+  {
+   "default": "List",
+   "description": "The view type that owns the settings: List for the plain list.",
+   "fieldname": "type",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Type",
+   "reqd": 1
+  },
+  {
+   "description": "Whose view this is. Blank means the site's, which a System Manager sets for everyone.",
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "User",
+   "not_nullable": 1,
+   "options": "User"
+  },
+  {
+   "description": "Blank for the doctype's plain view of this type; a saved view carries its name here.",
+   "fieldname": "label",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Label",
+   "not_nullable": 1
+  },
+  {
+   "fieldname": "settings_section",
+   "fieldtype": "Section Break",
+   "label": "Settings"
+  },
+  {
+   "description": "The view's whole shape as one object; what is inside it is the view type's to check.",
+   "fieldname": "settings",
+   "fieldtype": "JSON",
+   "label": "Settings"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-09-10 10:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Desk",
+ "name": "Doctype View",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "read": 1,
+   "role": "Desk User"
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/frappe/desk/doctype/doctype_view/doctype_view.py
+++ b/frappe/desk/doctype/doctype_view/doctype_view.py
@@ -19,6 +19,10 @@ VIEW_TYPES = ("List",)
 SETTINGS_SIZE_LIMIT = 16 * 1024
 
 
+class DuplicateViewError(frappe.ValidationError):
+	pass
+
+
 class DoctypeView(Document):
 	"""One view of one doctype at one scope; `settings` is the view type's own shape."""
 
@@ -78,6 +82,7 @@ class DoctypeView(Document):
 					frappe.bold(self.reference_doctype), self.type, frappe.bold(existing)
 				),
 				title=_("Already Exists"),
+				exc=DuplicateViewError,
 			)
 
 	def address(self) -> dict:

--- a/frappe/desk/doctype/doctype_view/doctype_view.py
+++ b/frappe/desk/doctype/doctype_view/doctype_view.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2026, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+import json
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+
+# Blank, not `None`: every `NULL` is distinct to the unique index, so a nullable column
+# would let one doctype hold two site rows for one view.
+SITE_ROW = ""
+PLAIN_VIEW = ""
+
+# The types the desk renders; an app's own type arrives with the views map, not here.
+VIEW_TYPES = ("List",)
+
+# Bytes of stored JSON; a list's columns, sort and quick filters fit in well under one.
+SETTINGS_SIZE_LIMIT = 16 * 1024
+
+
+class DoctypeView(Document):
+	"""One view of one doctype at one scope; `settings` is the view type's own shape."""
+
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		label: DF.Data
+		reference_doctype: DF.Link
+		settings: DF.JSON | None
+		type: DF.Data
+		user: DF.Link
+	# end: auto-generated types
+
+	def validate(self):
+		self.user = self.user or SITE_ROW
+		self.label = self.label or PLAIN_VIEW
+		self.validate_type()
+		self.validate_settings()
+		self.refuse_a_second_row_at_this_address()
+
+	def validate_type(self):
+		if self.type not in VIEW_TYPES:
+			frappe.throw(
+				_("{0} is not a view type.").format(frappe.bold(self.type)), title=_("Unknown View Type")
+			)
+
+	def validate_settings(self):
+		"""One JSON object under the size cap; what is inside it is the view type's to check."""
+		stored = self.settings if isinstance(self.settings, str) else json.dumps(self.settings or {})
+
+		if len(stored.encode()) > SETTINGS_SIZE_LIMIT:
+			frappe.throw(
+				_("The settings of this view are larger than {0} KB.").format(SETTINGS_SIZE_LIMIT // 1024),
+				title=_("Settings Too Large"),
+			)
+
+		try:
+			parsed = frappe.parse_json(stored)
+		except ValueError:
+			parsed = None
+
+		if not isinstance(parsed, dict):
+			frappe.throw(_("The settings of a view are one object."), title=_("Not Settings"))
+
+	def refuse_a_second_row_at_this_address(self):
+		"""Refuse the duplicate here: `db_insert` would read the unique index's refusal as a hash retry."""
+		existing = frappe.db.get_value(self.doctype, self.address())
+
+		if existing and existing != self.name:
+			frappe.throw(
+				_("{0} already has a {1} view at this address. Edit {2} instead.").format(
+					frappe.bold(self.reference_doctype), self.type, frappe.bold(existing)
+				),
+				title=_("Already Exists"),
+			)
+
+	def address(self) -> dict:
+		return {
+			"reference_doctype": self.reference_doctype,
+			"type": self.type,
+			"user": self.user,
+			"label": self.label,
+		}
+
+
+def on_doctype_update():
+	"""One row per address, held by the schema so a bulk write cannot bypass it."""
+	frappe.db.add_unique(
+		"Doctype View",
+		("reference_doctype", "type", "user", "label"),
+		constraint_name="unique_view_address",
+	)
+
+
+def is_site_administrator(user: str | None = None) -> bool:
+	user = user or frappe.session.user
+
+	return user == "Administrator" or "System Manager" in frappe.get_roles(user)
+
+
+def has_permission(doc, ptype="read", user=None, debug=False):
+	"""A System Manager may see every row; everyone else the site's rows and their own."""
+	user = user or frappe.session.user
+	if is_site_administrator(user):
+		return True
+
+	if ptype == "read":
+		return doc.user in (SITE_ROW, user)
+
+	return bool(doc.user) and doc.user == user
+
+
+def get_permission_query_conditions(user=None):
+	"""The list-query half of `has_permission`: reports, the API and export go through this."""
+	user = user or frappe.session.user
+	if is_site_administrator(user):
+		return None
+
+	return frappe.qb.DocType("Doctype View").user.isin([SITE_ROW, user])

--- a/frappe/desk/doctype/doctype_view/test_doctype_view.py
+++ b/frappe/desk/doctype/doctype_view/test_doctype_view.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2026, Frappe Technologies and Contributors
+# License: MIT. See LICENSE
+
+import frappe
+from frappe.desk.doctype.doctype_view.api import get, reset, save
+from frappe.exceptions import FrappeTypeError
+from frappe.tests import IntegrationTestCase
+from frappe.tests.classes.context_managers import set_user
+
+# A doctype every Desk User reads, and one only a System Manager reads.
+DOCTYPE = "Note"
+PRIVATE_DOCTYPE = "System Settings"
+
+PERSON = "test_view_person@example.com"
+OTHER = "test_view_other@example.com"
+MANAGER = "test_view_manager@example.com"
+
+
+def a_person(email: str, role: str = "Desk User") -> str:
+	if not frappe.db.exists("User", email):
+		frappe.get_doc(
+			doctype="User",
+			email=email,
+			first_name="Viewer",
+			user_type="System User",
+			roles=[{"role": role}],
+		).insert(ignore_permissions=True)
+
+	return email
+
+
+def make_view(**kwargs):
+	return frappe.get_doc({"doctype": "Doctype View", "reference_doctype": DOCTYPE, "type": "List", **kwargs})
+
+
+class DoctypeViewTestCase(IntegrationTestCase):
+	def setUp(self):
+		super().setUp()
+		# The class rolls back once, so each test starts from no rows of its own.
+		frappe.db.delete("Doctype View", {"reference_doctype": DOCTYPE})
+		self.person = a_person(PERSON)
+		self.other = a_person(OTHER)
+		self.manager = a_person(MANAGER, role="System Manager")
+
+
+class TestDoctypeView(DoctypeViewTestCase):
+	def test_a_blank_user_and_label_are_stored_as_blank(self):
+		doc = make_view(settings={"sort": []}).insert()
+
+		self.assertEqual(frappe.db.get_value("Doctype View", doc.name, ["user", "label"]), ("", ""))
+
+	def test_a_second_row_at_one_address_is_refused_cleanly(self):
+		make_view(settings={}).insert()
+
+		self.assertRaisesRegex(
+			frappe.ValidationError, "already has a List view", make_view(settings={}).insert
+		)
+
+	def test_an_unknown_type_is_refused(self):
+		self.assertRaisesRegex(frappe.ValidationError, "not a view type", make_view(type="Kanban").insert)
+
+	def test_settings_are_one_object(self):
+		self.assertRaisesRegex(frappe.ValidationError, "one object", make_view(settings=["columns"]).insert)
+
+	def test_settings_are_capped(self):
+		self.assertRaisesRegex(
+			frappe.ValidationError, "larger than", make_view(settings={"note": "x" * 20_000}).insert
+		)
+
+	def test_settings_that_are_not_json_are_refused(self):
+		self.assertRaisesRegex(frappe.ValidationError, "one object", make_view(settings="not json").insert)
+
+	def test_the_document_gate_lets_a_person_read_the_site_row_and_write_only_their_own(self):
+		site = make_view(settings={}).insert()
+		own = make_view(user=self.person, settings={}).insert()
+		other = make_view(user=self.other, settings={}).insert()
+
+		self.assertTrue(frappe.has_permission("Doctype View", "read", site, user=self.person))
+		self.assertTrue(frappe.has_permission("Doctype View", "read", own, user=self.person))
+		self.assertFalse(frappe.has_permission("Doctype View", "read", other, user=self.person))
+		self.assertFalse(frappe.has_permission("Doctype View", "write", site, user=self.person))
+		self.assertTrue(frappe.has_permission("Doctype View", "read", other, user=self.manager))
+
+	def test_a_person_reads_the_site_row_and_their_own_and_nothing_else(self):
+		make_view(settings={}).insert()
+		make_view(user=self.person, settings={}).insert()
+		make_view(user=self.other, settings={}).insert()
+
+		with set_user(self.person):
+			seen = frappe.get_list("Doctype View", filters={"reference_doctype": DOCTYPE}, pluck="user")
+
+		self.assertEqual(sorted(seen), ["", self.person])
+
+
+class TestApi(DoctypeViewTestCase):
+	def test_nothing_stored_reads_as_two_absences(self):
+		with set_user(self.person):
+			self.assertEqual(get(DOCTYPE), {"site": None, "user": None})
+
+	def test_a_save_patches_keys_on_the_caller_s_own_row(self):
+		with set_user(self.person):
+			save(DOCTYPE, "List", "user", {"columns": [{"fieldname": "title"}]})
+			rows = save(DOCTYPE, "List", "user", {"sort": [{"fieldname": "title", "direction": "asc"}]})
+
+		self.assertEqual(
+			rows["user"],
+			{"columns": [{"fieldname": "title"}], "sort": [{"fieldname": "title", "direction": "asc"}]},
+		)
+		self.assertIsNone(rows["site"])
+		self.assertEqual(
+			frappe.db.get_value("Doctype View", {"reference_doctype": DOCTYPE}, "user"), self.person
+		)
+
+	def test_a_save_takes_the_patch_as_a_json_string_too(self):
+		with set_user(self.person):
+			rows = save(DOCTYPE, "List", "user", '{"quick_filter_fields": ["title"]}')
+
+		self.assertEqual(rows["user"], {"quick_filter_fields": ["title"]})
+
+	def test_a_reset_clears_one_key_and_drops_an_empty_row(self):
+		with set_user(self.person):
+			save(DOCTYPE, "List", "user", {"columns": [], "sort": []})
+			rows = reset(DOCTYPE, "List", "user", "columns")
+			self.assertEqual(rows["user"], {"sort": []})
+
+			rows = reset(DOCTYPE, "List", "user", "sort")
+
+		self.assertIsNone(rows["user"])
+		self.assertFalse(frappe.db.exists("Doctype View", {"reference_doctype": DOCTYPE}))
+
+	def test_the_site_scope_needs_a_system_manager(self):
+		with set_user(self.person):
+			self.assertRaises(frappe.PermissionError, save, DOCTYPE, "List", "site", {"sort": []})
+
+		with set_user(self.manager):
+			rows = save(DOCTYPE, "List", "site", {"sort": []})
+
+		self.assertEqual(rows["site"], {"sort": []})
+		self.assertEqual(frappe.db.get_value("Doctype View", {"reference_doctype": DOCTYPE}, "user"), "")
+
+	def test_everyone_reads_the_site_row_beside_their_own(self):
+		with set_user(self.manager):
+			save(DOCTYPE, "List", "site", {"sort": []})
+
+		with set_user(self.person):
+			save(DOCTYPE, "List", "user", {"columns": []})
+			self.assertEqual(get(DOCTYPE), {"site": {"sort": []}, "user": {"columns": []}})
+
+		with set_user(self.other):
+			self.assertEqual(get(DOCTYPE), {"site": {"sort": []}, "user": None})
+
+	def test_a_doctype_the_caller_cannot_read_is_refused(self):
+		with set_user(self.person):
+			self.assertRaises(frappe.PermissionError, get, PRIVATE_DOCTYPE)
+
+	def test_a_bad_argument_is_refused_before_anything_is_read(self):
+		with set_user(self.person):
+			self.assertRaises(frappe.ValidationError, get, "No Such Doctype")
+			self.assertRaises(frappe.ValidationError, get, DOCTYPE, "Kanban")
+			self.assertRaises(frappe.ValidationError, save, DOCTYPE, "List", "everyone", {})
+			self.assertRaises(frappe.ValidationError, save, DOCTYPE, "List", "user", "not json")
+			self.assertRaises(FrappeTypeError, save, DOCTYPE, "List", "user", ["a list"])
+			self.assertRaises(FrappeTypeError, reset, DOCTYPE, "List", "user", ["a list"])

--- a/frappe/desk/doctype/doctype_view/test_doctype_view.py
+++ b/frappe/desk/doctype/doctype_view/test_doctype_view.py
@@ -1,7 +1,10 @@
 # Copyright (c) 2026, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 
+from unittest.mock import patch
+
 import frappe
+from frappe.desk.doctype.doctype_view import api
 from frappe.desk.doctype.doctype_view.api import get, reset, save
 from frappe.exceptions import FrappeTypeError
 from frappe.tests import IntegrationTestCase
@@ -111,11 +114,22 @@ class TestApi(DoctypeViewTestCase):
 			frappe.db.get_value("Doctype View", {"reference_doctype": DOCTYPE}, "user"), self.person
 		)
 
-	def test_a_save_takes_the_patch_as_a_json_string_too(self):
-		with set_user(self.person):
-			rows = save(DOCTYPE, "List", "user", '{"quick_filter_fields": ["title"]}')
+	def test_a_first_save_that_loses_the_race_lands_on_the_twin_s_row(self):
+		"""Two first saves can both see no row; the loser's insert hits the index and runs again."""
+		real = api._locked
+		reads = []
 
-		self.assertEqual(rows["user"], {"quick_filter_fields": ["title"]})
+		def racing(address):
+			reads.append(address)
+			return (None, {}) if len(reads) == 1 else real(address)
+
+		with set_user(self.person):
+			save(DOCTYPE, "List", "user", {"columns": []})
+			with patch.object(api, "_locked", side_effect=racing):
+				rows = save(DOCTYPE, "List", "user", {"sort": []})
+
+		self.assertEqual(len(reads), 2)
+		self.assertEqual(rows["user"], {"columns": [], "sort": []})
 
 	def test_a_reset_clears_one_key_and_drops_an_empty_row(self):
 		with set_user(self.person):
@@ -158,6 +172,6 @@ class TestApi(DoctypeViewTestCase):
 			self.assertRaises(frappe.ValidationError, get, "No Such Doctype")
 			self.assertRaises(frappe.ValidationError, get, DOCTYPE, "Kanban")
 			self.assertRaises(frappe.ValidationError, save, DOCTYPE, "List", "everyone", {})
-			self.assertRaises(frappe.ValidationError, save, DOCTYPE, "List", "user", "not json")
+			self.assertRaises(FrappeTypeError, save, DOCTYPE, "List", "user", "not json")
 			self.assertRaises(FrappeTypeError, save, DOCTYPE, "List", "user", ["a list"])
 			self.assertRaises(FrappeTypeError, reset, DOCTYPE, "List", "user", ["a list"])

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -157,6 +157,7 @@ permission_query_conditions = {
 	"Custom Sidebar": "frappe.desk.doctype.custom_sidebar.custom_sidebar.get_permission_query_conditions",
 	"Dock": "frappe.desk.doctype.dock.dock.get_permission_query_conditions",
 	"Rail": "frappe.desk.doctype.rail.rail.get_permission_query_conditions",
+	"Doctype View": "frappe.desk.doctype.doctype_view.doctype_view.get_permission_query_conditions",
 	"Sidebar": "frappe.desk.doctype.sidebar.sidebar.get_permission_query_conditions",
 	"DocType": "frappe.app_state.get_module_permission_query_conditions",
 	"Page": "frappe.app_state.get_module_permission_query_conditions",
@@ -195,6 +196,7 @@ has_permission = {
 	"Custom Sidebar": "frappe.desk.doctype.custom_sidebar.custom_sidebar.has_permission",
 	"Dock": "frappe.desk.doctype.dock.dock.has_permission",
 	"Rail": "frappe.desk.doctype.rail.rail.has_permission",
+	"Doctype View": "frappe.desk.doctype.doctype_view.doctype_view.has_permission",
 	"Sidebar": "frappe.desk.doctype.sidebar.sidebar.has_permission",
 }
 

--- a/frontend/src/list/storedSettings.ts
+++ b/frontend/src/list/storedSettings.ts
@@ -1,0 +1,98 @@
+// The list's stored shape, fieldnames only, and its conversion to what the controls hold. Labels
+// come from meta, and a fieldname meta no longer has, or the person cannot read, is dropped.
+import { getColumnAlign, getColumnOptions, type Column } from "@framework/ui/ColumnSettings";
+import type { ListColumn } from "@framework/ui/experimental/List";
+import { getFilterableFields, type FilterField } from "@framework/ui/Filter";
+import type { RawMetaField } from "@framework/ui/FormLayout";
+import { getSortOptions, type Sort } from "@framework/ui/SortBy";
+
+export interface StoredColumn {
+	fieldname: string;
+	width?: string;
+}
+
+/** One row's `settings`; every key is optional and a missing one inherits from the tier below. */
+export interface ListSettings {
+	columns?: StoredColumn[];
+	sort?: Sort[];
+	quick_filter_fields?: string[];
+}
+
+export type ListSettingsKey = keyof ListSettings;
+
+/** Whether the person may read this fieldname; a standard field names no meta field and passes. */
+export type Readable = (fieldname: string) => boolean;
+
+export function columnsFrom(
+	stored: unknown,
+	fields: RawMetaField[],
+	readable: Readable
+): ListColumn[] {
+	const options = new Map(getColumnOptions(fields).map((option) => [option.fieldname, option]));
+	const columns: ListColumn[] = [];
+	for (const entry of asList(stored)) {
+		const fieldname = fieldnameOf(entry);
+		const option = fieldname && options.get(fieldname);
+		if (!option || !readable(fieldname) || columns.some((c) => c.fieldname === fieldname)) continue;
+		const column: ListColumn = { fieldname, label: option.label, align: alignOf(fieldname, fields) };
+		const width = (entry as StoredColumn).width;
+		if (typeof width === "string" && width) column.width = width;
+		columns.push(column);
+	}
+	return columns;
+}
+
+export function sortFrom(stored: unknown, fields: RawMetaField[], readable: Readable): Sort[] {
+	const sortable = new Set(getSortOptions(fields).map((option) => option.fieldname));
+	const sort: Sort[] = [];
+	for (const entry of asList(stored)) {
+		const fieldname = fieldnameOf(entry);
+		const direction = (entry as Sort).direction;
+		if (!fieldname || !sortable.has(fieldname) || !readable(fieldname)) continue;
+		if (direction !== "asc" && direction !== "desc") continue;
+		sort.push({ fieldname, direction });
+	}
+	return sort;
+}
+
+export function quickFilterFieldsFrom(
+	stored: unknown,
+	doctype: string,
+	fields: RawMetaField[],
+	readable: Readable
+): FilterField[] {
+	const filterable = new Map(
+		getFilterableFields(fields, doctype).map((field) => [field.fieldname, field])
+	);
+	const chosen: FilterField[] = [];
+	for (const fieldname of asList(stored)) {
+		if (typeof fieldname !== "string") continue;
+		const field = filterable.get(fieldname);
+		if (!field || !readable(fieldname) || chosen.includes(field)) continue;
+		chosen.push(field);
+	}
+	return chosen;
+}
+
+/** Width travels; the label does not, since meta names the column at read time. */
+export function toStoredColumns(columns: Column[]): StoredColumn[] {
+	return columns.map(({ fieldname, width }) => (width ? { fieldname, width } : { fieldname }));
+}
+
+export function toStoredQuickFilterFields(fields: FilterField[]): string[] {
+	return fields.map((field) => field.fieldname);
+}
+
+function asList(value: unknown): unknown[] {
+	return Array.isArray(value) ? value : [];
+}
+
+function fieldnameOf(entry: unknown): string | null {
+	const fieldname = (entry as { fieldname?: unknown } | null)?.fieldname;
+	return typeof fieldname === "string" && fieldname ? fieldname : null;
+}
+
+function alignOf(fieldname: string, fields: RawMetaField[]): "left" | "right" {
+	const fieldtype = fields.find((field) => field.fieldname === fieldname)?.fieldtype;
+	return getColumnAlign(fieldtype ?? "Data");
+}

--- a/frontend/src/list/tests/storedSettings.test.ts
+++ b/frontend/src/list/tests/storedSettings.test.ts
@@ -1,0 +1,78 @@
+// The stored shape as claims: what a row's JSON becomes on the page, and what the page stores.
+import { describe, expect, it } from "vitest";
+import {
+	columnsFrom,
+	quickFilterFieldsFrom,
+	sortFrom,
+	toStoredColumns,
+	toStoredQuickFilterFields,
+} from "../storedSettings";
+
+const FIELDS = [
+	{ fieldname: "title", label: "Title", fieldtype: "Data" },
+	{ fieldname: "amount", label: "Amount", fieldtype: "Currency" },
+	{ fieldname: "secret", label: "Secret", fieldtype: "Data", permlevel: 1 },
+	{ fieldname: "notes_section", label: "Notes", fieldtype: "Section Break" },
+];
+
+const readable = (fieldname: string) => fieldname !== "secret";
+
+describe("columnsFrom", () => {
+	it("names each column from meta and keeps a stored width", () => {
+		const columns = columnsFrom([{ fieldname: "amount", width: "120px" }, { fieldname: "title" }], FIELDS, readable);
+		expect(columns).toEqual([
+			{ fieldname: "amount", label: "Amount", align: "right", width: "120px" },
+			{ fieldname: "title", label: "Title", align: "left" },
+		]);
+	});
+
+	it("keeps a standard field and drops what meta lacks, the person cannot read, a break, and a repeat", () => {
+		const stored = [
+			{ fieldname: "modified" },
+			{ fieldname: "gone" },
+			{ fieldname: "secret" },
+			{ fieldname: "notes_section" },
+			{ fieldname: "title" },
+			{ fieldname: "title" },
+		];
+		expect(columnsFrom(stored, FIELDS, readable).map((c) => c.fieldname)).toEqual(["modified", "title"]);
+	});
+
+	it("reads a shape that is not a list of columns as nothing", () => {
+		expect(columnsFrom("title", FIELDS, readable)).toEqual([]);
+		expect(columnsFrom([{ width: "1px" }, null, 3], FIELDS, readable)).toEqual([]);
+	});
+});
+
+describe("sortFrom", () => {
+	it("keeps a sortable field with a direction and drops the rest", () => {
+		const stored = [
+			{ fieldname: "amount", direction: "desc" },
+			{ fieldname: "secret", direction: "asc" },
+			{ fieldname: "title", direction: "up" },
+			{ fieldname: "creation", direction: "asc" },
+		];
+		expect(sortFrom(stored, FIELDS, readable)).toEqual([
+			{ fieldname: "amount", direction: "desc" },
+			{ fieldname: "creation", direction: "asc" },
+		]);
+	});
+});
+
+describe("quickFilterFieldsFrom", () => {
+	it("resolves fieldnames to the filterable fields, in the stored order", () => {
+		const fields = quickFilterFieldsFrom(["amount", "name", "secret", "gone", "amount"], "Lead", FIELDS, readable);
+		expect(fields.map((field) => field.fieldname)).toEqual(["amount", "name"]);
+		expect(fields[1]).toMatchObject({ fieldtype: "Link", options: "Lead" });
+	});
+});
+
+describe("the stored form", () => {
+	it("keeps fieldname and width and drops the label", () => {
+		expect(toStoredColumns([{ fieldname: "title", label: "Mine", width: "90px" }, { fieldname: "amount", label: "Amount" }])).toEqual([
+			{ fieldname: "title", width: "90px" },
+			{ fieldname: "amount" },
+		]);
+		expect(toStoredQuickFilterFields([{ fieldname: "title", value: "title", label: "Title", fieldtype: "Data" }])).toEqual(["title"]);
+	});
+});

--- a/frontend/src/list/tests/useListPage.test.ts
+++ b/frontend/src/list/tests/useListPage.test.ts
@@ -8,6 +8,7 @@ const fake = vi.hoisted(() => ({
 	meta: null as Record<string, unknown> | null,
 	contributed: [] as { columns?: { fieldname: string; width?: number }[] }[],
 	lists: [] as any[],
+	tiers: { site: null, user: null } as { site: unknown; user: unknown },
 	useList: vi.fn(),
 	call: vi.fn(),
 	remove: vi.fn(),
@@ -17,8 +18,9 @@ vi.mock("frappe-ui", async (importOriginal) => ({
 	...(await importOriginal<object>()),
 	call: fake.call,
 	useList: fake.useList,
-	createResource: () => ({
+	createResource: ({ url }: { url: string }) => ({
 		get data() {
+			if (url.endsWith("get_current_user_roles")) return ["Desk User"];
 			return fake.meta && { docs: [fake.meta] };
 		},
 		loading: false,
@@ -35,8 +37,12 @@ import { Addresses } from "@/addresses";
 import type { Boot } from "@/boot";
 import { registerShell } from "@/router/routeFor";
 import { resetDoctypeMeta } from "@framework/ui/composables/useDoctypeMeta";
+import { resetUserRoles } from "@framework/ui/composables/useUserRoles";
 import { forgetRows, readListMemory, recallRows, writeListMemory } from "../pageState";
 import { useListPage, type ListPage } from "../useListPage";
+import { resetListSettings, useListSettings } from "../useListSettings";
+
+const SETTINGS_API = "frappe.desk.doctype.doctype_view.api";
 
 const FIELDS = [
 	{ fieldname: "title", label: "Title", fieldtype: "Data", in_list_view: 1 },
@@ -100,6 +106,25 @@ async function settle() {
 	}
 }
 
+/** The count answers 42; a settings call answers the tiers, a write patched in. */
+function answer(method: string, args: Record<string, any>) {
+	if (method === "frappe.client.get_count") return Promise.resolve(42);
+	if (method.endsWith(".save")) {
+		const row = (fake.tiers[args.scope as "site" | "user"] ?? {}) as Record<string, unknown>;
+		fake.tiers = { ...fake.tiers, [args.scope]: { ...row, ...args.settings } };
+	}
+	if (method.endsWith(".reset")) {
+		const row = { ...(fake.tiers[args.scope as "site" | "user"] as Record<string, unknown>) };
+		delete row[args.key];
+		fake.tiers = { ...fake.tiers, [args.scope]: Object.keys(row).length ? row : null };
+	}
+	return Promise.resolve(fake.tiers);
+}
+
+function writes() {
+	return fake.call.mock.calls.filter(([method]) => method.startsWith(SETTINGS_API) && !method.endsWith(".get"));
+}
+
 /** A changed query waits out the typing debounce before it builds a list. */
 async function settleQuery() {
 	await new Promise((resolve) => setTimeout(resolve, 350));
@@ -108,13 +133,16 @@ async function settleQuery() {
 
 beforeEach(() => {
 	resetDoctypeMeta();
+	resetUserRoles();
+	resetListSettings();
 	forgetRows("Lead");
 	history.replaceState(null, "");
 	fake.meta = { name: "Lead", title_field: "title", sort_field: "amount", sort_order: "ASC", fields: FIELDS };
 	fake.contributed = [];
 	fake.lists = [];
+	fake.tiers = { site: null, user: null };
 	fake.useList.mockReset().mockImplementation(fakeList);
-	fake.call.mockReset().mockResolvedValue(42);
+	fake.call.mockReset().mockImplementation(answer);
 	fake.remove.mockReset().mockResolvedValue("ok");
 });
 
@@ -157,6 +185,121 @@ describe("seeding", () => {
 		expect(fake.call).toHaveBeenCalledWith("frappe.client.get_count", { doctype: "Lead", filters: {}, limit: 1001 });
 		expect(page.totalCount.value).toBe(42);
 		expect(page.hasCounts.value).toBe(true);
+	});
+});
+
+describe("the tiers", () => {
+	it("fetches the rows beside meta and seeds the person's columns over the site's sort", async () => {
+		fake.tiers = {
+			site: { columns: [{ fieldname: "amount" }], sort: [{ fieldname: "title", direction: "desc" }] },
+			user: { columns: [{ fieldname: "status", width: "80px" }, { fieldname: "title" }] },
+		};
+		await mount("/lead");
+		expect(fake.call).toHaveBeenCalledWith(`${SETTINGS_API}.get`, { doctype: "Lead", type: "List" });
+		expect(page.columns.value).toEqual([
+			{ fieldname: "status", label: "Status", align: "left", width: "80px" },
+			{ fieldname: "title", label: "Title", align: "left" },
+		]);
+		expect(page.sort.value).toEqual([{ fieldname: "title", direction: "desc" }]);
+		expect(page.columnsCustomized.value).toBe(true);
+		await settle();
+		expect(router.currentRoute.value.query).toEqual({});
+		expect(fake.useList.mock.calls[0][0]).toMatchObject({ fields: ["name", "status", "title"], orderBy: "title desc" });
+	});
+
+	it("drops a stored fieldname meta lacks or the person cannot read, and falls back when none is left", async () => {
+		fake.meta!.fields = [...FIELDS, { fieldname: "secret", label: "Secret", fieldtype: "Data", permlevel: 1 }];
+		fake.meta!.permissions = [{ role: "System Manager", permlevel: 1, read: 1 }];
+		fake.tiers = { site: null, user: { columns: [{ fieldname: "secret" }, { fieldname: "gone" }], sort: [{ fieldname: "secret", direction: "asc" }] } };
+		await mount("/lead");
+		expect(page.columns.value.map((c) => c.fieldname)).toEqual(["title", "status", "amount"]);
+		expect(page.sort.value).toEqual([{ fieldname: "amount", direction: "asc" }]);
+	});
+
+	it("writes the person's column change after the debounce, without labels, and not a rename alone", async () => {
+		await mount("/lead");
+		await settle();
+		page.columns.value = page.columns.value.map((c) => (c.fieldname === "title" ? { ...c, label: "Mine" } : c));
+		await settle();
+		expect(writes()).toEqual([]);
+		page.resizeColumn("status", "70px");
+		await settle();
+		expect(writes()).toEqual([]);
+		await useListSettings("Lead").flush();
+		expect(writes()).toEqual([
+			[`${SETTINGS_API}.save`, { doctype: "Lead", type: "List", scope: "user", settings: { columns: [{ fieldname: "title" }, { fieldname: "status", width: "70px" }, { fieldname: "amount" }] } }],
+		]);
+		expect(page.columnsCustomized.value).toBe(true);
+	});
+
+	it("never writes a filter or a page size", async () => {
+		await mount("/lead");
+		await settle();
+		page.filters.value = [{ fieldname: "status", operator: "equals", value: "Open" } as never];
+		page.pageSize.value = 100;
+		await settleQuery();
+		await useListSettings("Lead").flush();
+		expect(writes()).toEqual([]);
+	});
+
+	it("drops _sort from the URL once the person's sort has landed as their default", async () => {
+		await mount("/lead");
+		await settle();
+		page.sort.value = [{ fieldname: "status", direction: "desc" }];
+		await settle();
+		expect(router.currentRoute.value.query).toEqual({ _sort: "status desc" });
+		await useListSettings("Lead").flush();
+		await settle();
+		expect(router.currentRoute.value.query).toEqual({});
+		expect(page.sort.value).toEqual([{ fieldname: "status", direction: "desc" }]);
+	});
+
+	it("writes the person's sort and never one the URL carried in", async () => {
+		await mount("/lead?_sort=status%20desc");
+		await settle();
+		await router.replace({ query: { _sort: "title asc" } });
+		await settle();
+		expect(page.sort.value).toEqual([{ fieldname: "title", direction: "asc" }]);
+		await useListSettings("Lead").flush();
+		expect(writes()).toEqual([]);
+		page.sort.value = [{ fieldname: "amount", direction: "desc" }];
+		await settle();
+		await useListSettings("Lead").flush();
+		expect(writes()[0][1]).toMatchObject({ scope: "user", settings: { sort: [{ fieldname: "amount", direction: "desc" }] } });
+	});
+
+	it("writes the quick filter's fields when customizing ends, not while it runs", async () => {
+		await mount("/lead");
+		await settle();
+		page.customizing.value = true;
+		page.quickFilterFields.value = [{ fieldname: "status", value: "status", label: "Status", fieldtype: "Select" }];
+		await settle();
+		await useListSettings("Lead").flush();
+		expect(writes()).toEqual([]);
+		page.customizing.value = false;
+		await settle();
+		await useListSettings("Lead").flush();
+		expect(writes()[0][1]).toMatchObject({ settings: { quick_filter_fields: ["status"] } });
+	});
+
+	it("resets the person's columns to the site's, and a site act reaches the page too", async () => {
+		fake.tiers = { site: { columns: [{ fieldname: "amount" }] }, user: { columns: [{ fieldname: "status" }] } };
+		await mount("/lead");
+		await settle();
+		page.filters.value = [{ fieldname: "status", operator: "equals", value: "" } as never];
+		await settle();
+		await page.resetColumns();
+		expect(page.filters.value).toHaveLength(1);
+		expect(writes()[0]).toEqual([`${SETTINGS_API}.reset`, { doctype: "Lead", type: "List", scope: "user", key: "columns" }]);
+		expect(page.columns.value.map((c) => c.fieldname)).toEqual(["amount"]);
+		expect(page.columnsCustomized.value).toBe(false);
+		await page.saveForSite({ sort: [{ fieldname: "status", direction: "asc" }] });
+		expect(writes()[1][1]).toMatchObject({ scope: "site", settings: { sort: [{ fieldname: "status", direction: "asc" }] } });
+		expect(page.sort.value).toEqual([{ fieldname: "status", direction: "asc" }]);
+		await page.resetForSite("columns");
+		expect(page.columns.value.map((c) => c.fieldname)).toEqual(["title", "status", "amount"]);
+		await useListSettings("Lead").flush();
+		expect(writes()).toHaveLength(3);
 	});
 });
 

--- a/frontend/src/list/tests/useListSettings.test.ts
+++ b/frontend/src/list/tests/useListSettings.test.ts
@@ -1,0 +1,122 @@
+// The settings composable as claims: one fetch per doctype, the layering, the debounced write, and
+// the reset. frappe-ui's `call` is faked; the debounce runs on fake timers.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
+
+const fake = vi.hoisted(() => ({ call: vi.fn() }));
+
+vi.mock("frappe-ui", async (importOriginal) => ({
+	...(await importOriginal<object>()),
+	call: fake.call,
+}));
+
+import { resetListSettings, useListSettings, WRITE_DEBOUNCE_MS } from "../useListSettings";
+
+const API = "frappe.desk.doctype.doctype_view.api";
+const ADDRESS = { doctype: "Lead", type: "List" };
+
+let tiers: { site: unknown; user: unknown };
+
+function respond(method: string, args: { settings?: Record<string, unknown>; key?: string; scope?: string }) {
+	if (method.endsWith(".save")) {
+		const row = (tiers[args.scope as "site" | "user"] ?? {}) as Record<string, unknown>;
+		tiers = { ...tiers, [args.scope!]: { ...row, ...args.settings } };
+	}
+	if (method.endsWith(".reset")) {
+		const row = { ...(tiers[args.scope as "site" | "user"] as Record<string, unknown>) };
+		delete row[args.key!];
+		tiers = { ...tiers, [args.scope!]: Object.keys(row).length ? row : null };
+	}
+	return Promise.resolve(tiers);
+}
+
+async function settle() {
+	for (let turn = 0; turn < 3; turn++) {
+		await Promise.resolve();
+		await nextTick();
+	}
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	resetListSettings();
+	tiers = { site: { sort: [{ fieldname: "title", direction: "asc" }] }, user: null };
+	fake.call.mockReset().mockImplementation(respond);
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("reading", () => {
+	it("fetches once per doctype and layers the person's row over the site's", async () => {
+		const first = useListSettings("Lead");
+		const second = useListSettings("Lead");
+		expect(first.loaded.value).toBe(false);
+		await settle();
+		expect(fake.call).toHaveBeenCalledTimes(1);
+		expect(fake.call).toHaveBeenCalledWith(`${API}.get`, ADDRESS);
+		expect(second.loaded.value).toBe(true);
+		expect(second.stored.value).toEqual({ sort: [{ fieldname: "title", direction: "asc" }] });
+		expect(first.has("site", "sort")).toBe(true);
+		expect(first.has("user", "sort")).toBe(false);
+	});
+
+	it("reads a failed fetch as no rows, and is still loaded", async () => {
+		fake.call.mockRejectedValue(new Error("down"));
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const handle = useListSettings("Lead");
+		await settle();
+		expect(handle.loaded.value).toBe(true);
+		expect(handle.stored.value).toEqual({});
+		warn.mockRestore();
+	});
+});
+
+describe("writing", () => {
+	it("joins patches inside the window into one write and takes the response as the rows", async () => {
+		const handle = useListSettings("Lead");
+		await settle();
+		handle.save({ columns: [{ fieldname: "title" }] });
+		handle.save({ sort: [] });
+		expect(handle.has("user", "columns")).toBe(true);
+		expect(fake.call).toHaveBeenCalledTimes(1);
+		vi.advanceTimersByTime(WRITE_DEBOUNCE_MS);
+		await settle();
+		expect(fake.call).toHaveBeenCalledTimes(2);
+		expect(fake.call).toHaveBeenLastCalledWith(`${API}.save`, {
+			...ADDRESS,
+			scope: "user",
+			settings: { columns: [{ fieldname: "title" }], sort: [] },
+		});
+		expect(handle.stored.value).toEqual({ columns: [{ fieldname: "title" }], sort: [] });
+	});
+
+	it("sends a waiting write before a reset, and the reset drops the key from the person's row", async () => {
+		const handle = useListSettings("Lead");
+		await settle();
+		handle.save({ columns: [{ fieldname: "title" }], quick_filter_fields: ["name"] });
+		await handle.reset("columns");
+		expect(fake.call.mock.calls.map(([method]) => method.split(".").pop())).toEqual(["get", "save", "reset"]);
+		expect(fake.call).toHaveBeenLastCalledWith(`${API}.reset`, { ...ADDRESS, scope: "user", key: "columns" });
+		expect(handle.has("user", "columns")).toBe(false);
+		expect(handle.stored.value).toEqual({
+			sort: [{ fieldname: "title", direction: "asc" }],
+			quick_filter_fields: ["name"],
+		});
+	});
+
+	it("writes the site scope at once, by name", async () => {
+		const handle = useListSettings("Lead");
+		await settle();
+		await handle.saveForSite({ columns: [{ fieldname: "amount" }] });
+		expect(fake.call).toHaveBeenLastCalledWith(`${API}.save`, {
+			...ADDRESS,
+			scope: "site",
+			settings: { columns: [{ fieldname: "amount" }] },
+		});
+		await handle.resetForSite("sort");
+		expect(fake.call).toHaveBeenLastCalledWith(`${API}.reset`, { ...ADDRESS, scope: "site", key: "sort" });
+		expect(handle.stored.value).toEqual({ columns: [{ fieldname: "amount" }] });
+	});
+});

--- a/frontend/src/list/tests/useListSettings.test.ts
+++ b/frontend/src/list/tests/useListSettings.test.ts
@@ -125,6 +125,27 @@ describe("writing", () => {
 		warn.mockRestore();
 	});
 
+	it("does not bring back a key the person reset while its failed write was in flight", async () => {
+		const handle = useListSettings("Lead");
+		await settle();
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		fake.call.mockRejectedValueOnce(new Error("down"));
+		handle.save({ columns: [{ fieldname: "title" }], sort: [] });
+		const failing = handle.flush();
+		const resetting = handle.reset("columns");
+		await Promise.all([failing, resetting]);
+		expect(handle.has("user", "columns")).toBe(false);
+		expect(handle.has("user", "sort")).toBe(true);
+		handle.save({ quick_filter_fields: [] });
+		await handle.flush();
+		expect(fake.call).toHaveBeenLastCalledWith(`${API}.save`, {
+			...ADDRESS,
+			scope: "user",
+			settings: { sort: [], quick_filter_fields: [] },
+		});
+		warn.mockRestore();
+	});
+
 	it("writes the site scope at once, by name", async () => {
 		const handle = useListSettings("Lead");
 		await settle();

--- a/frontend/src/list/tests/useListSettings.test.ts
+++ b/frontend/src/list/tests/useListSettings.test.ts
@@ -106,6 +106,25 @@ describe("writing", () => {
 		});
 	});
 
+	it("keeps a patch whose write failed for the next flush", async () => {
+		const handle = useListSettings("Lead");
+		await settle();
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		fake.call.mockRejectedValueOnce(new Error("down"));
+		handle.save({ columns: [{ fieldname: "title" }] });
+		await handle.flush();
+		expect(handle.stored.value).toEqual({ sort: [{ fieldname: "title", direction: "asc" }] });
+		expect(handle.has("user", "columns")).toBe(true);
+		handle.save({ sort: [] });
+		await handle.flush();
+		expect(fake.call).toHaveBeenLastCalledWith(`${API}.save`, {
+			...ADDRESS,
+			scope: "user",
+			settings: { columns: [{ fieldname: "title" }], sort: [] },
+		});
+		warn.mockRestore();
+	});
+
 	it("writes the site scope at once, by name", async () => {
 		const handle = useListSettings("Lead");
 		await settle();

--- a/frontend/src/list/useListPage.ts
+++ b/frontend/src/list/useListPage.ts
@@ -1,6 +1,7 @@
-// One doctype's list: the state the controls edit, seeded from meta and a contributed `list.js`,
-// with filters and sort mirrored to the URL query. Every act is a model or a plain function.
+// One doctype's list: the state the controls edit, seeded from the app default under the site's
+// and the person's stored rows, mirrored to the URL query, and written back on the person's acts.
 import { useDoctypeMeta } from "@framework/ui/composables/useDoctypeMeta";
+import { useDocPermissions } from "@framework/ui/composables/useDocPermissions";
 import { applyColumnWidth, clearColumnWidth } from "@framework/ui/ColumnSettings";
 import type { ListColumn } from "@framework/ui/experimental/List";
 import { serializeFilters, type FilterCondition, type FilterField } from "@framework/ui/Filter";
@@ -12,7 +13,17 @@ import { routeFor } from "@/router/routeFor";
 import { defaultColumns, defaultSort, fetchFields, sameSort, type ListMeta } from "./defaults";
 import { readListMemory, recallRows, rememberRows, writeListMemory } from "./pageState";
 import { addressFromQuery, completeFilters, ownedKeys, queryFromAddress, sameQuery } from "./query";
+import {
+	columnsFrom,
+	quickFilterFieldsFrom,
+	sortFrom,
+	toStoredColumns,
+	toStoredQuickFilterFields,
+	type ListSettings,
+	type ListSettingsKey,
+} from "./storedSettings";
 import { useListRows, type ListRow, type ListRows } from "./useListRows";
+import { useListSettings } from "./useListSettings";
 
 export interface DeleteOutcome {
 	deleted: string[];
@@ -22,10 +33,11 @@ export interface DeleteOutcome {
 export interface ListPage extends ListRows {
 	/** Written to the URL query. */
 	filters: Ref<FilterCondition[]>;
-	/** Written to the URL query; the header click edits the same list. */
+	/** Written to the URL query and, on the person's own change, to their row. */
 	sort: Ref<Sort[]>;
-	/** In memory for the visit. */
+	/** Written to the person's row. */
 	columns: Ref<ListColumn[]>;
+	/** Written to the person's row when customizing ends. */
 	quickFilterFields: Ref<FilterField[] | undefined>;
 	customizing: Ref<boolean>;
 	selection: Ref<string[]>;
@@ -34,10 +46,15 @@ export interface ListPage extends ListRows {
 	/** The filters and sort the rows belong to, as one string: the session memory's key. */
 	rowsKey: () => string;
 	metaError: ComputedRef<string | null>;
+	/** True when the person's own row holds columns. */
 	columnsCustomized: ComputedRef<boolean>;
-	resetColumns: () => void;
+	/** Clears the person's columns, so the site's or the app's show. */
+	resetColumns: () => Promise<void>;
 	resizeColumn: (fieldname: string, width: string) => void;
 	resetColumnWidth: (fieldname: string) => void;
+	/** The site's defaults, which everyone without their own inherits; a System Manager's act. */
+	saveForSite: (settings: ListSettings) => Promise<void>;
+	resetForSite: (key: ListSettingsKey) => Promise<void>;
 	rowLink: (row: ListRow) => RouteLocationRaw;
 	/** Deletes the selection one row at a time; the page confirms first. */
 	deleteSelection: () => Promise<DeleteOutcome>;
@@ -47,6 +64,8 @@ export function useListPage(doctype: string): ListPage {
 	const route = useRoute();
 	const router = useRouter();
 	const { meta, error } = useDoctypeMeta(doctype);
+	const permissions = useDocPermissions(doctype);
+	const settings = useListSettings(doctype);
 	const listMeta = computed(() => meta.value as ListMeta | null);
 	const fields = computed(() => listMeta.value?.fields ?? []);
 	const contributed = listHandlersFor(doctype).map(({ handlers }) => handlers);
@@ -59,27 +78,75 @@ export function useListPage(doctype: string): ListPage {
 	const selection = ref<string[]>([]);
 	const pageSize = ref(readListMemory().pageSize ?? 20);
 	const seeded = ref(false);
+	// What the page last set itself, per key: a change that matches it is not the person's act.
+	const applied: Partial<Record<ListSettingsKey, string>> = {};
 	// Set once meta lands: the rows an earlier visit to this query showed, by Back or a breadcrumb.
 	let remembered: ReturnType<typeof recallRows>;
 
+	const ready = computed(
+		() => Boolean(listMeta.value) && settings.loaded.value && !permissions.loading.value
+	);
+
+	const readable = (fieldname: string) => {
+		const field = fields.value.find((one) => one.fieldname === fieldname);
+		return !field || permissions.fieldAccess(field) !== "none";
+	};
+
+	const defaults = computed(() =>
+		listMeta.value ? defaultColumns(listMeta.value, contributed) : []
+	);
+
+	/** The columns the tiers resolve to: the person's, else the site's, else the app default. */
+	function resolvedColumns(): ListColumn[] {
+		const stored = columnsFrom(settings.stored.value.columns, fields.value, readable);
+		return stored.length ? stored : defaults.value;
+	}
+
+	function resolvedSort(): Sort[] {
+		const stored = sortFrom(settings.stored.value.sort, fields.value, readable);
+		return stored.length ? stored : defaultSort(listMeta.value!);
+	}
+
+	function resolvedQuickFilterFields(): FilterField[] | undefined {
+		const stored = settings.stored.value.quick_filter_fields;
+		if (!stored) return undefined;
+		return quickFilterFieldsFrom(stored, doctype, fields.value, readable);
+	}
+
+	function applyStored() {
+		columns.value = resolvedColumns();
+		applied.columns = JSON.stringify(toStoredColumns(columns.value));
+		quickFilterFields.value = resolvedQuickFilterFields();
+		applied.quick_filter_fields = JSON.stringify(
+			quickFilterFields.value && toStoredQuickFilterFields(quickFilterFields.value)
+		);
+	}
+
+	function readQuery(value: ListMeta) {
+		const address = addressFromQuery(route.query, doctype, value.fields ?? []);
+		filters.value = address.filters ?? [];
+		readSort();
+	}
+
+	/** After a row changed under the page: the sort follows, a filter still being typed stays. */
+	function readSort() {
+		const address = addressFromQuery(route.query, doctype, fields.value);
+		sort.value = address.sort ?? resolvedSort();
+		applied.sort = JSON.stringify(sort.value);
+	}
+
 	watch(
-		listMeta,
+		ready,
 		(value) => {
 			if (!value || seeded.value) return;
-			columns.value = defaultColumns(value, contributed);
-			readQuery(value);
+			applyStored();
+			readQuery(listMeta.value!);
 			remembered = recallRows(doctype, stateKey());
 			if (remembered && readListMemory().pageSize == null) pageSize.value = remembered.pageSize;
 			seeded.value = true;
 		},
 		{ immediate: true }
 	);
-
-	function readQuery(value: ListMeta) {
-		const address = addressFromQuery(route.query, doctype, value.fields ?? []);
-		filters.value = address.filters ?? [];
-		sort.value = address.sort ?? defaultSort(value);
-	}
 
 	// Only a query the page did not write itself is read back: Back, Forward, a pasted link.
 	watch(
@@ -89,26 +156,43 @@ export function useListPage(doctype: string): ListPage {
 		}
 	);
 
-	// A replace, so the tweak is not a step Back has to undo.
-	watch([filters, sort], writeQuery, { deep: true });
+	// A replace, so the tweak is not a step Back has to undo. A landed write moves the resolved
+	// sort, so the URL is spelled again and a `_sort` that became the default goes.
+	watch([filters, sort, settings.stored], writeQuery, { deep: true });
 
 	function writeQuery() {
 		if (!seeded.value || sameQuery(route.query, stateQuery())) return;
 		router.replace({ query: stateQuery(), hash: route.hash }).catch(() => {});
 	}
 
-	/** The query the state spells: foreign keys kept, the default sort left unwritten. */
+	/** The query the state spells: foreign keys kept, the resolved sort left unwritten. */
 	function stateQuery() {
 		const owned = ownedKeys(doctype, fields.value);
 		const kept = Object.fromEntries(
 			Object.entries(route.query).filter(([key]) => !owned.has(key))
 		);
-		const written = sameSort(sort.value, defaultSort(listMeta.value!)) ? [] : sort.value;
+		const written = sameSort(sort.value, resolvedSort()) ? [] : sort.value;
 		return { ...kept, ...queryFromAddress({ filters: filters.value, sort: written }) };
 	}
 
 	function stateKey() {
 		return JSON.stringify(queryFromAddress({ filters: filters.value, sort: sort.value }));
+	}
+
+	// The person's own acts write; a value the page set itself, from a row or the URL, does not.
+	watch(columns, (value) => persist("columns", toStoredColumns(value)), { deep: true });
+	watch(sort, (value) => persist("sort", value), { deep: true });
+	watch(customizing, (now, before) => {
+		if (before && !now && quickFilterFields.value) {
+			persist("quick_filter_fields", toStoredQuickFilterFields(quickFilterFields.value));
+		}
+	});
+
+	function persist<Key extends ListSettingsKey>(key: Key, value: ListSettings[Key]) {
+		const json = JSON.stringify(value);
+		if (!seeded.value || applied[key] === json) return;
+		applied[key] = json;
+		settings.save({ [key]: value });
 	}
 
 	const rows = useListRows(doctype, () => {
@@ -117,7 +201,7 @@ export function useListPage(doctype: string): ListPage {
 			key: stateKey(),
 			fields: fetchFields(columns.value),
 			filters: filtersDict(filters.value),
-			orderBy: serializeOrderBy(sort.value.length ? sort.value : defaultSort(listMeta.value!)),
+			orderBy: serializeOrderBy(sort.value.length ? sort.value : resolvedSort()),
 			limit: pageSize.value,
 			restore: remembered?.shown,
 		};
@@ -141,10 +225,6 @@ export function useListPage(doctype: string): ListPage {
 		const present = new Set(current.map((row) => row.name));
 		selection.value = selection.value.filter((name) => present.has(name));
 	});
-
-	const defaults = computed(() =>
-		listMeta.value ? defaultColumns(listMeta.value, contributed) : []
-	);
 
 	async function deleteSelection(): Promise<DeleteOutcome> {
 		const outcome: DeleteOutcome = { deleted: [], failed: [] };
@@ -172,14 +252,26 @@ export function useListPage(doctype: string): ListPage {
 		pageSize,
 		rowsKey,
 		metaError: computed(() => (error.value ? messageOf(error.value) : null)),
-		columnsCustomized: computed(
-			() => JSON.stringify(columns.value) !== JSON.stringify(defaults.value)
-		),
-		resetColumns: () => (columns.value = defaults.value),
+		columnsCustomized: computed(() => settings.has("user", "columns")),
+		resetColumns: async () => {
+			await settings.reset("columns");
+			applyStored();
+			readSort();
+		},
 		resizeColumn: (fieldname, width) =>
 			(columns.value = applyColumnWidth(columns.value, fieldname, width) as ListColumn[]),
 		resetColumnWidth: (fieldname) =>
 			(columns.value = clearColumnWidth(columns.value, fieldname) as ListColumn[]),
+		saveForSite: async (value) => {
+			await settings.saveForSite(value);
+			applyStored();
+			readSort();
+		},
+		resetForSite: async (key) => {
+			await settings.resetForSite(key);
+			applyStored();
+			readSort();
+		},
 		rowLink: (row) => routeFor(doctype, row.name),
 		deleteSelection,
 	};

--- a/frontend/src/list/useListSettings.ts
+++ b/frontend/src/list/useListSettings.ts
@@ -1,0 +1,143 @@
+// One doctype's stored list settings: the site row and the person's own, fetched once per session
+// beside meta, and written back silently. A write's response replaces both rows.
+import { call } from "frappe-ui";
+import { computed, getCurrentScope, onScopeDispose, ref, type ComputedRef, type Ref } from "vue";
+import type { ListSettings, ListSettingsKey } from "./storedSettings";
+
+const API = "frappe.desk.doctype.doctype_view.api";
+export const VIEW_TYPE = "List";
+/** Column edits in the popover come in bursts; one write carries the burst. */
+export const WRITE_DEBOUNCE_MS = 500;
+
+export type Scope = "user" | "site";
+
+export interface ListSettingsHandle {
+	loaded: ComputedRef<boolean>;
+	/** The site row under the person's own, key by key. */
+	stored: ComputedRef<ListSettings>;
+	has: (scope: Scope, key: ListSettingsKey) => boolean;
+	/** Debounced; a later patch in the window joins the same write. */
+	save: (patch: ListSettings) => void;
+	reset: (key: ListSettingsKey) => Promise<void>;
+	saveForSite: (patch: ListSettings) => Promise<void>;
+	resetForSite: (key: ListSettingsKey) => Promise<void>;
+	/** Sends a waiting write now. */
+	flush: () => Promise<void>;
+}
+
+interface Tiers {
+	site: ListSettings | null;
+	user: ListSettings | null;
+}
+
+interface Entry {
+	tiers: Ref<Tiers>;
+	loaded: Ref<boolean>;
+	pending: ListSettings | null;
+	timer: ReturnType<typeof setTimeout> | null;
+	/** Writes go out one after another, so a late response cannot overwrite a later one. */
+	queue: Promise<void>;
+}
+
+const entries = new Map<string, Entry>();
+
+export function useListSettings(doctype: string): ListSettingsHandle {
+	const entry = entryFor(doctype);
+	const address = { doctype, type: VIEW_TYPE };
+
+	function flush(): Promise<void> {
+		const patch = entry.pending;
+		entry.pending = null;
+		if (entry.timer) clearTimeout(entry.timer);
+		entry.timer = null;
+		if (!patch) return entry.queue;
+		return write(entry, () => call(`${API}.save`, { ...address, scope: "user", settings: patch }));
+	}
+
+	function save(patch: ListSettings) {
+		entry.pending = { ...entry.pending, ...patch };
+		if (entry.timer) clearTimeout(entry.timer);
+		entry.timer = setTimeout(flush, WRITE_DEBOUNCE_MS);
+	}
+
+	async function reset(key: ListSettingsKey) {
+		if (entry.pending) delete entry.pending[key];
+		await flush();
+		await write(entry, () => call(`${API}.reset`, { ...address, scope: "user", key }));
+	}
+
+	async function saveForSite(patch: ListSettings) {
+		await write(entry, () => call(`${API}.save`, { ...address, scope: "site", settings: patch }));
+	}
+
+	async function resetForSite(key: ListSettingsKey) {
+		await write(entry, () => call(`${API}.reset`, { ...address, scope: "site", key }));
+	}
+
+	if (getCurrentScope()) onScopeDispose(() => void flush());
+
+	return {
+		loaded: computed(() => entry.loaded.value),
+		stored: computed(() => ({ ...entry.tiers.value.site, ...entry.tiers.value.user })),
+		has: (scope, key) => {
+			if (scope === "user" && entry.pending && key in entry.pending) return true;
+			const row = entry.tiers.value[scope];
+			return row != null && key in row;
+		},
+		save,
+		reset,
+		saveForSite,
+		resetForSite,
+		flush,
+	};
+}
+
+/** Drops every fetched row, so one test's settings cannot reach the next. */
+export function resetListSettings(): void {
+	for (const entry of entries.values()) if (entry.timer) clearTimeout(entry.timer);
+	entries.clear();
+}
+
+function entryFor(doctype: string): Entry {
+	const existing = entries.get(doctype);
+	if (existing) return existing;
+	const entry: Entry = {
+		tiers: ref({ site: null, user: null }),
+		loaded: ref(false),
+		pending: null,
+		timer: null,
+		queue: Promise.resolve(),
+	};
+	entries.set(doctype, entry);
+	load(entry, doctype);
+	return entry;
+}
+
+async function load(entry: Entry, doctype: string) {
+	try {
+		entry.tiers.value = tiersOf(await call(`${API}.get`, { doctype, type: VIEW_TYPE }));
+	} catch (failure) {
+		console.warn(`[list] settings for ${doctype} did not load`, failure);
+	}
+	entry.loaded.value = true;
+}
+
+function write(entry: Entry, send: () => Promise<unknown>): Promise<void> {
+	entry.queue = entry.queue.then(async () => {
+		try {
+			entry.tiers.value = tiersOf(await send());
+		} catch (failure) {
+			console.warn("[list] settings were not saved", failure);
+		}
+	});
+	return entry.queue;
+}
+
+function tiersOf(response: unknown): Tiers {
+	const rows = (response ?? {}) as { site?: unknown; user?: unknown };
+	return { site: settingsOf(rows.site), user: settingsOf(rows.user) };
+}
+
+function settingsOf(value: unknown): ListSettings | null {
+	return typeof value === "object" && value && !Array.isArray(value) ? (value as ListSettings) : null;
+}

--- a/frontend/src/list/useListSettings.ts
+++ b/frontend/src/list/useListSettings.ts
@@ -51,7 +51,7 @@ export function useListSettings(doctype: string): ListSettingsHandle {
 		if (entry.timer) clearTimeout(entry.timer);
 		entry.timer = null;
 		if (!patch) return entry.queue;
-		return write(entry, () => call(`${API}.save`, { ...address, scope: "user", settings: patch }));
+		return write(entry, () => call(`${API}.save`, { ...address, scope: "user", settings: patch }), patch);
 	}
 
 	function save(patch: ListSettings) {
@@ -122,11 +122,13 @@ async function load(entry: Entry, doctype: string) {
 	entry.loaded.value = true;
 }
 
-function write(entry: Entry, send: () => Promise<unknown>): Promise<void> {
+/** A patch that fails waits for the next flush, under whatever was saved since. */
+function write(entry: Entry, send: () => Promise<unknown>, patch?: ListSettings): Promise<void> {
 	entry.queue = entry.queue.then(async () => {
 		try {
 			entry.tiers.value = tiersOf(await send());
 		} catch (failure) {
+			if (patch) entry.pending = { ...patch, ...entry.pending };
 			console.warn("[list] settings were not saved", failure);
 		}
 	});

--- a/frontend/src/list/useListSettings.ts
+++ b/frontend/src/list/useListSettings.ts
@@ -34,6 +34,8 @@ interface Entry {
 	tiers: Ref<Tiers>;
 	loaded: Ref<boolean>;
 	pending: ListSettings | null;
+	/** How many times each key was reset; a failed patch comes back only for keys reset no further. */
+	resets: Partial<Record<ListSettingsKey, number>>;
 	timer: ReturnType<typeof setTimeout> | null;
 	/** Writes go out one after another, so a late response cannot overwrite a later one. */
 	queue: Promise<void>;
@@ -51,7 +53,10 @@ export function useListSettings(doctype: string): ListSettingsHandle {
 		if (entry.timer) clearTimeout(entry.timer);
 		entry.timer = null;
 		if (!patch) return entry.queue;
-		return write(entry, () => call(`${API}.save`, { ...address, scope: "user", settings: patch }), patch);
+		const marks = { ...entry.resets };
+		return write(entry, () => call(`${API}.save`, { ...address, scope: "user", settings: patch }), () =>
+			restore(entry, patch, marks)
+		);
 	}
 
 	function save(patch: ListSettings) {
@@ -62,6 +67,7 @@ export function useListSettings(doctype: string): ListSettingsHandle {
 
 	async function reset(key: ListSettingsKey) {
 		if (entry.pending) delete entry.pending[key];
+		entry.resets[key] = (entry.resets[key] ?? 0) + 1;
 		await flush();
 		await write(entry, () => call(`${API}.reset`, { ...address, scope: "user", key }));
 	}
@@ -105,6 +111,7 @@ function entryFor(doctype: string): Entry {
 		tiers: ref({ site: null, user: null }),
 		loaded: ref(false),
 		pending: null,
+		resets: {},
 		timer: null,
 		queue: Promise.resolve(),
 	};
@@ -122,17 +129,25 @@ async function load(entry: Entry, doctype: string) {
 	entry.loaded.value = true;
 }
 
-/** A patch that fails waits for the next flush, under whatever was saved since. */
-function write(entry: Entry, send: () => Promise<unknown>, patch?: ListSettings): Promise<void> {
+function write(entry: Entry, send: () => Promise<unknown>, onFailure?: () => void): Promise<void> {
 	entry.queue = entry.queue.then(async () => {
 		try {
 			entry.tiers.value = tiersOf(await send());
 		} catch (failure) {
-			if (patch) entry.pending = { ...patch, ...entry.pending };
+			onFailure?.();
 			console.warn("[list] settings were not saved", failure);
 		}
 	});
 	return entry.queue;
+}
+
+/** A patch that failed waits for the next flush, under whatever was saved since, minus any key reset since. */
+function restore(entry: Entry, patch: ListSettings, marks: Entry["resets"]) {
+	const kept: ListSettings = {};
+	for (const key of Object.keys(patch) as ListSettingsKey[]) {
+		if ((entry.resets[key] ?? 0) === (marks[key] ?? 0)) Object.assign(kept, { [key]: patch[key] });
+	}
+	entry.pending = { ...kept, ...entry.pending };
 }
 
 function tiersOf(response: unknown): Tiers {


### PR DESCRIPTION
Builds the list's three tiers on `desk-v2`. Ticket: the build ticket on the shell-and-list map, "Build: Doctype View and the list's three tiers" (#42700), opened by the three-tiers grilling (#42657), whose sixteen rulings this follows.

## What a person gets

Customize the columns, the sort or the quick filter's fields on a list, and they are there on the next visit. A System Manager can set a site default for a list through two named acts, and everyone without their own row inherits it.

| Before any act | After removing a column and sorting by Status | After a reload |
| --- | --- | --- |
| ![before](https://raw.githubusercontent.com/shariquerik/frappe/assets/doctype-view-42700/walk-before.png) | ![after acts](https://raw.githubusercontent.com/shariquerik/frappe/assets/doctype-view-42700/walk-after-acts.png) | ![after reload](https://raw.githubusercontent.com/shariquerik/frappe/assets/doctype-view-42700/walk-after-reload.png) |

After the reload the URL carries no `_sort`: the person's stored sort is now their default.

## Server

- **`Doctype View`** (module Desk): `reference_doctype`, `type`, `user`, `label`, one `settings` JSON. `autoname: hash`, a unique index on the four identity fields, and a guard in `validate` so a duplicate is a clean error. The server never reads inside `settings`: it checks that it is one object under 16 KB.
- **Three methods** in the doctype's `api.py`: `get(doctype, type)` returns `{site, user}`; `save(doctype, type, scope, settings)` patches keys; `reset(doctype, type, scope, key)` clears one key and deletes an empty row. The user scope is always the session user. The site scope needs a System Manager. Anyone must be able to read the doctype the view is of.
- **Permissions** as `Rail`: System Manager full, Desk User read; the `has_permission` hook lets a person read the site row and their own, and write only their own.

## Desk

- **`useListSettings`** (`frontend/src/list/`): one `get` per doctype per session, fetched beside meta; a shallow key merge of the site row under the user row; debounced (500 ms) silent writes on the person's own acts, serialized so a late response cannot overwrite a later one; a pending write is sent on unmount.
- **`storedSettings`**: the stored shape is fieldnames only. Labels come from meta at read time. A fieldname meta lacks, or the person cannot read by permlevel, is dropped.
- **`useListPage`** seeds columns, sort and quick-filter fields from the tiers; writes only on the person's acts, never for a value the page set itself from a row or the URL; the quick filter writes when customizing ends; `_sort` appears in the URL only off the resolved tier sort; `resetColumns` clears the person's `columns` key; `saveForSite` and `resetForSite` are the site scope's named acts.

Filters and page size do not persist, as ruled.

## Tests

- 16 Python tests: the controller's guards, the three methods, the scopes, the permission hooks.
- 19 new frontend tests across the two modules and the page composable; the frontend suite is 568 green.

>no-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
