### PR TITLE
fix: JS error triggered on btn_disabled_enabled

### DIFF
--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -844,7 +844,7 @@ frappe.ui.Page = class Page {
 		// .prop("disabled") pokes from outside still work (es-button styles
 		// :disabled) — this only changes what the page does on its own.
 		const busy = (on) => (on ? btn.attr("aria-busy", "true") : btn.removeAttr("aria-busy"));
-		if (response && response.then) {
+		if (response && response.finally) {
 			busy(true);
 			response.finally(() => busy(false));
 		} else if (response && response.always) {


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

An JS error is triggred on create payment form customer (Frappe version-16 ERPNext version-16)


If it's harmless most of the case it does not allow custom JS script to be executed on the load pages

> Explain the **details** for making this change. What existing problem does the pull request solve?

In the JS page.js the test is done on 
`response && response.then`
instead of 
`response && response.finally`

> Screenshots/GIFs

<img width="1856" height="751" alt="image" src="https://github.com/user-attachments/assets/e1b17330-b32a-4d7a-a873-22361dda4c55" />


Note to the reveiwer:
If this PR is merge please backport to version-16