### PR TITLE
fix(ui): composer spinner placement and seeded recipient labels

### DIFF
--- a/ui/src/components/Composer/ComposerEditor.vue
+++ b/ui/src/components/Composer/ComposerEditor.vue
@@ -148,11 +148,14 @@
 							</div>
 							<div class="flex shrink-0 items-center gap-2">
 								<Button v-if="!isEmpty" label="Discard" @click="reset" />
+								<!-- The spinner trails the label; Button's own `loading` would lead it. -->
 								<Button
 									variant="solid"
 									:label="submitLabel"
 									:disabled="isDisabled"
-									:loading="submitting"
+									:icon-right="submitting ? Spinner : undefined"
+									:class="{ 'pointer-events-none': submitting }"
+									:aria-busy="submitting || undefined"
 									@click="submit"
 								/>
 							</div>
@@ -167,7 +170,7 @@
 <script setup lang="ts">
 import { computed, nextTick, ref, useTemplateRef, watch } from "vue";
 import { useScroll } from "@vueuse/core";
-import { Button, toast } from "frappe-ui";
+import { Button, Spinner, toast } from "frappe-ui";
 import LucideFile from "~icons/lucide/file";
 import LucideFileArchive from "~icons/lucide/file-archive";
 import LucideFileAudio from "~icons/lucide/file-audio";

--- a/ui/src/components/Composer/EmailComposer/RecipientSelect.vue
+++ b/ui/src/components/Composer/EmailComposer/RecipientSelect.vue
@@ -60,13 +60,19 @@ const emails = computed<string[]>({
 	},
 });
 
-const options = computed<MultiEmailOption[]>(() =>
-	searchResults.value.map((recipient) => ({
+// Model recipients go in too: MultiEmailInput learns a chip's details from
+// options, so one seeded with a label is known before any search runs.
+const options = computed<MultiEmailOption[]>(() => {
+	const byEmail = new Map<string, Recipient>();
+	for (const recipient of [...searchResults.value, ...model.value]) {
+		if (!byEmail.has(recipient.email)) byEmail.set(recipient.email, recipient);
+	}
+	return [...byEmail.values()].map((recipient) => ({
 		label: recipient.label || recipient.email,
 		value: recipient.email,
 		image: recipient.image,
-	}))
-);
+	}));
+});
 
 // null until the user searches, so the composer doesn't fetch on mount.
 const query = ref<string | null>(null);


### PR DESCRIPTION
Two composer commits pushed to #42696 after it was merged, rebased onto develop.

## Changes

| | Before | After |
|---|---|---|
| Submit button while `submitting` | frappe-ui `loading`, which leads with the spinner | the spinner trails the label as the button's `iconRight`, so it takes the icon size and text colour for free; the button stays inert with `pointer-events-none` and `aria-busy`, and `submit()` still guards the shortcut |
| Recipient chips | a recipient the host seeded with a label showed its bare address until a search happened to return it | the model's recipients feed the input's option cache alongside the search results, results first, so seeded names and avatars show from the first render |

Helpdesk's floating composer (frappe/helpdesk#3674) passes "Sending" as the label and seeds the ticket contact's name on To; both need these.

no-docs
