### PR TITLE
feat(desk-v2): the user avatar and its menu at the foot of the rail

### DIFF
--- a/frontend/src/shell/LogoutDialog.vue
+++ b/frontend/src/shell/LogoutDialog.vue
@@ -1,0 +1,31 @@
+<!-- The confirmation before a log out, on a boolean. A failure is toasted and keeps the dialog. -->
+<template>
+	<Dialog
+		v-model="open"
+		title="Log out?"
+		message="You will need to sign in again."
+		size="sm"
+		:actions="actions"
+	/>
+</template>
+
+<script setup lang="ts">
+import { Dialog, toast } from "frappe-ui";
+import { logout } from "./session";
+
+const open = defineModel<boolean>({ default: false });
+
+// `Dialog` awaits an action and shows its loading state itself.
+const actions = [
+	{ label: "Cancel", onClick: () => (open.value = false) },
+	{ label: "Log out", variant: "outline", theme: "red", onClick: confirm },
+];
+
+async function confirm() {
+	try {
+		await logout();
+	} catch {
+		toast.error("Could not log out");
+	}
+}
+</script>

--- a/frontend/src/shell/RailColumn.vue
+++ b/frontend/src/shell/RailColumn.vue
@@ -62,13 +62,30 @@
 				</div>
 			</nav>
 		</ScrollArea>
+
+		<!-- The person's cell, pinned to the foot by the `ScrollArea`'s `flex-1` above it. -->
+		<div class="mt-3 flex shrink-0 items-center justify-center">
+			<Dropdown :options="userMenu" side="right" align="end">
+				<button
+					type="button"
+					data-key="user-menu"
+					:class="USER_CELL"
+					:aria-label="boot.user.full_name"
+				>
+					<Avatar :image="boot.user.user_image" :label="boot.user.full_name" size="md" />
+				</button>
+			</Dropdown>
+		</div>
+
+		<LogoutDialog v-model="confirmingLogout" />
 	</Rail>
 </template>
 
 <script setup lang="ts">
-import { computed, inject } from "vue";
+import { computed, inject, ref } from "vue";
 import type { RouteLocationRaw } from "vue-router";
 import {
+	Avatar,
 	Dropdown,
 	Rail,
 	RailItem,
@@ -84,6 +101,7 @@ import { labelOf, renderingOf } from "@/navigation/registry";
 import type { ItemNode } from "@/navigation/tree";
 import { useItemTree } from "@/navigation/useItemTree";
 import type { ItemContext } from "@/navigation/types";
+import LogoutDialog from "./LogoutDialog.vue";
 
 type Cell = { key: string; label: string; icon?: string; sidebar?: string } & (
 	| { to: RouteLocationRaw }
@@ -94,6 +112,8 @@ const TILE =
 	"flex size-7 items-center justify-center rounded-[7px] transition focus-visible:ring-0 focus-visible:focus-ring";
 const LETTER_TILE =
 	"bg-surface-gray-3 text-sm font-medium text-ink-gray-8 hover:bg-surface-gray-4";
+const USER_CELL =
+	"flex rounded-full transition hover:opacity-90 focus-visible:ring-0 focus-visible:focus-ring";
 // `RailItem`'s own inactive tile.
 const CELL =
 	"relative flex size-7 shrink-0 items-center justify-center rounded-[7px] bg-surface-gray-3 text-base transition focus-visible:ring-0 focus-visible:focus-ring";
@@ -139,25 +159,8 @@ function cellOf(item: NavigationItem): Cell | null {
 		: { ...cell, href: rendering.href, sidebar: rendering.sidebar };
 }
 
-const { colorScheme, setColorScheme } = useColorScheme();
-const SCHEMES = [
-	{ label: "Light", value: "light", icon: "lucide-sun" },
-	{ label: "Dark", value: "dark", icon: "lucide-moon" },
-	{ label: "System", value: "system", icon: "lucide-monitor" },
-] as const;
-
 const menu = computed<DropdownOptions>(() => [
 	{ label: "All apps", icon: "lucide-layout-grid", onClick: () => leave("/apps") },
-	{
-		label: "Theme",
-		icon: "lucide-sun-moon",
-		submenu: SCHEMES.map((scheme) => ({
-			label: scheme.label,
-			icon: scheme.icon,
-			selected: colorScheme.value === scheme.value,
-			onClick: () => setColorScheme(scheme.value),
-		})),
-	},
 	...(props.customizable
 		? [
 				{
@@ -168,6 +171,59 @@ const menu = computed<DropdownOptions>(() => [
 		  ]
 		: []),
 	...(props.shareLink ? [{ label: "Copy link", icon: "lucide-link", onClick: copyLink }] : []),
+]);
+
+const { colorScheme, setColorScheme } = useColorScheme();
+const SCHEMES = [
+	{ label: "Light", value: "light", icon: "lucide-sun" },
+	{ label: "Dark", value: "dark", icon: "lucide-moon" },
+	{ label: "System", value: "system", icon: "lucide-monitor" },
+] as const;
+
+const confirmingLogout = ref(false);
+
+// Workaround: the settings dialog has no profile pane yet, so *My settings* opens v1's User form.
+const userMenu = computed<DropdownOptions>(() => [
+	{
+		group: "",
+		hideLabel: true,
+		options: [
+			{
+				label: "My settings",
+				icon: "lucide-circle-user",
+				onClick: () => leave(`/app/user/${encodeURIComponent(boot.user.name)}`),
+			},
+			{
+				label: "Theme",
+				icon: "lucide-sun-moon",
+				submenu: SCHEMES.map((scheme) => ({
+					label: scheme.label,
+					icon: scheme.icon,
+					selected: colorScheme.value === scheme.value,
+					onClick: () => setColorScheme(scheme.value),
+				})),
+			},
+		],
+	},
+	{
+		group: "",
+		hideLabel: true,
+		options: [
+			{ label: "Desk v1", icon: "lucide-arrow-left-right", onClick: () => leave("/app") },
+		],
+	},
+	{
+		group: "",
+		hideLabel: true,
+		options: [
+			{
+				label: "Log out",
+				icon: "lucide-log-out",
+				theme: "red",
+				onClick: () => (confirmingLogout.value = true),
+			},
+		],
+	},
 ]);
 
 function leave(href: string) {

--- a/frontend/src/shell/SidebarPanel.vue
+++ b/frontend/src/shell/SidebarPanel.vue
@@ -28,7 +28,8 @@
 				/>
 			</div>
 
-			<ScrollArea class="min-h-0 flex-1" viewportClass="px-2 pb-2">
+			<!-- `pt-0.5`: the first row's shadow is otherwise clipped on the viewport's top edge. -->
+			<ScrollArea class="min-h-0 flex-1" viewportClass="px-2 pb-2 pt-0.5">
 				<nav class="flex flex-col gap-0.5" :aria-label="title">
 					<SidebarRow
 						v-for="node in tree"

--- a/frontend/src/shell/session.ts
+++ b/frontend/src/shell/session.ts
@@ -1,0 +1,10 @@
+// The person's session: plain functions, no confirmation inside them.
+
+import { call } from "frappe-ui";
+
+/** Ends the session, then goes to the login page with the way back to this page and query. */
+export async function logout(): Promise<void> {
+	await call("logout");
+	const back = window.location.pathname + window.location.search;
+	window.location.assign(`/login?redirect-to=${encodeURIComponent(back)}`);
+}

--- a/frontend/src/shell/tests/rail.test.ts
+++ b/frontend/src/shell/tests/rail.test.ts
@@ -1,6 +1,6 @@
 // What the rail draws. Mounted with Vue's own `createApp`: this package has no `@vue/test-utils`.
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { createApp, h, nextTick, ref, type Ref } from "vue";
+import { createApp, h, nextTick, ref, type App, type Ref } from "vue";
 import { createMemoryHistory, createRouter, type Router } from "vue-router";
 
 import { Addresses } from "@/addresses";
@@ -12,6 +12,13 @@ import { itemContext } from "@/navigation/context";
 import { resetNavigationReports } from "@/navigation/registry";
 import { loadSprite, resetSprite } from "@/icons/sprite";
 import RailColumn from "../RailColumn.vue";
+
+// `logout` posts through frappe-ui's `call`, and a toast needs a provider the rail lacks.
+vi.mock("frappe-ui", async (importOriginal) => ({
+	...(await importOriginal<typeof import("frappe-ui")>()),
+	call: vi.fn().mockResolvedValue(null),
+	toast: { success: vi.fn(), error: vi.fn() },
+}));
 
 const addresses = new Addresses({
 	doctypes: {
@@ -27,12 +34,21 @@ const crm = {
 	app_title: "CRM",
 	shell_base: "/apps/crm",
 	prefixes: { crm: { app: "crm", modular: false } },
+	user: { name: "jane@example.com", full_name: "Jane Doe" },
 } as unknown as Boot;
 
 async function flush() {
 	await Promise.resolve();
 	await Promise.resolve();
 	await nextTick();
+}
+
+// Every app mounted, unmounted before the body is wiped: a portal torn down after loses its nodes.
+const mounted: App[] = [];
+
+function unmountAll() {
+	mounted.splice(0).forEach((app) => app.unmount());
+	document.body.innerHTML = "";
 }
 
 type Options = {
@@ -77,6 +93,7 @@ function mount(
 	app.provide("addresses", addresses);
 	app.use(router);
 	app.mount(host);
+	mounted.push(app);
 
 	return { host, items, router };
 }
@@ -124,11 +141,13 @@ function withSprite() {
 }
 
 beforeEach(() => {
-	document.body.innerHTML = "";
+	unmountAll();
 	resetNavigationReports();
 	resetSprite();
 	vi.unstubAllGlobals();
 	vi.restoreAllMocks();
+	// `restoreAllMocks` leaves a `vi.fn()`'s call history alone.
+	vi.clearAllMocks();
 });
 
 describe("the kinds the rail draws", () => {
@@ -312,7 +331,7 @@ describe("the app tile", () => {
 describe("the app menu", () => {
 	/** The menu's text once opened from the keyboard; it renders in a portal on `body`. */
 	async function opened(options: Options) {
-		document.body.innerHTML = "";
+		unmountAll();
 		const host = rail([], options);
 		const tile = host.querySelector<HTMLElement>("[data-key='app-menu']")!;
 		tile.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
@@ -321,10 +340,10 @@ describe("the app menu", () => {
 		return document.body.textContent ?? "";
 	}
 
-	it("offers All apps and Theme everywhere", async () => {
+	it("offers All apps everywhere, and Theme no longer: a theme is the person's", async () => {
 		const text = await opened({});
 		expect(text).toContain("All apps");
-		expect(text).toContain("Theme");
+		expect(text).not.toContain("Theme");
 	});
 
 	it("offers Customize sidebar inside an app", async () => {
@@ -359,5 +378,143 @@ describe("an authored icon", () => {
 
 		expect(cell(host, "CRM Deal")?.querySelector("use")).toBeNull();
 		expect(target(host, "CRM Deal")?.textContent?.trim()).toBe("D");
+	});
+});
+
+describe("the person's cell", () => {
+	function userCell(host: HTMLElement) {
+		return host.querySelector<HTMLElement>("[data-key='user-menu']")!;
+	}
+
+	it("sits at the foot, named by the full name, with the initial as the fallback", () => {
+		const host = rail([doctype("CRM Deal")]);
+		const button = userCell(host);
+
+		expect(button.getAttribute("aria-label")).toBe("Jane Doe");
+		expect(button.textContent?.trim()).toBe("J");
+		expect(button.querySelector("img")).toBeNull();
+		// After the scrolling column, so the column's `flex-1` pins it to the foot.
+		const scroll = host.querySelector("[data-key='CRM Deal']")!.closest("[data-slot='scroll-area']");
+		expect(button.compareDocumentPosition(scroll!) & Node.DOCUMENT_POSITION_PRECEDING).toBeTruthy();
+	});
+
+	it("shows the person's image when boot carries one", () => {
+		const boot = { ...crm, user: { ...crm.user, user_image: "/files/jane.png" } } as Boot;
+		const image = userCell(rail([], { boot })).querySelector("img");
+		expect(image?.getAttribute("src")).toBe("/files/jane.png");
+	});
+});
+
+describe("the user menu", () => {
+	/** The menu once opened from the keyboard; it renders in a portal on `body`. */
+	async function opened(options: Options = {}) {
+		unmountAll();
+		const host = rail([], options);
+		const button = host.querySelector<HTMLElement>("[data-key='user-menu']")!;
+		button.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+		await flush();
+		await flush();
+		return document.body.querySelector<HTMLElement>("[role='menu']")!;
+	}
+
+	function rows(menu: HTMLElement) {
+		return Array.from(menu.querySelectorAll<HTMLElement>("[role='menuitem']")).map((row) =>
+			row.textContent?.trim()
+		);
+	}
+
+	function row(menu: HTMLElement, label: string) {
+		return Array.from(menu.querySelectorAll<HTMLElement>("[role='menuitem']")).find(
+			(node) => node.textContent?.trim() === label
+		)!;
+	}
+
+	it("carries no header: the name is the button's", async () => {
+		const menu = await opened();
+		expect(menu.querySelector("[data-slot='group-label']")).toBeNull();
+		expect(menu.textContent).not.toContain("Jane Doe");
+	});
+
+	it("offers the four rows in order, with Log out in red", async () => {
+		const menu = await opened();
+		expect(rows(menu)).toEqual(["My settings", "Theme", "Desk v1", "Log out"]);
+		expect(row(menu, "Log out").className).toContain("red");
+	});
+
+	it("separates the groups: the person's rows, Desk v1, Log out", async () => {
+		const menu = await opened();
+		const groups = Array.from(menu.querySelectorAll("[data-slot='group']")).map((group) =>
+			Array.from(group.querySelectorAll("[role='menuitem']")).length
+		);
+		expect(groups).toEqual([2, 1, 1]);
+	});
+
+	it("sends My settings to the person's v1 User form, and Desk v1 to v1's home", async () => {
+		const assign = vi.spyOn(window.location, "assign").mockImplementation(() => {});
+
+		row(await opened(), "My settings").click();
+		await flush();
+		expect(assign).toHaveBeenLastCalledWith("/app/user/jane%40example.com");
+
+		row(await opened(), "Desk v1").click();
+		await flush();
+		expect(assign).toHaveBeenLastCalledWith("/app");
+	});
+
+	it("asks before logging out, and Cancel keeps the session", async () => {
+		const assign = vi.spyOn(window.location, "assign").mockImplementation(() => {});
+		const { call } = await import("frappe-ui");
+
+		row(await opened(), "Log out").click();
+		await flush();
+
+		const dialog = document.body.querySelector<HTMLElement>("[role='dialog']")!;
+		expect(dialog.textContent).toContain("Log out?");
+		expect(dialog.textContent).toContain("You will need to sign in again.");
+
+		Array.from(dialog.querySelectorAll("button"))
+			.find((button) => button.textContent?.trim() === "Cancel")!
+			.click();
+		await flush();
+
+		expect(document.body.querySelector("[role='dialog']")).toBeNull();
+		expect(call).not.toHaveBeenCalled();
+		expect(assign).not.toHaveBeenCalled();
+	});
+
+	it("logs out on confirmation and goes to login with the way back, hash dropped", async () => {
+		const assign = vi.spyOn(window.location, "assign").mockImplementation(() => {});
+		const { call } = await import("frappe-ui");
+		window.history.replaceState(null, "", "/crm-deal?sidebar=fcrm#customize/rail");
+
+		row(await opened(), "Log out").click();
+		await flush();
+		Array.from(document.body.querySelector("[role='dialog']")!.querySelectorAll("button"))
+			.find((button) => button.textContent?.trim() === "Log out")!
+			.click();
+		await flush();
+		await flush();
+
+		expect(call).toHaveBeenCalledWith("logout");
+		expect(assign).toHaveBeenCalledWith("/login?redirect-to=%2Fcrm-deal%3Fsidebar%3Dfcrm");
+		window.history.replaceState(null, "", "/");
+	});
+
+	it("keeps the dialog and toasts when the log out fails", async () => {
+		const assign = vi.spyOn(window.location, "assign").mockImplementation(() => {});
+		const { call, toast } = await import("frappe-ui");
+		vi.mocked(call).mockRejectedValueOnce(new Error("offline"));
+
+		row(await opened(), "Log out").click();
+		await flush();
+		Array.from(document.body.querySelector("[role='dialog']")!.querySelectorAll("button"))
+			.find((button) => button.textContent?.trim() === "Log out")!
+			.click();
+		await flush();
+		await flush();
+
+		expect(document.body.querySelector("[role='dialog']")).not.toBeNull();
+		expect(toast.error).toHaveBeenCalledWith("Could not log out");
+		expect(assign).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
Builds the person's cell at the foot of the rail on `desk-v2`. Ticket: the build ticket on the shell-and-list map, "Build: the user avatar and its menu at the foot of the rail" (#42707), opened by the avatar grilling (#42587), whose fourteen rulings this follows, with one amendment from the walk.

## What a person gets

A round avatar at the foot of the rail. It opens a menu to the right with *My settings*, *Theme*, *Desk v1* and *Log out*. Log out asks first. Theme has moved here from the app tile, which keeps *All apps*, *Customize sidebar* and *Copy link*.

| Before | After | The menu |
| --- | --- | --- |
| ![before](https://raw.githubusercontent.com/shariquerik/frappe/assets/user-menu-42707/before-leads.png) | ![after](https://raw.githubusercontent.com/shariquerik/frappe/assets/user-menu-42707/after-leads.png) | ![menu](https://raw.githubusercontent.com/shariquerik/frappe/assets/user-menu-42707/after-menu.png) |

| Theme | Log out asks | After confirming |
| --- | --- | --- |
| ![theme](https://raw.githubusercontent.com/shariquerik/frappe/assets/user-menu-42707/after-theme.png) | ![dialog](https://raw.githubusercontent.com/shariquerik/frappe/assets/user-menu-42707/after-logout.png) | ![login](https://raw.githubusercontent.com/shariquerik/frappe/assets/user-menu-42707/after-confirm.png) |

The before/after pair also shows the sidebar's first row: its shadow was clipped on the viewport's top edge, and the viewport now has `pt-0.5`, as CRM's own sidebar does.

## Amendment from the walk

The grilling ruled a header group labelled with the full name over the boot name. Built, the two lines crowd frappe-ui's fixed-height group label and, for Administrator, repeat one word. The owner dropped the header during the walk: the menu starts at *My settings*, and the button's `aria-label` carries the name.

## Shell

- **`RailColumn.vue`**: a raw button in a `Dropdown` (`side="right" align="end"`) after the rail's `ScrollArea`, whose `flex-1` pins it to the foot, holding an `Avatar` off `boot.user`. Three groups, separators from grouping. *My settings* opens the v1 User form with a marked workaround until the settings dialog has a profile pane. *Desk v1* is a full-document link to `/app`.
- **`LogoutDialog.vue`**: a plain `Dialog` on a boolean, "Log out?", "You will need to sign in again.", *Cancel*, then a red outline *Log out* on the right, as the owner asked during the walk.
- **`session.ts`**: `logout()` posts to frappe's `logout` method, then goes to `/login?redirect-to=<path+query>`, hash dropped. No confirmation on the function.

Boot gains nothing: `name`, `full_name` and `user_image` were already there. The menu adds no request; the avatar image is one `<img>` the browser fetches.

## Tests

Nine new tests in the rail's suite: the cell's name, initial and image; the four rows in order and their groups; Log out in red; where *My settings* and *Desk v1* go; Cancel keeps the session; confirming posts `logout` and redirects with the query kept and the hash dropped; a failed log out is toasted and keeps the dialog. The app tile's test now asserts Theme is gone. The frontend suite is 579 green, also in shuffled order.

>no-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
