### PR TITLE
feat: a Desk v2 row in desk v1's user menus

### DIFF
--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -270,6 +270,13 @@ class DesktopPage {
 				},
 				order: 40,
 			},
+			// The way over to desk v2, mirroring the "Desk v1" row its user menu offers.
+			{
+				icon: "arrow-left-right",
+				label: "Desk v2",
+				url: "/apps",
+				order: 45,
+			},
 		];
 		// sort() is stable, so items sharing an `order` keep the order they were added in.
 		menu_items = [...menu_items, ...this.desktop_menu_items].sort(
@@ -292,7 +299,7 @@ class DesktopPage {
 		});
 	}
 	// `item.order` is optional; lower sorts higher up the menu. Built-ins occupy
-	// 10-40, so omitting it drops the item below them (see DEFAULT_MENU_ITEM_ORDER).
+	// 10-45, so omitting it drops the item below them (see DEFAULT_MENU_ITEM_ORDER).
 	// Logout is always last and can't be displaced.
 	add_menu_item(item) {
 		if (this.desktop_menu_items.find((i) => i.label === item.label)) return;

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -270,7 +270,7 @@ class DesktopPage {
 				},
 				order: 40,
 			},
-			// The way over to desk v2, mirroring the "Desk v1" row its user menu offers.
+			// A full-document link: desk v2 is a separate document, not a v1 route.
 			{
 				icon: "arrow-left-right",
 				label: "Desk v2",

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -656,8 +656,7 @@ frappe.ui.Sidebar = class Sidebar {
 						},
 					],
 				},
-				// The way over to desk v2, mirroring the "Desk v1" row its user menu offers. A full
-				// link, since the two desks are separate documents.
+				// A full-document link: desk v2 is a separate document, not a v1 route.
 				{
 					group: "",
 					options: [

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -656,6 +656,19 @@ frappe.ui.Sidebar = class Sidebar {
 						},
 					],
 				},
+				// The way over to desk v2, mirroring the "Desk v1" row its user menu offers. A full
+				// link, since the two desks are separate documents.
+				{
+					group: "",
+					options: [
+						{
+							name: "desk-v2",
+							label: __("Desk v2"),
+							icon: "arrow-left-right",
+							href: "/apps",
+						},
+					],
+				},
 				// Logout is a section of its own, which is the rule the divider row here used to
 				// draw by hand.
 				{


### PR DESCRIPTION
Desk v2's user menu offers a *Desk v1* row (PR #42714). This is the way back: a *Desk v2* row in desk v1's user menus, a full link to `/apps`, the app screen, since v1 has no app context to map from.

Task ticket: #42708 on the shell-and-list map #42569.

## What changed

- **The sidebar / dock user menu** (`frappe.ui.Sidebar.create_user_menu`, shared by the sidebar's user button and the dock's avatar): a *Desk v2* row in its own group, between the Settings / Manage Dock / Reload group and Logout. Same shape as the v2 menu, where *Desk v1* is its own group above *Log out*.
- **The desktop page's avatar menu** (`DesktopPage.setup_avatar`): a *Desk v2* built-in at `order: 45`, after Frappe Support and above anything an app adds through `add_menu_item()` (which lands at 50). The comment on `add_menu_item` now says the built-ins occupy 10-45.

## Why not the patch the ticket named

The ticket asked for a `Navbar Settings` patch, the v13 *Toggle Theme* precedent. On this branch that no longer reaches the user menu: `settings_dropdown` rows render in the sidebar **header's** menu, flat beside *Edit Sidebar* and *Help* (`SidebarHeader.navbar_items`), and the `standard_navbar_items` hook list is gone from `hooks.py`, so `sync_standard_items` on migrate would reap a standard row and a new site would never get one. The row is hard-coded, as its v2 sibling is; a contribution channel stays fog on the map.

## Walk

Dock user menu on a v1 list page, and the desktop page's avatar menu, on the local bench. Clicking the row lands on `/apps/` with no console errors.

![dock user menu](https://raw.githubusercontent.com/shariquerik/frappe/assets/desk-v2-row-42708/sidebar-menu.png)

![desktop avatar menu](https://raw.githubusercontent.com/shariquerik/frappe/assets/desk-v2-row-42708/desktop-menu.png)

The literal `/apps` sits in v1's JS, mirroring the literal `/app` in v2's rail; v1's boot does not carry the shell root.

>no-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
