### PR TITLE
fix: hide an app whose every module is blocked from the apps screen and icon grid

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -294,6 +294,7 @@ def get_app_data() -> list[dict]:
 	`get_app_entry_set`, which asks the same question about the same user.
 	"""
 	from frappe.desk.doctype.dock.dock import get_app_entry_set
+	from frappe.utils.modules import is_app_visible
 
 	app_data = []
 
@@ -341,8 +342,10 @@ def get_app_data() -> list[dict]:
 			dict(
 				# Whether the app opts into the apps screen via the add_to_apps_screen hook. An app
 				# that pins into a host app's dock never takes a slot of its own, even if it still
-				# declares add_to_apps_screen from before the dock existed: the pin wins.
-				on_apps_screen=bool(apps) and app_name not in app_rail_host,
+				# declares add_to_apps_screen from before the dock existed: the pin wins. An app
+				# whose every module this user blocked is off the screen too: the block is how
+				# they said they don't want it, and its tile would open an empty rail.
+				on_apps_screen=bool(apps) and app_name not in app_rail_host and is_app_visible(app_name),
 				# Sort order for the apps (desktop) screen; lower shows first, Framework is pinned
 				# last (sequence_id 1000). Apps that don't declare one fall to a middle default.
 				sequence_id=app_info.get("sequence_id") or DEFAULT_APP_SEQUENCE_ID,

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -168,11 +168,16 @@ def is_icon_permitted(icon, bootinfo, roles: list[str], icon_module: str | None)
 
 
 def _has_app_permission(icon) -> bool:
+	from frappe.utils.modules import is_app_visible
+
 	for a in frappe.get_active_apps():
 		# An app need not declare `app_title`. Asking for the hook by name returns [] instead of
 		# raising, so one such app cannot abort the whole grid's permission check.
 		app_title = (frappe.get_hooks("app_title", app_name=a) or [None])[0]
 		if app_title == icon.label or icon.app == a:
+			if not is_app_visible(a):
+				return False
+
 			app_detail = frappe.get_hooks("add_to_apps_screen", app_name=a)
 			if len(app_detail) != 0:
 				permission_method = app_detail[0].get("has_permission", None)

--- a/frappe/tests/test_boot.py
+++ b/frappe/tests/test_boot.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import frappe
+from frappe.boot import get_app_data
 from frappe.desk.desk_views import DeskViews
 from frappe.desk.doctype.note.note import _get_unseen_notes, get_unseen_notes, mark_as_seen
 from frappe.desk.doctype.sidebar.test_sidebar import developer_mode
@@ -294,3 +295,34 @@ class TestPermissionQueries(IntegrationTestCase):
 		# Test user must not see admin user's report
 		self.assertNotIn("Test Admin Report", allowed_reports)
 		self.assertIn("Test User Report", allowed_reports)
+
+
+class TestAppsScreenBlockedModules(IntegrationTestCase):
+	def setUp(self):
+		self.user = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": "blocked-modules@example.com",
+				"first_name": "Blocked Modules",
+				"send_welcome_email": 0,
+				"roles": [{"role": "System Manager"}],
+			}
+		).insert(ignore_if_duplicate=True)
+		self.addCleanup(frappe.set_user, "Administrator")
+
+	def frappe_tile(self):
+		frappe.set_user(self.user.name)
+		try:
+			return next(app for app in get_app_data() if app["app_name"] == "frappe")
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_app_with_every_module_blocked_is_off_the_apps_screen(self):
+		self.assertTrue(self.frappe_tile()["on_apps_screen"])
+
+		for module in frappe.get_all("Module Def", filters={"app_name": "frappe"}, pluck="name"):
+			self.user.append("block_modules", {"module": module})
+		self.user.save()
+		frappe.clear_cache(user=self.user.name)
+
+		self.assertFalse(self.frappe_tile()["on_apps_screen"])

--- a/frappe/utils/modules.py
+++ b/frappe/utils/modules.py
@@ -62,6 +62,13 @@ def get_visible_modules(modules: list[str], user: str | None = None) -> list[str
 	return [m for m in modules if m not in blocked]
 
 
+def is_app_visible(app: str, user: str | None = None) -> bool:
+	"""Whether `app` may appear in `user`'s desk navigation: it owns no modules, or at least one is visible."""
+	modules = frappe.get_all("Module Def", filters={"app_name": app}, pluck="name")
+
+	return not modules or bool(get_visible_modules(modules, user))
+
+
 def get_code_only_modules() -> set[str]:
 	"""Return the modules whose own app says they ship no navigation.
 


### PR DESCRIPTION
- new `frappe.utils.modules.is_app_visible`: an app is visible if it owns no modules or at least one is not blocked for the user
- apps screen (`boot.get_app_data`) and App-type desktop icons now use it; module-linked icons already respected `is_module_visible`
- test: an app with every module blocked is off the apps screen

fixes #42709