### PR TITLE
refactor(desk): drop Navigation Item Type's label and icon columns

### DIFF
--- a/frappe/desk/doctype/navigation_item_type/navigation_item_type.json
+++ b/frappe/desk/doctype/navigation_item_type/navigation_item_type.json
@@ -9,8 +9,6 @@
  "engine": "InnoDB",
  "field_order": [
   "type_name",
-  "label",
-  "icon",
   "column_break_defn",
   "module",
   "target_doctype",
@@ -25,20 +23,6 @@
    "label": "Type Name",
    "reqd": 1,
    "unique": 1
-  },
-  {
-   "description": "Fallback label for an item of this kind that has none of its own.",
-   "fieldname": "label",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Label"
-  },
-  {
-   "description": "Fallback icon for an item of this kind.",
-   "fieldname": "icon",
-   "fieldtype": "Icon",
-   "label": "Icon",
-   "options": "Emojis"
   },
   {
    "fieldname": "column_break_defn",
@@ -72,7 +56,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-09-03 18:03:47.000000",
+ "modified": "2026-09-10 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Navigation Item Type",

--- a/frappe/desk/doctype/navigation_item_type/navigation_item_type.py
+++ b/frappe/desk/doctype/navigation_item_type/navigation_item_type.py
@@ -20,8 +20,6 @@ class NavigationItemType(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		icon: DF.Icon | None
-		label: DF.Data | None
 		module: DF.Link
 		permission_rule: DF.Literal[
 			"Readable DocType",

--- a/frappe/desk/navigation_item_type/doctype/doctype.json
+++ b/frappe/desk/navigation_item_type/doctype/doctype.json
@@ -3,7 +3,6 @@
  "docstatus": 0,
  "doctype": "Navigation Item Type",
  "idx": 0,
- "label": "DocType",
  "modified": "2026-09-01 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Desk",

--- a/frappe/desk/navigation_item_type/link/link.json
+++ b/frappe/desk/navigation_item_type/link/link.json
@@ -3,7 +3,6 @@
  "docstatus": 0,
  "doctype": "Navigation Item Type",
  "idx": 0,
- "label": "Link",
  "modified": "2026-09-01 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Desk",

--- a/frappe/desk/navigation_item_type/module/module.json
+++ b/frappe/desk/navigation_item_type/module/module.json
@@ -3,7 +3,6 @@
  "docstatus": 0,
  "doctype": "Navigation Item Type",
  "idx": 0,
- "label": "Module",
  "modified": "2026-09-01 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Desk",

--- a/frappe/desk/navigation_item_type/module_contents/module_contents.json
+++ b/frappe/desk/navigation_item_type/module_contents/module_contents.json
@@ -3,7 +3,6 @@
  "docstatus": 0,
  "doctype": "Navigation Item Type",
  "idx": 0,
- "label": "Module Contents",
  "modified": "2026-09-01 18:00:00.000000",
  "modified_by": "Administrator",
  "module": "Desk",

--- a/frappe/desk/navigation_item_type/page/page.json
+++ b/frappe/desk/navigation_item_type/page/page.json
@@ -3,7 +3,6 @@
  "docstatus": 0,
  "doctype": "Navigation Item Type",
  "idx": 0,
- "label": "Page",
  "modified": "2026-09-01 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Desk",

--- a/frappe/desk/navigation_item_type/record/record.json
+++ b/frappe/desk/navigation_item_type/record/record.json
@@ -3,7 +3,6 @@
  "docstatus": 0,
  "doctype": "Navigation Item Type",
  "idx": 0,
- "label": "Record",
  "modified": "2026-09-01 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Desk",

--- a/frappe/desk/navigation_item_type/section/section.json
+++ b/frappe/desk/navigation_item_type/section/section.json
@@ -3,7 +3,6 @@
  "docstatus": 0,
  "doctype": "Navigation Item Type",
  "idx": 0,
- "label": "Section",
  "modified": "2026-09-01 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Desk",

--- a/frappe/desk/navigation_item_type/sidebar/sidebar.json
+++ b/frappe/desk/navigation_item_type/sidebar/sidebar.json
@@ -3,7 +3,6 @@
  "docstatus": 0,
  "doctype": "Navigation Item Type",
  "idx": 0,
- "label": "Sidebar",
  "modified": "2026-09-01 18:00:00.000000",
  "modified_by": "Administrator",
  "module": "Desk",


### PR DESCRIPTION
`Navigation Item Type` carried two presentation columns, `label` and `icon`, described as the fallback label and icon for an item of that kind. Nothing read either one:

- The server selects only `permission_rule` and `target_doctype` off the doctype (`frappe/shell/navigation_filter.py`), and no payload carries the type row to the browser.
- The frontend build plugin (`frontend/plugin/contributions.js`) reads only the row's name.
- The kind-level label fallback already lives beside the renderer, as `ItemRenderer.label?()` in `frontend/src/navigation/types.ts`, which is what `labelOf` calls.
- Every shipped row set `label` to its own name; no row set `icon`.

The renderer is the kind's presentation contract, so a JSON column duplicating it is a second place to look. Both columns go. A kind that wants a default icon adds `ItemRenderer.icon?()` beside `label?()` when the need arrives.

**What changed:** the two fields leave the doctype JSON (with a `modified` bump so migrate re-imports it) and the controller's type stub; the eight shipped type rows drop their redundant `label` key.

**Left on purpose:**
- The database columns stay, as frappe does for any removed field. The doctype exists only on this branch.
- The eight row files keep their `modified` stamp, so existing sites keep the old row; the stale `label` value sits in an orphan column that nothing reads.
- ERPNext's `Default Company` type row still carries a `label` key. The import drops unknown keys silently, so it is harmless dead text; a one-line follow-up removes it.

Tests: the four navigation suites pass on a migrated site (`test_navigation_filter` 44, `test_rail` 19, `test_sidebar` 115, `test_shell` 54) and the frontend navigation and contributions suites pass (82).

Resolves the task ticket "Navigation Item Type's label and icon columns are read by nothing" (#42470) on the shell-and-list map (#42569).

>no-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
