### PR TITLE
refactor: refactor site_cache to leverage existing client_cache 

### DIFF
--- a/frappe/utils/caching.py
+++ b/frappe/utils/caching.py
@@ -104,7 +104,7 @@ def site_cache(ttl: int | None = 3600, maxsize: int = 16) -> Callable:
 		func.cached_values_counter = 0
 
 		@wraps(func)
-		def redis_cache_wrapper(*args, **kwargs):
+		def site_cache_wrapper(*args, **kwargs):
 			# NOTE: reason for both checks is to support `site_cache` functionality too, but by default it would create
 			# a `boot-strapping` problem, as internally `redis_wrapper` depends on `local.conf`. We also wait for `frappe.client_cache` to be available.
 			if not (frappe.client_cache) or not (hasattr(frappe.local, "conf")):
@@ -128,7 +128,7 @@ def site_cache(ttl: int | None = 3600, maxsize: int = 16) -> Callable:
 			func.cached_values_counter += 1
 			return val
 
-		return redis_cache_wrapper
+		return site_cache_wrapper
 
 	if callable(ttl):
 		return wrapper(ttl)

--- a/frappe/utils/caching.py
+++ b/frappe/utils/caching.py
@@ -102,7 +102,6 @@ def site_cache(ttl: int | None = 3600, maxsize: int = 16) -> Callable:
 		func.ttl = ttl if not callable(ttl) else 3600
 		func.maxsize = maxsize
 		func.cached_values_counter = 0
-		func.expiry = time.monotonic() + func.ttl
 
 		@wraps(func)
 		def site_cache_wrapper(*args, **kwargs):
@@ -114,10 +113,6 @@ def site_cache(ttl: int | None = 3600, maxsize: int = 16) -> Callable:
 			func_call_key = f"{func_key}::{hash(__generate_request_cache_key(args, kwargs))}"
 			cached_val = frappe.client_cache.get_value(func_call_key, shared=False, ttl=func.ttl)
 			if cached_val is not None:
-				if time.monotonic() > func.expiry:
-					# expired. We do it again, since `client_cache.get_value` returns the cached_value only for now. Updating that API is cumbersome.
-					func.cached_values_counter -= 1
-					assert func.cached_values_counter >= 0
 				return cached_val
 
 			val = func(*args, **kwargs)

--- a/frappe/utils/caching.py
+++ b/frappe/utils/caching.py
@@ -77,97 +77,61 @@ def request_cache(func: Callable) -> Callable:
 	return wrapper
 
 
-def site_cache(ttl: int | None = None, maxsize: int | None = None) -> Callable:
-	"""
-	Decorator to cache method calls across requests.
-
-	The cache is stored in `frappe.utils.caching._SITE_CACHE`.
-
-	The cache persists on the parent process.
-
-	It offers a light-weight cache for the current process without the additional
-	overhead of serializing / deserializing Python objects.
-
-	Note: This cache isn't shared among workers. If you need to share data across
-	workers, use redis (frappe.cache API) instead.
-
-	---
-	Usage:
-	```
-	        from frappe.utils.caching import site_cache
-
-	        @site_cache
-	        def calculate_pi():
-	            import math, time
-
-	            precision = get_precision("Math Constant", "Pi") # depends on site data
-	            return round(math.pi, precision)
-
-	        calculate_pi(10) # will calculate value
-	        calculate_pi(10) # will return value from cache
-	        calculate_pi.clear_cache() # clear this function's cache for all sites
-	        calculate_pi(10) # will calculate value
-	```
+def site_cache(ttl: int | None = 3600, maxsize: int = 16) -> Callable:
+	"""Decorator to cache method calls and its return values in Client_cache.
+		# TODO: implement some policy to evict. Just set `maxsize` to be double or higher count for desired functions for now.
+		# NOTE: `shared = False` is used as cache is supposed to be site-specific.
+	args:
+	        ttl: time to expiry in seconds, defaults to 1 hour
+	        maxsize:int   to limit the number of count, a func can be called with different arguments.
 	"""
 
-	def time_cache_wrapper(func: Callable | None = None) -> Callable:
+	def wrapper(func: Callable | None = None) -> Callable:
+		# Final key would be conditioned on function_name + args + site/database name.
+		func_key = f"{func.__module__}.{func.__qualname__}"
+
 		def clear_cache():
-			"""Clear cache for this function for all sites if not specified."""
-			_SITE_CACHE[func].clear()
+			if (
+				frappe.client_cache
+			):  # In case called during boot-straping itself, frappe.client_cache won't be available.
+				frappe.client_cache.delete_keys(func_key, shared=False)
+				func.cached_values_counter = 0
 
 		func.clear_cache = clear_cache
-
-		if ttl is not None and not callable(ttl):
-			func.ttl = ttl
-			func.expiration = time.monotonic() + func.ttl
-
-		if maxsize is not None and not callable(maxsize):
-			assert maxsize > 0, "site_cache maxsize must be positive to allow caching"
-			func.maxsize = maxsize
+		func.ttl = ttl if not callable(ttl) else 3600
+		func.maxsize = maxsize
+		func.cached_values_counter = 0
 
 		@wraps(func)
-		def site_cache_wrapper(*args, **kwargs):
-			site = getattr(frappe.local, "site", None)
-			if not site:
+		def redis_cache_wrapper(*args, **kwargs):
+			# NOTE: reason for both checks is to support `site_cache` functionality too, but by default it would create
+			# a `boot-strapping` problem, as internally `redis_wrapper` depends on `local.conf`. We also wait for `frappe.client_cache` to be available.
+			if not (frappe.client_cache) or not (hasattr(frappe.local, "conf")):
 				return func(*args, **kwargs)
 
-			arguments_key = (site, __generate_request_cache_key(args, kwargs))
+			func_call_key = f"{func_key}::{hash(__generate_request_cache_key(args, kwargs))}"
+			cached_val = frappe.client_cache.get_value(func_call_key, shared=False)
+			if cached_val is not None:
+				return cached_val
 
-			if hasattr(func, "ttl") and time.monotonic() >= func.expiration:
-				func.clear_cache()
-				func.expiration = time.monotonic() + func.ttl
+			val = func(*args, **kwargs)
+			if (func.cached_values_counter + 1) > func.maxsize:
+				return val
 
-			# NOTE: Important things to consider from thread safety POV:
-			#   1. Other thread can issue clear_cache and delete entire dictionary.
-			#   2. Other thread can pop the exact elemement we are reading if maxsize is hit.
+			if val is None:
+				return None
 
-			# NOTE: Keep a local reference to dictionary of interest so it doesn't get swapped
-			function_cache = _SITE_CACHE[func]
+			ttl = getattr(func, "ttl", 3600)
+			frappe.client_cache.set_value(func_call_key, val, shared=False, ttl=ttl)
+			# NOTE: since `client_cache` is technically a dictionary, so assumed we would always be successful set_value (given no error occured), we increment the following counter)
+			func.cached_values_counter += 1
+			return val
 
-			try:
-				return function_cache[arguments_key]
-
-			# not handling TypeError here, expecting arguments_key to be hashable
-			except (KeyError, RuntimeError):
-				# NOTE: This is just a cache miss or dictionary was modified while reading it
-				pass
-
-			if hasattr(func, "maxsize") and len(function_cache) >= func.maxsize:
-				# Note: This implements FIFO eviction policy
-				with suppress(RuntimeError):
-					function_cache.pop(next(iter(function_cache)), None)
-
-			result = func(*args, **kwargs)
-			function_cache[arguments_key] = result
-
-			return result
-
-		return site_cache_wrapper
+		return redis_cache_wrapper
 
 	if callable(ttl):
-		return time_cache_wrapper(ttl)
-
-	return time_cache_wrapper
+		return wrapper(ttl)
+	return wrapper
 
 
 def redis_cache(ttl: int | None = 3600, user: str | bool | None = None, shared: bool = False) -> Callable:

--- a/frappe/utils/caching.py
+++ b/frappe/utils/caching.py
@@ -102,6 +102,7 @@ def site_cache(ttl: int | None = 3600, maxsize: int = 16) -> Callable:
 		func.ttl = ttl if not callable(ttl) else 3600
 		func.maxsize = maxsize
 		func.cached_values_counter = 0
+		func.expiry = time.monotonic() + func.ttl
 
 		@wraps(func)
 		def site_cache_wrapper(*args, **kwargs):
@@ -111,8 +112,12 @@ def site_cache(ttl: int | None = 3600, maxsize: int = 16) -> Callable:
 				return func(*args, **kwargs)
 
 			func_call_key = f"{func_key}::{hash(__generate_request_cache_key(args, kwargs))}"
-			cached_val = frappe.client_cache.get_value(func_call_key, shared=False)
+			cached_val = frappe.client_cache.get_value(func_call_key, shared=False, ttl=func.ttl)
 			if cached_val is not None:
+				if time.monotonic() > func.expiry:
+					# expired. We do it again, since `client_cache.get_value` returns the cached_value only for now. Updating that API is cumbersome.
+					func.cached_values_counter -= 1
+					assert func.cached_values_counter >= 0
 				return cached_val
 
 			val = func(*args, **kwargs)

--- a/frappe/utils/caching.py
+++ b/frappe/utils/caching.py
@@ -95,7 +95,7 @@ def site_cache(ttl: int | None = 3600, maxsize: int = 16) -> Callable:
 			if (
 				frappe.client_cache
 			):  # In case called during boot-straping itself, frappe.client_cache won't be available.
-				frappe.client_cache.delete_keys(func_key, shared=False)
+				frappe.client_cache.delete_keys(func_key)
 				func.cached_values_counter = 0
 
 		func.clear_cache = clear_cache

--- a/frappe/utils/caching.py
+++ b/frappe/utils/caching.py
@@ -78,7 +78,8 @@ def request_cache(func: Callable) -> Callable:
 
 
 def site_cache(ttl: int | None = 3600, maxsize: int = 16) -> Callable:
-	"""Decorator to cache method calls and its return values in Client_cache.
+	"""
+	Decorator to cache method calls and its return values in Client_cache.
 		# TODO: implement some policy to evict. Just set `maxsize` to be double or higher count for desired functions for now.
 		# NOTE: `shared = False` is used as cache is supposed to be site-specific.
 	args:
@@ -123,7 +124,7 @@ def site_cache(ttl: int | None = 3600, maxsize: int = 16) -> Callable:
 
 			ttl = getattr(func, "ttl", 3600)
 			frappe.client_cache.set_value(func_call_key, val, shared=False, ttl=ttl)
-			# NOTE: since `client_cache` is technically a dictionary, so assumed we would always be successful set_value (given no error occured), we increment the following counter)
+			# NOTE: since `client_cache` is technically a dictionary, so assumed we would always be successful in `set_value` call (given no error occured), we increment the following counter.
 			func.cached_values_counter += 1
 			return val
 

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -70,12 +70,16 @@ class RedisWrapper(redis.Redis):
 		:param user: Prepends key with User
 		:param expires_in_sec: Expire value of this key in X seconds
 
-		Return the size of the serialized value in bytes.
+		Return the size of the serialized value in bytes. Zero would mean fail to set value in redis.
 		"""
 		key = self.make_key(key, user, shared)
 
 		frappe.local.cache[key] = val
-		serialized = pickle.dumps(val, protocol=DEFAULT_PICKLE_PROTOCOL)
+		try:
+			serialized = pickle.dumps(val, protocol=DEFAULT_PICKLE_PROTOCOL)
+		except Exception:
+			# TODO: warning ?
+			return 0
 
 		with suppress(redis.exceptions.ConnectionError):
 			self.set(name=key, value=serialized, ex=expires_in_sec)
@@ -213,14 +217,15 @@ class RedisWrapper(redis.Redis):
 	def hset(
 		self,
 		name: str,
-		key: str,
+		key: str | None,
 		value,
 		shared: bool = False,
 		*args,
 		**kwargs,
-	):
+	) -> bool:
+		status = True  # can only be set to False on any error/exception.
 		if key is None:
-			return
+			return False
 
 		_name = self.make_key(name, shared=shared)
 
@@ -229,9 +234,17 @@ class RedisWrapper(redis.Redis):
 
 		# set in redis
 		try:
-			super().hset(_name, key, pickle.dumps(value, protocol=DEFAULT_PICKLE_PROTOCOL), *args, **kwargs)
+			serialized = pickle.dumps(value, protocol=DEFAULT_PICKLE_PROTOCOL)
+		except Exception:
+			# TODO: Warning ?
+			status = False
+			return status
+
+		try:
+			super().hset(_name, key, serialized, *args, **kwargs)
 		except redis.exceptions.ConnectionError:
-			pass
+			status = False
+		return status
 
 	def hexists(self, name: str, key: str, shared: bool = False) -> bool:
 		if key is None:
@@ -250,8 +263,8 @@ class RedisWrapper(redis.Redis):
 		except redis.exceptions.ConnectionError:
 			return False
 
-	def hgetall(self, name):
-		value = super().hgetall(self.make_key(name))
+	def hgetall(self, name, shared: bool = False):
+		value = super().hgetall(self.make_key(name, shared=shared))
 		return {key: pickle.loads(value) for key, value in value.items()}
 
 	def hget(self, name, key, generator=None, shared=False):
@@ -287,7 +300,7 @@ class RedisWrapper(redis.Redis):
 		keys: str | list | tuple,
 		shared=False,
 		pipeline: redis.client.Pipeline | None = None,
-	):
+	) -> bool:
 		"""
 		A wrapper around redis' HDEL command
 
@@ -296,6 +309,7 @@ class RedisWrapper(redis.Redis):
 		:param shared: shared frappe key or not
 		:param pipeline: A redis.client.Pipeline object, if this transaction is to be run in a pipeline
 		"""
+		status = True  # can only be set to False on any error/exception.
 		_name = self.make_key(name, shared=shared)
 
 		name_in_local_cache = _name in frappe.local.cache
@@ -303,14 +317,14 @@ class RedisWrapper(redis.Redis):
 		if not isinstance(keys, list | tuple):
 			if name_in_local_cache and keys in frappe.local.cache[_name]:
 				del frappe.local.cache[_name][keys]
-			if pipeline:
-				pipeline.hdel(_name, keys)
-			else:
-				try:
+			try:
+				if pipeline:
+					pipeline.hdel(_name, keys)
+				else:
 					super().hdel(_name, keys)
-				except redis.exceptions.ConnectionError:
-					pass
-			return
+			except redis.exceptions.ConnectionError:
+				status = False
+			return status
 
 		local_pipeline = False
 
@@ -322,13 +336,17 @@ class RedisWrapper(redis.Redis):
 			if name_in_local_cache:
 				if key in frappe.local.cache[_name]:
 					del frappe.local.cache[_name][key]
-			pipeline.hdel(_name, key)
+			try:
+				pipeline.hdel(_name, key)
+			except redis.exceptions.ConnectionError:
+				status = False
 
 		if local_pipeline:
 			try:
 				pipeline.execute()
 			except redis.exceptions.ConnectionError:
-				pass
+				status = False
+		return status
 
 	def hdel_names(self, names: list | tuple, key: str):
 		"""
@@ -356,9 +374,9 @@ class RedisWrapper(redis.Redis):
 		except redis.exceptions.ConnectionError:
 			pass
 
-	def hkeys(self, name):
+	def hkeys(self, name, shared: bool = False):
 		try:
-			return super().hkeys(self.make_key(name))
+			return super().hkeys(self.make_key(name, shared=shared))
 		except redis.exceptions.ConnectionError:
 			return []
 
@@ -593,12 +611,15 @@ class ClientCache:
 
 		return val
 
-	def set_value(self, key, val, *, shared=False):
+	def set_value(self, key, val, *, shared=False, ttl: int | None = None):
 		key = self.redis.make_key(key, shared=shared)
 		size = self.redis.set_value(key, val, shared=True)
 		if not self.healthy:
 			return
 		self.ensure_max_size()
+		if ttl is not None:
+			assert isinstance(ttl, int)
+			self.local_ttl = ttl
 		with self.lock:
 			self._put(key, val, time.monotonic() + self.local_ttl, size)
 		# XXX: We need to tell redis that we indeed read this key we just wrote

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -568,7 +568,8 @@ class ClientCache:
 		)
 		self.invalidator_thread = self.run_invalidator_thread()
 
-	def get_value(self, key, *, shared=False, generator=None):
+	def get_value(self, key, *, shared=False, generator=None, ttl: int | None = None):
+		# NOTE: `ttl` has to be remembered. For now only used for `site_cache` which store ttl in closure scope.
 		if not self.healthy:
 			return self.redis.get_value(key, shared=shared, generator=generator)
 
@@ -606,8 +607,12 @@ class ClientCache:
 		with self.lock:
 			# Note: If our placeholder value is not present then it's possible that value we just
 			# got is invalidated, so we should not store it in local cache.
+			if ttl is not None:
+				assert isinstance(ttl, int)
+			else:
+				ttl = self.local_ttl
 			if key in self.cache:
-				self._put(key, val, time.monotonic() + self.local_ttl, size)
+				self._put(key, val, time.monotonic() + ttl, size)
 
 		return val
 
@@ -619,9 +624,10 @@ class ClientCache:
 		self.ensure_max_size()
 		if ttl is not None:
 			assert isinstance(ttl, int)
-			self.local_ttl = ttl
+		else:
+			ttl = self.local_ttl
 		with self.lock:
-			self._put(key, val, time.monotonic() + self.local_ttl, size)
+			self._put(key, val, time.monotonic() + ttl, size)
 		# XXX: We need to tell redis that we indeed read this key we just wrote
 		# This is an edge case:
 		# - Client A writes a key and reads it again from local cache


### PR DESCRIPTION
This PR now enables `site_cache` through existing `frappe.client_cache` to reduce redundancy.
Necessary miscellaneous fixes are made to `redis_wrapper` to better handle errors and allowing user supplied `ttl` for `client_cache`. 