### PR TITLE
chore(ui): build against frappe-ui 1.0.0-beta.63

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -102,7 +102,7 @@
     "@vitejs/plugin-vue": ">=4",
     "@vueuse/core": ">=10.4.1",
     "autoprefixer": "^10.4.0",
-    "frappe-ui": ">=1.0.0-beta.55",
+    "frappe-ui": ">=1.0.0-beta.63",
     "tailwindcss": "^3.4.0",
     "typescript": ">=5",
     "vite": ">=4",

--- a/ui/src/components/ActivityTimeline/DOCS.md
+++ b/ui/src/components/ActivityTimeline/DOCS.md
@@ -385,8 +385,8 @@ import LucideReply from "~icons/lucide/reply";
     <template #item-comment="{ activity }">
       <CommentItem :comment="activity">
         <template #actions>
-          <Button variant="ghost" icon="edit-2" @click="onEdit(activity)" />
-          <Button variant="ghost" icon="trash-2" @click="onDelete(activity)" />
+          <Button variant="ghost" icon="lucide-pencil" @click="onEdit(activity)" />
+          <Button variant="ghost" icon="lucide-trash-2" @click="onDelete(activity)" />
         </template>
       </CommentItem>
     </template>
@@ -486,7 +486,7 @@ function onSave(activity, content: string) {
         <template #actions>
           <Button
             variant="ghost"
-            icon="edit-2"
+            icon="lucide-pencil"
             @click="editingKey = activity.key"
           />
         </template>

--- a/ui/src/components/ActivityTimeline/stories/ActivityTimeline.story.vue
+++ b/ui/src/components/ActivityTimeline/stories/ActivityTimeline.story.vue
@@ -39,7 +39,7 @@
 						<template v-if="withSlots" #actions>
 							<Button
 								variant="ghost"
-								icon="trash-2"
+								icon="lucide-trash-2"
 								@click="log('delete', activity.data.name)"
 							/>
 						</template>

--- a/ui/src/components/ActivityTimeline/types.ts
+++ b/ui/src/components/ActivityTimeline/types.ts
@@ -25,7 +25,7 @@ export interface Pagination {
     position?: "top" | "bottom" | "inline";
     /** Button copy; default "Load more" / "lucide-refresh-cw". */
     label?: string;
-    /** lucide-* string, FeatherIcon name, or a component — same as `Button`'s icon. */
+    /** lucide-* string or a component — same as `Button`'s icon. */
     icon?: string | Component;
   };
 }

--- a/ui/src/components/Composer/EmailComposer/RecipientSelect.vue
+++ b/ui/src/components/Composer/EmailComposer/RecipientSelect.vue
@@ -17,7 +17,7 @@
 					class="grid size-4 place-items-center rounded-1 text-ink-gray-5 hover:bg-surface-gray-4"
 					@click.stop="removeTag"
 				>
-					<FeatherIcon name="x" class="size-3" />
+					<LucideX class="size-3" />
 				</button>
 			</template>
 
@@ -40,7 +40,8 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
 import { computedAsync, useDebounceFn } from "@vueuse/core";
-import { Avatar, FeatherIcon, toast } from "frappe-ui";
+import { Avatar, toast } from "frappe-ui";
+import LucideX from "~icons/lucide/x";
 import { MultiEmailInput, type MultiEmailOption } from "frappe-ui/experimental";
 import type { Recipient, RecipientSearch } from "../types";
 

--- a/ui/src/components/DataImport/DataImportList.vue
+++ b/ui/src/components/DataImport/DataImportList.vue
@@ -9,7 +9,7 @@
 			</div>
 			<Button variant="solid" @click="showModal = true">
 				<template #prefix>
-					<FeatherIcon name="plus" class="size-4 stroke-1.5" />
+					<LucidePlus class="size-4 stroke-1.5" />
 				</template>
 				Import
 			</Button>
@@ -56,7 +56,7 @@
 			<div class="my-5 flex justify-center">
 				<Button v-if="props.dataImports.hasNextPage" @click="props.dataImports.next?.()">
 					<template #prefix>
-						<FeatherIcon name="refresh-cw" class="size-4 stroke-1.5" />
+						<LucideRefreshCw class="size-4 stroke-1.5" />
 					</template>
 					Load More
 				</Button>
@@ -97,8 +97,10 @@
 import { computed, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import type { DataImports, DataImport } from "./types";
-import { Badge, Button, Dialog, FeatherIcon, FormControl, dayjs, toast } from "frappe-ui";
+import { Badge, Button, Dialog, FormControl, dayjs, toast } from "frappe-ui";
 import type { BadgeProps } from "frappe-ui";
+import LucidePlus from "~icons/lucide/plus";
+import LucideRefreshCw from "~icons/lucide/refresh-cw";
 import { Link } from "../Link";
 import { getBadgeColor } from "./dataImport";
 

--- a/ui/src/components/DataImport/ImportSteps.vue
+++ b/ui/src/components/DataImport/ImportSteps.vue
@@ -7,9 +7,8 @@
 			}"
 			@click="emit('updateStep', 'upload', { ...data })"
 		>
-			<FeatherIcon
+			<LucideCheck
 				v-if="uploadStepCompleted"
-				name="check"
 				class="size-5 text-sm border rounded-[5px] p-0.5"
 				:class="{
 					'text-ink-base bg-surface-gray-10': onUploadStep,
@@ -34,9 +33,8 @@
 			}"
 			@click="moveToMapStep()"
 		>
-			<FeatherIcon
+			<LucideCheck
 				v-if="mapStepCompleted"
-				name="check"
 				class="size-5 text-sm border rounded-[5px] p-0.5"
 				:class="{
 					'text-ink-base bg-surface-gray-10': onMapStep,
@@ -61,9 +59,8 @@
 			}"
 			@click="moveToPreviewStep()"
 		>
-			<FeatherIcon
+			<LucideCheck
 				v-if="previewStepCompleted"
-				name="check"
 				class="size-5 text-sm border rounded-[5px] p-0.5"
 				:class="{
 					'text-ink-base bg-surface-gray-10': onPreviewStep,
@@ -85,7 +82,7 @@
 <script setup lang="ts">
 import type { DataImport } from "./types";
 import { computed } from "vue";
-import { FeatherIcon } from "frappe-ui";
+import LucideCheck from "~icons/lucide/check";
 
 const emit = defineEmits(["updateStep"]);
 

--- a/ui/src/components/DataImport/PreviewStep.vue
+++ b/ui/src/components/DataImport/PreviewStep.vue
@@ -33,7 +33,7 @@
 						{{ map[0] }}
 					</div>
 					<div class="flex justify-end">
-						<FeatherIcon name="arrow-right" class="inline size-4 text-ink-gray-5" />
+						<LucideArrowRight class="inline size-4 text-ink-gray-5" />
 					</div>
 					<div>
 						{{ map[1] }}
@@ -46,7 +46,7 @@
 			<div class="text-ink-gray-5 text-sm">Warnings</div>
 			<div class="rounded-5 bg-surface-amber-2 p-2 space-y-2 text-xs">
 				<div v-for="warning in warnings" class="flex items-center space-x-2">
-					<FeatherIcon name="alert-circle" class="size-3 text-ink-amber-6" />
+					<LucideCircleAlert class="size-3 text-ink-amber-6" />
 					<div v-html="warning.message" class="text-ink-amber-6"></div>
 				</div>
 			</div>
@@ -153,7 +153,7 @@
 							>
 								<HoverCard v-if="row.exception" side="left" align="start">
 									<template #trigger>
-										<FeatherIcon name="info" class="size-4" />
+										<LucideInfo class="size-4" />
 									</template>
 									<div class="w-[500px] p-2 text-xs leading-5 font-mono">
 										{{ row.exception }}
@@ -172,7 +172,10 @@
 import { getPreviewData, getBadgeColor } from "./dataImport";
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import type { DataImport, DataImports, DataImportSocket } from "./types";
-import { Badge, Button, FeatherIcon, HoverCard, TabButtons, call } from "frappe-ui";
+import { Badge, Button, HoverCard, TabButtons, call } from "frappe-ui";
+import LucideArrowRight from "~icons/lucide/arrow-right";
+import LucideCircleAlert from "~icons/lucide/circle-alert";
+import LucideInfo from "~icons/lucide/info";
 
 const preview = ref<any>(null);
 const emit = defineEmits(["updateStep"]);

--- a/ui/src/components/DataImport/UploadStep.vue
+++ b/ui/src/components/DataImport/UploadStep.vue
@@ -25,10 +25,7 @@
 				class="h-[300px] flex items-center justify-center bg-surface-gray-1 border border-dashed border-outline-gray-3 rounded-5"
 			>
 				<div v-if="showFileSelector && !uploading" class="w-4/5 lg:w-2/5 text-center">
-					<FeatherIcon
-						name="upload-cloud"
-						class="size-6 stroke-1.5 text-ink-gray-6 mx-auto mb-2.5"
-					/>
+					<LucideCloudUpload class="size-6 stroke-1.5 text-ink-gray-6 mx-auto mb-2.5" />
 					<input
 						ref="fileInput"
 						type="file"
@@ -87,8 +84,7 @@
 							{{ convertToKB(importFile.file_size) }}
 						</div>
 					</div>
-					<FeatherIcon
-						name="trash-2"
+					<LucideTrash2
 						class="size-4 stroke-1.5 text-ink-red-6 cursor-pointer"
 						@click="deleteFile"
 					/>
@@ -100,11 +96,7 @@
 				class="flex flex-col h-[300px] p-4 border border-dashed border-outline-gray-3 rounded-5"
 			>
 				<div class="flex items-center space-x-2 text-ink-gray-7">
-					<FeatherIcon
-						name="chevron-left"
-						class="size-4 cursor-pointer"
-						@click="backToFileSelector"
-					/>
+					<LucideChevronLeft class="size-4 cursor-pointer" @click="backToFileSelector" />
 					<div>Google Sheet</div>
 				</div>
 				<div
@@ -148,12 +140,11 @@
 					<template v-slot="{ open }">
 						<Button variant="ghost">
 							<template #prefix>
-								<FeatherIcon name="download" class="size-4 stroke-1.5" />
+								<LucideDownload class="size-4 stroke-1.5" />
 							</template>
 							Download CSV Template
 							<template #suffix>
-								<FeatherIcon
-									name="chevron-down"
+								<LucideChevronDown
 									:class="[
 										'w-4 h-4 stroke-1.5 ml-1 transform transition-transform',
 										open ? 'rotate-180' : '',
@@ -177,7 +168,12 @@
 import { computed, nextTick, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import type { DataImports, DataImport, DocField, DocType } from "./types";
-import { Badge, Button, Dropdown, FeatherIcon, FileUploadHandler, toast } from "frappe-ui";
+import { Badge, Button, Dropdown, FileUploadHandler, toast } from "frappe-ui";
+import LucideChevronDown from "~icons/lucide/chevron-down";
+import LucideChevronLeft from "~icons/lucide/chevron-left";
+import LucideCloudUpload from "~icons/lucide/cloud-upload";
+import LucideDownload from "~icons/lucide/download";
+import LucideTrash2 from "~icons/lucide/trash-2";
 import { fieldsToIgnore, getChildTableName, getBadgeColor } from "./dataImport";
 import TemplateModal from "./TemplateModal.vue";
 

--- a/ui/src/components/Fields/CodeEditorField.vue
+++ b/ui/src/components/Fields/CodeEditorField.vue
@@ -116,8 +116,7 @@
 // `doc` (Frappe JSON/Code fields store strings) — the contract is unchanged.
 import { computed, onBeforeUnmount, onMounted, ref, useId, watch } from "vue";
 import { Button } from "frappe-ui";
-import { InputLabel, InputDescription } from "frappe-ui/experimental";
-import { CodeEditor, CodePreview } from "frappe-ui/code-editor";
+import { CodeEditor, CodePreview, InputDescription, InputLabel } from "frappe-ui/experimental";
 import { fieldtypeToLanguage } from "./fieldtypeToLanguage";
 import type { FieldComponentEmits, FieldComponentProps } from "./types";
 

--- a/ui/src/components/Fields/fieldtypeToLanguage.ts
+++ b/ui/src/components/Fields/fieldtypeToLanguage.ts
@@ -1,5 +1,5 @@
 // Maps a Frappe FormLayout fieldtype to a CodeMirror language key for the
-// CodeEditor primitive (now published from `frappe-ui/code-editor`). This is
+// CodeEditor primitive (published from `frappe-ui/experimental`). This is
 // FormLayout-specific glue — it understands Frappe fieldtypes and the Ace mode
 // stored in `field.options` — so it lives here with the field wrapper rather than
 // in the framework-agnostic editor primitive.

--- a/ui/src/components/ListView/stories/ListViewToolbar.vue
+++ b/ui/src/components/ListView/stories/ListViewToolbar.vue
@@ -125,17 +125,14 @@
 </template>
 
 <script setup lang="ts">
+import { Badge, Button, Dropdown, toast } from "frappe-ui";
 import {
-	Badge,
-	Button,
-	Dropdown,
 	ListView,
 	ListHeader,
 	ListRows,
 	ListSelectBanner,
 	ListFooter,
-	toast,
-} from "frappe-ui";
+} from "frappe-ui/experimental";
 import { computed, onMounted, watch } from "vue";
 import { ListViewShell } from "../index";
 import { useListView } from "../useListView";

--- a/ui/src/components/Onboarding/GettingStartedBanner.vue
+++ b/ui/src/components/Onboarding/GettingStartedBanner.vue
@@ -22,9 +22,8 @@
 						{{ "You are all set" }}
 					</div>
 				</div>
-				<FeatherIcon
-					name="x"
-					class="h-4 cursor-pointer"
+				<LucideX
+					class="size-4 cursor-pointer"
 					@click="
 						() => {
 							showHelpCenter = true;
@@ -44,7 +43,7 @@
 			@click="openOnboarding"
 		>
 			<template #prefix>
-				<FeatherIcon name="chevrons-right" class="size-4" />
+				<LucideChevronsRight class="size-4" />
 			</template>
 		</Button>
 	</div>
@@ -53,7 +52,9 @@
 	</Button>
 </template>
 <script setup lang="ts">
-import { Button, FeatherIcon } from "frappe-ui";
+import { Button } from "frappe-ui";
+import LucideChevronsRight from "~icons/lucide/chevrons-right";
+import LucideX from "~icons/lucide/x";
 import { StepsIcon } from "frappe-ui/icons";
 import { useOnboarding } from "./onboarding";
 import { showHelpCenter } from "./helpCenter";

--- a/ui/src/components/Onboarding/HelpCenter.vue
+++ b/ui/src/components/Onboarding/HelpCenter.vue
@@ -8,14 +8,14 @@
 				:debounce="300"
 			>
 				<template #prefix>
-					<FeatherIcon name="search" class="h-4 text-ink-gray-5" />
+					<LucideSearch class="size-4 text-ink-gray-5" />
 				</template>
 			</TextInput>
 		</div>
 		<div class="flex justify-between items-center text-base text-ink-gray-5 mx-2">
 			<div>All articles</div>
 			<Button variant="ghost" @click="openDocs">
-				<FeatherIcon name="arrow-up-right" class="h-4 text-ink-gray-5" />
+				<LucideArrowUpRight class="size-4 text-ink-gray-5" />
 			</Button>
 		</div>
 		<div class="flex flex-col gap-1.5 overflow-y-auto">
@@ -25,9 +25,9 @@
 					@click="a.opened = !a.opened"
 				>
 					<div class="flex items-center gap-2">
-						<FeatherIcon
-							:name="a.opened ? 'chevron-down' : 'chevron-right'"
-							class="h-4 text-ink-gray-5"
+						<component
+							:is="a.opened ? LucideChevronDown : LucideChevronRight"
+							class="size-4 text-ink-gray-5"
 						/>
 						<div class="text-base text-ink-gray-8">{{ a.title }}</div>
 					</div>
@@ -40,14 +40,13 @@
 						@click="() => openDoc(subArticle.name)"
 					>
 						<div class="flex items-center gap-2">
-							<FeatherIcon name="file-text" class="h-4 text-ink-gray-5" />
+							<LucideFileText class="size-4 text-ink-gray-5" />
 							<div class="text-base text-ink-gray-8">
 								{{ subArticle.title }}
 							</div>
 						</div>
-						<FeatherIcon
-							name="arrow-up-right"
-							class="h-4 hidden group-hover:flex text-ink-gray-5"
+						<LucideArrowUpRight
+							class="size-4 hidden group-hover:flex text-ink-gray-5"
 						/>
 					</div>
 				</div>
@@ -56,7 +55,12 @@
 	</div>
 </template>
 <script setup lang="ts">
-import { Button, FeatherIcon, TextInput } from "frappe-ui";
+import { Button, TextInput } from "frappe-ui";
+import LucideArrowUpRight from "~icons/lucide/arrow-up-right";
+import LucideChevronDown from "~icons/lucide/chevron-down";
+import LucideChevronRight from "~icons/lucide/chevron-right";
+import LucideFileText from "~icons/lucide/file-text";
+import LucideSearch from "~icons/lucide/search";
 import { ref, computed, onMounted } from "vue";
 import type { HelpArticle, HelpCenterProps } from "./types";
 

--- a/ui/src/components/Onboarding/HelpModal.vue
+++ b/ui/src/components/Onboarding/HelpModal.vue
@@ -11,13 +11,13 @@
 			</div>
 			<div class="flex gap-1">
 				<Dropdown v-if="options.length" :options="options">
-					<Button variant="ghost" icon="more-horizontal" />
+					<Button variant="ghost" icon="lucide-ellipsis" />
 				</Dropdown>
 				<Button @click="minimize = !minimize" variant="ghost">
 					<component :is="minimize ? MaximizeIcon : MinimizeIcon" class="h-3.5" />
 				</Button>
 				<Button variant="ghost" @click="show = false">
-					<FeatherIcon name="x" class="h-3.5" />
+					<LucideX class="size-3.5" />
 				</Button>
 			</div>
 		</div>
@@ -46,7 +46,8 @@
 	</div>
 </template>
 <script setup lang="ts">
-import { Button, Dropdown, FeatherIcon } from "frappe-ui";
+import { Button, Dropdown } from "frappe-ui";
+import LucideX from "~icons/lucide/x";
 import { HelpIcon, MaximizeIcon, MinimizeIcon, StepsIcon } from "frappe-ui/icons";
 import OnboardingSteps from "./OnboardingSteps.vue";
 import HelpCenter from "./HelpCenter.vue";

--- a/ui/src/components/Phone/Phone.vue
+++ b/ui/src/components/Phone/Phone.vue
@@ -221,7 +221,6 @@ const inputClasses = computed(() => {
 		sm: "h-7 rounded-4",
 		md: "h-8 rounded-4",
 		lg: "h-10 rounded-5",
-		xl: "h-10 rounded-5",
 	}[props.size];
 
 	const variantClasses = props.disabled

--- a/ui/src/components/Phone/PhoneInput.cy.ts
+++ b/ui/src/components/Phone/PhoneInput.cy.ts
@@ -197,7 +197,7 @@ describe('PhoneInput', () => {
   })
 
   it('reflects each size and variant on the shell', () => {
-    for (const size of ['sm', 'md', 'lg', 'xl'] as const) {
+    for (const size of ['sm', 'md', 'lg'] as const) {
       cy.mount(PhoneInput, { props: { size } })
       cy.get('[data-slot="phone-input"]').should('have.attr', 'data-size', size)
     }

--- a/ui/src/components/Phone/stories/CountryDetect.vue
+++ b/ui/src/components/Phone/stories/CountryDetect.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref } from "vue";
-import { Button, PhoneInput } from "frappe-ui";
+import { Button } from "frappe-ui";
+import { Phone } from "../index";
 
 const phone = ref("");
 
@@ -13,7 +14,7 @@ const customers = [
 
 <template>
 	<div class="flex w-full max-w-sm flex-col gap-3">
-		<PhoneInput v-model="phone" label="Customer phone" />
+		<Phone v-model="phone" label="Customer phone" />
 		<div class="flex gap-2">
 			<Button
 				v-for="customer in customers"

--- a/ui/src/components/Phone/stories/Default.vue
+++ b/ui/src/components/Phone/stories/Default.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import { ref } from "vue";
-import { PhoneInput } from "frappe-ui";
+import { Phone } from "../index";
 
 const phone = ref("");
 </script>
 
 <template>
 	<div class="flex w-full max-w-sm flex-col gap-2">
-		<PhoneInput v-model="phone" placeholder="98765 43210" />
+		<Phone v-model="phone" placeholder="98765 43210" />
 		<p class="text-p-sm text-ink-gray-5">v-model: {{ phone || "—" }}</p>
 	</div>
 </template>

--- a/ui/src/components/Phone/stories/Labeling.vue
+++ b/ui/src/components/Phone/stories/Labeling.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
-import { Checkbox, PhoneInput } from "frappe-ui";
+import { Checkbox } from "frappe-ui";
+import { Phone } from "../index";
 
 const phone = ref("");
 const required = ref(true);
@@ -13,7 +14,7 @@ const error = computed(() =>
 
 <template>
 	<div class="flex items-start gap-8">
-		<PhoneInput
+		<Phone
 			v-model="phone"
 			label="Delivery contact"
 			description="The courier will call this number on arrival."

--- a/ui/src/components/Phone/stories/Sizes.vue
+++ b/ui/src/components/Phone/stories/Sizes.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
-import { PhoneInput } from "frappe-ui";
+import { Phone } from "../index";
 </script>
 
 <template>
 	<div class="flex w-full max-w-sm flex-col gap-3">
-		<PhoneInput size="sm" placeholder="Small" />
-		<PhoneInput size="md" placeholder="Medium" />
-		<PhoneInput size="lg" placeholder="Large" />
-		<PhoneInput size="xl" placeholder="Extra large" />
+		<Phone size="sm" placeholder="Small" />
+		<Phone size="md" placeholder="Medium" />
+		<Phone size="lg" placeholder="Large" />
 	</div>
 </template>

--- a/ui/src/components/Phone/stories/States.vue
+++ b/ui/src/components/Phone/stories/States.vue
@@ -1,16 +1,16 @@
 <script setup lang="ts">
 import { ref } from "vue";
-import { PhoneInput } from "frappe-ui";
+import { Phone } from "../index";
 
 const disabledValue = ref("+91-9876543210");
 </script>
 
 <template>
 	<div class="flex w-full max-w-sm flex-col gap-4">
-		<PhoneInput label="Default" placeholder="98765 43210" />
-		<PhoneInput label="Required" required placeholder="98765 43210" />
-		<PhoneInput v-model="disabledValue" label="Disabled" disabled />
-		<PhoneInput
+		<Phone label="Default" placeholder="98765 43210" />
+		<Phone label="Required" required placeholder="98765 43210" />
+		<Phone v-model="disabledValue" label="Disabled" disabled />
+		<Phone
 			label="With error"
 			error="This number can't receive OTPs."
 			placeholder="98765 43210"

--- a/ui/src/components/Phone/stories/Suffix.vue
+++ b/ui/src/components/Phone/stories/Suffix.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
-import { PhoneInput } from "frappe-ui";
+import { Phone } from "../index";
 
 const phone = ref("+91-9876543210");
 
@@ -11,9 +11,9 @@ const isVerified = computed(() => {
 </script>
 
 <template>
-	<PhoneInput v-model="phone" label="WhatsApp number" class="w-72">
+	<Phone v-model="phone" label="WhatsApp number" class="w-72">
 		<template #suffix>
 			<span v-if="isVerified" class="lucide-circle-check size-4 text-ink-green-3" />
 		</template>
-	</PhoneInput>
+	</Phone>
 </template>

--- a/ui/src/components/Phone/stories/Variants.vue
+++ b/ui/src/components/Phone/stories/Variants.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { PhoneInput } from "frappe-ui";
+import { Phone } from "../index";
 </script>
 
 <template>
 	<div class="flex w-full max-w-sm flex-col gap-3">
-		<PhoneInput variant="subtle" placeholder="Subtle" />
-		<PhoneInput variant="outline" placeholder="Outline" />
+		<Phone variant="subtle" placeholder="Subtle" />
+		<Phone variant="outline" placeholder="Outline" />
 	</div>
 </template>

--- a/ui/src/components/SignupBanner/SignupBanner.vue
+++ b/ui/src/components/SignupBanner/SignupBanner.vue
@@ -6,7 +6,7 @@
 		<div class="flex flex-col gap-1">
 			<slot>
 				<div class="inline-flex gap-2 items-center font-medium">
-					<FeatherIcon class="h-4" name="info" />
+					<LucideInfo class="size-4" />
 					Loved the demo?
 				</div>
 				<div class="text-ink-gray-7 text-p-sm">
@@ -25,7 +25,8 @@
 	</Button>
 </template>
 <script setup lang="ts">
-import { Button, FeatherIcon } from "frappe-ui";
+import { Button } from "frappe-ui";
+import LucideInfo from "~icons/lucide/info";
 import { LightningIcon } from "frappe-ui/icons";
 import type { SignupBannerProps } from "./types";
 

--- a/ui/src/components/types.ts
+++ b/ui/src/components/types.ts
@@ -6,7 +6,7 @@ export interface InputLabelingProps {
 }
 
 /** Size scale for text-style inputs. */
-export type InputSize = "sm" | "md" | "lg" | "xl";
+export type InputSize = "sm" | "md" | "lg";
 
 /** Variant scale for text-style inputs that have a container surface. */
 export type InputVariant = "subtle" | "outline" | "ghost";


### PR DESCRIPTION
Part of the standing map "Keep frappe-ui current" (#42719); resolves its task #42720. The desk pin bump follows in #42721 on `desk-v2`.

`@framework/ui` declares `frappe-ui >=1.0.0-beta.55`, but its root barrel did not import on beta.55 or beta.63. This PR fixes every call site that `frappe-ui` no longer serves and raises the floor to beta.63, the version this was tested against.

## What changed

- `CodeEditorField.vue` imported `CodeEditor` and `CodePreview` from `frappe-ui/code-editor`, a subpath that does not exist. The primitive is exported from `frappe-ui/experimental`. This was the first import to fail when the root barrel was loaded.
- `FeatherIcon` is gone from `frappe-ui` (the component and the `feather-icons` dependency were removed for 1.0.0). Every use is replaced with the lucide icon of the same name through `~icons/lucide/<name>`, the form the rest of the tree already uses. Four names differ: `upload-cloud` → `cloud-upload`, `alert-circle` → `circle-alert`, `more-horizontal` → `ellipsis`, `edit-2` → `pencil`. The lucide component sets `width="24" height="24"` on its svg where `FeatherIcon` set neither, so the seven icons that carried a height-only class (`h-4`, `h-3.5`) now use `size-4` / `size-3.5` to keep their square box.
- A bare feather-style name on a Button `icon` prop renders nothing now. The three such sites (one component, one story, two doc snippets) take the `lucide-` prefix.
- The seven Phone stories imported `PhoneInput` from `frappe-ui`, which has no such export. They now render the local `Phone` component. The `xl` size is dropped from the story, the local `InputSize` type, the Phone size map and its Cypress spec, because the frappe-ui input scale the component forwards to no longer has it and resolved it to `sm` with a warning.
- The ListView story imported the `ListView` family from the root; it lives on `frappe-ui/experimental`.
- `ui/package.json`: `frappe-ui >=1.0.0-beta.63`.

## Verification

With this diff applied to the `desk-v2` checkout (which links `ui/` as raw source):

- `frontend/` vitest: 39 files, 579 tests, all green.
- `bench build --app frappe`: green, 1226 modules.
- A throwaway test importing the `@framework/ui` root barrel now gets past every `frappe-ui` import. On the pristine tree it failed on `./code-editor`. It next stops on a pre-existing relative import of `frappe/geo/country_info.json` in `Phone/utils.ts`, which resolves wrongly through the package symlink under `preserveSymlinks`; that is unrelated to `frappe-ui` and is recorded on the `@framework/ui` map (#42660).

No screenshots: the icon swap is one-for-one (same names, same 1.5 stroke, same box after the `size-*` fix) and the `ui/` stories have no runner on this bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
