### PR TITLE
fix(user): run the owner sweep after a rename as a background job

### DIFF
--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -14,6 +14,7 @@ from frappe.core.doctype.user.user import (
 	User,
 	handle_password_test_fail,
 	reset_password,
+	rewrite_owner_fields,
 	sign_up,
 	test_password_strength,
 	update_password,
@@ -320,6 +321,39 @@ class TestUser(IntegrationTestCase):
 		self.assertTrue(frappe.db.exists("Notification Settings", new_name))
 
 		frappe.delete_doc("User", new_name)
+
+	def test_user_rename_defers_the_owner_sweep(self):
+		old_name = "test_user_rename_owner@example.com"
+		new_name = "test_user_rename_owner_new@example.com"
+		user = frappe.get_doc(
+			{"doctype": "User", "email": old_name, "first_name": "_Test", "send_welcome_email": 0}
+		).insert(ignore_permissions=True, ignore_if_duplicate=True)
+
+		todo = frappe.get_doc({"doctype": "ToDo", "description": "owned by a renamed user"}).insert()
+		frappe.db.set_value(
+			"ToDo", todo.name, {"owner": old_name, "modified_by": old_name}, update_modified=False
+		)
+
+		with patch("frappe.enqueue") as enqueue:
+			frappe.rename_doc("User", user.name, new_name)
+
+		enqueue.assert_any_call(
+			"frappe.core.doctype.user.user.rewrite_owner_fields",
+			old_name=old_name,
+			new_name=new_name,
+			commit=True,
+			queue="long",
+			timeout=36000,
+			enqueue_after_commit=True,
+			job_id=f"rewrite-owner-fields-{old_name}-{new_name}",
+			deduplicate=True,
+		)
+		self.assertEqual(frappe.db.get_value("ToDo", todo.name, "owner"), old_name)
+
+		rewrite_owner_fields(old_name, new_name)
+
+		self.assertEqual(frappe.db.get_value("ToDo", todo.name, "owner"), new_name)
+		self.assertEqual(frappe.db.get_value("ToDo", todo.name, "modified_by"), new_name)
 
 	def test_user_rename_updates_private_workspace(self):
 		old_name = "test_user_rename_ws@example.com"

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -698,17 +698,17 @@ class User(Document):
 		validate_email_address(email.strip(), True)
 
 	def after_rename(self, old_name, new_name, merge=False):
-		tables = frappe.db.get_tables()
-		for tab in tables:
-			desc = frappe.db.get_table_columns_description(tab)
-			has_fields = [d.get("name") for d in desc if d.get("name") in ["owner", "modified_by"]]
-			for field in has_fields:
-				frappe.db.sql(
-					"""UPDATE `{}`
-					SET `{}` = {}
-					WHERE `{}` = {}""".format(tab, field, "%s", field, "%s"),
-					(new_name, old_name),
-				)
+		frappe.enqueue(
+			"frappe.core.doctype.user.user.rewrite_owner_fields",
+			old_name=old_name,
+			new_name=new_name,
+			commit=True,
+			queue="long",
+			timeout=36000,
+			enqueue_after_commit=True,
+			job_id=f"rewrite-owner-fields-{old_name}-{new_name}",
+			deduplicate=True,
+		)
 
 		if frappe.db.exists("Notification Settings", old_name):
 			frappe.rename_doc("Notification Settings", old_name, new_name, force=True, show_alert=False)
@@ -1123,6 +1123,28 @@ def _get_user_for_update_password(key, old_password):
 		user = frappe.session.user
 		result.user = user
 	return result
+
+
+def rewrite_owner_fields(old_name: str, new_name: str, commit: bool = False):
+	"""Point `owner` and `modified_by` at a renamed user's new name in every table.
+
+	Neither column is indexed, so this runs for minutes on a large site; `commit` releases the
+	read view and its row locks one table at a time. Running it again is safe.
+	"""
+	tables = frappe.db.get_tables()
+	for tab in tables:
+		desc = frappe.db.get_table_columns_description(tab)
+		has_fields = [d.get("name") for d in desc if d.get("name") in ["owner", "modified_by"]]
+		for field in has_fields:
+			frappe.db.sql(
+				"""UPDATE `{}`
+				SET `{}` = {}
+				WHERE `{}` = {}""".format(tab, field, "%s", field, "%s"),
+				(new_name, old_name),
+			)
+
+		if commit:
+			frappe.db.commit()
 
 
 def reset_user_data(user):

--- a/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py
+++ b/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py
@@ -6,6 +6,7 @@ import re
 
 import frappe
 from frappe import _
+from frappe.core.doctype.user.user import rewrite_owner_fields
 from frappe.core.utils import find
 from frappe.desk.doctype.notification_settings.notification_settings import is_email_notifications_enabled
 from frappe.model.document import Document
@@ -293,6 +294,8 @@ class PersonalDataDeletionRequest(Document):
 				frappe.db.commit()
 
 		frappe.rename_doc("User", email, anon, force=True, show_alert=False)
+		# the rename only queues this; the address has to be gone before the status below
+		rewrite_owner_fields(email, anon, commit=commit)
 		self.db_set("status", "Deleted")
 
 		if commit:

--- a/frappe/website/doctype/personal_data_deletion_request/test_personal_data_deletion_request.py
+++ b/frappe/website/doctype/personal_data_deletion_request/test_personal_data_deletion_request.py
@@ -28,6 +28,14 @@ class TestPersonalDataDeletionRequest(IntegrationTestCase):
 		self.assertTrue("Subject: Confirm Deletion of Account" in email_queue[0].message)
 
 	def test_anonymized_data(self):
+		todo = frappe.get_doc({"doctype": "ToDo", "description": "owned by a deleted user"}).insert()
+		frappe.db.set_value(
+			"ToDo",
+			todo.name,
+			{"owner": self.delete_request.email, "modified_by": self.delete_request.email},
+			update_modified=False,
+		)
+
 		self.delete_request.status = "Pending Approval"
 		self.delete_request.save()
 		self.delete_request.trigger_data_deletion()
@@ -46,6 +54,10 @@ class TestPersonalDataDeletionRequest(IntegrationTestCase):
 			deleted_user.birth_date,
 			datetime.strptime(self.delete_request.anonymization_value_map["Date"], "%Y-%m-%d").date(),
 		)
+
+		self.assertEqual(frappe.db.get_value("ToDo", todo.name, "owner"), self.delete_request.name)
+		self.assertEqual(frappe.db.get_value("ToDo", todo.name, "modified_by"), self.delete_request.name)
+
 		self.assertEqual(self.delete_request.status, "Deleted")
 
 	def test_unverified_record_removal(self):


### PR DESCRIPTION
## Bug

Renaming a user on a large site fails. Desk shows "Deadlock Occurred", or the request times out, and the rename is rolled back with a `QueryDeadlockError` comment left on the User document.

`after_rename` rewrites `owner` and `modified_by` across every table in the database. Neither column is indexed, so each statement is a full table scan; one reported job spent 19m37s inside a single transaction. Any other write on the site during that window, and a login is enough, invalidates that transaction's read view. MariaDB answers 1020 `ER_CHECKREAD` and frappe raises `QueryDeadlockError`.

## Fix

The sweep moves out of the rename into `rewrite_owner_fields`, queued on `long` once the rename has committed and committing after each table. The rename returns without waiting for it, and the sweep holds a read view for one table at a time instead of for its whole run.

While a sweep is pending, both of its names are reserved. Renaming or deleting a user whose name is the old or new name of a queued or running sweep throws; other jobs on the queue are not counted. Without that, a rename from A to B followed by B to C can run the two sweeps out of order and leave rows on B; and a new user created at A and then renamed away or deleted would have their rows handed to B.

A new user who takes the old name and keeps it is handled in the sweep: rows written after that user was created stay theirs.

A personal data deletion request runs the sweep inline instead, and sets `frappe.flags.in_personal_data_deletion` around the rename so no second sweep is queued. That path renames the user to the anonymized name as its last act before reporting the request Deleted, so the address has to be gone from those columns by then.

## Note

`owner` and `modified_by` catch up shortly after the rename rather than within it. Anything reading them straight after `rename_doc("User", ...)` sees the old name until the sweep lands. A failed sweep does not block later renames; it is logged to Error Log and running it again finishes the remaining tables.