### PR TITLE
chore(desk): pin frappe-ui to 1.0.0-beta.63

### DIFF
--- a/frontend/package.base.json
+++ b/frontend/package.base.json
@@ -13,7 +13,7 @@
     "@framework/ui": "link:../ui",
     "@vueuse/core": "^11.3.0",
     "dompurify": "^3.3.3",
-    "frappe-ui": "1.0.0-beta.55",
+    "frappe-ui": "1.0.0-beta.63",
     "reka-ui": "^2.9.6",
     "socket.io-client": "^4.7.2",
     "vue": "^3.5.13",

--- a/frontend/src/shell/RailColumn.vue
+++ b/frontend/src/shell/RailColumn.vue
@@ -1,11 +1,11 @@
 <!--
-  The rail on frappe-ui's `Rail`: an icon column with the app tile first, which opens the app menu.
+  The rail on frappe-ui's `SidebarRail`: an icon column with the app tile first, which opens the app menu.
   A heading has no icon form, so its children draw flat; rows fetched on demand are not drawn.
 -->
 <template>
-	<Rail>
+	<SidebarRail>
 		<div class="mb-3 flex shrink-0 items-center justify-center">
-			<!-- A raw button: `Dropdown` cannot reach a trigger through `RailItem`'s `Tooltip`. -->
+			<!-- A raw button: `Dropdown` cannot reach a trigger through `SidebarRailItem`'s `Tooltip`. -->
 			<Dropdown :options="menu" side="right" align="start">
 				<button
 					type="button"
@@ -24,17 +24,17 @@
 			</Dropdown>
 		</div>
 
-		<!-- Stretched over `Rail`'s own padding, so the scrollbar sits on the rail's edge. -->
+		<!-- Stretched over `SidebarRail`'s own padding, so the scrollbar sits on the rail's edge. -->
 		<ScrollArea class="-mx-[11px] min-h-0 flex-1 self-stretch" viewportClass="px-[11px]">
 			<nav class="flex flex-col items-center gap-3" :aria-label="appTitle">
-				<!-- `RailItem`'s `Tooltip` drops attributes, so the test hooks sit on a wrapper. -->
+				<!-- `SidebarRailItem`'s `Tooltip` drops attributes, so the test hooks sit on a wrapper. -->
 				<div
 					v-for="cell in cells"
 					:key="cell.key"
 					:data-key="cell.key"
 					:data-sidebar="cell.sidebar"
 				>
-					<RailItem
+					<SidebarRailItem
 						v-if="'to' in cell"
 						:to="cell.to"
 						:label="cell.label"
@@ -42,14 +42,14 @@
 					>
 						<Icon v-if="cell.icon" :name="cell.icon" />
 						<span v-else class="text-sm font-medium">{{ cell.label.charAt(0) }}</span>
-					</RailItem>
+					</SidebarRailItem>
 
-					<!-- Off this prefix: a full document load, so an `<a>` with `RailItem`'s classes,
+					<!-- Off this prefix: a full document load, so an `<a>` with `SidebarRailItem`'s classes,
 					     which has no anchor form of its own. Never current: `current` is a route. -->
 					<Tooltip v-else :text="cell.label" side="right">
 						<a
 							:href="cell.href"
-							data-slot="rail-item"
+							data-slot="sidebar-rail-item"
 							:class="CELL"
 							:aria-label="cell.label"
 						>
@@ -78,7 +78,7 @@
 		</div>
 
 		<LogoutDialog v-model="confirmingLogout" />
-	</Rail>
+	</SidebarRail>
 </template>
 
 <script setup lang="ts">
@@ -87,8 +87,8 @@ import type { RouteLocationRaw } from "vue-router";
 import {
 	Avatar,
 	Dropdown,
-	Rail,
-	RailItem,
+	SidebarRail,
+	SidebarRailItem,
 	ScrollArea,
 	Tooltip,
 	toast,
@@ -114,7 +114,7 @@ const LETTER_TILE =
 	"bg-surface-gray-3 text-sm font-medium text-ink-gray-8 hover:bg-surface-gray-4";
 const USER_CELL =
 	"flex rounded-full transition hover:opacity-90 focus-visible:ring-0 focus-visible:focus-ring";
-// `RailItem`'s own inactive tile.
+// `SidebarRailItem`'s own inactive tile.
 const CELL =
 	"relative flex size-7 shrink-0 items-center justify-center rounded-[7px] bg-surface-gray-3 text-base transition focus-visible:ring-0 focus-visible:focus-ring";
 

--- a/frontend/src/shell/tests/history.test.ts
+++ b/frontend/src/shell/tests/history.test.ts
@@ -103,7 +103,7 @@ async function shell(path: string): Promise<{ host: HTMLElement; router: Router;
 
 /** The sidebar open now, read off the rail cell the shell marks current. */
 function open(host: HTMLElement): string | null | undefined {
-	const marked = host.querySelector("[data-slot='rail'] [aria-current='page']");
+	const marked = host.querySelector("[data-slot='sidebar-rail'] [aria-current='page']");
 	return marked?.closest("[data-key]")?.getAttribute("data-sidebar");
 }
 
@@ -135,7 +135,7 @@ async function walk() {
 	const panel = () => host.querySelector("[data-slot='sidebar']")!;
 
 	await follow(panel(), router, "item");
-	await follow(host.querySelector("[data-slot='rail']")!, router, "buying");
+	await follow(host.querySelector("[data-slot='sidebar-rail']")!, router, "buying");
 
 	return { host, router, app };
 }
@@ -226,7 +226,7 @@ describe("what the address-keyed record is left holding", () => {
 	it("answers a push arriving from an independent rail item", async () => {
 		const { host, router } = await walk();
 
-		await follow(host.querySelector("[data-slot='rail']")!, router, "note");
+		await follow(host.querySelector("[data-slot='sidebar-rail']")!, router, "note");
 		expect(open(host)).toBe(null);
 
 		// A fresh entry, so no stamp, and nothing open to carry: the record is all there is.

--- a/frontend/src/shell/tests/rail.test.ts
+++ b/frontend/src/shell/tests/rail.test.ts
@@ -109,7 +109,7 @@ function cell(host: HTMLElement, key: string) {
 
 /** The link or button inside a cell. */
 function target(host: HTMLElement, key: string) {
-	return cell(host, key)?.querySelector("[data-slot='rail-item']") ?? null;
+	return cell(host, key)?.querySelector("[data-slot='sidebar-rail-item']") ?? null;
 }
 
 function marked(host: HTMLElement) {
@@ -172,7 +172,7 @@ describe("the kinds the rail draws", () => {
 	});
 
 	it("makes a Link a plain anchor, so middle-click and copy-address survive", () => {
-		// A full document load the router cannot resolve, and one `RailItem` cannot draw.
+		// A full document load the router cannot resolve, and one `SidebarRailItem` cannot draw.
 		const host = rail([{ key: "docs", item_type: "Link", url: "https://docs.frappe.io" }]);
 		const anchor = target(host, "docs") as HTMLAnchorElement;
 

--- a/frontend/src/shell/tests/sidebar.test.ts
+++ b/frontend/src/shell/tests/sidebar.test.ts
@@ -79,7 +79,7 @@ function panel(host: HTMLElement) {
 }
 
 function rail(host: HTMLElement) {
-	return host.querySelector("[data-slot='rail']");
+	return host.querySelector("[data-slot='sidebar-rail']");
 }
 
 /** The keys marked current: the ARIA state sits one element under the `data-key` hook. */

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1663,10 +1663,10 @@ fraction.js@^5.3.4:
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-5.3.4.tgz#8c0fcc6a9908262df4ed197427bdeef563e0699a"
   integrity sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==
 
-frappe-ui@1.0.0-beta.55:
-  version "1.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-1.0.0-beta.55.tgz#405b8e569d456d8b6679f4dd3109068c3982dfcc"
-  integrity sha512-+G+5GDVIr31+QJ2ekDpM8FOXUWzTO4oBhh9rMjfDzJnFGzISbAy4U7V/XOF3hYOkQz4R/QqnrHTD55o+JRcOoA==
+frappe-ui@1.0.0-beta.63:
+  version "1.0.0-beta.63"
+  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-1.0.0-beta.63.tgz#4538261c9fd8bad4802d55b9b46c3f42548cb1bd"
+  integrity sha512-wUVIAFwpBGQTnmItSfWaDVu1/OxT885ENWMH7FUVb9j9NGDnSwcQDwaPAJyRUjGp+91jL4Be2xS0cBCzhXcpvA==
   dependencies:
     "@codemirror/lang-css" "^6.3.0"
     "@codemirror/lang-html" "^6.4.9"


### PR DESCRIPTION
Pins the desk frontend to `frappe-ui` 1.0.0-beta.63 (from beta.55). The `ui/` half of this bump merged to develop as `fcb0299a11` (#42726) and reached `desk-v2` in the fourth sync (#42729). Ticket: #42721 on the standing map #42719.

## What broke and what changed

- **`Rail` / `RailItem` are renamed** to `SidebarRail` / `SidebarRailItem` with no alias, and their `data-slot` hooks went from `rail` / `rail-item` to `sidebar-rail` / `sidebar-rail-item`. Props, slots, events and the tile classes are unchanged (diffed the two component sources). `shell/RailColumn.vue` follows the rename; its own `<a>` cell for off-prefix links carries the new hook, and the three shell tests that query the rail use the new selectors. The local `CELL` constant still matches `SidebarRailItem`'s inactive `tile` classes.
- **Form typography is a fixed 13px** for labels, descriptions and Textarea text, labels in `ink-gray-6`. Accepted as-is per the map's ruling; nothing overridden.
- **`toast.message` / `toast.loading` now render inline HTML.** Every `toast` call in `frontend/src` is `toast.success(string)` or `toast.error(string)`, and the record page's `PageToast` forwards client-script strings through the same four semantic creators, so nothing to change.
- **`@vueuse/core` peer:** beta.63 declares no peer on it (`vue` and `vue-router` only), so the `^11.3.0` dependency stays.
- `yarn.lock`: only the `frappe-ui` entry moves.

## Gate

- `frontend/` vitest: 39 files, 579 tests, green.
- `bench build --app frappe`: green.
- Before/after headless screenshots (1440x900, crm.localhost), pixel-identical on both pages:

| | before (beta.55) | after (beta.63) |
| --- | --- | --- |
| list | ![before-list](https://raw.githubusercontent.com/shariquerik/frappe/assets/frappe-ui-beta63-42721/before-list.png) | ![after-list](https://raw.githubusercontent.com/shariquerik/frappe/assets/frappe-ui-beta63-42721/after-list.png) |
| record | ![before-record](https://raw.githubusercontent.com/shariquerik/frappe/assets/frappe-ui-beta63-42721/before-record.png) | ![after-record](https://raw.githubusercontent.com/shariquerik/frappe/assets/frappe-ui-beta63-42721/after-record.png) |

The record page for CRM Lead on this bench has no Form Layout, so it renders the raw field dump and the 13px form typography is not exercised in the pair.

>no-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
