### PR TITLE
fix(search): reject blank search_term and cap page_length in get_names_for_mentions

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -496,8 +496,16 @@ def filter_translated(values, txt: str, as_dict: bool) -> list:
 	]
 
 
+MAX_MENTIONS_PAGE_LENGTH = 20
+
+
 @frappe.whitelist()
-def get_names_for_mentions(search_term: str):
+def get_names_for_mentions(search_term: str, page_length: int = 10):
+	if not search_term or not search_term.strip():
+		return []
+
+	page_length = min(max(cint(page_length), 1), MAX_MENTIONS_PAGE_LENGTH)
+
 	users_for_mentions = frappe.cache.get_value("users_for_mentions", get_users_for_mentions)
 	user_groups = frappe.cache.get_value("user_groups", get_user_groups)
 
@@ -512,7 +520,7 @@ def get_names_for_mentions(search_term: str):
 
 		filtered_mentions.append(mention_data)
 
-	return sorted(filtered_mentions, key=lambda d: d["value"])
+	return sorted(filtered_mentions, key=lambda d: d["value"])[:page_length]
 
 
 def get_users_for_mentions():

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -63,7 +63,9 @@ class TestSearch(IntegrationTestCase):
 				"System Manager",
 			)
 
-		names_for_mention = [user.get("id") for user in get_names_for_mentions("")]
+		names_for_mention = [
+			user.get("id") for user in get_names_for_mentions("test_disabled_user_in_mentions")
+		]
 		self.assertNotIn(email, names_for_mention)
 
 	def test_allowed_in_mentions_cache_invalidation(self):
@@ -83,14 +85,14 @@ class TestSearch(IntegrationTestCase):
 		user.add_roles("System Manager")
 
 		# Populate the users_for_mentions cache.
-		names_for_mention = [user.get("id") for user in get_names_for_mentions("")]
+		names_for_mention = [user.get("id") for user in get_names_for_mentions("test_allowed_in_mentions")]
 		self.assertIn(email, names_for_mention)
 
 		# Changing Allowed In Mentions should invalidate the cache.
 		user.allowed_in_mentions = False
 		user.save()
 
-		names_for_mention = [user.get("id") for user in get_names_for_mentions("")]
+		names_for_mention = [user.get("id") for user in get_names_for_mentions("test_allowed_in_mentions")]
 		self.assertNotIn(email, names_for_mention)
 
 		frappe.delete_doc("User", email)


### PR DESCRIPTION
Reject blank `search_term` and cap page_length in `get_names_for_mentions`.

Capped it as : `MAX_MENTIONS_PAGE_LENGTH = 20` (Mentions should not really be a long list anyways, 20 seems like a generous number for such a use case.)