### PR TITLE
fix(link): keep list format filters when merging link filters

### DIFF
--- a/cypress/integration/control_link.js
+++ b/cypress/integration/control_link.js
@@ -372,6 +372,7 @@ context("Control Link", () => {
 						filters: [
 							["ToDo", "status", "=", "Open"],
 							["ToDo", "priority", "=", "High"],
+							["Communication", "status", "=", "Open"],
 							["description", "like", "%test todo%"],
 						],
 					}),
@@ -386,6 +387,7 @@ context("Control Link", () => {
 
 			expect(filters).to.deep.eq([
 				["ToDo", "priority", "=", "High"],
+				["Communication", "status", "=", "Open"],
 				["description", "like", "%test todo%"],
 				["status", "=", "Closed"],
 			]);

--- a/cypress/integration/control_link.js
+++ b/cypress/integration/control_link.js
@@ -357,4 +357,38 @@ context("Control Link", () => {
 				cy.get(".custom-link-option").should("be.visible");
 			});
 	});
+
+	it("keeps list format filters when merging link filters", () => {
+		cy.dialog({
+			title: "Link",
+			fields: [
+				{
+					label: "Select ToDo",
+					fieldname: "link",
+					fieldtype: "Link",
+					options: "ToDo",
+					link_filters: '[["ToDo", "status", "=", "Closed"]]',
+					get_query: () => ({
+						filters: [
+							["ToDo", "status", "=", "Open"],
+							["ToDo", "priority", "=", "High"],
+							["description", "like", "%test todo%"],
+						],
+					}),
+				},
+			],
+		}).as("dialog");
+
+		cy.wait(500);
+
+		cy.get("@dialog").then((dialog) => {
+			let filters = dialog.get_field("link").get_search_args("").filters;
+
+			expect(filters).to.deep.eq([
+				["ToDo", "priority", "=", "High"],
+				["description", "like", "%test todo%"],
+				["status", "=", "Closed"],
+			]);
+		});
+	});
 });

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -845,7 +845,21 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 		}
 
 		if (this.df.link_filters && !!this.df.link_filters.length) {
-			args.filters = { ...(args.filters || {}), ...this.apply_link_field_filters() };
+			const link_filters = this.apply_link_field_filters();
+
+			if (Array.isArray(args.filters)) {
+				const fieldnames = Object.keys(link_filters);
+				args.filters = args.filters
+					.filter(
+						(filter) =>
+							!fieldnames.includes(filter.length >= 4 ? filter[1] : filter[0])
+					)
+					.concat(
+						fieldnames.map((fieldname) => [fieldname, ...link_filters[fieldname]])
+					);
+			} else {
+				args.filters = { ...(args.filters || {}), ...link_filters };
+			}
 		}
 	}
 

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -848,12 +848,14 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			const link_filters = this.apply_link_field_filters();
 
 			if (Array.isArray(args.filters)) {
+				const doctype = this.get_options();
 				const fieldnames = Object.keys(link_filters);
 				args.filters = args.filters
-					.filter(
-						(filter) =>
-							!fieldnames.includes(filter.length >= 4 ? filter[1] : filter[0])
-					)
+					.filter((filter) => {
+						const [filter_doctype, fieldname] =
+							filter.length >= 4 ? filter : [doctype, filter[0]];
+						return filter_doctype !== doctype || !fieldnames.includes(fieldname);
+					})
 					.concat(
 						fieldnames.map((fieldname) => [fieldname, ...link_filters[fieldname]])
 					);


### PR DESCRIPTION
A Link field can be filtered two ways at once: Link Filters set on the field in customize form, and a `set_query` written in script. Setting both breaks the field's search. 

**For example** - On a PO with link filters on a warehouse field, clicking that field pops an error instead of listing warehouses.

```
Operator must be one of not in, descendants of (inclusive), fiscal year, descendants of, not like, timespan, next, between, in, previous, =, is, >=, <, not ancestors of, <=, ancestors of, !=, like, >, not descendants of
```

`set_query` filters come in two shapes; an object keyed by fieldname, or a list of filter rows. Link filters are always the object shape, and `set_custom_query` in `link.js` merged the two with an object spread. Spreading a list into an object keeps each row as a value under its index, so `["Warehouse", "company", "in", [...]]` arrives at the server as fieldname `0` with operator `Warehouse`.

## Fix

Merge by the shape the query returned. A list stays a list; rows whose fieldname the link filters also set are dropped, then the link filters rows are appended, so the customisation still wins over the script. Keeping the list also keeps the doctype column that only that shape carries, which a cross doctype row such as `["Bin", "item_code", "=", item_code]` in `sales_order.js` depends on.

Filters already in the object shape take the same path as before.

---

Ref: https://support.frappe.io/helpdesk/tickets/78195?view=VIEW-HD+Ticket-1252