### PR TITLE
feat(print): add after_print hook for PDF post-processing

### DIFF
--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -8,6 +8,7 @@ import frappe
 from frappe import _
 from frappe.utils.data import cint
 from frappe.utils.jinja_globals import is_rtl
+from frappe.utils.print_utils import postprocess_pdf
 
 
 @frappe.whitelist()
@@ -413,7 +414,7 @@ class PrintFormatGenerator:
 						pdf_generator=generator_name,
 					)
 					if pdf:
-						return pdf
+						return postprocess_pdf(self.doc.doctype, self.doc.name, pdf)
 			finally:
 				frappe.local.print_format_generator = previous
 		from frappe.utils.typst_emitter import has_typst_blocks
@@ -436,13 +437,14 @@ class PrintFormatGenerator:
 			options["header-includes-top-margin"] = True
 		if password:
 			options["password"] = password
-		return get_chrome_pdf(
+		pdf = get_chrome_pdf(
 			print_format=pf.name,
 			html=html,
 			options=options,
 			output=None,
 			pdf_generator="chrome",
 		)
+		return postprocess_pdf(self.doc.doctype, self.doc.name, pdf)
 
 	def render_typst_pdf(self, password=None):
 		"""Compile the resolved layout through Typst — ~10-15x faster than Chromium.

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -8,7 +8,7 @@ import frappe
 from frappe import _
 from frappe.utils.data import cint
 from frappe.utils.jinja_globals import is_rtl
-from frappe.utils.print_utils import postprocess_pdf
+from frappe.utils.print_utils import run_after_print_hook
 
 
 @frappe.whitelist()
@@ -414,7 +414,7 @@ class PrintFormatGenerator:
 						pdf_generator=generator_name,
 					)
 					if pdf:
-						return postprocess_pdf(self.doc.doctype, self.doc.name, pdf)
+						return run_after_print_hook(self.doc.doctype, self.doc.name, pdf)
 			finally:
 				frappe.local.print_format_generator = previous
 		from frappe.utils.typst_emitter import has_typst_blocks
@@ -444,7 +444,7 @@ class PrintFormatGenerator:
 			output=None,
 			pdf_generator="chrome",
 		)
-		return postprocess_pdf(self.doc.doctype, self.doc.name, pdf)
+		return run_after_print_hook(self.doc.doctype, self.doc.name, pdf)
 
 	def render_typst_pdf(self, password=None):
 		"""Compile the resolved layout through Typst — ~10-15x faster than Chromium.

--- a/frappe/utils/print_utils.py
+++ b/frappe/utils/print_utils.py
@@ -118,26 +118,17 @@ def get_print(
 				print_format=print_format,
 				html=html,
 				options=pdf_options,
-				output=output,
+				output=None,
 				pdf_generator=local.form_dict.pdf_generator,
 			)
 			# if hook returns a value, assume it was the correct pdf_generator and return it
 			if pdf:
-				if output and isinstance(pdf, bytes):
-					from io import BytesIO
-
-					from pypdf import PdfReader
-
-					reader = PdfReader(BytesIO(pdf))
-					for page in reader.pages:
-						output.add_page(page)
-					return output
-				return postprocess_pdf(doctype, name, pdf)
+				return _finalize_pdf(doctype, name, pdf, output)
 
 	for hook in frappe.get_hooks("on_print_pdf"):
 		frappe.call(hook, doctype=doctype, name=name, print_format=print_format)
 
-	return postprocess_pdf(doctype, name, get_pdf(html, options=pdf_options, output=output))
+	return _finalize_pdf(doctype, name, get_pdf(html, options=pdf_options), output)
 
 
 def attach_print(
@@ -191,7 +182,7 @@ def attach_print(
 			if cint(print_settings.send_print_as_pdf):
 				ext = ".pdf"
 				if html:
-					content = postprocess_pdf(
+					content = run_after_print_hook(
 						doctype, name, get_pdf(html, options={"password": password} if password else None)
 					)
 				elif render_via_generator:
@@ -283,6 +274,28 @@ def convert_uom(
 	return f"{round(number * converstion_factor[0][f'from_{from_uom}'][0][f'to_{to_uom}'], 3)}{to_uom}"
 
 
-def postprocess_pdf(doctype: str, name: str, pdf: bytes) -> bytes:
+def _finalize_pdf(doctype: str, name: str, pdf, output=None):
+	"""When output is provided, append the after_print-hook PDF-pages to output"""
+	from io import BytesIO
+
+	from pypdf import PdfReader, PdfWriter
+
+	from frappe.utils.pdf import get_file_data_from_writer
+
+	if isinstance(pdf, PdfWriter):
+		pdf = get_file_data_from_writer(pdf)
+	assert isinstance(pdf, bytes)
+
+	pdf = run_after_print_hook(doctype, name, pdf)
+
+	if output:
+		for page in PdfReader(BytesIO(pdf)).pages:
+			output.add_page(page)
+		return output
+	return pdf
+
+
+def run_after_print_hook(doctype: str, name: str, pdf: bytes) -> bytes:
+	"""run the after_print hook for a document after its pdf is generated"""
 	doc = frappe.get_cached_doc(doctype, name)
 	return doc.run_method("after_print", pdf=pdf) or pdf

--- a/frappe/utils/print_utils.py
+++ b/frappe/utils/print_utils.py
@@ -132,12 +132,12 @@ def get_print(
 					for page in reader.pages:
 						output.add_page(page)
 					return output
-				return pdf
+				return postprocess_pdf(doctype, name, pdf)
 
 	for hook in frappe.get_hooks("on_print_pdf"):
 		frappe.call(hook, doctype=doctype, name=name, print_format=print_format)
 
-	return get_pdf(html, options=pdf_options, output=output)
+	return postprocess_pdf(doctype, name, get_pdf(html, options=pdf_options, output=output))
 
 
 def attach_print(
@@ -191,7 +191,9 @@ def attach_print(
 			if cint(print_settings.send_print_as_pdf):
 				ext = ".pdf"
 				if html:
-					content = get_pdf(html, options={"password": password} if password else None)
+					content = postprocess_pdf(
+						doctype, name, get_pdf(html, options={"password": password} if password else None)
+					)
 				elif render_via_generator:
 					from frappe.utils.print_format_generator import PrintFormatGenerator
 					from frappe.www.printview import validate_print_for_docstatus
@@ -279,3 +281,8 @@ def convert_uom(
 	if only_number:
 		return round(number * converstion_factor[0][f"from_{from_uom}"][0][f"to_{to_uom}"], 3)
 	return f"{round(number * converstion_factor[0][f'from_{from_uom}'][0][f'to_{to_uom}'], 3)}{to_uom}"
+
+
+def postprocess_pdf(doctype: str, name: str, pdf: bytes) -> bytes:
+	doc = frappe.get_cached_doc(doctype, name)
+	return doc.run_method("after_print", pdf=pdf) or pdf

--- a/frappe/utils/test_print_utils.py
+++ b/frappe/utils/test_print_utils.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+
+import io
+from unittest.mock import patch
+
+from pypdf import PdfReader, PdfWriter
+
+import frappe
+from frappe.tests import IntegrationTestCase
+from frappe.utils.print_utils import _finalize_pdf, run_after_print_hook
+
+
+def blank_pdf(page_count=1) -> bytes:
+	writer = PdfWriter()
+	for _ in range(page_count):
+		writer.add_blank_page(width=72, height=72)
+	stream = io.BytesIO()
+	writer.write(stream)
+	return stream.getvalue()
+
+
+def pdf_writer(page_count=1) -> PdfWriter:
+	writer = PdfWriter()
+	for _ in range(page_count):
+		writer.add_blank_page(width=72, height=72)
+	return writer
+
+
+class TestPrintUtils(IntegrationTestCase):
+	def _make_todo(self):
+		doc = frappe.get_doc({"doctype": "ToDo", "description": "print utils test"})
+		doc.insert(ignore_permissions=True)
+		self.addCleanup(doc.delete, ignore_permissions=True)
+		return doc
+
+	def test_finalize_pdf_accepts_pdfwriter(self):
+		"""PdfWriter input is converted to bytes before the after_print hook runs."""
+		todo = self._make_todo()
+		writer = pdf_writer()
+
+		with patch(
+			"frappe.utils.print_utils.run_after_print_hook", side_effect=lambda _d, _n, pdf: pdf
+		) as hook:
+			result = _finalize_pdf(todo.doctype, todo.name, writer)
+
+		self.assertIsInstance(result, bytes)
+		self.assertEqual(len(PdfReader(io.BytesIO(result)).pages), 1)
+		hook.assert_called_once()
+		self.assertIsInstance(hook.call_args.args[2], bytes)
+
+	def test_finalize_pdf_appends_to_output(self):
+		"""When output=PdfWriter is given, hook-processed pages are appended."""
+		todo = self._make_todo()
+		output = PdfWriter()
+		output.add_blank_page(width=72, height=72)
+
+		hook_pdf = blank_pdf(page_count=2)
+		with patch("frappe.utils.print_utils.run_after_print_hook", return_value=hook_pdf):
+			result = _finalize_pdf(todo.doctype, todo.name, blank_pdf(), output=output)
+
+		self.assertIs(result, output)
+		self.assertEqual(len(result.pages), 3)
+
+	def test_after_print_hook_returns_bytes(self):
+		"""Hook may replace the PDF with new bytes."""
+		todo = self._make_todo()
+		original = blank_pdf()
+		replacement = blank_pdf(page_count=3)
+
+		with patch("frappe.get_cached_doc", return_value=todo):
+			with patch.object(todo, "run_method", return_value=replacement) as run_method:
+				result = run_after_print_hook(todo.doctype, todo.name, original)
+
+		run_method.assert_called_once_with("after_print", pdf=original)
+		self.assertEqual(result, replacement)
+		self.assertEqual(len(PdfReader(io.BytesIO(result)).pages), 3)

--- a/frappe/utils/test_print_utils.py
+++ b/frappe/utils/test_print_utils.py
@@ -2,13 +2,14 @@
 # License: MIT. See LICENSE
 
 import io
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from pypdf import PdfReader, PdfWriter
 
 import frappe
 from frappe.tests import IntegrationTestCase
-from frappe.utils.print_utils import _finalize_pdf, run_after_print_hook
+from frappe.utils.print_format_generator import PrintFormatGenerator
+from frappe.utils.print_utils import _finalize_pdf, get_print, run_after_print_hook
 
 
 def blank_pdf(page_count=1) -> bytes:
@@ -75,3 +76,52 @@ class TestPrintUtils(IntegrationTestCase):
 		run_method.assert_called_once_with("after_print", pdf=original)
 		self.assertEqual(result, replacement)
 		self.assertEqual(len(PdfReader(io.BytesIO(result)).pages), 3)
+
+	def test_after_print_runs_for_all_pdf_backends(self):
+		"""after_print must run on wkhtmltopdf, Chrome, and Typst paths."""
+
+		todo = self._make_todo()
+		pdf = blank_pdf()
+
+		mock_hook = MagicMock(side_effect=lambda _d, _n, p: p)
+		with (
+			patch("frappe.utils.print_utils.run_after_print_hook", mock_hook),
+			patch("frappe.utils.print_format_generator.run_after_print_hook", mock_hook),
+		):
+			with (
+				patch(
+					"frappe.website.serve.get_response_without_exception_handling",
+					return_value=type("R", (), {"data": b"<html></html>"})(),
+				),
+				patch("frappe.utils.pdf.get_pdf", return_value=pdf),
+			):
+				get_print(todo.doctype, todo.name, as_pdf=True, pdf_generator="wkhtmltopdf")
+			mock_hook.assert_called_with(todo.doctype, todo.name, pdf)
+
+			self.assertEqual(mock_hook.call_count, 1)
+
+			pf = frappe.get_doc(
+				{
+					"doctype": "Print Format",
+					"name": f"_Test {frappe.generate_hash(length=6)}",
+					"doc_type": "ToDo",
+					"print_format_builder_beta": 1,
+					"format_data": '{"sections": [], "header": {"columns": []}, "footer": {"columns": []}}',
+				}
+			).insert(ignore_permissions=True)
+			self.addCleanup(pf.delete, ignore_permissions=True)
+
+			generator = PrintFormatGenerator(pf, todo)
+			with patch("frappe.utils.pdf.get_chrome_pdf", return_value=pdf):
+				generator.render_pdf()
+			mock_hook.assert_called_with(todo.doctype, todo.name, pdf)
+
+			self.assertEqual(mock_hook.call_count, 2)
+
+			pf.db_set("pdf_generator", "Typst")
+			generator = PrintFormatGenerator(pf, todo)
+			with patch.object(generator, "render_typst_pdf", return_value=pdf):
+				generator.render_pdf()
+			mock_hook.assert_called_with(todo.doctype, todo.name, pdf)
+
+			self.assertEqual(mock_hook.call_count, 3)


### PR DESCRIPTION
## What problem does this solve?

Frappe exposes `before_print` so apps can prepare a document before HTML rendering. There is no hook after the PDF bytes are generated.

Apps that need to post-process PDF output currently have limited options:

- **`on_print_pdf`** runs before PDF generation, when only HTML is available. It cannot transform the final PDF bytes.
- **Overriding whitelisted print methods** only covers specific entry points, not all paths that produce PDFs (email attachments, `attach_print`, Print Format Generator, etc.).

There is no single, **document-level** extension point for PDF post-processing.

## What does this change?

Introduce `postprocess_pdf()` in `print_utils.py`. It loads the document and calls `doc.run_method("after_print", pdf=pdf)`. If a handler returns modified bytes, those are used; otherwise the original PDF is kept.

Wire `postprocess_pdf()` into all PDF generation paths:

- **`get_print()`** for wkhtmltopdf and custom `pdf_generator` hooks
- **`attach_print()`** for direct HTML to PDF
- **`PrintFormatGenerator.render_pdf()`** for Chrome and custom `pdf_generator` hooks

## `doc_events`

Apps can hook into PDF post-processing via `after_print` in `doc_events` or as a method on the document controller:

```python
# hooks.py
doc_events = {
    "DocTypes": {
        "after_print": "my_app.extension.postprocess_pdf",
    }
}
```

```python
# handler
def postprocess_pdf(doc, method, pdf: bytes) -> bytes:
    # modify the pdf..
    return modified_pdf
```

`after_print` should be a counterpart to `before_print` https://github.com/frappe/frappe/blob/c2f17fb1b7738a14074fbe876751c2e8f4babfc2/frappe/www/printview.py#L461 which runs before HTML rendering with `print_settings`, `after_print` runs after PDF bytes exist with `pdf`.

## Notes for reviewers

- Return value handling follows existing `run_method` behaviour: `None` falls back to the original PDF via `or pdf`.
- Multiple handlers across apps compose through `run_method`; only the last non-`None` bytes return value is kept (same limitation as other hooks with return values).
- `on_print_pdf` is unchanged and still fires at its existing point in the pipeline.