### PR TITLE
fix(island): render overlays in the top layer

### DIFF
--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -158,15 +158,27 @@ export default class ChartWidget extends Widget {
 
 		this.island_handle.ready.then(
 			() => this.loading.hide(),
-			(e) => {
-				console.error(e);
-				this.chart_wrapper.hide();
-				this.loading.hide();
-				this.empty.hide();
-				this.error_state.text(__("Could not draw this chart: {0}", [e.message]));
-				this.error_state.show();
-			}
+			(error) => this.show_island_error(error)
 		);
+	}
+
+	// the error names a build step: console always, screen only in developer mode
+	show_island_error(error) {
+		console.error(`could not mount the "${this.island.name}" island`, error);
+
+		this.chart_wrapper.hide();
+		this.loading.hide();
+		this.empty.hide();
+		this.error_state.empty().append(
+			frappe.ui.empty_state({
+				icon: "package",
+				title: __("This chart has not been built"),
+				description: frappe.boot.developer_mode
+					? error.message
+					: __("Its assets are missing. Build the app that ships it."),
+			})
+		);
+		this.error_state.show();
 	}
 
 	/**

--- a/ui/README.md
+++ b/ui/README.md
@@ -249,6 +249,8 @@ Apply the reka-ui patch this package ships. Without it, a popover opened over a 
 
 See [decision 0007](island/decisions/0007-reka-ui-is-patched-to-read-the-shadow-root.md).
 
+Overlays render in the browser's top layer, above the host's chrome whatever stacking context the island sits in. The mount target must be in the document, and the browser needs the popover API: Safari 17, Chrome 114.
+
 ### Icons
 
 `~icons/lucide/<name>` works, through frappe-ui's resolver.

--- a/ui/island/mount.js
+++ b/ui/island/mount.js
@@ -23,10 +23,6 @@ import { portalTargetKey } from "frappe-ui";
 import { hostKey } from "./context.js";
 import { currentTheme, onThemeChange } from "./theme.js";
 
-// Desk's modal tier, Bootstrap's `.modal`. It is level with a desk dialog and
-// above every page-level control: the icon rail at 1020, menus at 1030.
-const OVERLAY_Z_INDEX = "1050";
-
 // url -> Promise<CSSStyleSheet>. One sheet object per URL for the whole page,
 // adopted into every shadow root. The browser fetches and parses it once.
 const styleSheets = new Map();
@@ -62,6 +58,10 @@ export async function mountVueIsland(el, options) {
 	if (!el || !el.appendChild) {
 		throw new Error("mountVueIsland: mount target is not an element");
 	}
+	// showPopover() below needs a connected element
+	if (!el.isConnected) {
+		throw new Error("mountVueIsland: mount target is not in the document");
+	}
 
 	const shadowHost = document.createElement("div");
 	shadowHost.className = "frappe-island";
@@ -87,15 +87,30 @@ export async function mountVueIsland(el, options) {
 	// a selector string against the document.
 	const portal = document.createElement("div");
 	portal.className = "frappe-island-portal";
-	// A shadow root is not a stacking context, so an overlay inside it competes
-	// with desk's page-level controls directly. At `z-index: auto` the browser
-	// paints the icon rail and desk's menus over the overlay, although the
-	// overlay covers them for hit testing. The portal carries the tier, not the
-	// host, so the island's content stays in the page flow.
-	portal.style.position = "relative";
-	portal.style.zIndex = OVERLAY_Z_INDEX;
+	// The top layer escapes any ancestor stacking context (a workspace sits in
+	// Editor.js's `.codex-editor` at z-index 1, under desk's sidebar). A z-index
+	// cannot. Staying in the shadow root keeps the reka patch, the adopted sheet
+	// and the theme attribute; a second host on <body> would split reka's layers
+	// across two roots. Needs Safari 17 / Chrome 114, which `target: esnext`
+	// already assumes.
+	portal.setAttribute("popover", "manual");
+	// undo the UA popover box; the overlays inside are `position: fixed`, so the
+	// portal shrink-wraps to nothing and needs no pointer-events (a non-modal
+	// popover would inherit `none` and go dead)
+	Object.assign(portal.style, {
+		inset: "auto",
+		width: "auto",
+		height: "auto",
+		margin: "0",
+		padding: "0",
+		border: "0",
+		background: "none",
+		overflow: "visible",
+		color: "inherit",
+	});
 
 	shadowRoot.append(root, portal);
+	portal.showPopover();
 
 	const applyTheme = (theme) => {
 		root.setAttribute("data-theme", theme);


### PR DESCRIPTION
An island's overlays teleport to a portal inside its shadow root. When a host ancestor forms a stacking context, the portal's z-index resolves inside it and desk chrome paints over the dialog. On a workspace the Editor.js root is `position: relative; z-index: 1`, so the sidebar and navbar covered every island dialog.

The portal is now a `popover="manual"` element in the top layer. It stays in the shadow root, so the reka patch, adopted stylesheets and theme sync are unchanged. `OVERLAY_Z_INDEX` is gone. Baseline Safari 17, Chrome 114, which `target: esnext` already implies.

Also here: a chart widget whose island fails to mount shows the empty state instead of the raw build error, which goes to the console.

Fixes:

<img width="3840" height="2076" alt="CleanShot 2026-09-10 at 16 30 10@2x" src="https://github.com/user-attachments/assets/7b7cb67b-d0ec-44da-a490-830fa9fe6756" />
