### PR TITLE
fix: close inherited descriptors before the re-exec

### DIFF
--- a/frappe/runner.py
+++ b/frappe/runner.py
@@ -338,6 +338,18 @@ class ThreadedWorker(FrappeWorkerNoFork):
 		pass
 
 
+def close_inherited_fds() -> None:
+	"""Close the descriptors of this generation, except the standard streams.
+
+	An exec keeps every descriptor that does not have the close-on-exec flag, and
+	some libraries open a file without it: the import of ctypes leaves one on the
+	interpreter itself. The runner execs on each restart, so those descriptors add
+	up until the process reaches its limit. The supervisor owns the standard
+	streams, thus they stay.
+	"""
+	os.closerange(3, os.sysconf("SC_OPEN_MAX"))
+
+
 class Runner:
 	"""Starts, stops, and restarts the web app, realtime, and the jobs together."""
 
@@ -375,6 +387,7 @@ class Runner:
 			# Use orig_argv and not argv: "-m frappe.runner" must come back in the same
 			# form. The path of this file puts the frappe directory on sys.path.
 			logger.info("re-exec")
+			close_inherited_fds()
 			os.execv(sys.executable, sys.orig_argv)
 
 	def drain(self, sig, frame=None) -> None:

--- a/frappe/tests/test_runner.py
+++ b/frappe/tests/test_runner.py
@@ -1,6 +1,10 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 # License: MIT. See LICENSE
 
+import os
+import subprocess
+import sys
+import textwrap
 import threading
 import unittest
 from types import SimpleNamespace
@@ -55,3 +59,70 @@ class TestSourceWatch(unittest.TestCase):
 		with patch.object(threading, "Timer") as timer:
 			watch.dispatch(make_event())
 		self.assertEqual(timer.call_count, 0)
+
+
+class TestCloseInheritedFds(unittest.TestCase):
+	"""Which descriptors reach the next generation of the runner.
+
+	The call closes the descriptors of the whole process, so it runs in a child.
+	"""
+
+	def _run(self, body: str) -> str:
+		script = textwrap.dedent(body)
+		child = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, timeout=60)
+		self.assertEqual(child.returncode, 0, child.stderr)
+		return child.stdout.strip()
+
+	def test_an_open_file_is_closed(self):
+		output = self._run("""
+			import os
+			from frappe.runner import close_inherited_fds
+
+			fd = os.open(os.devnull, os.O_RDONLY)
+			close_inherited_fds()
+			try:
+				os.fstat(fd)
+				print("open")
+			except OSError:
+				print("closed")
+		""")
+		self.assertEqual(output, "closed")
+
+	def test_the_standard_streams_survive(self):
+		output = self._run("""
+			import os
+			from frappe.runner import close_inherited_fds
+
+			close_inherited_fds()
+			os.write(1, b"stdout\\n")
+			os.fstat(0)
+			os.fstat(2)
+		""")
+		self.assertEqual(output, "stdout")
+
+	def test_the_count_stays_flat_across_execs(self):
+		output = self._run("""
+			import os
+			import sys
+			from frappe.runner import close_inherited_fds
+
+			if not os.path.isdir("/proc/self/fd"):
+				print("skip")
+				raise SystemExit
+
+			generation = int(os.environ.get("GENERATION", "0"))
+			# An open() of python sets close-on-exec. The leak comes from the
+			# libraries that do not, so the descriptor here must outlive an exec.
+			fd = os.open(os.devnull, os.O_RDONLY)
+			os.set_inheritable(fd, True)
+			print(len(os.listdir("/proc/self/fd")), flush=True)
+			if generation < 2:
+				os.environ["GENERATION"] = str(generation + 1)
+				close_inherited_fds()
+				os.execv(sys.executable, sys.orig_argv)
+		""")
+		if output == "skip":
+			self.skipTest("no /proc on this platform")
+		counts = output.splitlines()
+		self.assertEqual(len(counts), 3, output)
+		self.assertEqual(len(set(counts)), 1, f"the count grew across the execs: {counts}")


### PR DESCRIPTION
The runner execs itself on each restart and keeps its PID. An exec keeps every descriptor that does not have the close-on-exec flag, and some libraries open a file without it — on a python-build-standalone interpreter (what `uv` installs), the `ctypes` import leaves one descriptor on the interpreter itself.

They add up across generations. On the default limit of 1024 a process reaches the cap after about a thousand restarts, and every request then fails with `unable to open database file`. Seen on a lite-mode bench that restarts every 5 idle minutes: 1004 descriptors on the interpreter after 3.6 days.

Closing everything above the standard streams before the exec keeps the count flat:

```
without      with
gen=0 fds=1  gen=0 fds=1
gen=1 fds=2  gen=1 fds=1
gen=5 fds=6  gen=5 fds=1
```

Nothing needs to survive the exec. Uvicorn opens and closes its own listening socket inside `Server.run()`, the job threads are stopped and joined first, and the next generation opens its own queue connections and log files. The runner does not use socket activation, so fd 3 is never a passed-in listener — that would need handling here if it ever is.