### PR TITLE
fix(safe_exec): add request back into render_safe_globals

### DIFF
--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -572,6 +572,9 @@ def render_safe_globals():
 				if getattr(frappe.local, "session", None) and getattr(frappe.local.session, "data", None)
 				else "",
 			),
+			request=frappe._dict(
+				path=frappe.local.request.path if getattr(frappe.local, "request", None) else "",
+			),
 			make_get_request=make_safe_get_request,
 			socketio_port=frappe.conf.socketio_port,
 			sanitize_html=frappe.utils.sanitize_html,


### PR DESCRIPTION
Found a relevant case wherein path is needed for breadcrumb rendering. Thus adding for this particular use case.

ref: https://github.com/frappe/frappe/pull/42387#issuecomment-5629712051
