### PR TITLE
feat(desk-v2): the record page's field region — Details form, save channel, dialog hosts

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -38,7 +38,7 @@ yarn --cwd frontend test:run
 That is exactly what CI does (`.github/workflows/frontend-tests.yml`). The **base** file
 is the correct input, not a `bench build`-generated one: `yarn.lock` was resolved from
 `package.base.json` alone, and no test needs anything an app contributes. Baseline is
-**55 files / 702 tests**, under `recordPage/tests/`, `pages/record/tests/`,
+**56 files / 712 tests**, under `recordPage/tests/`, `pages/record/tests/`,
 `pages/record/panel/tests/`, `shell/tests/` and `navigation/tests/`.
 
 **`vitest.config.js` runs with `css: { postcss: {} }`, and that is not cosmetic.**

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -38,7 +38,7 @@ yarn --cwd frontend test:run
 That is exactly what CI does (`.github/workflows/frontend-tests.yml`). The **base** file
 is the correct input, not a `bench build`-generated one: `yarn.lock` was resolved from
 `package.base.json` alone, and no test needs anything an app contributes. Baseline is
-**50 files / 662 tests**, under `recordPage/tests/`, `pages/record/tests/`,
+**55 files / 702 tests**, under `recordPage/tests/`, `pages/record/tests/`,
 `pages/record/panel/tests/`, `shell/tests/` and `navigation/tests/`.
 
 **`vitest.config.js` runs with `css: { postcss: {} }`, and that is not cosmetic.**

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -38,7 +38,7 @@ yarn --cwd frontend test:run
 That is exactly what CI does (`.github/workflows/frontend-tests.yml`). The **base** file
 is the correct input, not a `bench build`-generated one: `yarn.lock` was resolved from
 `package.base.json` alone, and no test needs anything an app contributes. Baseline is
-**56 files / 712 tests**, under `recordPage/tests/`, `pages/record/tests/`,
+**56 files / 714 tests**, under `recordPage/tests/`, `pages/record/tests/`,
 `pages/record/panel/tests/`, `shell/tests/` and `navigation/tests/`.
 
 **`vitest.config.js` runs with `css: { postcss: {} }`, and that is not cosmetic.**

--- a/frontend/SCRIPTING.md
+++ b/frontend/SCRIPTING.md
@@ -207,3 +207,95 @@ export default {
   },
 }
 ```
+
+## The field: `page.fields`
+
+The Details form is the main column of the record: the doctype's `Details` layout, or its
+fields in DocType order when no row applies. `page.fields` is an **overlay** on the fields
+authored there, cleared before every replay. It has no `add`, `move` or `order`, since
+ordering is the Form Layout's job; it speaks `hide`, `show`, `update`, `has` and `get`,
+and one **act**, `focus(fieldname)`.
+
+### What `update` takes
+
+| Key | What it does |
+| --- | --- |
+| `label`, `placeholder`, `description` | The text drawn. |
+| `hidden`, `read_only`, `reqd` | Booleans, or `0`/`1` as a DocField spells them. Win over `depends_on`; never lift a permission floor. |
+| `options` | A Link target, or a Select's newline-separated choices. |
+| `link_filters` | Search filters for a Link field. |
+| `precision` | Decimal places for a numeric field. |
+| `component`, `props` | Another control in the field's slot, and what to bind onto it. |
+
+A key not named here is dropped with a development warning. `get(fieldname)` answers the
+field as it resolves now, post-override and post-`depends_on`, and is read-only.
+
+### The act: `focus(fieldname)`
+
+`focus` switches the form to the field's tab, scrolls to it and puts the cursor in its
+control. A read-only field gets the tab and the scroll and no cursor. An unknown or a
+hidden field warns in a development build and moves nobody, since `show()` is the verb
+that reveals one. On `activate`'s terms: resolved at the call, and inside a replay
+delivered when the replay commits. The panel's own expand of a long row uses it.
+
+### Saving: `page.save()`
+
+`page.save()` is the one path; the Save button, `Ctrl+S` / `Cmd+S` and a script all call
+it. The order is fixed:
+
+1. The edit still pending in a focused control is flushed, so its field handler runs.
+2. `beforeSave` fires. A throw is a veto: nothing is sent, and the message shows.
+3. The whole document goes to the server.
+4. `afterSave` fires only when the server accepted.
+
+On a clean document it resolves at once, sends nothing and shows nothing. The Save button
+is disabled then, with the tooltip "No changes to save", and the shortcut shows that text
+as a toast. A record saved by someone else since it was opened opens a dialog naming them
+and the fields changed here, with "Reload and lose my changes" and "Keep editing"; nothing
+is re-applied silently, and Save fails the same way until a reload.
+
+A field handler runs when the reader commits that field: `status(page)` on a status
+change, before any save. A child table's fields are addressed by the table, `products.qty`.
+
+### The script this design was judged by
+
+The third act of the map's proof walk, on a CRM Deal whose `probability` is a Percent field.
+
+```js
+export default {
+  onRefresh(page) {
+    // Rename one field by name; its control keeps working.
+    page.fields.update('probability', { label: 'Win chance (%)' })
+  },
+
+  // A field handler: runs when the reader commits `status`, before any save.
+  status(page) {
+    if (page.doc.status === 'Won') page.doc.probability = 100
+  },
+
+  // The save channel: a throw here is a veto, and the record stays unsaved.
+  beforeSave(page) {
+    if (page.doc.probability > 100) throw new Error('Win chance is a percentage')
+  },
+}
+```
+
+The walk: the label reads "Win chance (%)". Set status to Won, and the probability control
+shows 100 with no other click. Press Save, and a reload shows 100. Set probability to 120
+and press Save: the error shows and the server still has 100.
+
+And the act, with its two misses:
+
+```js
+export default {
+  onRefresh(page) {
+    if (page.doc.status === 'Lost') page.fields.focus('lost_notes')
+    page.header.add({
+      name: 'focus_sla',
+      label: 'Focus SLA status',
+      display: 'button',
+      run: (p) => p.fields.focus('sla_status'), // read-only: tab and scroll, no cursor
+    })
+  },
+}
+```

--- a/frontend/src/pages/Record.vue
+++ b/frontend/src/pages/Record.vue
@@ -23,15 +23,18 @@
 		</p>
 
 		<div v-else class="flex min-h-0 flex-1">
-			<ScrollArea class="min-h-0 flex-1" :viewportClass="[pageGutter, 'py-5']">
-				<p v-if="error" class="text-sm text-ink-red-4">{{ error }}</p>
+			<ScrollArea class="min-h-0 flex-1">
+				<p v-if="error" class="py-5 text-sm text-ink-red-4" :class="pageGutter">
+					{{ error }}
+				</p>
 
-				<div v-else-if="controller" ref="formRoot" class="max-w-4xl" data-record-form>
+				<div v-else-if="controller" ref="formRoot" data-record-form>
 					<FormLayout
 						v-if="form.length"
 						v-model:doc="doc"
 						:layout="form"
 						:tab="formTab"
+						:class="formClasses"
 						@update:tab="chooseFormTab"
 						@update:activeTab="activeFormTab = $event"
 					/>
@@ -131,6 +134,14 @@ const formRoot = ref<HTMLElement | null>(null);
 // The reader's intent and the strip's resolution, as `FormLayout` splits them.
 const formTab = ref("");
 const activeFormTab = ref("");
+
+// The form fills the column with no border of its own, and its strip stays put while the sections scroll.
+const formClasses = [
+	"!rounded-none !border-0",
+	"[&_[role='tablist']]:sticky [&_[role='tablist']]:top-0 [&_[role='tablist']]:z-10 [&_[role='tablist']]:bg-surface-base",
+	"[&_.sections]:mx-auto [&_.sections]:my-0 [&_.sections]:w-full [&_.sections]:max-w-3xl [&_.sections]:p-6",
+	"[&_.section-header]:!px-0 [&_.section-body]:!px-0",
+];
 
 // The right zone keeps this many top-level controls; the rest demote into `⋯`.
 const HEADER_BUDGET = 3;

--- a/frontend/src/pages/Record.vue
+++ b/frontend/src/pages/Record.vue
@@ -139,7 +139,7 @@ const activeFormTab = ref("");
 const formClasses = [
 	"!rounded-none !border-0",
 	"[&_[role='tablist']]:sticky [&_[role='tablist']]:top-0 [&_[role='tablist']]:z-10 [&_[role='tablist']]:bg-surface-base",
-	"[&_[role='tablist']]:gap-5 [&_[role='tablist']]:px-5 [&_[role='tab']]:py-2.5",
+	"[&_[role='tablist']]:gap-5 [&_[role='tablist']]:px-5 [&_[role='tab']]:py-2",
 	"[&_.sections]:mx-auto [&_.sections]:my-0 [&_.sections]:w-full [&_.sections]:max-w-3xl [&_.sections]:p-6",
 	"[&_.section-header]:!px-0 [&_.section-body]:!px-0",
 ];

--- a/frontend/src/pages/Record.vue
+++ b/frontend/src/pages/Record.vue
@@ -361,7 +361,8 @@ async function send() {
 		saved.value = { ...document };
 		doc.value = JSON.parse(JSON.stringify(document));
 	} finally {
-		saving.value = false;
+		// A request the previous record left behind must not clear this record's flag.
+		if (mine === generation) saving.value = false;
 	}
 	await controller.value?.refresh();
 	actionsVersion.value++;

--- a/frontend/src/pages/Record.vue
+++ b/frontend/src/pages/Record.vue
@@ -139,6 +139,7 @@ const activeFormTab = ref("");
 const formClasses = [
 	"!rounded-none !border-0",
 	"[&_[role='tablist']]:sticky [&_[role='tablist']]:top-0 [&_[role='tablist']]:z-10 [&_[role='tablist']]:bg-surface-base",
+	"[&_[role='tablist']]:gap-5 [&_[role='tablist']]:px-5 [&_[role='tab']]:py-2.5",
 	"[&_.sections]:mx-auto [&_.sections]:my-0 [&_.sections]:w-full [&_.sections]:max-w-3xl [&_.sections]:p-6",
 	"[&_.section-header]:!px-0 [&_.section-body]:!px-0",
 ];

--- a/frontend/src/pages/Record.vue
+++ b/frontend/src/pages/Record.vue
@@ -24,7 +24,6 @@
 
 		<div v-else class="flex min-h-0 flex-1">
 			<ScrollArea class="min-h-0 flex-1" :viewportClass="[pageGutter, 'py-5']">
-				<p v-if="actionError" class="mb-3 text-sm text-ink-red-4">{{ actionError }}</p>
 				<p v-if="error" class="text-sm text-ink-red-4">{{ error }}</p>
 
 				<div v-else-if="controller" ref="formRoot" class="max-w-4xl" data-record-form>
@@ -122,8 +121,6 @@ const meta = ref<any>(null);
 const docinfo = ref<DocInfo | null>(null);
 const linkTitles = ref<Record<string, string>>({});
 const error = ref("");
-// Apart from `error`: a failed action must not blank the record (the form is in its v-else).
-const actionError = ref("");
 const controller = shallowRef<RecordPageController | null>(null);
 // The doctype's Side Panel layout, or nothing: the panel never falls back to the Details layout.
 const panelLayout = shallowRef<UseFormLayout | null>(null);
@@ -225,7 +222,6 @@ async function load() {
 	const mine = ++generation;
 	const target = { doctype: doctype.value, name: docname.value };
 	error.value = "";
-	const carriedActionError = actionError.value;
 
 	// Blanked before the fetch: the heading changes synchronously, and the old controller's quick
 	// actions close over the previous page. `saved` goes with `doc` so `isDirty` stays false.
@@ -312,8 +308,6 @@ async function load() {
 	if (mine !== generation) return;
 	await created.refresh();
 	if (mine !== generation) return;
-	// A reload triggered by a failed action must not wipe the message explaining it.
-	actionError.value = carriedActionError;
 	actionsVersion.value++;
 }
 
@@ -389,24 +383,22 @@ async function resolveConflict() {
 
 // Not through `runAction`: a failed save must keep the draft on screen, not reload over it.
 async function runSave() {
-	actionError.value = "";
 	try {
 		await controller.value?.page.save();
 	} catch (e) {
-		if ((e as Error)?.name !== SAVE_CONFLICT) actionError.value = errorMessage(e);
+		if ((e as Error)?.name !== SAVE_CONFLICT) toast.error(errorMessage(e));
 	}
 }
 
 // A failing action would otherwise leave the draft mutated with no error, so it reloads;
 // a save the reader vetoed or must resolve keeps the draft, as the built-in Save does.
 async function runAction(action: QuickAction | HeaderItem) {
-	actionError.value = "";
 	try {
 		await action.run?.(controller.value!.page);
 	} catch (e) {
 		const name = (e as Error)?.name;
 		if (name === SAVE_CONFLICT) return;
-		actionError.value = errorMessage(e);
+		toast.error(errorMessage(e));
 		if (name !== SAVE_VETO) await load();
 	}
 }

--- a/frontend/src/pages/Record.vue
+++ b/frontend/src/pages/Record.vue
@@ -1,6 +1,6 @@
 <!--
   The generated record page every app gets at /apps/<prefix>/<slug>/<name>: a host for the
-  record-page engine with a real header row and panel, no form layout yet, and its own scroll.
+  record-page engine with a header row, the Details form, the panel and its own scroll.
 -->
 <template>
 	<PageFrame :scroll="false">
@@ -24,15 +24,19 @@
 
 		<div v-else class="flex min-h-0 flex-1">
 			<ScrollArea class="min-h-0 flex-1" :viewportClass="[pageGutter, 'py-5']">
-				<p v-if="actionError" class="text-sm text-ink-red-4">{{ actionError }}</p>
+				<p v-if="actionError" class="mb-3 text-sm text-ink-red-4">{{ actionError }}</p>
 				<p v-if="error" class="text-sm text-ink-red-4">{{ error }}</p>
 
-				<dl v-else class="grid max-w-2xl grid-cols-[12rem_1fr] gap-y-1.5 text-sm">
-					<template v-for="[field, value] in fields" :key="field">
-						<dt class="text-ink-gray-6" :data-fieldname="field">{{ field }}</dt>
-						<dd class="text-ink-gray-8">{{ value }}</dd>
-					</template>
-				</dl>
+				<div v-else-if="controller" ref="formRoot" class="max-w-4xl" data-record-form>
+					<FormLayout
+						v-if="form.length"
+						v-model:doc="doc"
+						:layout="form"
+						:tab="formTab"
+						@update:tab="chooseFormTab"
+						@update:activeTab="activeFormTab = $event"
+					/>
+				</div>
 			</ScrollArea>
 
 			<RecordPanel
@@ -50,16 +54,32 @@
 				@expand="expand"
 			/>
 		</div>
+
+		<PageDialogs v-if="controller" :controller="controller" />
 	</PageFrame>
 </template>
 
 <script setup lang="ts">
-import { computed, inject, ref, shallowRef, watch, type ComputedRef } from "vue";
-import { useRoute, useRouter } from "vue-router";
-import { ScrollArea } from "frappe-ui";
-import type { FieldNode, FormLayoutSchema } from "@framework/ui/components/FormLayout/types";
+import {
+	computed,
+	inject,
+	nextTick,
+	onMounted,
+	onUnmounted,
+	provide,
+	ref,
+	shallowRef,
+	watch,
+} from "vue";
+import { onBeforeRouteLeave, onBeforeRouteUpdate, useRoute, useRouter } from "vue-router";
+import { ScrollArea, toast } from "frappe-ui";
+import { FormLayout } from "@framework/ui/components/FormLayout";
+import { CommitKey, LinkTitlesKey } from "@framework/ui/components/Fields/types";
+import type { FieldNode } from "@framework/ui/components/FormLayout/types";
+import { identifyTabs } from "@framework/ui/components/FormLayout/tabIdentity";
 import {
 	createRecordPage,
+	errorMessage,
 	loadClientScripts,
 	projectHeader,
 	useFormLayout,
@@ -67,15 +87,25 @@ import {
 	type QuickAction,
 	type RecordPageController,
 } from "@/recordPage";
+import type { UseFormLayout } from "@/recordPage/formLayoutSource/useFormLayout";
 import { routeFor } from "@/router/routeFor";
 import RecordHeader from "./record/RecordHeader.vue";
+import PageDialogs from "./record/dialogs/PageDialogs.vue";
+import { formTabMemory } from "./record/formTabMemory";
 import { fetchMeta } from "./record/metaSource";
 import { PANEL_BUILTINS } from "./record/panel/builtins";
 import { quickActionBuiltins } from "./record/quickActionBuiltins";
-import type { DocInfo } from "./record/panel/context";
+import { personOf, type DocInfo } from "./record/panel/context";
 import { useDisclosure } from "./record/panel/disclosure";
 import { layoutItems, layoutSections } from "./record/panel/panelEntries";
 import RecordPanel from "./record/panel/RecordPanel.vue";
+import {
+	changedFields,
+	conflictError,
+	isTimestampMismatch,
+	SAVE_CONFLICT,
+	serverMessage,
+} from "./record/saveResponse";
 import PageFrame, { pageGutter } from "@/shell/PageFrame.vue";
 import type { Boot } from "@/boot";
 import type { Addresses } from "@/addresses";
@@ -89,14 +119,20 @@ const doc = ref<Record<string, any>>({});
 const saved = ref<Record<string, any>>({});
 const meta = ref<any>(null);
 const docinfo = ref<DocInfo | null>(null);
+const linkTitles = ref<Record<string, string>>({});
 const error = ref("");
-// Apart from `error`: a failed action must not blank the record (the field list is in its v-else).
+// Apart from `error`: a failed action must not blank the record (the form is in its v-else).
 const actionError = ref("");
 const controller = shallowRef<RecordPageController | null>(null);
 // The doctype's Side Panel layout, or nothing: the panel never falls back to the Details layout.
-const panelLayout = shallowRef<ComputedRef<FormLayoutSchema> | null>(null);
+const panelLayout = shallowRef<UseFormLayout | null>(null);
+const detailsLayout = shallowRef<UseFormLayout | null>(null);
 const actionsVersion = ref(0);
 const saving = ref(false);
+const formRoot = ref<HTMLElement | null>(null);
+// The reader's intent and the strip's resolution, as `FormLayout` splits them.
+const formTab = ref("");
+const activeFormTab = ref("");
 
 // The right zone keeps this many top-level controls; the rest demote into `⋯`.
 const HEADER_BUDGET = 3;
@@ -107,12 +143,6 @@ let generation = 0;
 const doctype = computed(() => addresses.doctypeOf(String(route.params.doctype)));
 const docname = computed(() => String(route.params.name));
 
-const fields = computed(() =>
-	Object.entries(doc.value ?? {})
-		.filter(([key]) => !key.startsWith("_") && key !== "doctype")
-		.slice(0, 25)
-);
-
 const dirty = computed(() => JSON.stringify(doc.value) !== JSON.stringify(saved.value));
 
 const header = computed(() => {
@@ -121,8 +151,10 @@ const header = computed(() => {
 	return projectHeader(resolved, HEADER_BUDGET);
 });
 
+const form = computed(() => detailsLayout.value?.layout.value ?? []);
+
 // Resolved against the draft, as the form's own `depends_on` is.
-const sections = computed(() => layoutSections(panelLayout.value?.value ?? [], doc.value));
+const sections = computed(() => layoutSections(panelLayout.value?.layout.value ?? [], doc.value));
 
 // Open sections are the reader's, per doctype; the surface's labelled items are what there is to open.
 const disclosure = useDisclosure(
@@ -133,6 +165,17 @@ const disclosure = useDisclosure(
 			.filter((item) => item.label)
 			.map((item) => ({ name: item.name, opened: item.opened !== false }))
 );
+
+const tabMemory = computed(() => formTabMemory(boot.user.name, doctype.value ?? ""));
+
+provide(LinkTitlesKey, linkTitles);
+
+// One channel for the form and the panel, forwarded so it follows the controller across loads.
+provide(CommitKey, {
+	pending: (fieldname, value, row) => controller.value?.commits.pending(fieldname, value, row),
+	commit: (fieldname, value, row) => controller.value?.commits.commit(fieldname, value, row),
+	rowChanged: (row, change) => controller.value?.commits.rowChanged(row, change),
+});
 
 // The row's built-ins, re-read on every resolve so the title crumb tracks the draft.
 function headerBuiltins(): HeaderItem[] {
@@ -146,7 +189,7 @@ function headerBuiltins(): HeaderItem[] {
 			href: router.resolve(routeFor(doctype.value!)).path,
 		},
 		{ name: "record", label: String(title), zone: "left", display: "crumb" },
-		{ name: "save", label: "Save", display: "button", run: saveFromHeader },
+		{ name: "save", label: "Save", display: "button", run: runSave },
 	];
 }
 
@@ -155,18 +198,12 @@ function panelBuiltins() {
 	return [...PANEL_BUILTINS, ...layoutItems(sections.value)];
 }
 
-// Not through `runAction`: a failed save must keep the draft on screen, not reload over it.
-async function saveFromHeader() {
-	if (!dirty.value) return;
-	actionError.value = "";
-	try {
-		await save();
-	} catch (e) {
-		actionError.value = String((e as Error)?.message ?? e);
-	}
+function chooseFormTab(identity: string) {
+	formTab.value = identity;
+	tabMemory.value.remember(identity);
 }
 
-/** `getdoc`: the document and its sidecar in one round trip; an absent record answers no docs. */
+/** `getdoc`: the document, its sidecar and the link titles in one round trip. */
 async function fetchDoc(target: { doctype: string; name: string }) {
 	const res = await fetch(
 		`/api/method/frappe.desk.form.load.getdoc?${new URLSearchParams(target)}`
@@ -175,7 +212,11 @@ async function fetchDoc(target: { doctype: string; name: string }) {
 	const body = await res.json();
 	const document = body.docs?.[0];
 	if (!document) throw new Error("404");
-	return { document, docinfo: body.docinfo as DocInfo };
+	return {
+		document,
+		docinfo: body.docinfo as DocInfo,
+		linkTitles: (body._link_titles ?? {}) as Record<string, string>,
+	};
 }
 
 async function load() {
@@ -192,7 +233,27 @@ async function load() {
 	docinfo.value = null;
 	controller.value = null;
 	panelLayout.value = null;
+	detailsLayout.value = null;
 	disclosure.reset();
+	formTab.value = tabMemory.value.recall();
+
+	// Both layouts need only the doctype, so their fetches ride beside `getdoc` and the meta.
+	// Against the saved document, so a keystroke cannot switch a layout under the reader.
+	const details = useFormLayout({
+		doctype: target.doctype,
+		type: "Details",
+		doc: saved,
+		fallback: "meta",
+		overrides: () => controller.value?.fields.resolve() ?? {},
+		tabOverrides: () => controller.value?.formTabs.resolve() ?? {},
+	});
+	const panel = useFormLayout({
+		doctype: target.doctype,
+		type: "Side Panel",
+		doc: saved,
+		fallback: "none",
+		overrides: () => controller.value?.fields.resolve() ?? {},
+	});
 	try {
 		const [loaded, metadata] = await Promise.all([
 			fetchDoc(target),
@@ -202,6 +263,7 @@ async function load() {
 		saved.value = { ...loaded.document };
 		doc.value = JSON.parse(JSON.stringify(loaded.document));
 		docinfo.value = loaded.docinfo;
+		linkTitles.value = loaded.linkTitles;
 		meta.value = metadata;
 	} catch (e) {
 		if (mine !== generation) return;
@@ -223,8 +285,12 @@ async function load() {
 		// No tab strip on this page, so activation is a no-op.
 		activeTab: () => "",
 		activateTab: () => {},
+		formLayout: () => form.value,
+		activeFormTab: () => activeFormTab.value,
+		activateFormTab: (identity) => void (formTab.value = identity),
 		discloseSection: disclosure.disclose,
-		save,
+		focusField: (fieldname, cursor) => void landOn(fieldname, cursor),
+		save: write,
 		reload: load,
 		router,
 		sourcesReady: () => loadClientScripts(target.doctype),
@@ -234,19 +300,12 @@ async function load() {
 		quickActionBuiltins(docinfo.value?.permissions ?? {})
 	);
 	created.panelSections.provideBuiltins(panelBuiltins);
-	// Against the saved document, so a keystroke cannot switch the layout under the reader.
-	const layoutSource = useFormLayout({
-		doctype: target.doctype,
-		type: "Side Panel",
-		doc: saved,
-		fallback: "none",
-		overrides: () => created.fields.resolve(),
-	});
-	panelLayout.value = layoutSource.layout;
+	panelLayout.value = panel;
+	detailsLayout.value = details;
 	controller.value = created;
 
-	// The first replay must see the layout's sections, or a script's act on one is dropped as unknown.
-	await layoutSource.settled();
+	// The first replay must see both layouts, or a script's act on a tab or section is dropped as unknown.
+	await Promise.all([details.settled(), panel.settled()]);
 	if (mine !== generation) return;
 	await created.refresh();
 	if (mine !== generation) return;
@@ -258,16 +317,16 @@ async function load() {
 // One request at a time: a `page.save()` that lands mid-flight awaits the one in flight.
 let inFlight: Promise<void> | null = null;
 
-async function save() {
+async function write() {
 	// Refuse to write the wrong record if the route moved while an action ran.
 	if (doc.value.name !== docname.value || doctype.value === null) {
 		throw new Error("The record changed while saving; nothing was written.");
 	}
-	if (!inFlight) inFlight = write().finally(() => (inFlight = null));
+	if (!inFlight) inFlight = send().finally(() => (inFlight = null));
 	await inFlight;
 }
 
-async function write() {
+async function send() {
 	const mine = generation;
 	saving.value = true;
 	try {
@@ -279,9 +338,16 @@ async function write() {
 			},
 			body: JSON.stringify({ doc: { ...doc.value, doctype: doctype.value } }),
 		});
-		if (!res.ok) throw new Error(`Save failed with ${res.status}`);
+		const body = await res.json().catch(() => null);
+		if (!res.ok) {
+			if (isTimestampMismatch(body)) {
+				await resolveConflict();
+				throw conflictError();
+			}
+			throw new Error(serverMessage(body) ?? `Save failed with ${res.status}`);
+		}
 
-		const document = (await res.json()).message;
+		const document = body.message;
 		if (mine !== generation) return;
 		saved.value = { ...document };
 		doc.value = JSON.parse(JSON.stringify(document));
@@ -292,6 +358,34 @@ async function write() {
 	actionsVersion.value++;
 }
 
+// Nothing is re-applied: the reader sees who saved and what they changed, and chooses.
+async function resolveConflict() {
+	const target = { doctype: doctype.value!, name: docname.value };
+	const latest = await fetchDoc(target).catch(() => null);
+	const editor = latest
+		? personOf(latest.docinfo, latest.document.modified_by).name
+		: "Someone else";
+	const changed = changedFields(doc.value, saved.value, meta.value?.fields);
+	const mine = changed.length ? `your changes to ${changed.join(", ")}` : "your changes";
+	const reload = await controller.value!.page.dialog.confirm({
+		title: "Saved by someone else",
+		message: `${editor} saved this record after you opened it, so ${mine} cannot be saved over theirs. Reload to see their version, or keep editing to copy your values out first.`,
+		confirmLabel: "Reload and lose my changes",
+		cancelLabel: "Keep editing",
+	});
+	if (reload) await load();
+}
+
+// Not through `runAction`: a failed save must keep the draft on screen, not reload over it.
+async function runSave() {
+	actionError.value = "";
+	try {
+		await controller.value?.page.save();
+	} catch (e) {
+		if ((e as Error)?.name !== SAVE_CONFLICT) actionError.value = errorMessage(e);
+	}
+}
+
 async function runAction(action: QuickAction | HeaderItem) {
 	// Awaited and caught: a failing action would otherwise leave the draft mutated on screen
 	// with no error. Reloading discards the rejected draft.
@@ -299,17 +393,81 @@ async function runAction(action: QuickAction | HeaderItem) {
 	try {
 		await action.run?.(controller.value!.page);
 	} catch (e) {
-		actionError.value = String((e as Error)?.message ?? e);
+		actionError.value = errorMessage(e);
 		await load();
 	}
 }
 
-// A panel row with no honest control opens where the main column shows the field.
-function expand(field: FieldNode) {
-	document
-		.querySelector(`dl [data-fieldname="${field.fieldname}"]`)
-		?.scrollIntoView({ block: "center" });
+/** The host's half of `page.fields.focus`: the field's tab, then the scroll, then the cursor. */
+async function landOn(fieldname: string, cursor: boolean) {
+	const tab = identifyTabs(form.value).find((one) =>
+		one.sections.some((section) =>
+			section.columns.some((column) =>
+				column.fields.some((field) => field.fieldname === fieldname)
+			)
+		)
+	);
+	if (tab) formTab.value = tab.identity;
+	// The strip mounts a tab's panel a frame after the model moves, so the cell is polled for.
+	for (let frame = 0; frame < 10; frame++) {
+		await nextTick();
+		const cell = formRoot.value?.querySelector<HTMLElement>(
+			`.field[data-fieldname="${fieldname}"]`
+		);
+		if (cell) {
+			cell.scrollIntoView({ block: "center" });
+			if (cursor)
+				cell.querySelector<HTMLElement>("input, textarea, select, button")?.focus();
+			return;
+		}
+		await new Promise(requestAnimationFrame);
+	}
 }
+
+function expand(field: FieldNode) {
+	controller.value?.page.fields.focus(field.fieldname);
+}
+
+async function confirmLeave() {
+	if (!dirty.value || !controller.value) return true;
+	const discard = await controller.value.page.dialog.confirm({
+		title: "Discard unsaved changes?",
+		message: "This record has changes that are not saved.",
+		confirmLabel: "Discard",
+		cancelLabel: "Keep editing",
+	});
+	return !!discard;
+}
+
+onBeforeRouteLeave(confirmLeave);
+onBeforeRouteUpdate((to, from) =>
+	to.params.doctype === from.params.doctype && to.params.name === from.params.name
+		? true
+		: confirmLeave()
+);
+
+function onBeforeUnload(event: BeforeUnloadEvent) {
+	if (!dirty.value) return;
+	event.preventDefault();
+}
+
+// A key press is a deliberate gesture, so a clean doc answers with the button's own tooltip text.
+function onKeydown(event: KeyboardEvent) {
+	if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== "s") return;
+	event.preventDefault();
+	if (!controller.value) return;
+	if (!dirty.value) toast.info("No changes to save");
+	runSave();
+}
+
+onMounted(() => {
+	window.addEventListener("keydown", onKeydown);
+	window.addEventListener("beforeunload", onBeforeUnload);
+});
+onUnmounted(() => {
+	window.removeEventListener("keydown", onKeydown);
+	window.removeEventListener("beforeunload", onBeforeUnload);
+});
 
 watch([doctype, docname], load, { immediate: true });
 </script>

--- a/frontend/src/pages/Record.vue
+++ b/frontend/src/pages/Record.vue
@@ -233,6 +233,7 @@ async function load() {
 	saved.value = {};
 	docinfo.value = null;
 	linkTitles.value = {};
+	saving.value = false;
 	controller.value = null;
 	panelLayout.value = null;
 	detailsLayout.value = null;

--- a/frontend/src/pages/Record.vue
+++ b/frontend/src/pages/Record.vue
@@ -139,7 +139,7 @@ const activeFormTab = ref("");
 const formClasses = [
 	"!rounded-none !border-0",
 	"[&_[role='tablist']]:sticky [&_[role='tablist']]:top-0 [&_[role='tablist']]:z-10 [&_[role='tablist']]:bg-surface-base",
-	"[&_[role='tablist']]:gap-5 [&_[role='tablist']]:px-5 [&_[role='tab']]:py-2",
+	"[&_[role='tablist']]:gap-5 [&_[role='tablist']]:px-5 [&_[role='tablist']]:py-2 [&_[role='tab']]:rounded-4",
 	"[&_.sections]:mx-auto [&_.sections]:my-0 [&_.sections]:w-full [&_.sections]:max-w-3xl [&_.sections]:p-6",
 	"[&_.section-header]:!px-0 [&_.section-body]:!px-0",
 ];

--- a/frontend/src/pages/Record.vue
+++ b/frontend/src/pages/Record.vue
@@ -316,16 +316,22 @@ async function load() {
 	actionsVersion.value++;
 }
 
-// One request at a time: a `page.save()` that lands mid-flight awaits the one in flight.
-let inFlight: Promise<void> | null = null;
+// One request per record at a time; a request the previous record left in flight is not joined.
+let inFlight: { generation: number; request: Promise<void> } | null = null;
 
 async function write() {
 	// Refuse to write the wrong record if the route moved while an action ran.
 	if (doc.value.name !== docname.value || doctype.value === null) {
 		throw new Error("The record changed while saving; nothing was written.");
 	}
-	if (!inFlight) inFlight = send().finally(() => (inFlight = null));
-	await inFlight;
+	if (inFlight?.generation !== generation) {
+		const mine = generation;
+		const request = send().finally(() => {
+			if (inFlight?.request === request) inFlight = null;
+		});
+		inFlight = { generation: mine, request };
+	}
+	await inFlight.request;
 }
 
 async function send() {

--- a/frontend/src/pages/Record.vue
+++ b/frontend/src/pages/Record.vue
@@ -82,6 +82,7 @@ import {
 	errorMessage,
 	loadClientScripts,
 	projectHeader,
+	SAVE_VETO,
 	useFormLayout,
 	type HeaderItem,
 	type QuickAction,
@@ -231,6 +232,7 @@ async function load() {
 	doc.value = {};
 	saved.value = {};
 	docinfo.value = null;
+	linkTitles.value = {};
 	controller.value = null;
 	panelLayout.value = null;
 	detailsLayout.value = null;
@@ -341,6 +343,7 @@ async function send() {
 		const body = await res.json().catch(() => null);
 		if (!res.ok) {
 			if (isTimestampMismatch(body)) {
+				saving.value = false;
 				await resolveConflict();
 				throw conflictError();
 			}
@@ -386,15 +389,17 @@ async function runSave() {
 	}
 }
 
+// A failing action would otherwise leave the draft mutated with no error, so it reloads;
+// a save the reader vetoed or must resolve keeps the draft, as the built-in Save does.
 async function runAction(action: QuickAction | HeaderItem) {
-	// Awaited and caught: a failing action would otherwise leave the draft mutated on screen
-	// with no error. Reloading discards the rejected draft.
 	actionError.value = "";
 	try {
 		await action.run?.(controller.value!.page);
 	} catch (e) {
+		const name = (e as Error)?.name;
+		if (name === SAVE_CONFLICT) return;
 		actionError.value = errorMessage(e);
-		await load();
+		if (name !== SAVE_VETO) await load();
 	}
 }
 
@@ -422,6 +427,10 @@ async function landOn(fieldname: string, cursor: boolean) {
 		}
 		await new Promise(requestAnimationFrame);
 	}
+	if (import.meta.env.DEV)
+		console.warn(
+			`[record-page] page.fields.focus("${fieldname}") — not on the form; the reader was not moved.`
+		);
 }
 
 function expand(field: FieldNode) {
@@ -455,7 +464,7 @@ function onBeforeUnload(event: BeforeUnloadEvent) {
 function onKeydown(event: KeyboardEvent) {
 	if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== "s") return;
 	event.preventDefault();
-	if (!controller.value) return;
+	if (!controller.value || event.repeat) return;
 	if (!dirty.value) toast.info("No changes to save");
 	runSave();
 }

--- a/frontend/src/pages/record/dialogs/PageDialogs.vue
+++ b/frontend/src/pages/record/dialogs/PageDialogs.vue
@@ -1,0 +1,22 @@
+<!-- The page's own dialog stack: `open` and `form` need a host; `confirm` and `danger`
+     render on frappe-ui's own stack. -->
+<template>
+	<component
+		:is="entry.kind === 'form' ? PageFormDialog : PageOpenDialog"
+		v-for="entry in controller.dialogs.value"
+		:key="entry.id"
+		:entry="entry"
+	/>
+</template>
+
+<script setup lang="ts">
+import { onUnmounted } from "vue";
+import type { RecordPageController } from "@/recordPage";
+import PageFormDialog from "./PageFormDialog.vue";
+import PageOpenDialog from "./PageOpenDialog.vue";
+
+const props = defineProps<{ controller: RecordPageController }>();
+
+// Unmounting is navigating away: every open dialog resolves `null`, so no script hangs on it.
+onUnmounted(() => props.controller.closeDialogs());
+</script>

--- a/frontend/src/pages/record/dialogs/PageFormDialog.vue
+++ b/frontend/src/pages/record/dialogs/PageFormDialog.vue
@@ -1,0 +1,211 @@
+<!-- `page.dialog.form()`'s host: the declarative tier. The doc is local and dies with the
+     dialog; nothing here touches the record behind it. -->
+<template>
+	<Dialog
+		v-model:open="isOpen"
+		:title="options.title || 'Dialog'"
+		:size="size"
+		:dismissible="dismissible"
+		:show-close-button="dismissible"
+		@after-leave="entry.dismiss()"
+	>
+		<FormLayout v-if="layout.length" v-model:doc="doc" :layout="layout" />
+		<ErrorMessage v-if="error" class="mt-2" :message="error" />
+		<template #actions>
+			<div v-if="options.actions?.length" class="flex justify-end gap-2">
+				<Button
+					v-for="(action, index) in options.actions"
+					:key="action.label"
+					:label="action.label"
+					:variant="(action.variant as any) ?? 'subtle'"
+					:theme="action.theme as any"
+					:icon-left="action.icon"
+					:loading="actionLoading[index]"
+					:disabled="busy && !actionLoading[index]"
+					@click="runAction(action, index)"
+				/>
+			</div>
+			<div v-else class="flex flex-row-reverse gap-2">
+				<Button
+					variant="solid"
+					:label="options.submitLabel || 'Submit'"
+					:loading="submitting"
+					@click="submit"
+				/>
+				<!-- Desk v1's rule: the Cancel button appears only when it is labelled. -->
+				<Button
+					v-if="options.cancelLabel"
+					variant="outline"
+					:label="options.cancelLabel"
+					:disabled="submitting"
+					@click="cancel"
+				/>
+			</div>
+		</template>
+	</Dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, provide, reactive, ref, watch } from "vue";
+import { Button, Dialog, ErrorMessage } from "frappe-ui";
+import type { DialogSize } from "frappe-ui";
+import { FormLayout } from "@framework/ui/components/FormLayout";
+import { CommitKey, NO_COMMIT } from "@framework/ui/components/FormLayout/types";
+import type { FormLayoutSchema } from "@framework/ui/components/FormLayout/types";
+import { useDoctypeMeta } from "@framework/ui/composables/useDoctypeMeta";
+import { useDocPermissions } from "@framework/ui/composables/useDocPermissions";
+import { useFormLayout } from "@/recordPage";
+import type { PageDialogEntry } from "@/recordPage/dialog";
+import { errorMessage } from "@/recordPage/errorMessage";
+import {
+	applyRequired,
+	formData,
+	initialDoc,
+	layoutFromFields,
+	layoutFromTabs,
+	layoutMode,
+	missingRequired,
+	pickMetaFields,
+	warnAmbiguousLayout,
+} from "@/recordPage/formDialogLayout";
+import type { PageDialogAction } from "@/recordPage/types";
+
+// The dialog's fields commit to nothing, or they would fire the record's handlers under the same names.
+provide(CommitKey, NO_COMMIT);
+
+const props = defineProps<{ entry: PageDialogEntry }>();
+
+const options = props.entry.form!;
+const mode = layoutMode(options);
+warnAmbiguousLayout(options);
+
+const isOpen = ref(true);
+const error = ref("");
+const submitting = ref(false);
+const actionLoading = reactive((options.actions ?? []).map(() => false));
+
+const doc = ref<Record<string, any>>({ ...(options.defaults ?? {}) });
+// A `Quick Entry` row's condition reads this, not the live draft: a layout switch mid-keystroke steals focus.
+const conditionDoc = ref<Record<string, any>>({ ...(options.defaults ?? {}) });
+
+// The whole form is the doctype's `Quick Entry` layout; a picked handful comes from the meta.
+const quickEntry =
+	mode === "doctype" && !options.fieldnames
+		? useFormLayout({
+				doctype: options.doctype!,
+				type: "Quick Entry",
+				doc: conditionDoc,
+				fallback: "meta",
+		  })
+		: null;
+
+const picked = options.fieldnames ? options.doctype! : null;
+const doctypeMeta = picked ? useDoctypeMeta(picked) : null;
+const permissions = picked ? useDocPermissions(picked) : null;
+
+const layout = computed<FormLayoutSchema>(() => applyRequired(baseLayout(), options.required));
+
+function baseLayout(): FormLayoutSchema {
+	if (mode === "fields") return layoutFromFields(options.fields!);
+	if (mode === "tabs") return layoutFromTabs(options.tabs!);
+	if (mode !== "doctype") return [];
+	if (!options.fieldnames) return quickEntry!.layout.value;
+	return pickMetaFields(
+		doctypeMeta!.meta.value?.fields,
+		options.fieldnames,
+		permissions!.fieldAccess
+	);
+}
+
+// `doctype` mode resolves its fields a fetch later than the dialog opens; edits already made are kept.
+watch(
+	layout,
+	(current) => {
+		doc.value = { ...initialDoc(current, options.defaults), ...doc.value };
+	},
+	{ immediate: true }
+);
+
+const dismissible = options.dismissible !== false;
+const size = (options.size as DialogSize) ?? "xl";
+const busy = computed(() => submitting.value || actionLoading.some(Boolean));
+
+// The ways out overlap (Esc mid-transition, a page unmounting), so the author hears `onCancel` once.
+let answered = false;
+
+function dismissed() {
+	if (answered) return;
+	answered = true;
+	options.onCancel?.();
+}
+
+// Navigating off the record unmounts this component before the watcher below can run.
+props.entry.onDismissed = dismissed;
+
+watch(isOpen, (open) => {
+	if (open) return;
+	dismissed();
+	props.entry.settle(null);
+});
+
+// Settled now, not on `after-leave`: a page unmounting mid-transition must not turn a submit into a cancel.
+function close(value: any = null) {
+	answered = true;
+	props.entry.settle(value);
+	isOpen.value = false;
+}
+
+function cancel() {
+	isOpen.value = false;
+}
+
+function validate(): boolean {
+	const missing = missingRequired(layout.value, doc.value);
+	error.value = missing.length ? `Please fill in ${missing.join(", ")}` : "";
+	return missing.length === 0;
+}
+
+async function submit() {
+	if (busy.value || !validate()) return;
+	submitting.value = true;
+	error.value = "";
+	try {
+		const data = formData(layout.value, doc.value);
+		await options.onSubmit?.(data);
+		close(data);
+	} catch (exception) {
+		// The dialog stays open with the error inline, so a failed server call can be retried.
+		report("onSubmit", exception);
+	} finally {
+		submitting.value = false;
+	}
+}
+
+// The reader gets the message; the console gets the script's name.
+function report(hook: string, exception: unknown) {
+	error.value = errorMessage(exception);
+	console.error(`[record-page] ${props.entry.source} page.dialog.form ${hook} threw`, exception);
+}
+
+// A custom action never closes on its own; `close(result)` is how it resolves the promise.
+async function runAction(action: PageDialogAction, index: number) {
+	if (busy.value) return;
+	actionLoading[index] = true;
+	error.value = "";
+	try {
+		if (!action.onClick) {
+			if (validate()) close(formData(layout.value, doc.value));
+			return;
+		}
+		await action.onClick({
+			data: formData(layout.value, doc.value),
+			close,
+			validate,
+		});
+	} catch (exception) {
+		report(`action "${action.label}"`, exception);
+	} finally {
+		actionLoading[index] = false;
+	}
+}
+</script>

--- a/frontend/src/pages/record/dialogs/PageOpenDialog.vue
+++ b/frontend/src/pages/record/dialogs/PageOpenDialog.vue
@@ -1,0 +1,38 @@
+<!-- `page.dialog.open()`'s host: the chrome is the host's, so Esc, the backdrop and the X
+     resolve `null`; the component renders the body and answers with `close(result)`. -->
+<template>
+	<Dialog
+		v-model:open="isOpen"
+		:title="entry.options.title"
+		:size="size"
+		:dismissible="dismissible"
+		:show-close-button="dismissible"
+		@after-leave="entry.dismiss()"
+	>
+		<component :is="entry.component" v-bind="entry.props" :close="close" />
+	</Dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from "vue";
+import { Dialog } from "frappe-ui";
+import type { DialogSize } from "frappe-ui";
+import type { PageDialogEntry } from "@/recordPage/dialog";
+
+const props = defineProps<{ entry: PageDialogEntry }>();
+
+const isOpen = ref(true);
+const dismissible = props.entry.options.dismissible !== false;
+const size = (props.entry.options.size as DialogSize) ?? "md";
+
+// Settled now, not on `after-leave`: a page unmounting mid-transition must not report a dismissal.
+function close(value: any = null) {
+	props.entry.settle(value);
+	isOpen.value = false;
+}
+
+// `settle` is idempotent, so a close that already answered wins over this.
+watch(isOpen, (open) => {
+	if (!open) props.entry.settle(null);
+});
+</script>

--- a/frontend/src/pages/record/formTabMemory.ts
+++ b/frontend/src/pages/record/formTabMemory.ts
@@ -1,0 +1,42 @@
+// The form tab the reader last chose, per doctype, in this browser; keyed by user because
+// a browser profile is shared and a choice is not.
+const KEY = "frappe:desk:formTab";
+
+type Stored = Record<string, Record<string, string>>;
+
+export interface FormTabMemory {
+  /** The identity the reader last chose for this doctype, or `""`. */
+  recall(): string;
+  remember(identity: string): void;
+}
+
+function read(): Stored {
+  try {
+    const raw = localStorage.getItem(KEY);
+    const parsed = raw ? JSON.parse(raw) : null;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function write(stored: Stored): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(stored));
+  } catch {
+    // Full or forbidden: the tab still switches for this page.
+  }
+}
+
+export function formTabMemory(user: string, doctype: string): FormTabMemory {
+  return {
+    recall() {
+      const identity = read()[user]?.[doctype];
+      return typeof identity === "string" ? identity : "";
+    },
+    remember(identity) {
+      const stored = read();
+      write({ ...stored, [user]: { ...stored[user], [doctype]: identity } });
+    },
+  };
+}

--- a/frontend/src/pages/record/panel/RecordPanel.vue
+++ b/frontend/src/pages/record/panel/RecordPanel.vue
@@ -35,7 +35,6 @@
 
 <script setup lang="ts">
 import { provide, ref, toRef } from "vue";
-import { CommitKey } from "@framework/ui/components/FormLayout/types";
 import type { FieldNode } from "@framework/ui/components/FormLayout/types";
 import type { QuickAction, RecordPageController } from "@/recordPage";
 import { PanelContextKey, type DocInfo } from "./context";
@@ -73,12 +72,5 @@ provide(PanelContextKey, {
 	docinfo: toRef(props, "docinfo"),
 	controller: props.controller,
 	run: props.run,
-});
-
-// A row's commit is the field's handler; a pending edit has no save-time flush here yet.
-provide(CommitKey, {
-	pending: () => {},
-	commit: (fieldname) => void props.controller.fireEvent(fieldname),
-	rowChanged: () => {},
 });
 </script>

--- a/frontend/src/pages/record/saveResponse.ts
+++ b/frontend/src/pages/record/saveResponse.ts
@@ -1,0 +1,46 @@
+// What a failed `frappe.client.save` answers, read into the two things the page acts on:
+// a timestamp mismatch, and the message the server meant the reader to see.
+import type { RawMetaField } from "@framework/ui/components/FormLayout/types";
+
+/** The name a save rejected for a conflict throws under; the dialog has already told the reader. */
+export const SAVE_CONFLICT = "SaveConflict";
+
+export function isTimestampMismatch(body: any): boolean {
+  return body?.exc_type === "TimestampMismatchError";
+}
+
+/** The server's first `msgprint`, or nothing; `_server_messages` is a JSON list of JSON strings. */
+export function serverMessage(body: any): string | undefined {
+  try {
+    const messages: string[] = JSON.parse(body?._server_messages ?? "[]");
+    const first = messages[0] && JSON.parse(messages[0]);
+    return typeof first?.message === "string" ? first.message : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** The labels of the fields the draft changed, in meta order, then any key the meta does not carry. */
+export function changedFields(
+  doc: Record<string, any>,
+  saved: Record<string, any>,
+  fields: RawMetaField[] | undefined,
+): string[] {
+  const changed = new Set(
+    [...Object.keys(doc), ...Object.keys(saved)].filter(
+      (key) => !key.startsWith("_") && JSON.stringify(doc[key]) !== JSON.stringify(saved[key]),
+    ),
+  );
+  const labelled: string[] = [];
+  for (const field of fields ?? []) {
+    if (!changed.delete(field.fieldname)) continue;
+    labelled.push(field.label || field.fieldname);
+  }
+  return [...labelled, ...changed];
+}
+
+export function conflictError(): Error {
+  const error = new Error("Saved elsewhere; reload to save your changes.");
+  error.name = SAVE_CONFLICT;
+  return error;
+}

--- a/frontend/src/pages/record/saveResponse.ts
+++ b/frontend/src/pages/record/saveResponse.ts
@@ -9,15 +9,24 @@ export function isTimestampMismatch(body: any): boolean {
   return body?.exc_type === "TimestampMismatchError";
 }
 
-/** The server's first `msgprint`, or nothing; `_server_messages` is a JSON list of JSON strings. */
+/** The server's first `msgprint` as text, or nothing; `_server_messages` is a JSON list of JSON strings. */
 export function serverMessage(body: any): string | undefined {
   try {
     const messages: string[] = JSON.parse(body?._server_messages ?? "[]");
     const first = messages[0] && JSON.parse(messages[0]);
-    return typeof first?.message === "string" ? first.message : undefined;
+    return typeof first?.message === "string" ? stripTags(first.message) : undefined;
   } catch {
     return undefined;
   }
+}
+
+// A msgprint is often HTML; the page renders it as text, so the tags go and a break becomes a space.
+function stripTags(html: string): string {
+  return html
+    .replace(/<br\s*\/?>/gi, " ")
+    .replace(/<[^>]+>/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 /** The labels of the fields the draft changed, in meta order, then any key the meta does not carry. */

--- a/frontend/src/pages/record/tests/formDialog.test.ts
+++ b/frontend/src/pages/record/tests/formDialog.test.ts
@@ -1,0 +1,228 @@
+// The `form` host's own behaviours: the throw that holds the dialog open, custom
+// actions, and the dismissal paths that answer the opener.
+import { describe, expect, it, vi } from "vitest";
+import { createApp, defineComponent, h, nextTick } from "vue";
+
+// The chrome is frappe-ui's; a passthrough here reads the form's behaviour, not reka-ui's transitions.
+vi.mock("frappe-ui", () => ({
+  Dialog: defineComponent({
+    props: { open: { type: Boolean, default: true } },
+    emits: ["update:open", "after-leave"],
+    setup(props, { slots }) {
+      return () =>
+        props.open
+          ? h("div", [h("div", slots.default?.()), h("div", slots.actions?.())])
+          : null;
+    },
+  }),
+  Button: defineComponent({
+    props: { label: String, loading: Boolean, disabled: Boolean },
+    setup(props, { attrs }) {
+      return () =>
+        h("button", { ...attrs, disabled: props.disabled }, props.label);
+    },
+  }),
+  ErrorMessage: defineComponent({
+    props: { message: String },
+    setup: (props) => () => h("p", { class: "error" }, props.message),
+  }),
+  createResource: () => ({
+    data: null,
+    loading: false,
+    fetch() {},
+    reload() {},
+  }),
+  frappeRequest: vi.fn(),
+  call: vi.fn(),
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@framework/ui/components/FormLayout", () => ({
+  // The real FormLayout is exercised in Chrome; here it only has to own the doc.
+  FormLayout: defineComponent({
+    props: {
+      layout: { type: Array, required: true },
+      doc: { type: Object, required: true },
+    },
+    emits: ["update:doc"],
+    setup: () => () => h("form"),
+  }),
+}));
+
+import PageFormDialog from "../dialogs/PageFormDialog.vue";
+import type { PageDialogEntry } from "@/recordPage/dialog";
+import type { PageDialogFormOptions } from "@/recordPage/types";
+
+function makeEntry(form: PageDialogFormOptions) {
+  const entry: PageDialogEntry & { settled: any[] } = {
+    id: 1,
+    source: "page-script:deal-hello",
+    kind: "form",
+    props: {},
+    options: {},
+    form,
+    settled: [],
+    // Idempotent, like the real one: the dismissal after a close must not overwrite the answer.
+    settle: (result: any = null) => {
+      if (!entry.settled.length) entry.settled.push(result);
+    },
+    dismiss: vi.fn(),
+  };
+  return entry;
+}
+
+const FIELDS = [{ fieldname: "note", fieldtype: "Data", label: "Note" }];
+
+/** Mount the dialog into a throwaway root; no test-utils dependency to add. */
+function render(entry: PageDialogEntry) {
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  createApp(PageFormDialog, { entry }).mount(root);
+  return root;
+}
+
+function button(root: HTMLElement, label: string) {
+  return [...root.querySelectorAll("button")].find(
+    (element) => element.textContent?.trim() === label,
+  );
+}
+
+/** Let a click's async handler and the re-render it causes both land. */
+async function settle() {
+  await nextTick();
+  await Promise.resolve();
+  await nextTick();
+}
+
+async function click(root: HTMLElement, label: string) {
+  button(root, label)!.dispatchEvent(new MouseEvent("click"));
+  await settle();
+}
+
+describe("the form host", () => {
+  it("holds the dialog open with the error inline when onSubmit throws", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const entry = makeEntry({
+      fields: FIELDS,
+      onSubmit: () => {
+        throw new Error("Not allowed on a won deal");
+      },
+    });
+    const root = render(entry);
+
+    await click(root, "Submit");
+
+    expect(root.querySelector(".error")!.textContent).toBe(
+      "Not allowed on a won deal",
+    );
+    expect(entry.settled).toEqual([]);
+    expect(button(root, "Submit")).toBeTruthy();
+    // The reader sees the message; the console names the script behind it.
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining("page-script:deal-hello"),
+      expect.anything(),
+    );
+    error.mockRestore();
+  });
+
+  it("resolves with the field values on a clean submit", async () => {
+    const onSubmit = vi.fn();
+    const entry = makeEntry({
+      fields: FIELDS,
+      defaults: { note: "hi" },
+      onSubmit,
+    });
+    const root = render(entry);
+
+    await click(root, "Submit");
+
+    expect(onSubmit).toHaveBeenCalledWith({ note: "hi" });
+    expect(entry.settled).toEqual([{ note: "hi" }]);
+  });
+
+  it("refuses a submit that leaves a mandatory field empty", async () => {
+    const onSubmit = vi.fn();
+    const entry = makeEntry({
+      fields: [
+        { fieldname: "note", fieldtype: "Data", label: "Note", reqd: 1 },
+      ],
+      onSubmit,
+    });
+    const root = render(entry);
+
+    await click(root, "Submit");
+
+    expect(root.querySelector(".error")!.textContent).toBe(
+      "Please fill in Note",
+    );
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(entry.settled).toEqual([]);
+  });
+
+  it("hands a custom action { data, close, validate } and lets it answer", async () => {
+    let seen: any = null;
+    const entry = makeEntry({
+      fields: FIELDS,
+      defaults: { note: "why" },
+      actions: [
+        {
+          label: "Reject",
+          onClick: (context) => {
+            seen = context;
+            context.close("rejected");
+          },
+        },
+      ],
+    });
+    const root = render(entry);
+
+    expect(button(root, "Submit")).toBeUndefined();
+    await click(root, "Reject");
+
+    expect(seen.data).toEqual({ note: "why" });
+    expect(typeof seen.validate).toBe("function");
+    expect(entry.settled).toEqual(["rejected"]);
+  });
+
+  it("validates and closes with the data for a custom action with no onClick", async () => {
+    const entry = makeEntry({
+      fields: FIELDS,
+      defaults: { note: "ok" },
+      actions: [{ label: "Save" }],
+    });
+    const root = render(entry);
+
+    await click(root, "Save");
+
+    expect(entry.settled).toEqual([{ note: "ok" }]);
+  });
+
+  it("runs onCancel and resolves null when the page goes away", async () => {
+    const onCancel = vi.fn();
+    const entry = makeEntry({ fields: FIELDS, onCancel });
+    render(entry);
+
+    // What `closeAll` does to a live dialog.
+    entry.onDismissed?.();
+    entry.settle(null);
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(entry.settled).toEqual([null]);
+  });
+
+  it("does not run onCancel after the reader already submitted", async () => {
+    const onCancel = vi.fn();
+    const entry = makeEntry({
+      fields: FIELDS,
+      defaults: { note: "x" },
+      onCancel,
+    });
+    const root = render(entry);
+
+    await click(root, "Submit");
+    entry.onDismissed?.();
+
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(entry.settled).toEqual([{ note: "x" }]);
+  });
+});

--- a/frontend/src/pages/record/tests/formTabMemory.test.ts
+++ b/frontend/src/pages/record/tests/formTabMemory.test.ts
@@ -1,0 +1,34 @@
+// The reader's form tab, per doctype and per user, in the browser.
+import { beforeEach, describe, expect, it } from "vitest";
+import { formTabMemory } from "../formTabMemory";
+
+beforeEach(() => localStorage.clear());
+
+describe("formTabMemory", () => {
+  it("answers nothing until the reader chooses", () => {
+    expect(formTabMemory("alice", "CRM Deal").recall()).toBe("");
+  });
+
+  it("remembers the last choice per doctype", () => {
+    const deal = formTabMemory("alice", "CRM Deal");
+    const lead = formTabMemory("alice", "CRM Lead");
+    deal.remember("products");
+    lead.remember("details");
+    deal.remember("activity");
+    expect(deal.recall()).toBe("activity");
+    expect(lead.recall()).toBe("details");
+  });
+
+  it("keeps one reader's choice from another's", () => {
+    formTabMemory("alice", "CRM Deal").remember("products");
+    expect(formTabMemory("bob", "CRM Deal").recall()).toBe("");
+  });
+
+  it("survives a broken store", () => {
+    localStorage.setItem("frappe:desk:formTab", "not json");
+    const memory = formTabMemory("alice", "CRM Deal");
+    expect(memory.recall()).toBe("");
+    memory.remember("products");
+    expect(memory.recall()).toBe("products");
+  });
+});

--- a/frontend/src/pages/record/tests/saveResponse.test.ts
+++ b/frontend/src/pages/record/tests/saveResponse.test.ts
@@ -33,6 +33,15 @@ describe("serverMessage", () => {
     expect(serverMessage(body)).toBe("Amount is required");
   });
 
+  it("reads a msgprint's HTML as text", () => {
+    const body = {
+      _server_messages: JSON.stringify([
+        JSON.stringify({ message: "<b>Amount</b> is required<br>for a won deal" }),
+      ]),
+    };
+    expect(serverMessage(body)).toBe("Amount is required for a won deal");
+  });
+
   it("answers nothing for a body with no messages or a broken one", () => {
     expect(serverMessage({})).toBeUndefined();
     expect(serverMessage({ _server_messages: "nope" })).toBeUndefined();

--- a/frontend/src/pages/record/tests/saveResponse.test.ts
+++ b/frontend/src/pages/record/tests/saveResponse.test.ts
@@ -1,0 +1,68 @@
+// A failed save's response, read the two ways the page acts on it.
+import { describe, expect, it } from "vitest";
+import {
+  changedFields,
+  conflictError,
+  isTimestampMismatch,
+  SAVE_CONFLICT,
+  serverMessage,
+} from "../saveResponse";
+
+const FIELDS = [
+  { fieldname: "status", fieldtype: "Select", label: "Status" },
+  { fieldname: "probability", fieldtype: "Percent", label: "Probability" },
+  { fieldname: "notes", fieldtype: "Text" },
+];
+
+describe("isTimestampMismatch", () => {
+  it("reads the exception class the server names", () => {
+    expect(isTimestampMismatch({ exc_type: "TimestampMismatchError" })).toBe(true);
+    expect(isTimestampMismatch({ exc_type: "ValidationError" })).toBe(false);
+    expect(isTimestampMismatch(null)).toBe(false);
+  });
+});
+
+describe("serverMessage", () => {
+  it("unwraps the first msgprint from the doubly encoded list", () => {
+    const body = {
+      _server_messages: JSON.stringify([
+        JSON.stringify({ message: "Amount is required", title: "Message" }),
+        JSON.stringify({ message: "Second" }),
+      ]),
+    };
+    expect(serverMessage(body)).toBe("Amount is required");
+  });
+
+  it("answers nothing for a body with no messages or a broken one", () => {
+    expect(serverMessage({})).toBeUndefined();
+    expect(serverMessage({ _server_messages: "nope" })).toBeUndefined();
+    expect(serverMessage(null)).toBeUndefined();
+  });
+});
+
+describe("changedFields", () => {
+  it("names the changed fields by label, in meta order, and skips private keys", () => {
+    const saved = { status: "Open", probability: 50, notes: "", _user_tags: "" };
+    const doc = { status: "Won", probability: 100, notes: "", _user_tags: "x" };
+    expect(changedFields(doc, saved, FIELDS)).toEqual(["Status", "Probability"]);
+  });
+
+  it("falls back to the fieldname without a label, and lists keys the meta lacks last", () => {
+    const saved = { notes: "a", extra: 1 };
+    const doc = { notes: "b", extra: 2 };
+    expect(changedFields(doc, saved, FIELDS)).toEqual(["notes", "extra"]);
+  });
+
+  it("compares by value, so a re-ordered child row list still counts", () => {
+    const saved = { items: [{ name: "a" }] };
+    const doc = { items: [{ name: "a" }] };
+    expect(changedFields(doc, saved, [])).toEqual([]);
+    expect(changedFields({ items: [] }, saved, [])).toEqual(["items"]);
+  });
+});
+
+describe("conflictError", () => {
+  it("carries the name the save path suppresses its message under", () => {
+    expect(conflictError().name).toBe(SAVE_CONFLICT);
+  });
+});

--- a/frontend/src/recordPage/commitChannel.ts
+++ b/frontend/src/recordPage/commitChannel.ts
@@ -1,0 +1,75 @@
+// Turns a field's commit into the event key a script's handler is registered under,
+// so events are dispatched where the value changed, not diffed out of the document.
+import type {
+  CommitChannel,
+  RowAddress,
+  RowChange,
+} from "@framework/ui/components/Fields/types";
+import { ROW_EVENTS } from "./flattenHandlers";
+
+export interface CommitChannelHost {
+  dispatch: (event: string, row?: RowAddress) => Promise<void> | void;
+}
+
+export interface RecordCommitChannel extends CommitChannel {
+  /** Fires the handler of an edit whose commit never arrived (save mid-typing). */
+  flush: () => Promise<void>;
+}
+
+interface Edit {
+  event: string;
+  value: any;
+  row?: RowAddress;
+}
+
+export function createCommitChannel(
+  host: CommitChannelHost,
+): RecordCommitChannel {
+  let pending: Edit | null = null;
+  let settled: Edit | null = null;
+
+  // An echo of the value already committed is a no-op: a control that re-emits as it
+  // commits, or the `change` a save's repaint fires on a focused input, must not refire.
+  function settles(event: string, value: any): boolean {
+    return !(settled?.event === event && Object.is(settled.value, value));
+  }
+
+  function commit(fieldname: string, value: any, row?: RowAddress) {
+    const event = fieldEvent(fieldname, row);
+    pending = null;
+    if (!settles(event, value)) return;
+    settled = { event, value, row };
+    return host.dispatch(event, row);
+  }
+
+  return {
+    pending: (fieldname, value, row) => {
+      const event = fieldEvent(fieldname, row);
+      if (settles(event, value)) pending = { event, value, row };
+    },
+    commit,
+    rowChanged: (row, change) => {
+      // A structural edit is itself a commit, and a removed row's pending edit has nowhere to land.
+      pending = null;
+      // A removed row has no address left to hand on; its handle would throw on every access.
+      host.dispatch(rowEvent(row, change), change === "add" ? row : undefined);
+    },
+    flush: async () => {
+      const edit = pending;
+      if (!edit) return;
+      pending = null;
+      settled = edit;
+      await host.dispatch(edit.event, edit.row);
+    },
+  };
+}
+
+/** A child field is addressed by its table, on the one character a fieldname cannot hold. */
+export function fieldEvent(fieldname: string, row?: RowAddress): string {
+  return row ? `${row.parentfield}.${fieldname}` : fieldname;
+}
+
+/** The lifecycle keys are `on`-prefixed, so they cannot collide with a child field called `add`. */
+export function rowEvent(row: RowAddress, change: RowChange): string {
+  return `${row.parentfield}.${ROW_EVENTS[change]}`;
+}

--- a/frontend/src/recordPage/commitChannel.ts
+++ b/frontend/src/recordPage/commitChannel.ts
@@ -12,7 +12,7 @@ export interface CommitChannelHost {
 }
 
 export interface RecordCommitChannel extends CommitChannel {
-  /** Fires the handler of an edit whose commit never arrived (save mid-typing). */
+  /** Fires the handler of an edit whose commit never arrived, and waits for the handlers already running. */
   flush: () => Promise<void>;
 }
 
@@ -27,39 +27,54 @@ export function createCommitChannel(
 ): RecordCommitChannel {
   let pending: Edit | null = null;
   let settled: Edit | null = null;
+  // Handlers a commit started and nobody awaited; a save waits for them before `beforeSave`.
+  const running = new Set<Promise<void>>();
 
   // An echo of the value already committed is a no-op: a control that re-emits as it
   // commits, or the `change` a save's repaint fires on a focused input, must not refire.
-  function settles(event: string, value: any): boolean {
-    return !(settled?.event === event && Object.is(settled.value, value));
+  function settles(event: string, value: any, row?: RowAddress): boolean {
+    return !(
+      settled?.event === event &&
+      settled.row?.key === row?.key &&
+      Object.is(settled.value, value)
+    );
+  }
+
+  function track(dispatched: Promise<void> | void) {
+    if (!dispatched) return;
+    const done = dispatched.finally(() => running.delete(done));
+    running.add(done);
+    return done;
   }
 
   function commit(fieldname: string, value: any, row?: RowAddress) {
     const event = fieldEvent(fieldname, row);
     pending = null;
-    if (!settles(event, value)) return;
+    if (!settles(event, value, row)) return;
     settled = { event, value, row };
-    return host.dispatch(event, row);
+    return track(host.dispatch(event, row));
   }
 
   return {
     pending: (fieldname, value, row) => {
       const event = fieldEvent(fieldname, row);
-      if (settles(event, value)) pending = { event, value, row };
+      if (settles(event, value, row)) pending = { event, value, row };
     },
     commit,
     rowChanged: (row, change) => {
       // A structural edit is itself a commit, and a removed row's pending edit has nowhere to land.
       pending = null;
       // A removed row has no address left to hand on; its handle would throw on every access.
-      host.dispatch(rowEvent(row, change), change === "add" ? row : undefined);
+      track(host.dispatch(rowEvent(row, change), change === "add" ? row : undefined));
     },
     flush: async () => {
       const edit = pending;
-      if (!edit) return;
-      pending = null;
-      settled = edit;
-      await host.dispatch(edit.event, edit.row);
+      if (edit) {
+        pending = null;
+        settled = edit;
+        await host.dispatch(edit.event, edit.row);
+      }
+      await Promise.all([...running]);
     },
   };
 }

--- a/frontend/src/recordPage/createRecordPage.ts
+++ b/frontend/src/recordPage/createRecordPage.ts
@@ -33,6 +33,16 @@ import type {
   TabsApi,
 } from "./types";
 
+/** The name a `beforeSave` veto rejects under, so a host keeps the draft instead of reloading. */
+export const SAVE_VETO = "SaveVeto";
+
+/** A veto keeps the script's message; a non-Error throw is wrapped so it can carry the name. */
+function asVeto(error: unknown): Error {
+  const veto = error instanceof Error ? error : new Error(String(error));
+  veto.name = SAVE_VETO;
+  return veto;
+}
+
 /** The closed event vocabulary; every other key is a fieldname. */
 export const RECORD_PAGE_EVENTS = [
   "onRefresh",
@@ -286,11 +296,23 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
     ready.value = true;
   }
 
+  // One sequence at a time: a second `page.save()` mid-flight joins it, so no handler fires twice.
+  let saving: Promise<void> | null = null;
+
   /** The one save path: a clean doc resolves at once, and a `beforeSave` throw sends nothing. */
-  async function save() {
-    if (!host.isDirty()) return;
+  function save() {
+    if (!host.isDirty()) return Promise.resolve();
+    if (!saving) saving = runSave().finally(() => (saving = null));
+    return saving;
+  }
+
+  async function runSave() {
     await commits.flush();
-    await fireEvent("beforeSave");
+    try {
+      await fireEvent("beforeSave");
+    } catch (error) {
+      throw asVeto(error);
+    }
     await host.save();
     await fireEvent("afterSave");
   }

--- a/frontend/src/recordPage/createRecordPage.ts
+++ b/frontend/src/recordPage/createRecordPage.ts
@@ -3,6 +3,7 @@
 import { computed, ref, type ComputedRef, type Ref } from "vue";
 import type { Router } from "vue-router";
 import { call, toast } from "frappe-ui";
+import { createCommitChannel, type RecordCommitChannel } from "./commitChannel";
 import { withRunningSource } from "./context";
 import { createPageDialogs, type PageDialogEntry } from "./dialog";
 import type { Decorator } from "@framework/ui/components/FormLayout/buildLayoutFromMeta";
@@ -95,6 +96,9 @@ export interface RecordPageHost {
   activateFormTab?: (identity: string) => void;
   /** Opens or shuts a panel section for the reader; the engine has already resolved the name. */
   discloseSection?: (name: string, open: boolean) => void;
+  /** Lands the reader on a field of the form; `cursor` is false for a read-only one. */
+  focusField?: (fieldname: string, cursor: boolean) => void;
+  /** Writes the draft; the engine flushes and fires `beforeSave` before it, `afterSave` after. */
   save: () => Promise<void>;
   reload: () => Promise<void>;
   router: Router;
@@ -116,6 +120,8 @@ export interface RecordPageController {
   fields: FieldsSurface;
   /** Form Layout tab overrides; fed to the same layout source alongside them. */
   formTabs: FormTabsSurface;
+  /** What the host provides as `CommitKey`: a field's commit fires its handler through it. */
+  commits: RecordCommitChannel;
   /** The replay: clears every surface, then runs every source's `refresh` in run order. */
   refresh: () => Promise<void>;
   /** `row` addresses the child row a dotted event happened to; see `Handler`. */
@@ -194,6 +200,17 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
     value: (name: string) => disclose(name, false),
   });
 
+  // Held on the same terms as an activation: the form on screen is the last replay's until commit.
+  let heldFocus: string | null = null;
+
+  Object.defineProperty(fields, "focus", {
+    value: (fieldname: string) => focusField(fieldname),
+  });
+
+  const commits = createCommitChannel({
+    dispatch: (event, row) => fireEvent(event, row),
+  });
+
   const dialogs = createPageDialogs({ isReplaying: () => isReplaying.value });
 
   const capabilities: RecordPageApi = {
@@ -228,7 +245,7 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
     fields,
     formTabs,
     rows: rows.rows,
-    save: () => host.save(),
+    save: () => save(),
     reload: () => host.reload(),
     refresh: () => refresh(),
     toast: {
@@ -263,9 +280,66 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
       if (!isReplaying.value) {
         releaseActivations();
         releaseDisclosures();
+        releaseFocus();
       }
     }
     ready.value = true;
+  }
+
+  /** The one save path: a clean doc resolves at once, and a `beforeSave` throw sends nothing. */
+  async function save() {
+    if (!host.isDirty()) return;
+    await commits.flush();
+    await fireEvent("beforeSave");
+    await host.save();
+    await fireEvent("afterSave");
+  }
+
+  function focusField(fieldname: string) {
+    if (!canFocus(fieldname)) return;
+    if (isReplaying.value) heldFocus = fieldname;
+    else deliverFocus(fieldname);
+  }
+
+  function releaseFocus() {
+    const held = heldFocus;
+    heldFocus = null;
+    if (held && canFocus(held, "it left the form before the replay settled"))
+      deliverFocus(held);
+  }
+
+  function canFocus(fieldname: string, gone = "no such field") {
+    if (!fields.has(fieldname)) {
+      warnFocus(fieldname, gone);
+      return false;
+    }
+    if (fields.get(fieldname)?.hidden) {
+      warnFocus(fieldname, "it is hidden — show() reveals a field");
+      return false;
+    }
+    return true;
+  }
+
+  function deliverFocus(fieldname: string) {
+    if (!host.focusField) {
+      warnFocus(fieldname, "this host draws no form");
+      return;
+    }
+    try {
+      host.focusField(fieldname, !fields.get(fieldname)?.read_only);
+    } catch (error) {
+      console.error(
+        `[record-page] page.fields.focus("${fieldname}") — the host threw`,
+        error,
+      );
+    }
+  }
+
+  function warnFocus(fieldname: string, because: string) {
+    if (!import.meta.env.DEV) return;
+    console.warn(
+      `[record-page] page.fields.focus("${fieldname}") — ${because}; the reader was not moved.`,
+    );
   }
 
   function releaseDisclosures() {
@@ -496,6 +570,7 @@ export function createRecordPage(host: RecordPageHost): RecordPageController {
     panelSections,
     fields,
     formTabs,
+    commits,
     refresh,
     fireEvent,
     ready,

--- a/frontend/src/recordPage/errorMessage.ts
+++ b/frontend/src/recordPage/errorMessage.ts
@@ -1,0 +1,4 @@
+export function errorMessage(exception: unknown): string {
+  const error = exception as { messages?: string[]; message?: string };
+  return error?.messages?.[0] || error?.message || String(exception);
+}

--- a/frontend/src/recordPage/fields.ts
+++ b/frontend/src/recordPage/fields.ts
@@ -91,6 +91,9 @@ export class FieldsSurface implements PageFields {
   private pending: Op[] | null = null;
   private replaying = 0;
 
+  /** Installed by `createRecordPage`, which holds the replay state a focus waits on. */
+  declare focus: (fieldname: string) => void;
+
   constructor(private host: FieldsSurfaceHost) {}
 
   hide(fieldname: string) {

--- a/frontend/src/recordPage/index.ts
+++ b/frontend/src/recordPage/index.ts
@@ -16,7 +16,7 @@ export {
   withRunningSource,
 } from "./context";
 
-export { createRecordPage } from "./createRecordPage";
+export { createRecordPage, SAVE_VETO } from "./createRecordPage";
 export { createCommitChannel } from "./commitChannel";
 export type { RecordCommitChannel } from "./commitChannel";
 export { errorMessage } from "./errorMessage";

--- a/frontend/src/recordPage/index.ts
+++ b/frontend/src/recordPage/index.ts
@@ -17,6 +17,9 @@ export {
 } from "./context";
 
 export { createRecordPage } from "./createRecordPage";
+export { createCommitChannel } from "./commitChannel";
+export type { RecordCommitChannel } from "./commitChannel";
+export { errorMessage } from "./errorMessage";
 export { loadClientScripts, reloadClientScripts } from "./clientScripts";
 export type { RecordPageController } from "./createRecordPage";
 

--- a/frontend/src/recordPage/tests/commitChannel.test.ts
+++ b/frontend/src/recordPage/tests/commitChannel.test.ts
@@ -111,6 +111,29 @@ describe("createCommitChannel", () => {
     expect(fired).toEqual(["qty"]);
   });
 
+  it("a second row committing the same value is not an echo of the first", () => {
+    const { commits, fired } = channel();
+    commits.commit("qty", 3, row);
+    commits.commit("qty", 3, { parentfield: "products", key: "row-2" });
+    expect(fired).toEqual(["products.qty", "products.qty"]);
+  });
+
+  it("flush waits for a commit's handler still running, so a save cannot outrun it", async () => {
+    const order: string[] = [];
+    let release!: () => void;
+    const commits = createCommitChannel({
+      dispatch: async (event) => {
+        await new Promise<void>((resolve) => (release = resolve));
+        order.push(event);
+      },
+    });
+    commits.commit("status", "Won");
+    const flushed = commits.flush().then(() => order.push("flushed"));
+    release();
+    await flushed;
+    expect(order).toEqual(["status", "flushed"]);
+  });
+
   it("awaits the handler it flushes, so the save cannot outrun it", async () => {
     const order: string[] = [];
     const commits = createCommitChannel({

--- a/frontend/src/recordPage/tests/commitChannel.test.ts
+++ b/frontend/src/recordPage/tests/commitChannel.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { createCommitChannel } from "../commitChannel";
+import type { RowAddress } from "@framework/ui/components/Fields/types";
+
+function channel() {
+  const fired: string[] = [];
+  const addressed: (RowAddress | undefined)[] = [];
+  const commits = createCommitChannel({
+    dispatch: (event, row) => void (fired.push(event), addressed.push(row)),
+  });
+  return { commits, fired, addressed };
+}
+
+const row: RowAddress = { parentfield: "products", key: "row-1" };
+
+describe("createCommitChannel", () => {
+  it("fires a top-level field under its own name", () => {
+    const { commits, fired } = channel();
+    commits.commit("status", "Won");
+    expect(fired).toEqual(["status"]);
+  });
+
+  it("addresses a child field by its table", () => {
+    const { commits, fired } = channel();
+    commits.commit("qty", 3, row);
+    expect(fired).toEqual(["products.qty"]);
+  });
+
+  it("fires add and remove on the same dotted family", () => {
+    const { commits, fired } = channel();
+    commits.rowChanged(row, "add");
+    commits.rowChanged(row, "remove");
+    expect(fired).toEqual(["products.onAdd", "products.onRemove"]);
+  });
+
+  // A handle for a removed row throws on every access, so `.onRemove` gets `(page)` alone.
+  it("carries the row on add and drops it on remove", () => {
+    const { commits, addressed } = channel();
+    commits.rowChanged(row, "add");
+    commits.rowChanged(row, "remove");
+    expect(addressed).toEqual([row, undefined]);
+  });
+
+  it("fires nothing while an edit is only pending", () => {
+    const { commits, fired } = channel();
+    commits.pending("qty", 3);
+    expect(fired).toEqual([]);
+  });
+
+  it("flushes a pending edit once, then has nothing left to flush", async () => {
+    const { commits, fired } = channel();
+    commits.pending("qty", 3);
+    await commits.flush();
+    await commits.flush();
+    expect(fired).toEqual(["qty"]);
+  });
+
+  it("flushes the pending edit at its row address", async () => {
+    const { commits, fired } = channel();
+    commits.pending("qty", 3, row);
+    await commits.flush();
+    expect(fired).toEqual(["products.qty"]);
+  });
+
+  it("a commit clears the pending edit, so a later save does not refire it", async () => {
+    const { commits, fired } = channel();
+    commits.pending("qty", 3);
+    commits.commit("qty", 3);
+    await commits.flush();
+    expect(fired).toEqual(["qty"]);
+  });
+
+  it("a row add or remove clears the pending edit", async () => {
+    const { commits, fired } = channel();
+    commits.pending("qty", 3, row);
+    commits.rowChanged(row, "remove");
+    await commits.flush();
+    expect(fired).toEqual(["products.onRemove"]);
+  });
+
+  it("ignores the echo a widget re-emits as it commits", async () => {
+    const { commits, fired } = channel();
+    commits.commit("qty", 3);
+    commits.pending("qty", 3);
+    await commits.flush();
+    expect(fired).toEqual(["qty"]);
+  });
+
+  it("ignores the commit a repaint fires as it unmounts a focused input", async () => {
+    const { commits, fired } = channel();
+    commits.pending("qty", 3);
+    await commits.flush();
+    commits.commit("qty", 3);
+    expect(fired).toEqual(["qty"]);
+  });
+
+  it("takes a real edit after a commit of the same field", async () => {
+    const { commits, fired } = channel();
+    commits.commit("qty", 3);
+    commits.pending("qty", 4);
+    await commits.flush();
+    expect(fired).toEqual(["qty", "qty"]);
+  });
+
+  it("does not flush the same edit twice", async () => {
+    const { commits, fired } = channel();
+    commits.pending("qty", 3);
+    await commits.flush();
+    commits.pending("qty", 3);
+    await commits.flush();
+    expect(fired).toEqual(["qty"]);
+  });
+
+  it("awaits the handler it flushes, so the save cannot outrun it", async () => {
+    const order: string[] = [];
+    const commits = createCommitChannel({
+      dispatch: async (event) => {
+        await Promise.resolve();
+        order.push(event);
+      },
+    });
+    commits.pending("qty", 3);
+    await commits.flush();
+    order.push("beforeSave");
+    expect(order).toEqual(["qty", "beforeSave"]);
+  });
+});

--- a/frontend/src/recordPage/tests/fieldFocus.test.ts
+++ b/frontend/src/recordPage/tests/fieldFocus.test.ts
@@ -1,0 +1,177 @@
+// `page.fields.focus` as executable claims: the host lands the reader, a read-only field
+// gets no cursor, an unknown or hidden one warns, and a replay's focus waits for the commit.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+
+vi.mock("frappe-ui", () => ({
+  call: vi.fn(),
+  toast: { success: vi.fn(), error: vi.fn() },
+  createResource: () => ({
+    data: null,
+    loading: false,
+    fetch() {},
+    reload() {},
+  }),
+  frappeRequest: vi.fn(),
+}));
+
+import { createRecordPage, type RecordPageHost } from "../createRecordPage";
+import { resetFieldWarnings } from "../fields";
+import { registerRecordPage, resetRegistry } from "../registry";
+import type { RawMetaField } from "@framework/ui/components/FormLayout/types";
+
+const FIELDS: RawMetaField[] = [
+  { fieldname: "status", fieldtype: "Select", options: "Open\nWon" },
+  { fieldname: "probability", fieldtype: "Percent" },
+  { fieldname: "owner_name", fieldtype: "Data", read_only: 1 },
+  { fieldname: "secret", fieldtype: "Data", hidden: 1 },
+  { fieldname: "rate", fieldtype: "Currency", depends_on: "eval:doc.status == 'Won'" },
+];
+
+function makeHost(overrides: Partial<RecordPageHost> = {}) {
+  const landed: [string, boolean][] = [];
+  const host: RecordPageHost = {
+    doctype: "CRM Deal",
+    docname: "CRM-DEAL-1",
+    doc: ref({ status: "Open" }),
+    saved: ref({ status: "Open" }),
+    meta: ref({ fields: FIELDS }),
+    perms: () => ({}),
+    isDirty: () => false,
+    activeTab: () => "",
+    activateTab: () => {},
+    focusField: (fieldname, cursor) => void landed.push([fieldname, cursor]),
+    save: async () => {},
+    reload: async () => {},
+    router: {} as any,
+    ...overrides,
+  };
+  return { host, landed };
+}
+
+let warnings: string[];
+
+beforeEach(() => {
+  resetRegistry();
+  resetFieldWarnings();
+  warnings = [];
+  vi.spyOn(console, "warn").mockImplementation((message: string) =>
+    warnings.push(message),
+  );
+});
+
+describe("landing on a field", () => {
+  it("hands the host the field with a cursor", () => {
+    const { host, landed } = makeHost();
+    const { page } = createRecordPage(host);
+
+    page.fields.focus("probability");
+
+    expect(landed).toEqual([["probability", true]]);
+    expect(warnings).toEqual([]);
+  });
+
+  it("a read-only field gets the tab and the scroll, and no cursor", () => {
+    const { host, landed } = makeHost();
+    const { page } = createRecordPage(host);
+
+    page.fields.focus("owner_name");
+
+    expect(landed).toEqual([["owner_name", false]]);
+  });
+
+  it("a script's read_only override is read the same way", () => {
+    const { host, landed } = makeHost();
+    const { page } = createRecordPage(host);
+
+    page.fields.update("probability", { read_only: 1 });
+    page.fields.focus("probability");
+
+    expect(landed).toEqual([["probability", false]]);
+  });
+});
+
+describe("three ways to miss", () => {
+  it("an unknown field warns and moves nobody", () => {
+    const { host, landed } = makeHost();
+    const { page } = createRecordPage(host);
+
+    page.fields.focus("nope");
+
+    expect(landed).toEqual([]);
+    expect(warnings).toEqual([
+      '[record-page] page.fields.focus("nope") — no such field; the reader was not moved.',
+    ]);
+  });
+
+  it("a hidden field warns and names the verb that reveals it", () => {
+    const { host, landed } = makeHost();
+    const { page } = createRecordPage(host);
+
+    page.fields.focus("secret");
+
+    expect(landed).toEqual([]);
+    expect(warnings[0]).toContain("it is hidden — show() reveals a field");
+  });
+
+  it("a field its depends_on hides is hidden", () => {
+    const { host, landed } = makeHost();
+    const { page } = createRecordPage(host);
+
+    page.fields.focus("rate");
+
+    expect(landed).toEqual([]);
+    expect(warnings[0]).toContain("it is hidden");
+  });
+
+  it("a host with no form says so instead of swallowing the act", () => {
+    const { host } = makeHost({ focusField: undefined });
+    const { page } = createRecordPage(host);
+
+    page.fields.focus("status");
+
+    expect(warnings[0]).toContain("this host draws no form");
+  });
+});
+
+describe("inside a replay", () => {
+  it("delivers the focus once the replay commits, and only the last one asked for", async () => {
+    const { host, landed } = makeHost();
+    const order: string[] = [];
+    registerRecordPage("CRM Deal", {
+      onRefresh: (page) => {
+        page.fields.focus("status");
+        page.fields.focus("probability");
+        order.push("refresh");
+      },
+    });
+    const controller = createRecordPage({
+      ...host,
+      focusField: (fieldname, cursor) => {
+        order.push(`land:${fieldname}`);
+        host.focusField!(fieldname, cursor);
+      },
+    });
+
+    await controller.refresh();
+
+    expect(order).toEqual(["refresh", "land:probability"]);
+    expect(landed).toEqual([["probability", true]]);
+  });
+
+  it("drops a held focus on a field a later source hid", async () => {
+    const { host, landed } = makeHost();
+    registerRecordPage("CRM Deal", {
+      onRefresh: (page) => {
+        page.fields.focus("probability");
+        page.fields.hide("probability");
+      },
+    });
+    const controller = createRecordPage(host);
+
+    await controller.refresh();
+
+    expect(landed).toEqual([]);
+    expect(warnings.at(-1)).toContain("it is hidden");
+  });
+});

--- a/frontend/src/recordPage/tests/saveOrder.test.ts
+++ b/frontend/src/recordPage/tests/saveOrder.test.ts
@@ -1,0 +1,134 @@
+// `page.save()` as executable claims: one path, CRM's order, and a clean doc that sends nothing.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+
+vi.mock("frappe-ui", () => ({
+  call: vi.fn(),
+  toast: { success: vi.fn(), error: vi.fn() },
+  createResource: () => ({
+    data: null,
+    loading: false,
+    fetch() {},
+    reload() {},
+  }),
+  frappeRequest: vi.fn(),
+}));
+
+import { createRecordPage, type RecordPageHost } from "../createRecordPage";
+import { registerRecordPage, resetRegistry } from "../registry";
+
+function makeHost(overrides: Partial<RecordPageHost> = {}) {
+  const order: string[] = [];
+  const doc = ref<Record<string, any>>({ status: "Open", probability: 50 });
+  const host: RecordPageHost = {
+    doctype: "CRM Deal",
+    docname: "CRM-DEAL-1",
+    doc,
+    saved: ref({ status: "Open", probability: 50 }),
+    meta: ref({ fields: [] }),
+    perms: () => ({}),
+    isDirty: () => true,
+    activeTab: () => "",
+    activateTab: () => {},
+    save: async () => void order.push("write"),
+    reload: async () => {},
+    router: {} as any,
+    ...overrides,
+  };
+  return { host, order, doc };
+}
+
+beforeEach(() => {
+  resetRegistry();
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+describe("page.save()", () => {
+  it("flushes the pending edit, then beforeSave, the write, then afterSave", async () => {
+    const { host, order } = makeHost();
+    registerRecordPage("CRM Deal", {
+      status: () => void order.push("status"),
+      beforeSave: () => void order.push("beforeSave"),
+      afterSave: () => void order.push("afterSave"),
+    });
+    const controller = createRecordPage(host);
+
+    controller.commits.pending("status", "Won");
+    await controller.page.save();
+
+    expect(order).toEqual(["status", "beforeSave", "write", "afterSave"]);
+  });
+
+  it("a beforeSave throw vetoes: nothing is written and afterSave never fires", async () => {
+    const { host, order } = makeHost();
+    registerRecordPage("CRM Deal", {
+      beforeSave: () => {
+        throw new Error("Win chance is a percentage");
+      },
+      afterSave: () => void order.push("afterSave"),
+    });
+    const controller = createRecordPage(host);
+
+    await expect(controller.page.save()).rejects.toThrow("Win chance is a percentage");
+    expect(order).toEqual([]);
+  });
+
+  it("a rejected write fires no afterSave", async () => {
+    const { host, order } = makeHost({
+      save: async () => {
+        throw new Error("Save failed with 417");
+      },
+    });
+    registerRecordPage("CRM Deal", {
+      afterSave: () => void order.push("afterSave"),
+    });
+    const controller = createRecordPage(host);
+
+    await expect(controller.page.save()).rejects.toThrow("417");
+    expect(order).toEqual([]);
+  });
+
+  it("a clean doc resolves at once: no flush, no handlers, no write", async () => {
+    const { host, order } = makeHost({ isDirty: () => false });
+    registerRecordPage("CRM Deal", {
+      beforeSave: () => void order.push("beforeSave"),
+      afterSave: () => void order.push("afterSave"),
+    });
+    const controller = createRecordPage(host);
+
+    await controller.page.save();
+
+    expect(order).toEqual([]);
+  });
+
+  it("the flushed handler's own write lands before beforeSave reads the doc", async () => {
+    const { host, doc } = makeHost();
+    let seen: number | undefined;
+    registerRecordPage("CRM Deal", {
+      status: (page) => {
+        if (page.doc.status === "Won") page.doc.probability = 100;
+      },
+      beforeSave: (page) => void (seen = page.doc.probability),
+    });
+    const controller = createRecordPage(host);
+
+    doc.value.status = "Won";
+    controller.commits.pending("status", "Won");
+    await controller.page.save();
+
+    expect(seen).toBe(100);
+  });
+
+  it("the controller's channel commits into the same dispatch a script's handlers hear", async () => {
+    const { host, order } = makeHost();
+    registerRecordPage("CRM Deal", {
+      status: () => void order.push("status"),
+    });
+    const controller = createRecordPage(host);
+
+    await controller.commits.commit("status", "Won");
+    await controller.page.save();
+
+    expect(order).toEqual(["status", "write"]);
+  });
+});

--- a/frontend/src/recordPage/tests/saveOrder.test.ts
+++ b/frontend/src/recordPage/tests/saveOrder.test.ts
@@ -14,7 +14,7 @@ vi.mock("frappe-ui", () => ({
   frappeRequest: vi.fn(),
 }));
 
-import { createRecordPage, type RecordPageHost } from "../createRecordPage";
+import { createRecordPage, SAVE_VETO, type RecordPageHost } from "../createRecordPage";
 import { registerRecordPage, resetRegistry } from "../registry";
 
 function makeHost(overrides: Partial<RecordPageHost> = {}) {
@@ -91,14 +91,55 @@ describe("page.save()", () => {
   it("a clean doc resolves at once: no flush, no handlers, no write", async () => {
     const { host, order } = makeHost({ isDirty: () => false });
     registerRecordPage("CRM Deal", {
+      status: () => void order.push("status"),
       beforeSave: () => void order.push("beforeSave"),
       afterSave: () => void order.push("afterSave"),
     });
     const controller = createRecordPage(host);
 
+    controller.commits.pending("status", "Won");
     await controller.page.save();
 
     expect(order).toEqual([]);
+  });
+
+  it("a veto rejects under its own name, keeping the script's message", async () => {
+    const { host } = makeHost();
+    registerRecordPage("CRM Deal", {
+      beforeSave: () => {
+        throw new Error("Win chance is a percentage");
+      },
+    });
+    const controller = createRecordPage(host);
+
+    const rejection = await controller.page.save().catch((e) => e);
+
+    expect(rejection.name).toBe(SAVE_VETO);
+    expect(rejection.message).toBe("Win chance is a percentage");
+  });
+
+  it("two saves mid-flight run the handlers and the write once", async () => {
+    let release!: () => void;
+    const { host, order } = makeHost({
+      save: async () => {
+        order.push("write");
+        await new Promise<void>((resolve) => (release = resolve));
+      },
+    });
+    registerRecordPage("CRM Deal", {
+      beforeSave: () => void order.push("beforeSave"),
+      afterSave: () => void order.push("afterSave"),
+    });
+    const controller = createRecordPage(host);
+
+    const first = controller.page.save();
+    while (!order.includes("write")) await Promise.resolve();
+    const second = controller.page.save();
+    expect(second).toBe(first);
+    release();
+    await Promise.all([first, second]);
+
+    expect(order).toEqual(["beforeSave", "write", "afterSave"]);
   });
 
   it("the flushed handler's own write lands before beforeSave reads the doc", async () => {

--- a/frontend/src/recordPage/types.ts
+++ b/frontend/src/recordPage/types.ts
@@ -160,6 +160,11 @@ export interface PageFields {
   has(fieldname: string): boolean;
   /** The field as it currently resolves — post-override, post-`depends_on`. */
   get(fieldname: string): PageField | null;
+  /**
+   * Moves the reader to the field: its form tab, scrolled into view, cursor in the
+   * control. A read-only field gets no cursor; an unknown or hidden one warns and does nothing.
+   */
+  focus(fieldname: string): void;
 }
 
 /** What a script may override on one of the Form Layout's tabs. */

--- a/frontend/src/recordPage/types.ts
+++ b/frontend/src/recordPage/types.ts
@@ -160,10 +160,7 @@ export interface PageFields {
   has(fieldname: string): boolean;
   /** The field as it currently resolves — post-override, post-`depends_on`. */
   get(fieldname: string): PageField | null;
-  /**
-   * Moves the reader to the field: its form tab, scrolled into view, cursor in the
-   * control. A read-only field gets no cursor; an unknown or hidden one warns and does nothing.
-   */
+  /** Moves the reader to the field: tab, scroll, cursor; read-only gets no cursor, unknown or hidden warns. */
   focus(fieldname: string): void;
 }
 

--- a/ui/src/components/Fields/LinkField.vue
+++ b/ui/src/components/Fields/LinkField.vue
@@ -3,6 +3,7 @@
 		v-model="value"
 		:doctype="field.options ?? ''"
 		:filters="field.filters"
+		:title="title"
 		:label="field.label"
 		:description="field.description"
 		:placeholder="field.placeholder"
@@ -17,12 +18,19 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, inject } from "vue";
 import { Link } from "../Link";
+import { LinkTitlesKey } from "./types";
 import type { FieldComponentEmits, FieldComponentProps } from "./types";
 
 const props = defineProps<FieldComponentProps>();
 const emit = defineEmits<FieldComponentEmits>();
+
+const titles = inject(LinkTitlesKey, null);
+
+const title = computed(() =>
+	props.modelValue ? titles?.value[`${props.field.options}::${props.modelValue}`] : undefined
+);
 
 const value = computed<string | null>({
 	get: () => props.modelValue ?? null,

--- a/ui/src/components/Fields/index.ts
+++ b/ui/src/components/Fields/index.ts
@@ -14,4 +14,4 @@ export type {
   FieldComponentProps,
   FieldComponentEmits,
 } from "./types";
-export { DocKey, ParentDocKey, UpdateKey } from "./types";
+export { DocKey, LinkTitlesKey, ParentDocKey, UpdateKey } from "./types";

--- a/ui/src/components/Fields/types.ts
+++ b/ui/src/components/Fields/types.ts
@@ -100,6 +100,10 @@ export const DocKey: InjectionKey<Ref<Record<string, any>>> =
 export const ParentDocKey: InjectionKey<Ref<Record<string, any>> | null> =
   Symbol("FormLayoutParentDoc");
 
+/** Titles a `Link` value shows before its options load, keyed `Doctype::name`. */
+export const LinkTitlesKey: InjectionKey<Ref<Record<string, string>>> =
+  Symbol("FormLayoutLinkTitles");
+
 /** Writes a field's live value into the doc on every change. Pure state sync. */
 export const UpdateKey: InjectionKey<(fieldname: string, value: any) => void> =
   Symbol("FormLayoutUpdate");

--- a/ui/src/components/FormLayout/FormLayout.vue
+++ b/ui/src/components/FormLayout/FormLayout.vue
@@ -4,7 +4,7 @@
 		:class="{ 'border border-outline-gray-1 border-outline-elevation-2 rounded-6': hasTabs }"
 	>
 		<Tabs
-			:model-value="activeIndex"
+			:model-value="active?.identity"
 			@update:model-value="select"
 			as="div"
 			:tabs="visibleTabs"
@@ -85,6 +85,7 @@ const visibleTabs = computed(() => {
 	const multipleTabs = tabs.length > 1;
 	return tabs.map((tab) => ({
 		...tab,
+		value: tab.identity,
 		label: tabStripLabel(tab.label, multipleTabs),
 		sections: tab.sections.filter((section) => !section.hidden),
 	}));
@@ -108,17 +109,11 @@ watch(
 	{ immediate: true }
 );
 
-// frappe-ui's `Tabs` addresses its tabs by index. That index is a wire format
-// living inside these two — it is never state, and because it is always derived
-// from the list we just rendered, it can never point at a tab that isn't there.
-const activeIndex = computed(() => Math.max(0, visibleTabs.value.indexOf(active.value)));
-
-function select(index: string | number) {
-	// An index naming no tab leaves the intent alone rather than blanking it:
-	// `desired` is the reader's, and on the Record page it belongs to a host that
-	// outlives this component. Writing `""` here would snap them to the first tab
-	// and throw away the memory that makes a returning tab free.
-	const chosen = visibleTabs.value[Number(index)];
+// frappe-ui's `Tabs` addresses a tab by its `value`, which here is the identity.
+function select(value: string | number) {
+	// A value naming no tab leaves the intent alone: `desired` is the reader's, and
+	// blanking it would snap them to the first tab and forget a returning tab.
+	const chosen = visibleTabs.value.find((tab) => tab.identity === String(value));
 	if (chosen) desired.value = chosen.identity;
 }
 

--- a/ui/src/components/FormLayout/index.ts
+++ b/ui/src/components/FormLayout/index.ts
@@ -10,7 +10,7 @@ export { buildLayoutFromMeta, compose } from "./buildLayoutFromMeta";
 export type { BuildLayoutOptions, Decorator } from "./buildLayoutFromMeta";
 export { fieldsToLayout } from "./fieldsToLayout";
 export { resolveLayout } from "./resolveLayout";
-export { CommitKey, NO_COMMIT } from "./types";
+export { CommitKey, LinkTitlesKey, NO_COMMIT } from "./types";
 export { newRowValues, layoutFields } from "./newRowValues";
 export { evaluateDependsOn } from "./dependsOn";
 export {

--- a/ui/src/components/FormLayout/stories/DemoLinkField.vue
+++ b/ui/src/components/FormLayout/stories/DemoLinkField.vue
@@ -16,6 +16,7 @@
 		:placeholder="field.placeholder"
 		:required="field.reqd"
 		:disabled="field.readOnly"
+		:title="title"
 		creatable
 		redirectable
 		editable
@@ -26,12 +27,19 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, inject } from "vue";
 import { Link } from "../../Link";
+import { LinkTitlesKey } from "../types";
 import type { FieldComponentEmits, FieldComponentProps } from "../types";
 
 const props = defineProps<FieldComponentProps>();
 const emit = defineEmits<FieldComponentEmits>();
+
+// The host's known titles, as the shipped `LinkField` reads them.
+const titles = inject(LinkTitlesKey, null);
+const title = computed(() =>
+	props.modelValue ? titles?.value[`${props.field.options}::${props.modelValue}`] : undefined
+);
 
 const value = computed<string | null>({
 	get: () => props.modelValue ?? null,

--- a/ui/src/components/FormLayout/stories/StaticSchema.story.vue
+++ b/ui/src/components/FormLayout/stories/StaticSchema.story.vue
@@ -8,9 +8,9 @@
 </template>
 
 <script setup lang="ts">
-import { provide, reactive } from "vue";
+import { provide, reactive, ref } from "vue";
 import FormLayout from "../FormLayout.vue";
-import { CommitKey, NO_COMMIT } from "../types";
+import { CommitKey, LinkTitlesKey, NO_COMMIT } from "../types";
 import { registerFieldType } from "../../Fields/fieldTypes";
 import DemoLinkField from "./DemoLinkField.vue";
 import DemoCurrencyField from "./DemoCurrencyField.vue";
@@ -20,6 +20,8 @@ import type { UploadTransport } from "../../FileUpload/types";
 
 // A story has no page behind it, so its fields commit to nothing.
 provide(CommitKey, NO_COMMIT);
+// A title the host already knows, shown by the Link before its search returns it.
+provide(LinkTitlesKey, ref({ "User::admin@example.com": "Administrator" }));
 
 // Fake transport for the stories: no backend, just a placeholder URL and a
 // simulated progress ramp (honoring the abort signal). The Attach/Attach Image
@@ -66,6 +68,7 @@ const doc = reactive<Record<string, any>>({
 	// Select field writes it; their `ui.props.view` getters read it back).
 	editor_view: "auto",
 	reference_id: "REF-0001",
+	owner: "admin@example.com",
 	quantity: 1234,
 	amount: 1234567.5,
 	progress: 42.5,

--- a/ui/src/components/FormLayout/types.ts
+++ b/ui/src/components/FormLayout/types.ts
@@ -12,6 +12,7 @@ export type {
 export {
   CommitKey,
   DocKey,
+  LinkTitlesKey,
   NO_COMMIT,
   ParentDocKey,
   UpdateKey,

--- a/ui/src/components/Link/Link.vue
+++ b/ui/src/components/Link/Link.vue
@@ -129,7 +129,11 @@ const createNewOption: ComboboxCustomOption = {
 };
 
 const linkOptions = computed<ComboboxOption[]>(() => {
-	const _options = options.data || [];
+	let _options: ComboboxOption[] = options.data || [];
+	const known = model.value && _options.some((option: any) => option.value === model.value);
+	if (props.title && model.value && !known) {
+		_options = [{ label: props.title, value: model.value }, ..._options];
+	}
 	if (props.creatable) {
 		return [..._options, createNewOption];
 	}

--- a/ui/src/components/Link/types.ts
+++ b/ui/src/components/Link/types.ts
@@ -8,6 +8,8 @@ export interface LinkProps extends InputLabelingProps {
   editable?: boolean;
   disabled?: boolean;
   placeholder?: string;
+  /** What the current value displays as until the search returns it. */
+  title?: string;
 }
 
 export interface LinkSlots {


### PR DESCRIPTION
Builds the record page's field region on `desk-v2`, as the field grilling settled it: the Details form in the main column, one save path with the commit channel, the dialog hosts, and the field's act. Ticket: [Task: build the field region](https://github.com/frappe/frappe/issues/42767), spec in the resolution of [#42759](https://github.com/frappe/frappe/issues/42759).

## What lands

- `Record.vue` mounts `FormLayout` on the doctype's `Details` layout with the meta as fallback, fed by `page.fields` and `page.formTabs`. The active tab is the reader's, remembered per doctype and per user in the browser.
- `page.fields.focus(fieldname)`: tab, scroll, cursor. A read-only field gets no cursor; an unknown or hidden one warns and moves nobody; inside a replay it is held until the commit. The panel's expand uses it.
- The commit channel ports into `frontend/src/recordPage/` and the page provides it as `CommitKey` for the form and the panel, replacing the panel's no-op.
- `page.save()` is the one path: flush the pending edit, `beforeSave` (a throw is a veto and sends nothing), `frappe.client.save` with the whole doc, `afterSave` on accept. A clean doc resolves at once with no request and no toast. Overlapping calls join one sequence.
- The `save` item is disabled when clean with the tooltip "No changes to save"; Ctrl+S and Cmd+S call `page.save()` and toast that text on a clean doc.
- Unsaved guard: a confirm on route leave and a `beforeunload` listener while dirty.
- A timestamp mismatch opens a dialog naming the other editor and the fields changed here, with "Reload and lose my changes" and "Keep editing". Nothing is re-applied; Save rejects the same way until a reload.
- `_link_titles` from `getdoc` reach the Link control, and a value the search has not returned yet shows its title.
- `PageDialogs`, `PageOpenDialog` and `PageFormDialog` port in, so `page.dialog.open` and `form` resolve.
- `frontend/SCRIPTING.md` gains "The field: `page.fields`"; `C28` in the coverage battery gains the third act and `C29` covers the focus act.

Two `ui/` commits ride along and are also raised against `develop` on their own: the Link title, and a fix for `FormLayout`'s tab strip, which since the frappe-ui beta.63 bump handed `Tabs` an index where it now selects by `value`, so every panel stayed inactive and the form under the strip was empty.

## The walk

Headless on `crm.localhost`, `CRM-DEAL-2026-00037`, with `COV C28` enabled:

| Step | Seen |
| --- | --- |
| Open the deal | The probability field is labelled "Win chance (%)"; Save is disabled with the tooltip. |
| Set status to Won | Probability reads 100 with no other click; Save enables. |
| Save, reload | The server has `status: Won, probability: 100`; the reload shows 100. |
| Set probability to 120, Save | "Win chance is a percentage" shows as a toast; the server still has 100. |
| Cmd+S on a clean doc | Toast "No changes to save". |
| Edit, click the doctype crumb | "Discard unsaved changes?" with Discard / Keep editing; Keep editing stays. |
| Another user saves first, then Save | The dialog names Daniel Okafor and "Probability"; Keep editing keeps 60; the next Save asks again; Reload shows their version. |
| `page.fields.focus('lost_notes')` from a script | The Lost Details tab opens with the cursor in Lost Notes; a read-only field on the SLA tab gets the tab and no cursor. |
| `C10` form dialog | "Log a call" opens with its four fields. |

![clean](https://raw.githubusercontent.com/shariquerik/frappe/be429e356be27c445fd83ec95a43788d769dc4a3/01-clean-label.png)
![won sets 100](https://raw.githubusercontent.com/shariquerik/frappe/be429e356be27c445fd83ec95a43788d769dc4a3/02-won-sets-100.png)
![veto](https://raw.githubusercontent.com/shariquerik/frappe/be429e356be27c445fd83ec95a43788d769dc4a3/04-veto.png)
![leave guard](https://raw.githubusercontent.com/shariquerik/frappe/be429e356be27c445fd83ec95a43788d769dc4a3/06-leave-guard.png)
![conflict](https://raw.githubusercontent.com/shariquerik/frappe/be429e356be27c445fd83ec95a43788d769dc4a3/07-conflict-dialog.png)
![focus](https://raw.githubusercontent.com/shariquerik/frappe/be429e356be27c445fd83ec95a43788d769dc4a3/09-focus.png)
![tab focus ring](https://raw.githubusercontent.com/shariquerik/frappe/be429e356be27c445fd83ec95a43788d769dc4a3/12-tab-focus.png)

## Review

`/quality-code-review` ran in a fresh subagent on the diff, the checklist, the AGENTS.md comment rule and the spec. No P1. Fixed before opening: a script's `page.save()` that was vetoed or conflicted reloaded over the draft (now rejects under `SAVE_VETO` and the action path keeps the draft); overlapping saves fired the handlers twice (now one sequence, and the shortcut ignores key repeat); the form dialog host's test was not ported (now is); a msgprint's HTML rendered as tags (stripped); a focus on a field the form does not draw was silent (warns). Left as follow-ups: a DOM test of the host's conflict branch and guards, which the headless walk covers. Greptile then found six more, all fixed and answered on their threads: a row-blind echo check, unawaited commit handlers, a save request shared across records, and two on the saving flag.

After review: errors report as toasts, not text above the form; the form draws no border, with the strip padding, height and focus ring CRM's frontend2 shows.

## Performance, caching and security, re-checked as built

- Cold load adds one request, the `Details` layout, fetched in the same tick as `getdoc` and the meta from the same memo the panel uses, keyed `(doctype, type)`. The channel, the guard, the shortcut and the hosts add no request until used.
- The layout memo lives for the page's life with the panel's key and invalidation; scripts keep the `get_client_scripts` precedent.
- `getdoc` filters `_link_titles` by read permission; `frappe.client.save` checks write and permlevels on the server; the client floor is a courtesy. A `beforeSave` veto is a script's rule, not a permission. The guard and the shortcut touch no data; the conflict dialog re-reads through `getdoc` and applies nothing.

Suite: 56 files / 714 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


>no-docs

