### PR TITLE
fix(ui): FormLayout tabs select by value on frappe-ui beta.63, and a Link title before search

### DIFF
--- a/ui/src/components/Fields/LinkField.vue
+++ b/ui/src/components/Fields/LinkField.vue
@@ -3,6 +3,7 @@
 		v-model="value"
 		:doctype="field.options ?? ''"
 		:filters="field.filters"
+		:title="title"
 		:label="field.label"
 		:description="field.description"
 		:placeholder="field.placeholder"
@@ -17,12 +18,19 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, inject } from "vue";
 import { Link } from "../Link";
+import { LinkTitlesKey } from "./types";
 import type { FieldComponentEmits, FieldComponentProps } from "./types";
 
 const props = defineProps<FieldComponentProps>();
 const emit = defineEmits<FieldComponentEmits>();
+
+const titles = inject(LinkTitlesKey, null);
+
+const title = computed(() =>
+	props.modelValue ? titles?.value[`${props.field.options}::${props.modelValue}`] : undefined
+);
 
 const value = computed<string | null>({
 	get: () => props.modelValue ?? null,

--- a/ui/src/components/Fields/index.ts
+++ b/ui/src/components/Fields/index.ts
@@ -14,4 +14,4 @@ export type {
   FieldComponentProps,
   FieldComponentEmits,
 } from "./types";
-export { DocKey, ParentDocKey, UpdateKey } from "./types";
+export { DocKey, LinkTitlesKey, ParentDocKey, UpdateKey } from "./types";

--- a/ui/src/components/Fields/types.ts
+++ b/ui/src/components/Fields/types.ts
@@ -100,6 +100,10 @@ export const DocKey: InjectionKey<Ref<Record<string, any>>> =
 export const ParentDocKey: InjectionKey<Ref<Record<string, any>> | null> =
   Symbol("FormLayoutParentDoc");
 
+/** Titles a `Link` value shows before its options load, keyed `Doctype::name`. */
+export const LinkTitlesKey: InjectionKey<Ref<Record<string, string>>> =
+  Symbol("FormLayoutLinkTitles");
+
 /** Writes a field's live value into the doc on every change. Pure state sync. */
 export const UpdateKey: InjectionKey<(fieldname: string, value: any) => void> =
   Symbol("FormLayoutUpdate");

--- a/ui/src/components/FormLayout/FormLayout.vue
+++ b/ui/src/components/FormLayout/FormLayout.vue
@@ -4,7 +4,7 @@
 		:class="{ 'border border-outline-gray-1 border-outline-elevation-2 rounded-6': hasTabs }"
 	>
 		<Tabs
-			:model-value="activeIndex"
+			:model-value="active?.identity"
 			@update:model-value="select"
 			as="div"
 			:tabs="visibleTabs"
@@ -85,6 +85,7 @@ const visibleTabs = computed(() => {
 	const multipleTabs = tabs.length > 1;
 	return tabs.map((tab) => ({
 		...tab,
+		value: tab.identity,
 		label: tabStripLabel(tab.label, multipleTabs),
 		sections: tab.sections.filter((section) => !section.hidden),
 	}));
@@ -108,17 +109,11 @@ watch(
 	{ immediate: true }
 );
 
-// frappe-ui's `Tabs` addresses its tabs by index. That index is a wire format
-// living inside these two — it is never state, and because it is always derived
-// from the list we just rendered, it can never point at a tab that isn't there.
-const activeIndex = computed(() => Math.max(0, visibleTabs.value.indexOf(active.value)));
-
-function select(index: string | number) {
-	// An index naming no tab leaves the intent alone rather than blanking it:
-	// `desired` is the reader's, and on the Record page it belongs to a host that
-	// outlives this component. Writing `""` here would snap them to the first tab
-	// and throw away the memory that makes a returning tab free.
-	const chosen = visibleTabs.value[Number(index)];
+// frappe-ui's `Tabs` addresses a tab by its `value`, which here is the identity.
+function select(value: string | number) {
+	// A value naming no tab leaves the intent alone: `desired` is the reader's, and
+	// blanking it would snap them to the first tab and forget a returning tab.
+	const chosen = visibleTabs.value.find((tab) => tab.identity === String(value));
 	if (chosen) desired.value = chosen.identity;
 }
 

--- a/ui/src/components/FormLayout/index.ts
+++ b/ui/src/components/FormLayout/index.ts
@@ -10,7 +10,7 @@ export { buildLayoutFromMeta, compose } from "./buildLayoutFromMeta";
 export type { BuildLayoutOptions, Decorator } from "./buildLayoutFromMeta";
 export { fieldsToLayout } from "./fieldsToLayout";
 export { resolveLayout } from "./resolveLayout";
-export { CommitKey, NO_COMMIT } from "./types";
+export { CommitKey, LinkTitlesKey, NO_COMMIT } from "./types";
 export { newRowValues, layoutFields } from "./newRowValues";
 export { evaluateDependsOn } from "./dependsOn";
 export {

--- a/ui/src/components/FormLayout/stories/DemoLinkField.vue
+++ b/ui/src/components/FormLayout/stories/DemoLinkField.vue
@@ -16,6 +16,7 @@
 		:placeholder="field.placeholder"
 		:required="field.reqd"
 		:disabled="field.readOnly"
+		:title="title"
 		creatable
 		redirectable
 		editable
@@ -26,12 +27,19 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, inject } from "vue";
 import { Link } from "../../Link";
+import { LinkTitlesKey } from "../types";
 import type { FieldComponentEmits, FieldComponentProps } from "../types";
 
 const props = defineProps<FieldComponentProps>();
 const emit = defineEmits<FieldComponentEmits>();
+
+// The host's known titles, as the shipped `LinkField` reads them.
+const titles = inject(LinkTitlesKey, null);
+const title = computed(() =>
+	props.modelValue ? titles?.value[`${props.field.options}::${props.modelValue}`] : undefined
+);
 
 const value = computed<string | null>({
 	get: () => props.modelValue ?? null,

--- a/ui/src/components/FormLayout/stories/StaticSchema.story.vue
+++ b/ui/src/components/FormLayout/stories/StaticSchema.story.vue
@@ -8,9 +8,9 @@
 </template>
 
 <script setup lang="ts">
-import { provide, reactive } from "vue";
+import { provide, reactive, ref } from "vue";
 import FormLayout from "../FormLayout.vue";
-import { CommitKey, NO_COMMIT } from "../types";
+import { CommitKey, LinkTitlesKey, NO_COMMIT } from "../types";
 import { registerFieldType } from "../../Fields/fieldTypes";
 import DemoLinkField from "./DemoLinkField.vue";
 import DemoCurrencyField from "./DemoCurrencyField.vue";
@@ -20,6 +20,8 @@ import type { UploadTransport } from "../../FileUpload/types";
 
 // A story has no page behind it, so its fields commit to nothing.
 provide(CommitKey, NO_COMMIT);
+// A title the host already knows, shown by the Link before its search returns it.
+provide(LinkTitlesKey, ref({ "User::admin@example.com": "Administrator" }));
 
 // Fake transport for the stories: no backend, just a placeholder URL and a
 // simulated progress ramp (honoring the abort signal). The Attach/Attach Image
@@ -66,6 +68,7 @@ const doc = reactive<Record<string, any>>({
 	// Select field writes it; their `ui.props.view` getters read it back).
 	editor_view: "auto",
 	reference_id: "REF-0001",
+	owner: "admin@example.com",
 	quantity: 1234,
 	amount: 1234567.5,
 	progress: 42.5,

--- a/ui/src/components/FormLayout/types.ts
+++ b/ui/src/components/FormLayout/types.ts
@@ -12,6 +12,7 @@ export type {
 export {
   CommitKey,
   DocKey,
+  LinkTitlesKey,
   NO_COMMIT,
   ParentDocKey,
   UpdateKey,

--- a/ui/src/components/Link/Link.vue
+++ b/ui/src/components/Link/Link.vue
@@ -129,7 +129,11 @@ const createNewOption: ComboboxCustomOption = {
 };
 
 const linkOptions = computed<ComboboxOption[]>(() => {
-	const _options = options.data || [];
+	let _options: ComboboxOption[] = options.data || [];
+	const known = model.value && _options.some((option: any) => option.value === model.value);
+	if (props.title && model.value && !known) {
+		_options = [{ label: props.title, value: model.value }, ..._options];
+	}
 	if (props.creatable) {
 		return [..._options, createNewOption];
 	}

--- a/ui/src/components/Link/types.ts
+++ b/ui/src/components/Link/types.ts
@@ -8,6 +8,8 @@ export interface LinkProps extends InputLabelingProps {
   editable?: boolean;
   disabled?: boolean;
   placeholder?: string;
+  /** What the current value displays as until the search returns it. */
+  title?: string;
 }
 
 export interface LinkSlots {


### PR DESCRIPTION
Two small `@framework/ui` changes the desk v2 record page needs, raised on their own so `ui/` history stays cherry-pickable (they also ride in frappe/frappe#42768 on `desk-v2`).

1. **`FormLayout` hands `Tabs` an index that beta.63 no longer accepts.** Since the frappe-ui beta.63 bump, `Tabs` selects a tab by its `value`, not by position. `FormLayout` still bound `activeIndex`, so no panel was ever active: the strip drew and the form under it was empty. Each visible tab now carries `value: identity`, the model is the active identity, and `select` finds the tab by it.
2. **A Link field can show a known title before its search returns.** A host that already holds titles (the record page keeps `getdoc`'s `_link_titles`) provides a `LinkTitlesKey` map keyed `Doctype::name`; `LinkField` reads it and passes `title` to `Link`, which prepends `{ label: title, value }` as an option only while the value is not among the loaded ones. A host that provides nothing sees no change.

No behaviour changes for callers that bind nothing new.

>no-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
