### PR TITLE
fix(ActivityTimeline): fade email bottom edge only while more remains below

### DIFF
--- a/ui/src/components/ActivityTimeline/EmailContent.vue
+++ b/ui/src/components/ActivityTimeline/EmailContent.vue
@@ -11,7 +11,7 @@
 <!-- sandboxed + CSP: scripts and external resources can't load -->
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
-import { applyCssToIframe, stripEmailColors, useDataTheme } from "./utils";
+import { applyCssToIframe, bottomFade, stripEmailColors, useDataTheme } from "./utils";
 
 const props = defineProps<{
 	content: string;
@@ -194,11 +194,7 @@ watch(iframeRef, (iframe) => {
 			parent.setAttribute("data-theme", dataTheme.value);
 
 			// fade the bottom edge only while there's more email below it
-			const syncMask = () => {
-				const { scrollTop, clientHeight, scrollHeight } = parent;
-				const more = scrollTop + clientHeight < scrollHeight - 1;
-				iframe.style.setProperty("--fade", more ? "18px" : "0px");
-			};
+			const syncMask = () => iframe.style.setProperty("--fade", bottomFade(parent));
 
 			// measure content → set iframe height; max-height caps it, so the rest scrolls
 			const syncHeight = () => {

--- a/ui/src/components/ActivityTimeline/EmailContent.vue
+++ b/ui/src/components/ActivityTimeline/EmailContent.vue
@@ -4,8 +4,7 @@
 		:srcdoc="htmlContent"
 		sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
 		referrerpolicy="no-referrer"
-		class="prose-f block h-10 w-full"
-		:class="{ 'email-clipped-fade': isClipped }"
+		class="prose-f email-fade block h-10 w-full"
 		:style="{ maxHeight: `${MAX_CONTENT_HEIGHT}px` }"
 	/>
 </template>
@@ -18,10 +17,9 @@ const props = defineProps<{
 	content: string;
 }>();
 
-const MAX_CONTENT_HEIGHT = 500; // in px; if the email content exceeds this, the bottom edge fades to indicate more content is clipped.
+const MAX_CONTENT_HEIGHT = 500; // in px; taller emails scroll inside the iframe, with the bottom edge faded while more remains.
 
 const iframeRef = ref<HTMLIFrameElement | null>(null);
-const isClipped = ref(false);
 const dataTheme = useDataTheme(); // needed for the iframe to inherit the host's theme (dark/light) so the email content matches the rest of the app.
 
 // reactive to content: strip inline colors + fold reply quotes into a CSS-only collapse
@@ -195,12 +193,20 @@ watch(iframeRef, (iframe) => {
 			if (!parent) return;
 			parent.setAttribute("data-theme", dataTheme.value);
 
-			// measure content → set iframe height; flag overflow so the edge fades
-			const syncHeight = () => {
-				const full = parent.offsetHeight + 1;
-				iframe.style.height = full + "px";
-				isClipped.value = full > MAX_CONTENT_HEIGHT;
+			// fade the bottom edge only while there's more email below it
+			const syncMask = () => {
+				const { scrollTop, clientHeight, scrollHeight } = parent;
+				const more = scrollTop + clientHeight < scrollHeight - 1;
+				iframe.style.setProperty("--fade", more ? "18px" : "0px");
 			};
+
+			// measure content → set iframe height; max-height caps it, so the rest scrolls
+			const syncHeight = () => {
+				iframe.style.height = `${parent.offsetHeight + 1}px`;
+				syncMask();
+			};
+
+			iframe.contentWindow?.addEventListener("scroll", syncMask, { passive: true });
 
 			// inherit host styles into the iframe; external sheets load async, so re-measure after
 			applyCssToIframe(iframe, syncHeight);
@@ -246,9 +252,8 @@ watch(dataTheme, (theme) => {
 </script>
 
 <style scoped>
-/* fade the clipped bottom edge (~18px) so a long email never hard-slices a line */
-.email-clipped-fade {
-	-webkit-mask-image: linear-gradient(to bottom, #000 calc(100% - 18px), transparent);
-	mask-image: linear-gradient(to bottom, #000 calc(100% - 18px), transparent);
+/* at 0px the stop sits on the edge, so the mask is simply opaque */
+.email-fade {
+	mask-image: linear-gradient(to bottom, #000 calc(100% - var(--fade, 0px)), transparent);
 }
 </style>

--- a/ui/src/components/ActivityTimeline/tests/emailFade.test.ts
+++ b/ui/src/components/ActivityTimeline/tests/emailFade.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { bottomFade } from "../utils";
+
+// Geometry below is measured from a real clipped email (3598px of content in
+// the 500px box) rather than invented, so the end-of-scroll case is exact.
+describe("bottomFade", () => {
+  it("fades while there is more email below the fold", () => {
+    expect(bottomFade({ scrollTop: 0, clientHeight: 500, scrollHeight: 3598 })).toBe("18px");
+    expect(bottomFade({ scrollTop: 1500, clientHeight: 500, scrollHeight: 3598 })).toBe("18px");
+  });
+
+  it("drops the fade once the last line is reached", () => {
+    expect(bottomFade({ scrollTop: 3098, clientHeight: 500, scrollHeight: 3598 })).toBe("0px");
+  });
+
+  it("drops the fade when the scroll lands fractionally short of the end", () => {
+    // scrollTop goes fractional on HiDPI/zoom; without the tolerance the fade
+    // would survive at the bottom, which is the bug this guards.
+    expect(bottomFade({ scrollTop: 3097.5, clientHeight: 500, scrollHeight: 3598 })).toBe("0px");
+  });
+
+  it("never fades content that fits", () => {
+    expect(bottomFade({ scrollTop: 0, clientHeight: 301, scrollHeight: 301 })).toBe("0px");
+  });
+});

--- a/ui/src/components/ActivityTimeline/utils.ts
+++ b/ui/src/components/ActivityTimeline/utils.ts
@@ -200,3 +200,20 @@ export function applyCssToIframe(
     head.insertBefore(clone, anchor);
   });
 }
+
+// How much of an email's bottom edge to fade, in px. Only while there is more
+// below the fold: reaching the end (or content that never overflows) gives 0,
+// which collapses the gradient stop onto the edge and leaves the mask opaque.
+// The 1px tolerance matters — `scrollTop` goes fractional on HiDPI/zoom, so an
+// exact comparison never clears the fade at the end of the scroll.
+const EMAIL_FADE_LENGTH = 18;
+
+export function bottomFade(scroller: {
+  scrollTop: number;
+  clientHeight: number;
+  scrollHeight: number;
+}): string {
+  const { scrollTop, clientHeight, scrollHeight } = scroller;
+  const more = scrollTop + clientHeight < scrollHeight - 1;
+  return `${more ? EMAIL_FADE_LENGTH : 0}px`;
+}

--- a/ui/src/components/Fields/fieldTypes.ts
+++ b/ui/src/components/Fields/fieldTypes.ts
@@ -1,9 +1,8 @@
-import type { Component } from "vue";
+import { defineAsyncComponent, type Component } from "vue";
 import { setScoped } from "../../utils/scopedRegistry";
 import AutocompleteField from "./AutocompleteField.vue";
 import ButtonField from "./ButtonField.vue";
 import CheckField from "./CheckField.vue";
-import CodeEditorField from "./CodeEditorField.vue";
 import DateField from "./DateField.vue";
 import DatetimeField from "./DatetimeField.vue";
 import DurationField from "./DurationField.vue";
@@ -82,7 +81,11 @@ for (const t of ["Small Text", "Text", "Long Text"]) {
 }
 
 // Code-family types share one CodeEditorField (CodeMirror 6 writer + sanitized
-// preview), with the language derived from the fieldtype/options.
+// preview), with the language derived from the fieldtype/options. Loaded lazily:
+// CodeMirror is heavy, and it's the only field pulling `CodeEditor`/`CodePreview`
+// from `frappe-ui/experimental`
+const CodeEditorField = defineAsyncComponent(() => import("./CodeEditorField.vue"));
+
 for (const t of ["Code", "JSON", "Markdown Editor", "HTML Editor"]) {
   registerFieldType(t, CodeEditorField);
 }

--- a/ui/src/components/Fields/tests/fieldTypes.test.ts
+++ b/ui/src/components/Fields/tests/fieldTypes.test.ts
@@ -51,11 +51,17 @@ describe("fieldTypes registry", () => {
     }
   });
 
-  it("resolves the code-family fieldtypes to CodeEditorField", () => {
+  it("resolves the code-family fieldtypes to CodeEditorField", async () => {
     // JSON / Markdown Editor / HTML Editor / Code share one CodeMirror-backed
-    // field (moved off TextareaField).
-    for (const t of ["Code", "JSON", "Markdown Editor", "HTML Editor"]) {
-      expect(getFieldComponent(t)).toBe(CodeEditorField);
+    // field (moved off TextareaField). It's registered lazily, so the registry
+    // holds Vue's async wrapper — unwrap it to assert the field it resolves to.
+    const lazyCodeEditorField = getFieldComponent("Code") as {
+      __asyncLoader: () => Promise<unknown>;
+    };
+    expect(await lazyCodeEditorField.__asyncLoader()).toBe(CodeEditorField);
+
+    for (const t of ["JSON", "Markdown Editor", "HTML Editor"]) {
+      expect(getFieldComponent(t)).toBe(lazyCodeEditorField);
     }
   });
 


### PR DESCRIPTION
The email fade was applied whenever the content exceeded `MAX_CONTENT_HEIGHT`, and stayed on at every scroll position — including the very end, where nothing is below it.

Now it tracks the scroll: the gradient stop is a CSS variable that drops to `0px` once the last line is reached, which collapses the stop onto the edge and leaves the mask opaque. No branch needed for the "no fade" case.

Also loads `CodeEditorField` lazily, so CodeMirror and its `frappe-ui/experimental` imports stay out of the eager graph.

**Before:**
<img width="1684" height="1192" alt="image" src="https://github.com/user-attachments/assets/0fd35fbd-2f5a-454d-81b0-40c28435af89" />

Blur at bottom of the Email


**After:**
<img width="1716" height="1212" alt="image" src="https://github.com/user-attachments/assets/f467b84e-ed4e-4d21-8ba9-d81a6d04ef36" />

