### PR TITLE
feat(desk-v2): make the panel's people built-in editable

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -38,7 +38,7 @@ yarn --cwd frontend test:run
 That is exactly what CI does (`.github/workflows/frontend-tests.yml`). The **base** file
 is the correct input, not a `bench build`-generated one: `yarn.lock` was resolved from
 `package.base.json` alone, and no test needs anything an app contributes. Baseline is
-**56 files / 714 tests**, under `recordPage/tests/`, `pages/record/tests/`,
+**59 files / 741 tests**, under `recordPage/tests/`, `pages/record/tests/`,
 `pages/record/panel/tests/`, `shell/tests/` and `navigation/tests/`.
 
 **`vitest.config.js` runs with `css: { postcss: {} }`, and that is not cosmetic.**

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -38,7 +38,7 @@ yarn --cwd frontend test:run
 That is exactly what CI does (`.github/workflows/frontend-tests.yml`). The **base** file
 is the correct input, not a `bench build`-generated one: `yarn.lock` was resolved from
 `package.base.json` alone, and no test needs anything an app contributes. Baseline is
-**59 files / 741 tests**, under `recordPage/tests/`, `pages/record/tests/`,
+**61 files / 746 tests**, under `recordPage/tests/`, `pages/record/tests/`,
 `pages/record/panel/tests/`, `shell/tests/` and `navigation/tests/`.
 
 **`vitest.config.js` runs with `css: { postcss: {} }`, and that is not cosmetic.**

--- a/frontend/SCRIPTING.md
+++ b/frontend/SCRIPTING.md
@@ -63,6 +63,7 @@ The generated page seeds three items, in this order:
 | `doctype` | left | The doctype's crumb; links to the list. |
 | `record` | left | The record's crumb: its title field, or its name. |
 | `save` | right | The Save button. Disabled by the host while nothing has changed. |
+| `delete` | right | A row in `⋯`, only with the delete right. Confirms, deletes, and leaves for the list. |
 
 `Save` is an ordinary item. `hide('save')` removes it, as desk v1's `frm.disable_save()`
 does. A new item with no anchor lands **after** `Save`; to sit to its left, anchor it:
@@ -153,7 +154,7 @@ them under the names the Form Layout stores:
 | Name | What it is |
 | --- | --- |
 | `identity` | The title, subtitle, image and tags. |
-| `quick_actions` | `page.quickActions`, as buttons; as icons when the panel is collapsed to a strip. The framework seeds `print`, `copy_link`, `delete` and `tags` there: the first and last two only with the right, and `tags` only while the record has none. A script hides or reorders them by name. |
+| `quick_actions` | `page.quickActions`, as buttons; as icons when the panel is collapsed to a strip. The framework seeds `print`, `copy_link` and `tags` there: `print` with the right, `tags` with write and only while the record has none. The row names its buttons from the left while the width lasts, then shows icons, then folds the rest into a `⋯` menu. A script hides or reorders them by name. |
 | `people` | Who the record is assigned to, and who it is shared with. |
 
 A doctype with no Side Panel row shows the three built-ins and nothing else. The panel never

--- a/frontend/SCRIPTING.md
+++ b/frontend/SCRIPTING.md
@@ -153,12 +153,53 @@ them under the names the Form Layout stores:
 | Name | What it is |
 | --- | --- |
 | `identity` | The title, subtitle, image and tags. |
-| `quick_actions` | `page.quickActions`, as buttons; as icons when the panel is collapsed to a strip. The framework seeds `print`, `copy_link` and `delete` there, the first and last only with the right; a script hides or reorders them by name. |
+| `quick_actions` | `page.quickActions`, as buttons; as icons when the panel is collapsed to a strip. The framework seeds `print`, `copy_link`, `delete` and `tags` there: the first and last two only with the right, and `tags` only while the record has none. A script hides or reorders them by name. |
 | `people` | Who the record is assigned to, and who it is shared with. |
 
 A doctype with no Side Panel row shows the three built-ins and nothing else. The panel never
 falls back to the Details layout, so no field shows twice; a doctype that wants fields in
 its panel ships a Side Panel row.
+
+### The people
+
+`people` edits with the rights the record's `docinfo.permissions` carries: assign and tag
+with `write`, share with `share`. Without the right the row reads, and still names the
+people. Each pick is one server call, and the row re-reads the sidecar after it; nothing is
+painted from the answer, so the row never disagrees with the server.
+
+| Act | Endpoint |
+| --- | --- |
+| Assign, unassign | `frappe.desk.form.assign_to.add`, `remove` |
+| Share, unshare | `frappe.share.add`, `set_permission` with `read` set to `0` |
+| Tag, untag | `frappe.desk.doctype.tag.tag.add_tag`, `remove_tag`; searched with `get_tags` |
+
+The share editor is a dialog on the page's own stack, opened through `page.dialog.open`.
+The tags stay on `identity`: hiding `people` leaves them standing. The first tag comes from
+the `tags` quick action, which goes once the record has one; from then on the chips carry
+their own "+".
+
+The surface gains no verb for any of this. A script assigns the way the row does, through
+`page.call`, and reloads so the row reads the new sidecar:
+
+```js
+export default {
+  onRefresh(page) {
+    page.quickActions.add({
+      name: 'assign_owner',
+      label: 'Assign to owner',
+      icon: 'lucide-user-check',
+      run: async (p) => {
+        await p.call('frappe.desk.form.assign_to.add', {
+          doctype: p.doctype,
+          name: p.docname,
+          assign_to: [p.doc.owner],
+        })
+        await p.reload()
+      },
+    })
+  },
+}
+```
 
 ### Opening and shutting
 

--- a/frontend/src/pages/Record.vue
+++ b/frontend/src/pages/Record.vue
@@ -53,6 +53,7 @@
 				:sections="sections"
 				:disclosure="disclosure"
 				:run="runAction"
+				:reloadDocinfo="reloadDocinfo"
 				@expand="expand"
 			/>
 		</div>
@@ -99,6 +100,7 @@ import { fetchMeta } from "./record/metaSource";
 import { PANEL_BUILTINS } from "./record/panel/builtins";
 import { quickActionBuiltins } from "./record/quickActionBuiltins";
 import { personOf, type DocInfo } from "./record/panel/context";
+import { tagsOf } from "./record/panel/people";
 import { useDisclosure } from "./record/panel/disclosure";
 import { layoutItems, layoutSections } from "./record/panel/panelEntries";
 import RecordPanel from "./record/panel/RecordPanel.vue";
@@ -149,6 +151,8 @@ const HEADER_BUDGET = 3;
 
 // The slower of two in-flight loads must not win: `save()` would then POST the wrong record.
 let generation = 0;
+// Likewise for two sidecar re-reads: several picks in one gesture each fire one.
+let docinfoRead = 0;
 
 const doctype = computed(() => addresses.doctypeOf(String(route.params.doctype)));
 const docname = computed(() => String(route.params.name));
@@ -229,9 +233,28 @@ async function fetchDoc(target: { doctype: string; name: string }) {
 	};
 }
 
+/** `get_docinfo` alone: the sidecar after an assign, share or tag, with the draft untouched. */
+async function fetchDocinfo(target: { doctype: string; name: string }) {
+	const res = await fetch(
+		`/api/method/frappe.desk.form.load.get_docinfo?${new URLSearchParams(target)}`
+	);
+	if (!res.ok) throw new Error(String(res.status));
+	return (await res.json()).docinfo as DocInfo;
+}
+
+async function reloadDocinfo() {
+	if (!doctype.value) return;
+	const mine = generation;
+	const read = ++docinfoRead;
+	const fresh = await fetchDocinfo({ doctype: doctype.value, name: docname.value });
+	if (mine !== generation || read !== docinfoRead) return;
+	docinfo.value = fresh;
+}
+
 async function load() {
 	if (!doctype.value) return;
 	const mine = ++generation;
+	docinfoRead++;
 	const target = { doctype: doctype.value, name: docname.value };
 	error.value = "";
 
@@ -308,7 +331,7 @@ async function load() {
 	});
 	created.header.provideBuiltins(headerBuiltins);
 	created.quickActions.provideBuiltins(() =>
-		quickActionBuiltins(docinfo.value?.permissions ?? {})
+		quickActionBuiltins(docinfo.value?.permissions ?? {}, tagsOf(docinfo.value).length > 0)
 	);
 	created.panelSections.provideBuiltins(panelBuiltins);
 	panelLayout.value = panel;

--- a/frontend/src/pages/Record.vue
+++ b/frontend/src/pages/Record.vue
@@ -98,7 +98,7 @@ import PageDialogs from "./record/dialogs/PageDialogs.vue";
 import { formTabMemory } from "./record/formTabMemory";
 import { fetchMeta } from "./record/metaSource";
 import { PANEL_BUILTINS } from "./record/panel/builtins";
-import { quickActionBuiltins } from "./record/quickActionBuiltins";
+import { headerMenuBuiltins, quickActionBuiltins } from "./record/builtinActions";
 import { personOf, type DocInfo } from "./record/panel/context";
 import { tagsOf } from "./record/panel/people";
 import { useDisclosure } from "./record/panel/disclosure";
@@ -204,6 +204,7 @@ function headerBuiltins(): HeaderItem[] {
 		},
 		{ name: "record", label: String(title), zone: "left", display: "crumb" },
 		{ name: "save", label: "Save", display: "button", run: runSave },
+		...headerMenuBuiltins(docinfo.value?.permissions ?? {}),
 	];
 }
 

--- a/frontend/src/pages/record/RecordHeader.vue
+++ b/frontend/src/pages/record/RecordHeader.vue
@@ -1,6 +1,6 @@
 <!--
-  The record's header row, drawn from `page.header`: crumbs left; controls, `⋯` and Save right.
-  Save stays last wherever a script puts it, so the menu is always at its left hand.
+  The record's header row, drawn from `page.header`: crumbs left; controls, `⋯` and Save right,
+  in the projection's order, with the menu slotted in at Save's left hand.
   A div, not a header: it fills the frame's pinned row, which is the `<header>` element.
 -->
 <template>
@@ -60,9 +60,19 @@
 		</nav>
 
 		<div class="flex shrink-0 items-center gap-2">
-			<template v-for="control in others" :key="control.item.name">
+			<template v-for="control in rightHand" :key="control.item.name">
+				<Dropdown v-if="control === MENU" :options="bands" side="bottom" align="end">
+					<div class="flex shrink-0">
+						<Button
+							icon="lucide-more-horizontal"
+							variant="subtle"
+							label="More actions"
+						/>
+					</div>
+				</Dropdown>
+
 				<Dropdown
-					v-if="control.kind === 'dropdown'"
+					v-else-if="control.kind === 'dropdown'"
 					:options="menuContent(control.members, run)"
 					side="bottom"
 					align="end"
@@ -78,6 +88,24 @@
 					</div>
 				</Dropdown>
 
+				<Tooltip
+					v-else-if="control.item.name === 'save'"
+					text="No changes to save"
+					:disabled="dirty"
+				>
+					<!-- A disabled button fires no pointer events, so the wrapper owns the box the tooltip hovers on. -->
+					<div class="flex shrink-0">
+						<Button
+							:label="control.item.label"
+							:icon-left="control.item.icon"
+							variant="solid"
+							:disabled="!dirty"
+							:loading="saving"
+							@click="run(control.item)"
+						/>
+					</div>
+				</Tooltip>
+
 				<Button
 					v-else
 					:label="control.item.label"
@@ -86,26 +114,6 @@
 					@click="run(control.item)"
 				/>
 			</template>
-
-			<Dropdown v-if="projection.bands.length" :options="bands" side="bottom" align="end">
-				<div class="flex shrink-0">
-					<Button icon="lucide-more-horizontal" variant="subtle" label="More actions" />
-				</div>
-			</Dropdown>
-
-			<Tooltip v-if="save" text="No changes to save" :disabled="dirty">
-				<!-- A disabled button fires no pointer events, so the wrapper owns the box the tooltip hovers on. -->
-				<div class="flex shrink-0">
-					<Button
-						:label="save.item.label"
-						:icon-left="save.item.icon"
-						variant="solid"
-						:disabled="!dirty"
-						:loading="saving"
-						@click="run(save.item)"
-					/>
-				</div>
-			</Tooltip>
 		</div>
 	</div>
 </template>
@@ -135,13 +143,16 @@ const bands = computed(() =>
 	}))
 );
 
-const save = computed(() =>
-	props.projection.controls.find((control) => control.item.name === "save")
-);
+// The menu's own row in the controls: at Save's left hand, or last when a script hid Save.
+const MENU = { kind: "button", item: { name: "more", label: "More actions" } } as HeaderControl;
 
-const others = computed(() =>
-	props.projection.controls.filter((control) => control.item.name !== "save")
-);
+const rightHand = computed(() => {
+	const controls = props.projection.controls;
+	if (!props.projection.bands.length) return controls;
+	const at = controls.findIndex((control) => control.item.name === "save");
+	if (at < 0) return [...controls, MENU];
+	return [...controls.slice(0, at), MENU, ...controls.slice(at)];
+});
 
 function isCrumb(control?: HeaderControl) {
 	return control?.kind === "crumb";

--- a/frontend/src/pages/record/RecordHeader.vue
+++ b/frontend/src/pages/record/RecordHeader.vue
@@ -1,5 +1,6 @@
 <!--
   The record's header row, drawn from `page.header`: crumbs left; controls, `⋯` and Save right.
+  Save stays last wherever a script puts it, so the menu is always at its left hand.
   A div, not a header: it fills the frame's pinned row, which is the `<header>` element.
 -->
 <template>
@@ -59,7 +60,7 @@
 		</nav>
 
 		<div class="flex shrink-0 items-center gap-2">
-			<template v-for="control in projection.controls" :key="control.item.name">
+			<template v-for="control in others" :key="control.item.name">
 				<Dropdown
 					v-if="control.kind === 'dropdown'"
 					:options="menuContent(control.members, run)"
@@ -77,24 +78,6 @@
 					</div>
 				</Dropdown>
 
-				<Tooltip
-					v-else-if="control.item.name === 'save'"
-					text="No changes to save"
-					:disabled="dirty"
-				>
-					<!-- A disabled button fires no pointer events, so the wrapper owns the box the tooltip hovers on. -->
-					<div class="flex shrink-0">
-						<Button
-							:label="control.item.label"
-							:icon-left="control.item.icon"
-							variant="solid"
-							:disabled="!dirty"
-							:loading="saving"
-							@click="run(control.item)"
-						/>
-					</div>
-				</Tooltip>
-
 				<Button
 					v-else
 					:label="control.item.label"
@@ -109,6 +92,20 @@
 					<Button icon="lucide-more-horizontal" variant="subtle" label="More actions" />
 				</div>
 			</Dropdown>
+
+			<Tooltip v-if="save" text="No changes to save" :disabled="dirty">
+				<!-- A disabled button fires no pointer events, so the wrapper owns the box the tooltip hovers on. -->
+				<div class="flex shrink-0">
+					<Button
+						:label="save.item.label"
+						:icon-left="save.item.icon"
+						variant="solid"
+						:disabled="!dirty"
+						:loading="saving"
+						@click="run(save.item)"
+					/>
+				</div>
+			</Tooltip>
 		</div>
 	</div>
 </template>
@@ -136,6 +133,14 @@ const bands = computed(() =>
 		hideLabel: !band.label,
 		options: bandRows(band.items, run),
 	}))
+);
+
+const save = computed(() =>
+	props.projection.controls.find((control) => control.item.name === "save")
+);
+
+const others = computed(() =>
+	props.projection.controls.filter((control) => control.item.name !== "save")
 );
 
 function isCrumb(control?: HeaderControl) {

--- a/frontend/src/pages/record/builtinActions.ts
+++ b/frontend/src/pages/record/builtinActions.ts
@@ -1,16 +1,22 @@
-// The quick actions every record gets from the framework, gated by the record's rights.
-// Each is an ordinary item on `page.quickActions`, so a script hides or reorders it by name.
-import type { QuickAction, RecordPageApi } from "@/recordPage";
+// The actions every record gets from the framework, gated by its rights: quick actions on
+// the panel, Delete in the header's menu. Each is an ordinary item a script hides or reorders by name.
+import type { HeaderItem, QuickAction, RecordPageApi } from "@/recordPage";
 import { routeFor } from "@/router/routeFor";
 
 export function quickActionBuiltins(perms: Record<string, any>, tagged = false): QuickAction[] {
   const actions: QuickAction[] = [];
   if (perms.print) actions.push({ name: "print", label: "Print", icon: "lucide-printer", run: print });
   actions.push({ name: "copy_link", label: "Copy link", icon: "lucide-link", run: copyLink });
-  if (perms.delete) actions.push({ name: "delete", label: "Delete", icon: "lucide-trash-2", run: remove });
   // Only while the record has no tag: a tagged record has the chips' own "+" instead.
   if (perms.write && !tagged) actions.push({ name: "tags", label: "Tags", icon: "lucide-tag", tagging: true });
   return actions;
+}
+
+/** The header's `⋯` rows: no `display`, so the projection files them under the menu. */
+export function headerMenuBuiltins(perms: Record<string, any>): HeaderItem[] {
+  const items: HeaderItem[] = [];
+  if (perms.delete) items.push({ name: "delete", label: "Delete", icon: "lucide-trash-2", run: remove });
+  return items;
 }
 
 // Desk v1's print view; the new shell has no print page of its own yet.

--- a/frontend/src/pages/record/panel/AssigneePicker.vue
+++ b/frontend/src/pages/record/panel/AssigneePicker.vue
@@ -1,0 +1,88 @@
+<!-- The assigned-to editor: the avatar stack as the trigger of a user picker. -->
+<template>
+	<MultiSelect
+		:modelValue="assigned"
+		:options="options"
+		:query="query"
+		:loading="loading"
+		:filterable="false"
+		:empty-text="error || 'No users found'"
+		placeholder="Assign to…"
+		@update:modelValue="reassign"
+		@update:query="onQuery"
+		@update:open="onOpen"
+	>
+		<template #trigger="{ open }">
+			<button
+				type="button"
+				class="flex w-fit min-w-0 items-center gap-1 rounded-1 px-1.5 py-1 transition hover:bg-surface-gray-2"
+				:aria-label="summary"
+				data-assign
+			>
+				<PeopleAvatars :people="assignees" placeholder="Add people…" />
+				<span
+					v-if="assignees.length"
+					:class="[
+						'lucide-chevron-down size-4 text-ink-gray-5 transition-transform',
+						open && 'rotate-180',
+					]"
+				/>
+			</button>
+		</template>
+
+		<template #item-prefix="{ item }">
+			<Avatar :label="item.label" :image="(item as SearchOption).image" size="sm" />
+		</template>
+	</MultiSelect>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { Avatar, MultiSelect } from "frappe-ui";
+import type { Person } from "./people";
+import { listDiff } from "./people";
+import PeopleAvatars from "./PeopleAvatars.vue";
+import { useUserSearch, type SearchOption } from "./remoteSearch";
+
+const props = defineProps<{
+	assignees: Person[];
+	call: (method: string, params?: Record<string, any>) => Promise<any>;
+}>();
+
+const emit = defineEmits<{ assign: [string]; unassign: [string] }>();
+
+const assigned = computed(() => props.assignees.map(({ id }) => id));
+
+const pinned = computed<SearchOption[]>(() =>
+	props.assignees.map(({ id, name, image }) => ({ label: name, value: id, image }))
+);
+
+const { options, loading, error, search, searchSoon } = useUserSearch(props.call, pinned);
+
+// Listening to the query owns it, so every open resets it and the list.
+const query = ref("");
+
+function onOpen(open: boolean) {
+	if (!open) return;
+	query.value = "";
+	search("");
+}
+
+function onQuery(text: string) {
+	query.value = text;
+	searchSoon(text);
+}
+
+const summary = computed(() =>
+	props.assignees.length
+		? `Assigned to ${props.assignees.map(({ name }) => name).join(", ")}`
+		: "Assign to…"
+);
+
+// The selection is server state: each pick fires one write and the re-read repaints it.
+function reassign(picked: (string | number)[]) {
+	const { added, dropped } = listDiff(picked.map(String), assigned.value);
+	added.forEach((user) => emit("assign", user));
+	dropped.forEach((user) => emit("unassign", user));
+}
+</script>

--- a/frontend/src/pages/record/panel/AssigneePicker.vue
+++ b/frontend/src/pages/record/panel/AssigneePicker.vue
@@ -23,7 +23,7 @@
 				<span
 					v-if="assignees.length"
 					:class="[
-						'lucide-chevron-down size-4 text-ink-gray-5 transition-transform',
+						'lucide-chevron-down size-3.5 text-ink-gray-5 transition-transform',
 						open && 'rotate-180',
 					]"
 				/>

--- a/frontend/src/pages/record/panel/PanelLayout.vue
+++ b/frontend/src/pages/record/panel/PanelLayout.vue
@@ -14,11 +14,14 @@
 				@toggle="emit('toggle', entry.name)"
 				@expand="emit('expand', $event)"
 			>
-				<component
-					:is="entry.component"
-					v-if="entry.component"
-					v-bind="scripted.has(entry.name) ? { ...entry.props, page } : entry.props"
-				/>
+				<component :is="entry.component" v-if="entry.component" v-bind="bindings(entry)">
+					<template v-if="entry.embedded" #default>
+						<component
+							:is="entry.embedded.component"
+							v-bind="bindings(entry.embedded)"
+						/>
+					</template>
+				</component>
 			</PanelSection>
 		</template>
 	</div>
@@ -38,7 +41,12 @@ import type { FieldNode } from "@framework/ui/components/FormLayout/types";
 import { BUILTIN, type Surface } from "@/recordPage/surface";
 import type { PanelSectionItem, RecordPageApi } from "@/recordPage";
 import PanelSection from "./PanelSection.vue";
-import { panelEntries, type LayoutSection } from "./panelEntries";
+import {
+	embedQuickActions,
+	panelEntries,
+	type LayoutSection,
+	type PanelEntry,
+} from "./panelEntries";
 
 const props = defineProps<{
 	surface: Surface<PanelSectionItem>;
@@ -53,7 +61,9 @@ const emit = defineEmits<{ toggle: [name: string]; expand: [field: FieldNode] }>
 
 const doc = defineModel<Record<string, any>>("doc", { required: true });
 
-const entries = computed(() => panelEntries(props.surface.visible(), props.sections));
+const entries = computed(() =>
+	embedQuickActions(panelEntries(props.surface.visible(), props.sections))
+);
 
 const scripted = computed(
 	() =>
@@ -75,6 +85,10 @@ const numbered = computed(() => {
 		divided: index > 0,
 	}));
 });
+
+function bindings(entry: PanelEntry) {
+	return scripted.value.has(entry.name) ? { ...entry.props, page: props.page } : entry.props;
+}
 
 function update(fieldname: string, value: any) {
 	doc.value[fieldname] = value;

--- a/frontend/src/pages/record/panel/PanelSection.vue
+++ b/frontend/src/pages/record/panel/PanelSection.vue
@@ -26,7 +26,7 @@
 
 	<div
 		v-if="headerIndex === null || open"
-		class="flex flex-col gap-2.5 px-4 pb-3 pt-2.5 empty:hidden"
+		class="flex flex-col gap-2.5 px-4 py-3 empty:hidden"
 		:class="headerIndex === null && divided ? 'border-t border-outline-gray-1' : ''"
 		:data-section="headerIndex === null ? name : undefined"
 	>

--- a/frontend/src/pages/record/panel/PeopleAvatars.vue
+++ b/frontend/src/pages/record/panel/PeopleAvatars.vue
@@ -1,0 +1,39 @@
+<!-- A stack of people as avatars, or the placeholder when there is nobody. -->
+<template>
+	<span v-if="!people.length" class="truncate text-base text-ink-gray-4">{{ placeholder }}</span>
+	<span v-else class="flex min-w-0 items-center gap-1">
+		<span class="flex -space-x-1.5">
+			<Tooltip v-for="person in visible" :key="person.id" :text="person.name">
+				<Avatar
+					class="ring-2 ring-outline-base"
+					:label="person.name"
+					:image="person.image"
+					size="sm"
+				/>
+			</Tooltip>
+			<span
+				v-if="overflow"
+				class="z-10 grid size-5 place-items-center rounded-full bg-surface-gray-3 text-p-xs-medium text-ink-gray-7"
+			>
+				+{{ overflow }}
+			</span>
+		</span>
+		<!-- One person has room for a name; a stack speaks through its tooltips. -->
+		<span v-if="people.length === 1" class="truncate text-base text-ink-gray-8">
+			{{ people[0].name }}
+		</span>
+	</span>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { Avatar, Tooltip } from "frappe-ui";
+import type { Person } from "./people";
+
+const MAX_AVATARS = 3;
+
+const props = defineProps<{ people: Person[]; placeholder: string }>();
+
+const visible = computed(() => props.people.slice(0, MAX_AVATARS));
+const overflow = computed(() => Math.max(0, props.people.length - MAX_AVATARS));
+</script>

--- a/frontend/src/pages/record/panel/PeopleAvatars.vue
+++ b/frontend/src/pages/record/panel/PeopleAvatars.vue
@@ -5,7 +5,7 @@
 		<span class="flex -space-x-1.5">
 			<Tooltip v-for="person in visible" :key="person.id" :text="person.name">
 				<Avatar
-					class="ring-2 ring-outline-base"
+					class="ring-2 ring-outline-base transition hover:z-10 hover:scale-110"
 					:label="person.name"
 					:image="person.image"
 					size="sm"

--- a/frontend/src/pages/record/panel/PeopleRow.vue
+++ b/frontend/src/pages/record/panel/PeopleRow.vue
@@ -1,42 +1,19 @@
-<!-- One people row, `assignees` or `shares`: a label named by an icon, then the people
-     as avatars. Always drawn; an empty row says so instead of vanishing. -->
+<!-- One people row, assigned or shared: a label named by an icon, then whatever edits or
+     shows the people. Always drawn; an empty row says so instead of vanishing. -->
 <template>
 	<div class="grid grid-cols-[130px_1fr] items-center gap-2">
 		<span class="flex min-w-0 items-center gap-2 truncate text-base text-ink-gray-5">
 			<span class="size-4 shrink-0" :class="icon" aria-hidden="true" />
 			{{ label }}
 		</span>
-
-		<span v-if="!people.length" class="truncate px-1.5 py-1 text-base text-ink-gray-4">
-			{{ placeholder }}
-		</span>
-		<span v-else class="flex min-w-0 items-center gap-1 px-1.5 py-1">
-			<span class="flex -space-x-1.5">
-				<Tooltip v-for="person in people" :key="person.id" :text="person.name">
-					<Avatar
-						class="ring-2 ring-outline-base"
-						:label="person.name"
-						:image="person.image"
-						size="sm"
-					/>
-				</Tooltip>
-			</span>
-			<!-- One person has room for a name; a stack speaks through its tooltips. -->
-			<span v-if="people.length === 1" class="truncate text-base text-ink-gray-8">
-				{{ people[0].name }}
-			</span>
-		</span>
+		<slot />
 	</div>
 </template>
 
 <script setup lang="ts">
-import { Avatar, Tooltip } from "frappe-ui";
-
 defineProps<{
 	label: string;
 	/** A lucide class, `lucide-user`. */
 	icon: string;
-	people: { id: string; name: string; image?: string }[];
-	placeholder: string;
 }>();
 </script>

--- a/frontend/src/pages/record/panel/QuickActions.vue
+++ b/frontend/src/pages/record/panel/QuickActions.vue
@@ -8,7 +8,29 @@
 		:class="vertical ? 'flex-col items-center' : 'flex-wrap'"
 	>
 		<template v-for="action in actions" :key="action.name">
-			<Tooltip v-if="vertical" :text="action.label" placement="left">
+			<!-- The tag action is the picker's own trigger, so it opens where it was pressed. -->
+			<TagPicker
+				v-if="action.tagging"
+				:doctype="context.doctype"
+				:tags="tags"
+				:call="context.controller.page.call"
+				:vertical="vertical"
+				@add="people.addTag"
+				@remove="people.removeTag"
+			>
+				<template #trigger>
+					<Tooltip v-if="vertical" :text="action.label" placement="left">
+						<Button :icon="action.icon" :label="action.label" variant="ghost" />
+					</Tooltip>
+					<Button
+						v-else
+						:icon-left="action.icon"
+						:label="action.label"
+						variant="subtle"
+					/>
+				</template>
+			</TagPicker>
+			<Tooltip v-else-if="vertical" :text="action.label" placement="left">
 				<Button
 					:icon="action.icon || 'lucide-zap'"
 					:label="action.label"
@@ -31,10 +53,15 @@
 import { computed, inject } from "vue";
 import { Button, Tooltip } from "frappe-ui";
 import { PanelContextKey } from "./context";
+import { tagsOf } from "./people";
+import { peopleActions } from "./peopleActions";
+import TagPicker from "./TagPicker.vue";
 
 defineProps<{ vertical?: boolean }>();
 
 const context = inject(PanelContextKey)!;
+const people = peopleActions(context);
 
 const actions = computed(() => context.controller.quickActions.visible());
+const tags = computed(() => tagsOf(context.docinfo.value));
 </script>

--- a/frontend/src/pages/record/panel/QuickActions.vue
+++ b/frontend/src/pages/record/panel/QuickActions.vue
@@ -1,13 +1,15 @@
 <!-- The `quick_actions` built-in: `page.quickActions` as buttons, or as icons down the
      collapsed strip. One name, one meaning in both renderings. -->
 <template>
-	<!-- Nothing to draw takes no room: the section's body hides itself when empty. -->
+	<!-- Nothing may shrink: the row has to overflow for the fit to be measurable. -->
 	<div
 		v-if="actions.length"
-		class="flex gap-1"
-		:class="vertical ? 'flex-col items-center' : 'flex-wrap'"
+		ref="row"
+		class="flex items-center gap-1 [&>*]:shrink-0"
+		:class="vertical ? 'flex-col' : ''"
 	>
-		<template v-for="action in actions" :key="action.name">
+		<!-- Named from the left while the width lasts; the rest keep to their tooltip. -->
+		<template v-for="(action, index) in actions.slice(0, visible)" :key="action.name">
 			<!-- The tag action is the picker's own trigger, so it opens where it was pressed. -->
 			<TagPicker
 				v-if="action.tagging"
@@ -19,49 +21,111 @@
 				@remove="people.removeTag"
 			>
 				<template #trigger>
-					<Tooltip v-if="vertical" :text="action.label" placement="left">
-						<Button :icon="action.icon" :label="action.label" variant="ghost" />
-					</Tooltip>
-					<Button
-						v-else
-						:icon-left="action.icon"
-						:label="action.label"
-						variant="subtle"
-					/>
+					<!-- The trigger must own a box: Tooltip drops the attrs the popover anchors on. -->
+					<div class="flex shrink-0">
+						<Tooltip
+							:text="action.label"
+							:placement="placement"
+							:disabled="index < labelled"
+						>
+							<Button
+								:icon="index < labelled ? undefined : action.icon"
+								:icon-left="index < labelled ? action.icon : undefined"
+								:label="action.label"
+								:variant="vertical ? 'ghost' : 'subtle'"
+							/>
+						</Tooltip>
+					</div>
 				</template>
 			</TagPicker>
-			<Tooltip v-else-if="vertical" :text="action.label" placement="left">
+
+			<Tooltip
+				v-else
+				:text="action.label"
+				:placement="placement"
+				:disabled="index < labelled"
+			>
 				<Button
-					:icon="action.icon || 'lucide-zap'"
+					:icon="index < labelled ? undefined : action.icon || 'lucide-zap'"
+					:icon-left="index < labelled ? action.icon : undefined"
 					:label="action.label"
-					variant="ghost"
+					:variant="vertical ? 'ghost' : 'subtle'"
 					@click="context.run(action)"
 				/>
 			</Tooltip>
-			<Button
-				v-else
-				:icon-left="action.icon"
-				:label="action.label"
-				variant="subtle"
-				@click="context.run(action)"
-			/>
 		</template>
+
+		<!-- The anchor overlays the trigger, so the picker opens under the menu it came from. -->
+		<div v-if="overflow.length" class="relative flex shrink-0">
+			<Dropdown :options="overflow" side="bottom" align="end">
+				<div class="flex shrink-0">
+					<Tooltip text="More quick actions" :placement="placement">
+						<Button
+							icon="lucide-more-horizontal"
+							label="More quick actions"
+							variant="subtle"
+						/>
+					</Tooltip>
+				</div>
+			</Dropdown>
+
+			<TagPicker
+				v-if="taggingOverflowed"
+				v-model:open="picking"
+				anchored
+				:doctype="context.doctype"
+				:tags="tags"
+				:call="context.controller.page.call"
+				@add="people.addTag"
+				@remove="people.removeTag"
+			/>
+		</div>
 	</div>
 </template>
 
 <script setup lang="ts">
-import { computed, inject } from "vue";
-import { Button, Tooltip } from "frappe-ui";
+import { computed, inject, ref, useTemplateRef, watch } from "vue";
+import { Button, Dropdown, Tooltip } from "frappe-ui";
+import type { QuickAction } from "@/recordPage";
 import { PanelContextKey } from "./context";
+import { useFittedActions } from "./fittedActions";
 import { tagsOf } from "./people";
 import { peopleActions } from "./peopleActions";
 import TagPicker from "./TagPicker.vue";
 
-defineProps<{ vertical?: boolean }>();
+const props = defineProps<{ vertical?: boolean }>();
 
 const context = inject(PanelContextKey)!;
 const people = peopleActions(context);
 
 const actions = computed(() => context.controller.quickActions.visible());
 const tags = computed(() => tagsOf(context.docinfo.value));
+const placement = computed(() => (props.vertical ? "left" : "top"));
+
+// The strip has no width to spend, so it names nothing and hides nothing.
+const row = useTemplateRef<HTMLElement>("row");
+const { labelled, visible } = useFittedActions(
+	row,
+	() => actions.value.length,
+	() => !props.vertical
+);
+
+const picking = ref(false);
+
+const overflow = computed(() =>
+	actions.value.slice(visible.value).map((action: QuickAction) => ({
+		label: action.label,
+		icon: action.icon || "lucide-zap",
+		onClick: () => (action.tagging ? (picking.value = true) : context.run(action)),
+	}))
+);
+
+const taggingOverflowed = computed(() =>
+	actions.value.slice(visible.value).some((action: QuickAction) => action.tagging)
+);
+
+// A pick tags the record and unmounts the anchor mid-open; the flag must not outlive it.
+watch(taggingOverflowed, (present) => {
+	if (!present) picking.value = false;
+});
 </script>

--- a/frontend/src/pages/record/panel/QuickActions.vue
+++ b/frontend/src/pages/record/panel/QuickActions.vue
@@ -1,91 +1,93 @@
 <!-- The `quick_actions` built-in: `page.quickActions` as buttons, or as icons down the
      collapsed strip. One name, one meaning in both renderings. -->
 <template>
-	<!-- Nothing may shrink: the row has to overflow for the fit to be measurable. -->
-	<div
-		v-if="actions.length"
-		ref="row"
-		class="flex items-center gap-1 [&>*]:shrink-0"
-		:class="vertical ? 'flex-col' : ''"
-	>
-		<!-- Named from the left while the width lasts; the rest keep to their tooltip. -->
-		<template v-for="(action, index) in actions.slice(0, visible)" :key="action.name">
-			<!-- The tag action is the picker's own trigger, so it opens where it was pressed. -->
-			<TagPicker
-				v-if="action.tagging"
-				:doctype="context.doctype"
-				:tags="tags"
-				:call="context.controller.page.call"
-				:vertical="vertical"
-				@add="people.addTag"
-				@remove="people.removeTag"
-			>
-				<template #trigger>
-					<!-- The trigger must own a box: Tooltip drops the attrs the popover anchors on. -->
+	<!-- One tooltip group: the first hover waits for nothing, and the next opens at once.
+	     Nothing may shrink: the row has to overflow for the fit to be measurable. -->
+	<TooltipProvider v-if="actions.length" :hover-delay="0" :skip-delay="0.5">
+		<div
+			ref="row"
+			class="flex items-center gap-1 [&>*]:shrink-0"
+			:class="vertical ? 'flex-col' : ''"
+		>
+			<!-- Named from the left while the width lasts; the rest keep to their tooltip. -->
+			<template v-for="(action, index) in actions.slice(0, visible)" :key="action.name">
+				<!-- The tag action is the picker's own trigger, so it opens where it was pressed. -->
+				<TagPicker
+					v-if="action.tagging"
+					:doctype="context.doctype"
+					:tags="tags"
+					:call="context.controller.page.call"
+					:vertical="vertical"
+					@add="people.addTag"
+					@remove="people.removeTag"
+				>
+					<template #trigger>
+						<!-- The trigger must own a box: Tooltip drops the attrs the popover anchors on. -->
+						<div class="flex shrink-0">
+							<Tooltip
+								:text="action.label"
+								:placement="placement"
+								:disabled="index < labelled"
+							>
+								<Button
+									:icon="index < labelled ? undefined : action.icon"
+									:icon-left="index < labelled ? action.icon : undefined"
+									:label="action.label"
+									:variant="vertical ? 'ghost' : 'subtle'"
+								/>
+							</Tooltip>
+						</div>
+					</template>
+				</TagPicker>
+
+				<Tooltip
+					v-else
+					:text="action.label"
+					:placement="placement"
+					:disabled="index < labelled"
+				>
+					<Button
+						:icon="index < labelled ? undefined : action.icon || 'lucide-zap'"
+						:icon-left="index < labelled ? action.icon : undefined"
+						:label="action.label"
+						:variant="vertical ? 'ghost' : 'subtle'"
+						@click="context.run(action)"
+					/>
+				</Tooltip>
+			</template>
+
+			<!-- The anchor overlays the trigger, so the picker opens under the menu it came from. -->
+			<div v-if="overflow.length" class="relative flex shrink-0">
+				<Dropdown :options="overflow" side="bottom" align="end">
 					<div class="flex shrink-0">
-						<Tooltip
-							:text="action.label"
-							:placement="placement"
-							:disabled="index < labelled"
-						>
+						<Tooltip text="More quick actions" :placement="placement">
 							<Button
-								:icon="index < labelled ? undefined : action.icon"
-								:icon-left="index < labelled ? action.icon : undefined"
-								:label="action.label"
-								:variant="vertical ? 'ghost' : 'subtle'"
+								icon="lucide-more-horizontal"
+								label="More quick actions"
+								variant="subtle"
 							/>
 						</Tooltip>
 					</div>
-				</template>
-			</TagPicker>
+				</Dropdown>
 
-			<Tooltip
-				v-else
-				:text="action.label"
-				:placement="placement"
-				:disabled="index < labelled"
-			>
-				<Button
-					:icon="index < labelled ? undefined : action.icon || 'lucide-zap'"
-					:icon-left="index < labelled ? action.icon : undefined"
-					:label="action.label"
-					:variant="vertical ? 'ghost' : 'subtle'"
-					@click="context.run(action)"
+				<TagPicker
+					v-if="taggingOverflowed"
+					v-model:open="picking"
+					anchored
+					:doctype="context.doctype"
+					:tags="tags"
+					:call="context.controller.page.call"
+					@add="people.addTag"
+					@remove="people.removeTag"
 				/>
-			</Tooltip>
-		</template>
-
-		<!-- The anchor overlays the trigger, so the picker opens under the menu it came from. -->
-		<div v-if="overflow.length" class="relative flex shrink-0">
-			<Dropdown :options="overflow" side="bottom" align="end">
-				<div class="flex shrink-0">
-					<Tooltip text="More quick actions" :placement="placement">
-						<Button
-							icon="lucide-more-horizontal"
-							label="More quick actions"
-							variant="subtle"
-						/>
-					</Tooltip>
-				</div>
-			</Dropdown>
-
-			<TagPicker
-				v-if="taggingOverflowed"
-				v-model:open="picking"
-				anchored
-				:doctype="context.doctype"
-				:tags="tags"
-				:call="context.controller.page.call"
-				@add="people.addTag"
-				@remove="people.removeTag"
-			/>
+			</div>
 		</div>
-	</div>
+	</TooltipProvider>
 </template>
 
 <script setup lang="ts">
 import { computed, inject, ref, useTemplateRef, watch } from "vue";
-import { Button, Dropdown, Tooltip } from "frappe-ui";
+import { Button, Dropdown, Tooltip, TooltipProvider } from "frappe-ui";
 import type { QuickAction } from "@/recordPage";
 import { PanelContextKey } from "./context";
 import { useFittedActions } from "./fittedActions";

--- a/frontend/src/pages/record/panel/RecordIdentity.vue
+++ b/frontend/src/pages/record/panel/RecordIdentity.vue
@@ -1,5 +1,5 @@
 <!-- The `identity` built-in: who this record is. Title, subtitle, image and tags; the tags
-     row draws only once the record has one. -->
+     row draws once the record has one, and until then the `tags` quick action adds the first. -->
 <template>
 	<div class="flex items-start gap-3">
 		<Avatar
@@ -19,10 +19,34 @@
 		<span
 			v-for="tag in tags"
 			:key="tag"
-			class="rounded-full border border-outline-gray-2 px-2 py-0.5 text-sm text-ink-gray-7"
+			class="group/tag flex items-center gap-1.5 rounded-full border border-outline-gray-2 py-0.5 pl-2 text-sm text-ink-gray-7"
+			:class="canWrite ? 'pr-1' : 'pr-2'"
 		>
+			<span
+				class="size-1.5 shrink-0 rounded-full"
+				:class="tagColor(tag)"
+				aria-hidden="true"
+			/>
 			{{ tag }}
+			<button
+				v-if="canWrite"
+				type="button"
+				class="grid size-4 place-content-center rounded-full text-ink-gray-4 opacity-0 transition hover:bg-surface-gray-3 hover:text-ink-gray-8 focus-visible:opacity-100 group-hover/tag:opacity-100"
+				:aria-label="`Remove ${tag}`"
+				@click="actions.removeTag(tag)"
+			>
+				<span class="lucide-x size-3.5" aria-hidden="true" />
+			</button>
 		</span>
+
+		<TagPicker
+			v-if="canWrite"
+			:doctype="context.doctype"
+			:tags="tags"
+			:call="context.controller.page.call"
+			@add="actions.addTag"
+			@remove="actions.removeTag"
+		/>
 	</div>
 </template>
 
@@ -30,8 +54,12 @@
 import { computed, inject } from "vue";
 import { Avatar } from "frappe-ui";
 import { PanelContextKey } from "./context";
+import { tagColor, tagsOf } from "./people";
+import { peopleActions } from "./peopleActions";
+import TagPicker from "./TagPicker.vue";
 
 const context = inject(PanelContextKey)!;
+const actions = peopleActions(context);
 
 const title = computed(() => {
 	const field = context.meta.value?.title_field;
@@ -48,10 +76,7 @@ const image = computed(() => {
 	return field ? (context.doc.value[field] as string | undefined) : undefined;
 });
 
-const tags = computed(() =>
-	(context.docinfo.value?.tags ?? "")
-		.split(",")
-		.map((tag) => tag.trim())
-		.filter(Boolean)
-);
+const tags = computed(() => tagsOf(context.docinfo.value));
+
+const canWrite = computed(() => Boolean(context.docinfo.value?.permissions?.write));
 </script>

--- a/frontend/src/pages/record/panel/RecordIdentity.vue
+++ b/frontend/src/pages/record/panel/RecordIdentity.vue
@@ -15,6 +15,9 @@
 		</div>
 	</div>
 
+	<!-- The quick actions, when the layout embeds them here. -->
+	<slot />
+
 	<div v-if="tags.length" class="flex flex-wrap items-center gap-1.5" data-tags>
 		<span
 			v-for="tag in tags"

--- a/frontend/src/pages/record/panel/RecordPanel.vue
+++ b/frontend/src/pages/record/panel/RecordPanel.vue
@@ -55,6 +55,7 @@ const props = defineProps<{
 	sections: LayoutSection[];
 	disclosure: Disclosure;
 	run: (action: QuickAction) => void;
+	reloadDocinfo: () => Promise<void>;
 }>();
 
 const emit = defineEmits<{ expand: [field: FieldNode] }>();
@@ -72,5 +73,6 @@ provide(PanelContextKey, {
 	docinfo: toRef(props, "docinfo"),
 	controller: props.controller,
 	run: props.run,
+	reloadDocinfo: props.reloadDocinfo,
 });
 </script>

--- a/frontend/src/pages/record/panel/RecordPeople.vue
+++ b/frontend/src/pages/record/panel/RecordPeople.vue
@@ -1,38 +1,63 @@
-<!-- The `people` built-in: who the record is assigned to and shared with, read from `docinfo`. -->
+<!-- The `people` built-in: who the record is assigned to and shared with, read from `docinfo`.
+     Each row edits with the right `docinfo.permissions` carries, and reads otherwise. -->
 <template>
-	<PeopleRow
-		label="Assigned to"
-		icon="lucide-user"
-		:people="assignees"
-		placeholder="Not assigned"
-	/>
-	<PeopleRow
-		label="Shared with"
-		icon="lucide-share-2"
-		:people="shares"
-		placeholder="Not shared"
-	/>
+	<PeopleRow label="Assigned to" icon="lucide-user">
+		<AssigneePicker
+			v-if="canWrite"
+			:assignees="assignees"
+			:call="page.call"
+			@assign="actions.assign"
+			@unassign="actions.unassign"
+		/>
+		<span v-else class="flex min-w-0 px-1.5 py-1">
+			<PeopleAvatars :people="assignees" placeholder="Not assigned" />
+		</span>
+	</PeopleRow>
+
+	<PeopleRow label="Shared with" icon="lucide-share-2">
+		<!-- w-fit: a grid child stretches, and the hover would run the column's whole width. -->
+		<button
+			v-if="canShare"
+			type="button"
+			class="flex w-fit min-w-0 items-center rounded-1 px-1.5 py-1 transition hover:bg-surface-gray-2"
+			:aria-label="shared.length ? 'Change who this record is shared with' : 'Share with…'"
+			data-share
+			@click="openShare"
+		>
+			<PeopleAvatars :people="shared" placeholder="Add people…" />
+		</button>
+		<span v-else class="flex min-w-0 px-1.5 py-1">
+			<PeopleAvatars :people="shared" placeholder="Not shared" />
+		</span>
+	</PeopleRow>
 </template>
 
 <script setup lang="ts">
-import { computed, inject } from "vue";
-import { PanelContextKey, personOf } from "./context";
+import { computed, inject, markRaw } from "vue";
+import AssigneePicker from "./AssigneePicker.vue";
+import { PanelContextKey } from "./context";
+import { assigneesOf, sharedWith } from "./people";
+import { peopleActions } from "./peopleActions";
+import PeopleAvatars from "./PeopleAvatars.vue";
 import PeopleRow from "./PeopleRow.vue";
+import ShareDialog from "./ShareDialog.vue";
 
 const context = inject(PanelContextKey)!;
+const page = context.controller.page;
+const actions = peopleActions(context);
 
-const assignees = computed(() =>
-	(context.docinfo.value?.assignments ?? []).map((row) =>
-		personOf(context.docinfo.value, row.owner)
-	)
-);
+const assignees = computed(() => assigneesOf(context.docinfo.value));
+const shared = computed(() => sharedWith(context.docinfo.value));
 
-// A share with everyone has no person to draw; it is named as such.
-const shares = computed(() =>
-	(context.docinfo.value?.shared ?? []).map((row) =>
-		row.everyone
-			? { id: "everyone", name: "Everyone" }
-			: personOf(context.docinfo.value, row.user)
-	)
-);
+const canWrite = computed(() => Boolean(context.docinfo.value?.permissions?.write));
+const canShare = computed(() => Boolean(context.docinfo.value?.permissions?.share));
+
+// The dialog reads the context, not a copy: a share it makes shows in its own list.
+function openShare() {
+	page.dialog.open(
+		markRaw(ShareDialog),
+		{ context: markRaw(context) },
+		{ title: "Share this record" }
+	);
+}
 </script>

--- a/frontend/src/pages/record/panel/ShareDialog.vue
+++ b/frontend/src/pages/record/panel/ShareDialog.vue
@@ -2,10 +2,11 @@
      people the record is shared with. The list is live, so a share shows as soon as it is re-read. -->
 <template>
 	<div class="flex flex-col gap-3" data-share-dialog>
+		<!-- `''`, not `null`: unset, reka keeps the pick as its own value and writes the
+		     label back into the input. -->
 		<Combobox
 			autofocus
-			trigger="button"
-			:modelValue="null"
+			:modelValue="''"
 			:query="query"
 			:options="options"
 			:loading="loading"
@@ -75,7 +76,7 @@ const { options, loading, error, search, searchSoon } = useUserSearch(
 	pinned
 );
 
-// Listening to the query owns it, and a pick writes the label into it, so every open resets both.
+// Listening to the query owns it, so every open resets it and the list.
 const query = ref("");
 
 function onOpen(shown: boolean) {

--- a/frontend/src/pages/record/panel/ShareDialog.vue
+++ b/frontend/src/pages/record/panel/ShareDialog.vue
@@ -1,0 +1,95 @@
+<!-- The body of the share dialog, opened through `page.dialog.open`: a user picker above the
+     people the record is shared with. The list is live, so a share shows as soon as it is re-read. -->
+<template>
+	<div class="flex flex-col gap-3" data-share-dialog>
+		<Combobox
+			autofocus
+			trigger="button"
+			:modelValue="null"
+			:query="query"
+			:options="options"
+			:loading="loading"
+			:filterable="false"
+			:empty-text="error || 'No users found'"
+			placeholder="Add people by name or email"
+			@update:modelValue="shareWith"
+			@update:query="onQuery"
+			@update:open="onOpen"
+		>
+			<template #item-prefix="{ item }">
+				<Avatar :label="item.label" :image="(item as SearchOption).image" size="sm" />
+			</template>
+		</Combobox>
+
+		<div class="flex flex-col">
+			<div
+				v-for="person in shared"
+				:key="person.id"
+				class="group/share flex items-center gap-2 py-1.5"
+				data-shared-with
+			>
+				<Avatar :label="person.name" :image="person.image" size="md" />
+				<span class="truncate text-base text-ink-gray-8">{{ person.name }}</span>
+				<span class="ml-auto text-base text-ink-gray-5">
+					{{ person.canWrite ? "Can edit" : "Can view" }}
+				</span>
+				<Button
+					class="opacity-0 transition focus-visible:opacity-100 group-hover/share:opacity-100"
+					icon="lucide-x"
+					variant="ghost"
+					:aria-label="`Stop sharing with ${person.name}`"
+					@click="actions.unshare(person.id, person.everyone)"
+				/>
+			</div>
+
+			<p v-if="!shared.length" class="py-1.5 text-base text-ink-gray-5">
+				This record is not shared with anyone.
+			</p>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { Avatar, Button, Combobox } from "frappe-ui";
+import type { PanelContext } from "./context";
+import { sharedWith } from "./people";
+import { peopleActions } from "./peopleActions";
+import { useUserSearch, type SearchOption } from "./remoteSearch";
+
+// `close` is the host's; the dialog stays open across shares, so it is never called here.
+const props = defineProps<{ context: PanelContext; close: (result?: any) => void }>();
+
+const actions = peopleActions(props.context);
+
+const shared = computed(() => sharedWith(props.context.docinfo.value));
+
+const pinned = computed<SearchOption[]>(() =>
+	shared.value
+		.filter((person) => !person.everyone)
+		.map(({ id, name, image }) => ({ label: name, value: id, image }))
+);
+
+const { options, loading, error, search, searchSoon } = useUserSearch(
+	props.context.controller.page.call,
+	pinned
+);
+
+// Listening to the query owns it, and a pick writes the label into it, so every open resets both.
+const query = ref("");
+
+function onOpen(shown: boolean) {
+	if (!shown) return;
+	query.value = "";
+	search("");
+}
+
+function onQuery(text: string) {
+	query.value = text;
+	searchSoon(text);
+}
+
+function shareWith(user: string | number | null) {
+	if (user) actions.share(String(user));
+}
+</script>

--- a/frontend/src/pages/record/panel/TagPicker.vue
+++ b/frontend/src/pages/record/panel/TagPicker.vue
@@ -1,7 +1,10 @@
 <!-- A tag picker with a create row: a pick adds, an unpick removes. The trigger is the "+"
-     chip among the record's tags, or whatever the slot supplies. -->
+     chip among the record's tags, whatever the slot supplies, or a bare anchor when
+     something else does the opening. -->
 <template>
+	<!-- `open` is bound only for the anchor: an undefined boolean prop reads as false. -->
 	<MultiSelect
+		v-bind="anchored ? { open } : {}"
 		:modelValue="tags"
 		:query="query"
 		:options="options"
@@ -12,10 +15,12 @@
 		:side="vertical ? 'left' : 'bottom'"
 		@update:modelValue="retag"
 		@update:query="onQuery"
-		@update:open="onOpen"
+		@update:open="(opened: boolean) => (open = opened)"
 	>
 		<template #trigger>
-			<slot name="trigger">
+			<!-- It only positions the popover; taking clicks would swallow the trigger it covers. -->
+			<div v-if="anchored" class="pointer-events-none absolute inset-0" aria-hidden="true" />
+			<slot v-else name="trigger">
 				<button
 					type="button"
 					class="grid size-5 place-content-center rounded-full text-sm text-ink-gray-5 transition hover:bg-surface-gray-3 hover:text-ink-gray-8"
@@ -51,7 +56,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 import { MultiSelect } from "frappe-ui";
 import { canCreateTag, listDiff, matchingTags, tagColor } from "./people";
 import { useTagSearch, type SearchOption } from "./remoteSearch";
@@ -62,9 +67,14 @@ const props = defineProps<{
 	call: (method: string, params?: Record<string, any>) => Promise<any>;
 	/** Opens beside the collapsed strip instead of below. */
 	vertical?: boolean;
+	/** Overlays whatever it sits on and opens from `open` alone. */
+	anchored?: boolean;
 }>();
 
 const emit = defineEmits<{ add: [string]; remove: [string] }>();
+
+// Left undefined the picker owns its own open state, which is what every trigger but the anchor wants.
+const open = defineModel<boolean | undefined>("open", { default: undefined });
 
 const query = ref("");
 
@@ -79,12 +89,13 @@ const { options, loading, error, search, searchSoon } = useTagSearch(
 	pinned
 );
 
-// Listening to the query owns it, so every open resets it and the list.
-function onOpen(open: boolean) {
-	if (!open) return;
+// Listening to the query owns it, so every open resets it and the list. Watched, not
+// handled: opened from the anchor, the picker never fires update:open.
+watch(open, (opened) => {
+	if (!opened) return;
 	query.value = "";
 	search("");
-}
+});
 
 function onQuery(text: string) {
 	query.value = text;

--- a/frontend/src/pages/record/panel/TagPicker.vue
+++ b/frontend/src/pages/record/panel/TagPicker.vue
@@ -1,0 +1,113 @@
+<!-- A tag picker with a create row: a pick adds, an unpick removes. The trigger is the "+"
+     chip among the record's tags, or whatever the slot supplies. -->
+<template>
+	<MultiSelect
+		:modelValue="tags"
+		:query="query"
+		:options="options"
+		:loading="loading"
+		:filterable="false"
+		:empty-text="error || 'No tags found'"
+		placeholder="Search or create tags"
+		:side="vertical ? 'left' : 'bottom'"
+		@update:modelValue="retag"
+		@update:query="onQuery"
+		@update:open="onOpen"
+	>
+		<template #trigger>
+			<slot name="trigger">
+				<button
+					type="button"
+					class="grid size-5 place-content-center rounded-full text-sm text-ink-gray-5 transition hover:bg-surface-gray-3 hover:text-ink-gray-8"
+					aria-label="Add tag"
+					data-add-tag
+				>
+					<span class="lucide-plus size-3.5" aria-hidden="true" />
+				</button>
+			</slot>
+		</template>
+
+		<template #item-prefix="{ item }">
+			<span
+				class="size-2 shrink-0 rounded-full"
+				:class="tagColor(item.label)"
+				aria-hidden="true"
+			/>
+		</template>
+
+		<template #footer>
+			<button
+				v-if="canCreate"
+				type="button"
+				class="flex w-full items-center gap-2 rounded-1 px-2 py-1.5 text-base text-ink-gray-6 hover:bg-surface-gray-2"
+				data-create-tag
+				@click="create()"
+			>
+				<span class="lucide-plus size-3.5 shrink-0" aria-hidden="true" />
+				<span class="truncate">Create “{{ query.trim() }}”</span>
+			</button>
+		</template>
+	</MultiSelect>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { MultiSelect } from "frappe-ui";
+import { canCreateTag, listDiff, matchingTags, tagColor } from "./people";
+import { useTagSearch, type SearchOption } from "./remoteSearch";
+
+const props = defineProps<{
+	doctype: string;
+	tags: string[];
+	call: (method: string, params?: Record<string, any>) => Promise<any>;
+	/** Opens beside the collapsed strip instead of below. */
+	vertical?: boolean;
+}>();
+
+const emit = defineEmits<{ add: [string]; remove: [string] }>();
+
+const query = ref("");
+
+// The record's own tags fill the gaps a paged answer leaves, so one already on it is never offered as new.
+const pinned = computed<SearchOption[]>(() =>
+	matchingTags(props.tags, query.value).map((tag) => ({ label: tag, value: tag }))
+);
+
+const { options, loading, error, search, searchSoon } = useTagSearch(
+	props.call,
+	props.doctype,
+	pinned
+);
+
+// Listening to the query owns it, so every open resets it and the list.
+function onOpen(open: boolean) {
+	if (!open) return;
+	query.value = "";
+	search("");
+}
+
+function onQuery(text: string) {
+	query.value = text;
+	searchSoon(text);
+}
+
+const canCreate = computed(() =>
+	canCreateTag(
+		options.value.map((option) => option.value),
+		query.value
+	)
+);
+
+// The selection is server state: each pick fires one write and the re-read repaints it.
+function retag(picked: (string | number)[]) {
+	const { added, dropped } = listDiff(picked.map(String), props.tags);
+	added.forEach((tag) => emit("add", tag));
+	dropped.forEach((tag) => emit("remove", tag));
+}
+
+function create() {
+	emit("add", query.value.trim());
+	query.value = "";
+	search("");
+}
+</script>

--- a/frontend/src/pages/record/panel/context.ts
+++ b/frontend/src/pages/record/panel/context.ts
@@ -5,7 +5,7 @@ import type { QuickAction, RecordPageController } from "@/recordPage";
 /** `getdoc`'s sidecar, the parts the panel reads; the rest is not typed here. */
 export interface DocInfo {
 	assignments?: { owner: string; description?: string }[];
-	shared?: { user: string; everyone?: 0 | 1 }[];
+	shared?: { user: string; everyone?: 0 | 1; write?: 0 | 1 }[];
 	tags?: string;
 	user_info?: Record<string, { fullname?: string; image?: string }>;
 	permissions?: Record<string, any>;
@@ -19,6 +19,8 @@ export interface PanelContext {
 	docinfo: Ref<DocInfo | null>;
 	controller: RecordPageController;
 	run: (action: QuickAction) => void;
+	/** Re-reads the sidecar alone, after an assign, share or tag. */
+	reloadDocinfo: () => Promise<void>;
 }
 
 export const PanelContextKey: InjectionKey<PanelContext> = Symbol("record-panel");

--- a/frontend/src/pages/record/panel/fittedActions.ts
+++ b/frontend/src/pages/record/panel/fittedActions.ts
@@ -1,0 +1,48 @@
+// How much of an action row fits: how many leading items wear their label, and how many
+// stay in the row at all. What is left over belongs in an overflow menu.
+import { nextTick, ref, watch, type Ref } from "vue";
+import { useResizeObserver } from "@vueuse/core";
+
+// The row must span its container, never shrink-wrap its content: otherwise naming an
+// item resizes the row, and the observer refits forever.
+export function useFittedActions(
+	row: Ref<HTMLElement | null>,
+	total: () => number,
+	fitting: () => boolean
+) {
+	const labelled = ref(fitting() ? total() : 0);
+	const visible = ref(total());
+	let attempt = 0;
+
+	// Labels go first, then whole items, so the row degrades before it hides anything.
+	async function fit() {
+		const element = row.value;
+		if (!element) return;
+		const token = ++attempt;
+		labelled.value = fitting() ? total() : 0;
+		visible.value = total();
+		await nextTick();
+		if (!fitting()) return;
+		await shrink(element, labelled, 1, token);
+		await shrink(element, visible, 1, token);
+	}
+
+	// Each drop is measured against real layout; nextTick is a microtask, so the browser
+	// never paints an oversized row.
+	async function shrink(element: HTMLElement, count: Ref<number>, floor: number, token: number) {
+		while (token === attempt && count.value > floor && overflowing(element)) {
+			count.value--;
+			await nextTick();
+		}
+	}
+
+	useResizeObserver(row, fit);
+	// The row is a source: the observer's first measure has no ref to watch at setup.
+	watch([row, total, fitting], fit, { flush: "post" });
+
+	return { labelled, visible, fit };
+}
+
+function overflowing(element: HTMLElement) {
+	return element.scrollWidth > element.clientWidth;
+}

--- a/frontend/src/pages/record/panel/panelEntries.ts
+++ b/frontend/src/pages/record/panel/panelEntries.ts
@@ -15,6 +15,8 @@ export interface PanelEntry {
 	fields: FieldNode[];
 	component?: Component;
 	props?: Record<string, any>;
+	/** An item drawn inside this one's component instead of as a section of its own. */
+	embedded?: PanelEntry;
 }
 
 /** One section of the layout as the surface addresses it: named, and labelled only when it shows a label. */
@@ -72,6 +74,23 @@ export function panelEntries(items: PanelSectionItem[], sections: LayoutSection[
 			props: section ? undefined : item.props,
 		};
 	});
+}
+
+/**
+ * The quick actions right after the identity draw inside it, between its title and its
+ * tags: one block to the eye. Moved anywhere else, or given a header, they are a section
+ * like any other.
+ */
+export function embedQuickActions(entries: PanelEntry[]): PanelEntry[] {
+	return entries.flatMap((entry, index) => {
+		if (embeds(entry, entries[index + 1])) return [{ ...entry, embedded: entries[index + 1] }];
+		if (embeds(entries[index - 1], entry)) return [];
+		return [entry];
+	});
+}
+
+function embeds(host?: PanelEntry, next?: PanelEntry) {
+	return host?.name === "identity" && next?.name === "quick_actions" && !next.label;
 }
 
 // The panel is one column, so a section's columns flatten into one list.

--- a/frontend/src/pages/record/panel/people.ts
+++ b/frontend/src/pages/record/panel/people.ts
@@ -1,0 +1,74 @@
+// What `docinfo` says about the record's people and tags, and the list arithmetic the pickers need.
+import { personOf, type DocInfo } from "./context";
+
+export interface Person {
+	id: string;
+	name: string;
+	image?: string;
+}
+
+export interface SharedPerson extends Person {
+	everyone: boolean;
+	canWrite: boolean;
+}
+
+export function assigneesOf(docinfo: DocInfo | null): Person[] {
+	return (docinfo?.assignments ?? []).map((row) => personOf(docinfo, row.owner));
+}
+
+// A share with everyone has no person to draw; it is named as such.
+export function sharedWith(docinfo: DocInfo | null): SharedPerson[] {
+	return (docinfo?.shared ?? []).map((row) => ({
+		...(row.everyone ? { id: "everyone", name: "Everyone" } : personOf(docinfo, row.user)),
+		everyone: Boolean(row.everyone),
+		canWrite: Boolean(row.write),
+	}));
+}
+
+/** `getdoc` joins the tags with commas. */
+export function tagsOf(docinfo: DocInfo | null): string[] {
+	return (docinfo?.tags ?? "")
+		.split(",")
+		.map((tag) => tag.trim())
+		.filter(Boolean);
+}
+
+/** What a new selection adds and drops against the one it replaces. */
+export function listDiff(picked: string[], current: string[]) {
+	return {
+		added: picked.filter((value) => !current.includes(value)),
+		dropped: current.filter((value) => !picked.includes(value)),
+	};
+}
+
+export function matchingTags(known: string[], query: string): string[] {
+	const wanted = normalize(query);
+	return known.filter((tag) => normalize(tag).includes(wanted));
+}
+
+// The server joins tags with commas, so a name with one would come back as two.
+export function canCreateTag(known: string[], query: string): boolean {
+	const wanted = normalize(query);
+	if (!wanted || wanted.includes(",")) return false;
+	return !known.some((tag) => normalize(tag) === wanted);
+}
+
+const PALETTE = [
+	"bg-blue-500",
+	"bg-green-500",
+	"bg-amber-500",
+	"bg-violet-500",
+	"bg-pink-500",
+	"bg-red-500",
+];
+
+/** Colour follows the tag's name, so the same tag looks the same on every record. */
+export function tagColor(tag: string): string {
+	let hash = 0;
+	for (const character of tag) hash = (hash * 31 + character.charCodeAt(0)) % 997;
+	return PALETTE[hash % PALETTE.length];
+}
+
+function normalize(text: string) {
+	return text.trim().toLowerCase();
+}

--- a/frontend/src/pages/record/panel/peopleActions.ts
+++ b/frontend/src/pages/record/panel/peopleActions.ts
@@ -1,0 +1,44 @@
+// The six writes the people editors make, each followed by a re-read of `docinfo`.
+import { errorMessage } from "@/recordPage";
+import type { PanelContext } from "./context";
+
+export function peopleActions(context: PanelContext) {
+	const { doctype, docname, controller, reloadDocinfo } = context;
+	const page = controller.page;
+
+	// The answer is discarded: only the re-read paints, so the row never disagrees with the server.
+	async function send(method: string, params: Record<string, any>) {
+		try {
+			await page.call(method, params);
+		} catch (caught) {
+			page.toast.error(errorMessage(caught));
+			return;
+		}
+		await reloadDocinfo();
+	}
+
+	return {
+		assign: (user: string) =>
+			send("frappe.desk.form.assign_to.add", { doctype, name: docname, assign_to: [user] }),
+		unassign: (user: string) =>
+			send("frappe.desk.form.assign_to.remove", { doctype, name: docname, assign_to: user }),
+		share: (user: string) =>
+			send("frappe.share.add", { doctype, name: docname, user, read: 1, write: 1 }),
+		// Dropping read drops the higher rights with it, and the empty share deletes itself.
+		unshare: (user: string, everyone = false) =>
+			send("frappe.share.set_permission", {
+				doctype,
+				name: docname,
+				user: everyone ? null : user,
+				permission_to: "read",
+				value: 0,
+				everyone: everyone ? 1 : 0,
+			}),
+		addTag: (tag: string) =>
+			send("frappe.desk.doctype.tag.tag.add_tag", { tag, dt: doctype, dn: docname }),
+		removeTag: (tag: string) =>
+			send("frappe.desk.doctype.tag.tag.remove_tag", { tag, dt: doctype, dn: docname }),
+	};
+}
+
+export type PeopleActions = ReturnType<typeof peopleActions>;

--- a/frontend/src/pages/record/panel/peopleActions.ts
+++ b/frontend/src/pages/record/panel/peopleActions.ts
@@ -7,14 +7,14 @@ export function peopleActions(context: PanelContext) {
 	const page = controller.page;
 
 	// The answer is discarded: only the re-read paints, so the row never disagrees with the server.
+	// A failed re-read toasts too: the write landed, and the row is now stale.
 	async function send(method: string, params: Record<string, any>) {
 		try {
 			await page.call(method, params);
+			await reloadDocinfo();
 		} catch (caught) {
 			page.toast.error(errorMessage(caught));
-			return;
 		}
-		await reloadDocinfo();
 	}
 
 	return {

--- a/frontend/src/pages/record/panel/remoteSearch.ts
+++ b/frontend/src/pages/record/panel/remoteSearch.ts
@@ -1,0 +1,92 @@
+// Options matched on the server as the reader types, for the assign, share and tag pickers.
+import { computed, ref, type Ref } from "vue";
+import { useDebounceFn } from "@vueuse/core";
+import { errorMessage } from "@/recordPage";
+
+export type SearchOption = { label: string; value: string; image?: string };
+
+type Call = (method: string, params?: Record<string, any>) => Promise<any>;
+
+const PAGE_LENGTH = 10;
+
+export function useUserSearch(call: Call, pinned: Ref<SearchOption[]>) {
+	return useRemoteSearch((query) => searchUsers(call, query), pinned);
+}
+
+export function useTagSearch(call: Call, doctype: string, pinned: Ref<SearchOption[]>) {
+	return useRemoteSearch((query) => searchTags(call, doctype, query), pinned);
+}
+
+/** The server's answer with the pinned options filling its gaps; a stale answer is dropped. */
+export function useRemoteSearch<Option extends SearchOption>(
+	fetchOptions: (query: string) => Promise<Option[]>,
+	pinned: Ref<Option[]>
+) {
+	const results = ref<Option[]>([]) as Ref<Option[]>;
+	const loading = ref(false);
+	const error = ref("");
+	const searched = ref(false);
+
+	let latestRequest = 0;
+
+	async function search(query = "") {
+		const request = ++latestRequest;
+		loading.value = true;
+		try {
+			const found = await fetchOptions(query);
+			if (request !== latestRequest) return;
+			results.value = found;
+			error.value = "";
+			searched.value = true;
+		} catch (caught) {
+			if (request !== latestRequest) return;
+			error.value = errorMessage(caught);
+		} finally {
+			if (request === latestRequest) loading.value = false;
+		}
+	}
+
+	const searchSoon = useDebounceFn(search, 250);
+
+	// The server's order wins, so picking a pinned option never reorders the list under the pointer.
+	const options = computed(() => {
+		const shown = new Map(results.value.map((option) => [option.value, option]));
+		for (const option of pinned.value) if (!shown.has(option.value)) shown.set(option.value, option);
+		return [...shown.values()];
+	});
+
+	return { options, loading, error, searched, search, searchSoon };
+}
+
+async function searchUsers(call: Call, query: string): Promise<SearchOption[]> {
+	const rows: any[] = await call("frappe.client.get_list", {
+		doctype: "User",
+		fields: ["name", "full_name", "user_image"],
+		filters: [
+			["enabled", "=", 1],
+			["user_type", "=", "System User"],
+			["name", "not in", ["Administrator", "Guest"]],
+		],
+		or_filters: query
+			? [
+					["full_name", "like", `%${query}%`],
+					["name", "like", `%${query}%`],
+			  ]
+			: undefined,
+		order_by: "full_name asc",
+		limit_page_length: PAGE_LENGTH,
+	});
+	return rows.map((row) => ({
+		label: row.full_name || row.name,
+		value: row.name,
+		image: row.user_image || "",
+	}));
+}
+
+async function searchTags(call: Call, doctype: string, query: string): Promise<SearchOption[]> {
+	const found: string[] = await call("frappe.desk.doctype.tag.tag.get_tags", {
+		doctype,
+		txt: query.trim(),
+	});
+	return (found ?? []).map((tag) => ({ label: tag, value: tag }));
+}

--- a/frontend/src/pages/record/panel/tests/fittedActions.test.ts
+++ b/frontend/src/pages/record/panel/tests/fittedActions.test.ts
@@ -1,0 +1,62 @@
+// The quick actions row's fit: labels go first, then whole items, measured against the row.
+import { describe, expect, it } from "vitest";
+import { nextTick, ref } from "vue";
+import { useFittedActions } from "../fittedActions";
+
+// A row whose width follows the fit: each label is 40 wide, each icon 20, until it fits `room`.
+function rowFor(room: number, counts: { labelled: () => number; visible: () => number }) {
+	return {
+		get clientWidth() {
+			return room;
+		},
+		get scrollWidth() {
+			return counts.labelled() * 40 + (counts.visible() - counts.labelled()) * 20;
+		},
+	} as unknown as HTMLElement;
+}
+
+async function settle() {
+	for (let i = 0; i < 12; i++) await nextTick();
+}
+
+describe("useFittedActions", () => {
+	it("names every item when the row has room", async () => {
+		const total = ref(3);
+		const row = ref<HTMLElement | null>(null);
+		const fit = useFittedActions(row, () => total.value, () => true);
+		row.value = rowFor(200, { labelled: () => fit.labelled.value, visible: () => fit.visible.value });
+		await settle();
+		expect([fit.labelled.value, fit.visible.value]).toEqual([3, 3]);
+	});
+
+	it("drops labels from the right before it hides anything", async () => {
+		const total = ref(3);
+		const row = ref<HTMLElement | null>(null);
+		const fit = useFittedActions(row, () => total.value, () => true);
+		row.value = rowFor(85, { labelled: () => fit.labelled.value, visible: () => fit.visible.value });
+		await settle();
+		// 40 + 20 + 20 = 80 fits; 40 + 40 + 20 does not.
+		expect([fit.labelled.value, fit.visible.value]).toEqual([1, 3]);
+	});
+
+	it("hides trailing items once no label is left to drop, keeping one", async () => {
+		const total = ref(4);
+		const row = ref<HTMLElement | null>(null);
+		const fit = useFittedActions(row, () => total.value, () => true);
+		row.value = rowFor(75, { labelled: () => fit.labelled.value, visible: () => fit.visible.value });
+		await settle();
+		// One label and two icons is 80; one label and one icon is 60.
+		expect([fit.labelled.value, fit.visible.value]).toEqual([1, 2]);
+		total.value = 1;
+		await settle();
+		expect([fit.labelled.value, fit.visible.value]).toEqual([1, 1]);
+	});
+
+	it("names nothing and hides nothing when not fitting", async () => {
+		const row = ref<HTMLElement | null>(null);
+		const fit = useFittedActions(row, () => 5, () => false);
+		row.value = rowFor(10, { labelled: () => 0, visible: () => 5 });
+		await settle();
+		expect([fit.labelled.value, fit.visible.value]).toEqual([0, 5]);
+	});
+});

--- a/frontend/src/pages/record/panel/tests/panelLayout.test.ts
+++ b/frontend/src/pages/record/panel/tests/panelLayout.test.ts
@@ -32,7 +32,14 @@ const LAYOUT: FormLayoutSchema = [
 	},
 ] as any;
 
-const Identity = defineComponent({ render: () => h("div", { "data-builtin": "identity" }) });
+const Identity = defineComponent({
+	render() {
+		return h("div", { "data-builtin": "identity" }, this.$slots.default?.());
+	},
+});
+const QuickActions = defineComponent({
+	render: () => h("div", { "data-builtin": "quick_actions" }),
+});
 const People = defineComponent({ render: () => h("div", { "data-builtin": "people" }) });
 
 const mounted: ReturnType<typeof createApp>[] = [];
@@ -51,6 +58,7 @@ async function mount(surface: Surface<PanelSectionItem>, opened: Record<string, 
 	const sections = layoutSections(LAYOUT, doc.value);
 	surface.provideBuiltins(() => [
 		{ name: "identity", component: Identity },
+		{ name: "quick_actions", component: QuickActions },
 		{ name: "people", component: People },
 		...layoutItems(sections),
 	]);
@@ -92,6 +100,35 @@ describe("one list", () => {
 		const { root } = await mount(new Surface<PanelSectionItem>());
 		const bodies = [...root.querySelectorAll<HTMLElement>("[data-section]")];
 		expect(bodies.map((el) => el.classList.contains("border-t"))).toEqual([false, true, true]);
+	});
+
+	it("draws the quick actions inside the identity, and apart once moved off it", async () => {
+		const embedded = await mount(new Surface<PanelSectionItem>());
+		expect(
+			embedded.root.querySelector("[data-builtin='identity'] [data-builtin='quick_actions']")
+		).not.toBeNull();
+
+		const surface = new Surface<PanelSectionItem>();
+		surface.move("quick_actions", { after: "people" });
+		const moved = await mount(surface);
+		expect(names(moved.root)).toEqual([
+			"identity",
+			"people",
+			"quick_actions",
+			"organization_section",
+		]);
+		const apart = moved.root.querySelector<HTMLElement>("[data-section='quick_actions']")!;
+		expect(apart.classList.contains("border-t")).toBe(true);
+		expect(apart.querySelector("[data-builtin='quick_actions']")).not.toBeNull();
+	});
+
+	it("keeps the quick actions a section of their own once a script gives them a header", async () => {
+		const surface = new Surface<PanelSectionItem>();
+		surface.update("quick_actions", { label: "Actions" });
+		const { root } = await mount(surface);
+		expect(root.querySelector("[data-builtin='identity'] [data-builtin='quick_actions']")).toBeNull();
+		expect(root.textContent).toContain("Actions");
+		expect(root.querySelector("[data-builtin='quick_actions']")).not.toBeNull();
 	});
 
 	it("hides one section by name and its neighbour stands", async () => {

--- a/frontend/src/pages/record/panel/tests/people.test.ts
+++ b/frontend/src/pages/record/panel/tests/people.test.ts
@@ -1,0 +1,69 @@
+// What `docinfo` says about people and tags, and the list arithmetic behind each pick.
+import { describe, expect, it } from "vitest";
+import {
+	assigneesOf,
+	canCreateTag,
+	listDiff,
+	matchingTags,
+	sharedWith,
+	tagColor,
+	tagsOf,
+} from "../people";
+
+const docinfo = {
+	assignments: [{ owner: "ann@example.com" }, { owner: "bob@example.com" }],
+	shared: [
+		{ user: "ann@example.com", write: 1 as const },
+		{ user: "", everyone: 1 as const },
+	],
+	tags: "urgent, q3 ,,",
+	user_info: { "ann@example.com": { fullname: "Ann", image: "/ann.png" } },
+};
+
+describe("people", () => {
+	it("names an assignee from user_info and falls back to the id", () => {
+		expect(assigneesOf(docinfo)).toEqual([
+			{ id: "ann@example.com", name: "Ann", image: "/ann.png" },
+			{ id: "bob@example.com", name: "bob@example.com", image: undefined },
+		]);
+	});
+
+	it("draws a share with everyone as such, and carries the write right", () => {
+		expect(sharedWith(docinfo)).toEqual([
+			{ id: "ann@example.com", name: "Ann", image: "/ann.png", everyone: false, canWrite: true },
+			{ id: "everyone", name: "Everyone", everyone: true, canWrite: false },
+		]);
+	});
+
+	it("reads nothing from a sidecar that has not landed", () => {
+		expect(assigneesOf(null)).toEqual([]);
+		expect(sharedWith(null)).toEqual([]);
+		expect(tagsOf(null)).toEqual([]);
+	});
+
+	it("splits the comma-joined tags", () => {
+		expect(tagsOf(docinfo)).toEqual(["urgent", "q3"]);
+	});
+});
+
+describe("picks", () => {
+	it("tells what a new selection adds and drops", () => {
+		expect(listDiff(["a", "c"], ["a", "b"])).toEqual({ added: ["c"], dropped: ["b"] });
+	});
+
+	it("matches the record's own tags case-insensitively", () => {
+		expect(matchingTags(["Urgent", "later"], "URG")).toEqual(["Urgent"]);
+	});
+
+	it("offers to create a tag only when the query names none that exist", () => {
+		expect(canCreateTag(["urgent"], " Urgent ")).toBe(false);
+		expect(canCreateTag(["urgent"], "")).toBe(false);
+		expect(canCreateTag(["urgent"], "a, b")).toBe(false);
+		expect(canCreateTag(["urgent"], "later")).toBe(true);
+	});
+
+	it("colours a tag by its name, the same on every record", () => {
+		expect(tagColor("urgent")).toBe(tagColor("urgent"));
+		expect(tagColor("urgent")).toMatch(/^bg-/);
+	});
+});

--- a/frontend/src/pages/record/panel/tests/quickActionsOverflow.test.ts
+++ b/frontend/src/pages/record/panel/tests/quickActionsOverflow.test.ts
@@ -34,6 +34,7 @@ vi.mock("frappe-ui", () => {
 		}),
 		Button: Plain("button"),
 		Tooltip: Plain("span"),
+		TooltipProvider: Plain("div"),
 	};
 });
 

--- a/frontend/src/pages/record/panel/tests/quickActionsOverflow.test.ts
+++ b/frontend/src/pages/record/panel/tests/quickActionsOverflow.test.ts
@@ -1,0 +1,95 @@
+// The quick actions row's overflow: a folded tag action opens its picker anchored under
+// the menu, and the anchor's open flag does not outlive the action.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApp, defineComponent, h, nextTick, ref } from "vue";
+
+vi.mock("../fittedActions", () => ({
+	useFittedActions: () => ({ labelled: ref(0), visible: ref(0), fit: vi.fn() }),
+}));
+
+const seen = vi.hoisted(() => ({ open: [] as unknown[] }));
+
+vi.mock("frappe-ui", () => {
+	const Plain = (tag: string) =>
+		defineComponent({ setup: (_, { slots }) => () => h(tag, slots.default?.()) });
+	return {
+		MultiSelect: defineComponent({
+			props: ["open"],
+			setup(props, { slots }) {
+				return () => {
+					seen.open.push(props.open);
+					return h("div", { "data-picker": "" }, slots.trigger?.({ open: false }));
+				};
+			},
+		}),
+		Dropdown: defineComponent({
+			props: ["options"],
+			setup: (props, { slots }) => () =>
+				h("div", [
+					slots.default?.(),
+					...props.options.map((option: any) =>
+						h("button", { "data-menu-row": option.label, onClick: option.onClick })
+					),
+				]),
+		}),
+		Button: Plain("button"),
+		Tooltip: Plain("span"),
+	};
+});
+
+import { PanelContextKey } from "../context";
+import QuickActions from "../QuickActions.vue";
+
+const mounted: ReturnType<typeof createApp>[] = [];
+
+afterEach(() => {
+	for (const app of mounted.splice(0)) app.unmount();
+	document.body.innerHTML = "";
+	seen.open.splice(0);
+});
+
+function mount(actions: ReturnType<typeof ref<any[]>>) {
+	const root = document.createElement("div");
+	document.body.appendChild(root);
+	const app = createApp(defineComponent({ render: () => h(QuickActions) }));
+	app.provide(PanelContextKey, {
+		doctype: "CRM Deal",
+		docname: "D-1",
+		doc: ref({}),
+		meta: ref(null),
+		docinfo: ref({ permissions: { write: 1 } }),
+		controller: { page: { call: vi.fn() }, quickActions: { visible: () => actions.value } } as any,
+		run: vi.fn(),
+		reloadDocinfo: vi.fn(async () => {}),
+	});
+	app.mount(root);
+	mounted.push(app);
+	return root;
+}
+
+describe("the overflow", () => {
+	it("folds every action into the menu, and the Tags row opens the anchored picker", async () => {
+		const actions = ref<any[]>([
+			{ name: "print", label: "Print", icon: "lucide-printer" },
+			{ name: "tags", label: "Tags", icon: "lucide-tag", tagging: true },
+		]);
+		const root = mount(actions);
+		expect(root.querySelectorAll("[data-menu-row]")).toHaveLength(2);
+		expect(seen.open.at(-1)).toBe(false);
+		root.querySelector<HTMLElement>("[data-menu-row='Tags']")!.click();
+		await nextTick();
+		expect(seen.open.at(-1)).toBe(true);
+
+		// The pick tags the record and the action goes; a later return must not pop the picker open.
+		actions.value = [{ name: "print", label: "Print", icon: "lucide-printer" }];
+		await nextTick();
+		expect(root.querySelector("[data-picker]")).toBeNull();
+		actions.value = [
+			{ name: "print", label: "Print", icon: "lucide-printer" },
+			{ name: "tags", label: "Tags", icon: "lucide-tag", tagging: true },
+		];
+		await nextTick();
+		await nextTick();
+		expect(seen.open.at(-1)).toBe(false);
+	});
+});

--- a/frontend/src/pages/record/panel/tests/recordPeople.test.ts
+++ b/frontend/src/pages/record/panel/tests/recordPeople.test.ts
@@ -1,0 +1,270 @@
+// The people editors on the panel: gated by the record's rights, each pick one write through
+// `page.call`, and the sidecar re-read after it.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApp, defineComponent, h, nextTick, ref } from "vue";
+
+// The pickers are stubbed to their trigger: `pick` stands in for a selection made inside.
+const stub = vi.hoisted(() => ({ nextPick: [] as string[] | string, nextQuery: "" }));
+
+vi.mock("frappe-ui", () => {
+	const Picker = defineComponent({
+		emits: ["update:modelValue", "update:query", "update:open"],
+		setup(_, { slots, emit }) {
+			return () =>
+				h("div", { "data-picker": "" }, [
+					slots.trigger?.({ open: false }),
+					h("button", {
+						"data-pick": "",
+						onClick: () => {
+							emit("update:query", stub.nextQuery);
+							emit("update:modelValue", stub.nextPick);
+						},
+					}),
+					slots.footer?.({}),
+				]);
+		},
+	});
+	const Plain = (tag: string) =>
+		defineComponent({ setup: (_, { slots }) => () => h(tag, slots.default?.()) });
+	return {
+		MultiSelect: Picker,
+		Combobox: Picker,
+		Avatar: defineComponent({
+			props: ["label"],
+			setup: (props) => () => h("span", { "data-avatar": props.label }),
+		}),
+		Tooltip: Plain("span"),
+		Button: defineComponent({
+			props: ["label"],
+			setup: (props, { slots }) => () => h("button", slots.default?.() ?? props.label),
+		}),
+	};
+});
+
+import { PanelContextKey, type DocInfo } from "../context";
+import PeopleAvatars from "../PeopleAvatars.vue";
+import QuickActions from "../QuickActions.vue";
+import RecordIdentity from "../RecordIdentity.vue";
+import RecordPeople from "../RecordPeople.vue";
+import ShareDialog from "../ShareDialog.vue";
+
+const mounted: ReturnType<typeof createApp>[] = [];
+// What `page.quickActions.visible()` answers; only the tag action's rendering is tested here.
+const quickActions: any[] = [];
+
+afterEach(() => {
+	for (const app of mounted.splice(0)) app.unmount();
+	document.body.innerHTML = "";
+	stub.nextPick = [];
+	stub.nextQuery = "";
+	quickActions.splice(0);
+});
+
+function setup(info: DocInfo, component: any = RecordPeople, props: Record<string, any> = {}) {
+	const page = {
+		call: vi.fn(async () => null),
+		toast: { error: vi.fn() },
+		dialog: { open: vi.fn(async () => null) },
+	};
+	const docinfo = ref<DocInfo | null>(info);
+	const reloadDocinfo = vi.fn(async () => {});
+	const context = {
+		doctype: "CRM Deal",
+		docname: "D-1",
+		doc: ref({}),
+		meta: ref(null),
+		docinfo,
+		controller: { page, quickActions: { visible: () => quickActions } } as any,
+		run: vi.fn(),
+		reloadDocinfo,
+	};
+	const root = document.createElement("div");
+	document.body.appendChild(root);
+	const app = createApp(defineComponent({ render: () => h(component, props) }));
+	app.provide(PanelContextKey, context);
+	app.mount(root);
+	mounted.push(app);
+	return { root, page, reloadDocinfo, docinfo, context };
+}
+
+const info = (permissions: Record<string, 0 | 1>): DocInfo => ({
+	assignments: [{ owner: "ann@example.com" }],
+	shared: [{ user: "bob@example.com" }],
+	tags: "urgent",
+	user_info: { "ann@example.com": { fullname: "Ann" }, "bob@example.com": { fullname: "Bob" } },
+	permissions,
+});
+
+async function pick(root: HTMLElement, values: string[] | string, query = "") {
+	stub.nextPick = values;
+	stub.nextQuery = query;
+	root.querySelector<HTMLElement>("[data-pick]")!.click();
+	await nextTick();
+}
+
+describe("the gate", () => {
+	it("edits assignees and shares with the write and share rights", () => {
+		const { root } = setup(info({ write: 1, share: 1 }));
+		expect(root.querySelector("[data-assign]")).not.toBeNull();
+		expect(root.querySelector("[data-share]")).not.toBeNull();
+	});
+
+	it("reads the rows without them, and still names the people", () => {
+		const { root } = setup(info({ read: 1 }));
+		expect(root.querySelector("[data-assign]")).toBeNull();
+		expect(root.querySelector("[data-share]")).toBeNull();
+		expect(root.textContent).toContain("Ann");
+		expect(root.textContent).toContain("Bob");
+	});
+
+	it("says so when nobody is assigned or shared", () => {
+		const { root } = setup({ permissions: { read: 1 } });
+		expect(root.textContent).toContain("Not assigned");
+		expect(root.textContent).toContain("Not shared");
+	});
+});
+
+describe("assigning", () => {
+	it("adds who the pick added, drops who it dropped, and re-reads the sidecar after each", async () => {
+		const { root, page, reloadDocinfo } = setup(info({ write: 1 }));
+		await pick(root, ["cy@example.com"]);
+		await vi.waitFor(() => expect(reloadDocinfo).toHaveBeenCalledTimes(2));
+		expect(page.call).toHaveBeenCalledWith("frappe.desk.form.assign_to.add", {
+			doctype: "CRM Deal",
+			name: "D-1",
+			assign_to: ["cy@example.com"],
+		});
+		expect(page.call).toHaveBeenCalledWith("frappe.desk.form.assign_to.remove", {
+			doctype: "CRM Deal",
+			name: "D-1",
+			assign_to: "ann@example.com",
+		});
+		const callOrder = page.call.mock.invocationCallOrder[0];
+		expect(reloadDocinfo.mock.invocationCallOrder[0]).toBeGreaterThan(callOrder);
+	});
+
+	it("toasts a refused write and leaves the sidecar alone", async () => {
+		const { root, page, reloadDocinfo } = setup(info({ write: 1 }));
+		page.call.mockRejectedValueOnce({ messages: ["Not permitted"] });
+		await pick(root, ["ann@example.com", "cy@example.com"]);
+		await vi.waitFor(() => expect(page.toast.error).toHaveBeenCalledWith("Not permitted"));
+		expect(reloadDocinfo).not.toHaveBeenCalled();
+	});
+});
+
+describe("sharing", () => {
+	it("opens the share dialog on the page's own stack, handed the live context", async () => {
+		const { root, page, docinfo } = setup(info({ share: 1 }));
+		root.querySelector<HTMLElement>("[data-share]")!.click();
+		expect(page.dialog.open).toHaveBeenCalledTimes(1);
+		const [component, props, options] = page.dialog.open.mock.calls[0] as any[];
+		expect(component).toBeTruthy();
+		expect(props.context.docinfo).toBe(docinfo);
+		expect(options).toEqual({ title: "Share this record" });
+	});
+});
+
+describe("the share dialog", () => {
+	// The dialog acts on the panel's context, so the assertions read the host's page.
+	function open(info: DocInfo) {
+		const host = setup(info);
+		const { root } = setup(info, ShareDialog, { context: host.context, close: vi.fn() });
+		return { root, page: host.page, context: host.context, docinfo: host.docinfo };
+	}
+
+	it("shares with read and write on a pick, and re-reads the sidecar", async () => {
+		const { root, page, context } = open(info({ share: 1 }));
+		await pick(root, "cy@example.com");
+		await vi.waitFor(() => expect(context.reloadDocinfo).toHaveBeenCalledTimes(1));
+		expect(page.call).toHaveBeenCalledWith("frappe.share.add", {
+			doctype: "CRM Deal",
+			name: "D-1",
+			user: "cy@example.com",
+			read: 1,
+			write: 1,
+		});
+	});
+
+	it("stops a share by dropping read, for a person and for everyone", async () => {
+		const shared = info({ share: 1 });
+		shared.shared = [{ user: "bob@example.com", write: 1 }, { user: "", everyone: 1 }];
+		const { root, page, context } = open(shared);
+		expect(root.textContent).toContain("Can edit");
+		root.querySelector<HTMLElement>("[aria-label='Stop sharing with Bob']")!.click();
+		root.querySelector<HTMLElement>("[aria-label='Stop sharing with Everyone']")!.click();
+		await vi.waitFor(() => expect(context.reloadDocinfo).toHaveBeenCalledTimes(2));
+		const stop = (user: string | null, everyone: 0 | 1) => ({
+			doctype: "CRM Deal",
+			name: "D-1",
+			user,
+			permission_to: "read",
+			value: 0,
+			everyone,
+		});
+		expect(page.call).toHaveBeenCalledWith("frappe.share.set_permission", stop("bob@example.com", 0));
+		expect(page.call).toHaveBeenCalledWith("frappe.share.set_permission", stop(null, 1));
+	});
+
+	it("follows the live sidecar, and says so when nobody is left", async () => {
+		const { root, docinfo } = open(info({ share: 1 }));
+		expect(root.querySelectorAll("[data-shared-with]")).toHaveLength(1);
+		docinfo.value = { ...docinfo.value, shared: [] };
+		await nextTick();
+		expect(root.querySelectorAll("[data-shared-with]")).toHaveLength(0);
+		expect(root.textContent).toContain("not shared with anyone");
+	});
+});
+
+describe("the avatar stack", () => {
+	it("shows three and counts the rest", () => {
+		const people = ["a", "b", "c", "d", "e"].map((id) => ({ id, name: id }));
+		const { root } = setup({}, PeopleAvatars, { people, placeholder: "Nobody" });
+		expect(root.querySelectorAll("[data-avatar]")).toHaveLength(3);
+		expect(root.textContent).toContain("+2");
+	});
+});
+
+describe("tags", () => {
+	it("draws no row until the record has a tag; the first comes from the quick action", async () => {
+		const bare = setup({ permissions: { write: 1 } }, RecordIdentity);
+		expect(bare.root.querySelector("[data-tags]")).toBeNull();
+
+		quickActions.push({ name: "tags", label: "Tags", icon: "lucide-tag", tagging: true });
+		const { root, page, reloadDocinfo } = setup({ permissions: { write: 1 } }, QuickActions);
+		expect(root.textContent).toContain("Tags");
+		await pick(root, ["first"], "first");
+		await vi.waitFor(() => expect(reloadDocinfo).toHaveBeenCalledTimes(1));
+		expect(page.call).toHaveBeenCalledWith("frappe.desk.doctype.tag.tag.add_tag", {
+			tag: "first",
+			dt: "CRM Deal",
+			dn: "D-1",
+		});
+	});
+
+	it("draws the chips read-only for a reader who may not write", () => {
+		const tagged = setup(info({ read: 1 }), RecordIdentity);
+		expect(tagged.root.textContent).toContain("urgent");
+		expect(tagged.root.querySelector("[data-add-tag]")).toBeNull();
+		expect(tagged.root.querySelector("[aria-label='Remove urgent']")).toBeNull();
+	});
+
+	it("removes a tag from its chip and adds one the picker created", async () => {
+		const { root, page, reloadDocinfo } = setup(info({ write: 1 }), RecordIdentity);
+		root.querySelector<HTMLElement>("[aria-label='Remove urgent']")!.click();
+		await vi.waitFor(() => expect(reloadDocinfo).toHaveBeenCalledTimes(1));
+		expect(page.call).toHaveBeenCalledWith("frappe.desk.doctype.tag.tag.remove_tag", {
+			tag: "urgent",
+			dt: "CRM Deal",
+			dn: "D-1",
+		});
+
+		await pick(root, ["urgent"], "later");
+		root.querySelector<HTMLElement>("[data-create-tag]")!.click();
+		await vi.waitFor(() => expect(reloadDocinfo).toHaveBeenCalledTimes(2));
+		expect(page.call).toHaveBeenCalledWith("frappe.desk.doctype.tag.tag.add_tag", {
+			tag: "later",
+			dt: "CRM Deal",
+			dn: "D-1",
+		});
+	});
+});

--- a/frontend/src/pages/record/panel/tests/recordPeople.test.ts
+++ b/frontend/src/pages/record/panel/tests/recordPeople.test.ts
@@ -34,6 +34,16 @@ vi.mock("frappe-ui", () => {
 			setup: (props) => () => h("span", { "data-avatar": props.label }),
 		}),
 		Tooltip: Plain("span"),
+		Dropdown: defineComponent({
+			props: ["options"],
+			setup: (props, { slots }) => () =>
+				h("div", { "data-dropdown": "" }, [
+					slots.default?.(),
+					...props.options.map((option: any) =>
+						h("button", { "data-menu-row": option.label, onClick: option.onClick })
+					),
+				]),
+		}),
 		Button: defineComponent({
 			props: ["label"],
 			setup: (props, { slots }) => () => h("button", slots.default?.() ?? props.label),
@@ -231,7 +241,7 @@ describe("tags", () => {
 
 		quickActions.push({ name: "tags", label: "Tags", icon: "lucide-tag", tagging: true });
 		const { root, page, reloadDocinfo } = setup({ permissions: { write: 1 } }, QuickActions);
-		expect(root.textContent).toContain("Tags");
+		await vi.waitFor(() => expect(root.textContent).toContain("Tags"));
 		await pick(root, ["first"], "first");
 		await vi.waitFor(() => expect(reloadDocinfo).toHaveBeenCalledTimes(1));
 		expect(page.call).toHaveBeenCalledWith("frappe.desk.doctype.tag.tag.add_tag", {

--- a/frontend/src/pages/record/panel/tests/recordPeople.test.ts
+++ b/frontend/src/pages/record/panel/tests/recordPeople.test.ts
@@ -34,6 +34,7 @@ vi.mock("frappe-ui", () => {
 			setup: (props) => () => h("span", { "data-avatar": props.label }),
 		}),
 		Tooltip: Plain("span"),
+		TooltipProvider: Plain("div"),
 		Dropdown: defineComponent({
 			props: ["options"],
 			setup: (props, { slots }) => () =>

--- a/frontend/src/pages/record/panel/tests/recordPeople.test.ts
+++ b/frontend/src/pages/record/panel/tests/recordPeople.test.ts
@@ -161,6 +161,13 @@ describe("assigning", () => {
 		await vi.waitFor(() => expect(page.toast.error).toHaveBeenCalledWith("Not permitted"));
 		expect(reloadDocinfo).not.toHaveBeenCalled();
 	});
+
+	it("toasts a re-read that fails after the write landed, instead of rejecting", async () => {
+		const { root, page, reloadDocinfo } = setup(info({ write: 1 }));
+		reloadDocinfo.mockRejectedValueOnce(new Error("Sidecar down"));
+		await pick(root, ["ann@example.com", "cy@example.com"]);
+		await vi.waitFor(() => expect(page.toast.error).toHaveBeenCalledWith("Sidecar down"));
+	});
 });
 
 describe("sharing", () => {

--- a/frontend/src/pages/record/panel/tests/remoteSearch.test.ts
+++ b/frontend/src/pages/record/panel/tests/remoteSearch.test.ts
@@ -1,0 +1,89 @@
+// The server search behind the pickers: the latest answer wins, pinned options fill its gaps.
+import { describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+import { useRemoteSearch, useTagSearch, useUserSearch, type SearchOption } from "../remoteSearch";
+
+const option = (value: string): SearchOption => ({ label: value, value });
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (reason: unknown) => void;
+	const promise = new Promise<T>((res, rej) => ((resolve = res), (reject = rej)));
+	return { promise, resolve, reject };
+}
+
+describe("useRemoteSearch", () => {
+	it("keeps the server's order and fills the gaps with the pinned options", async () => {
+		const pinned = ref([option("ann"), option("zed")]);
+		const { options, search, searched } = useRemoteSearch(
+			async () => [option("zed"), option("bob")],
+			pinned
+		);
+		expect(options.value.map((o) => o.value)).toEqual(["ann", "zed"]);
+		await search();
+		expect(searched.value).toBe(true);
+		expect(options.value.map((o) => o.value)).toEqual(["zed", "bob", "ann"]);
+	});
+
+	it("drops an earlier answer that lands after a later one", async () => {
+		const first = deferred<SearchOption[]>();
+		const second = deferred<SearchOption[]>();
+		const answers = [first.promise, second.promise];
+		const { options, loading, search } = useRemoteSearch(() => answers.shift()!, ref([]));
+		const one = search("a");
+		const two = search("ab");
+		second.resolve([option("ab")]);
+		await two;
+		expect(loading.value).toBe(false);
+		first.resolve([option("a")]);
+		await one;
+		expect(options.value.map((o) => o.value)).toEqual(["ab"]);
+	});
+
+	it("keeps the failure's message and the last good answer", async () => {
+		const { options, error, search } = useRemoteSearch(async (query) => {
+			if (query === "bad") throw { messages: ["Not permitted"] };
+			return [option("ok")];
+		}, ref([]));
+		await search("");
+		await search("bad");
+		expect(error.value).toBe("Not permitted");
+		expect(options.value.map((o) => o.value)).toEqual(["ok"]);
+	});
+});
+
+describe("the searches", () => {
+	it("looks users up by name or email and shapes the rows", async () => {
+		const call = vi.fn(async () => [
+			{ name: "ann@example.com", full_name: "Ann", user_image: "/ann.png" },
+			{ name: "bob@example.com", full_name: "", user_image: null },
+		]);
+		const { options, search } = useUserSearch(call, ref([]));
+		await search("an");
+		expect(call).toHaveBeenCalledWith(
+			"frappe.client.get_list",
+			expect.objectContaining({
+				doctype: "User",
+				or_filters: [
+					["full_name", "like", "%an%"],
+					["name", "like", "%an%"],
+				],
+			})
+		);
+		expect(options.value).toEqual([
+			{ label: "Ann", value: "ann@example.com", image: "/ann.png" },
+			{ label: "bob@example.com", value: "bob@example.com", image: "" },
+		]);
+	});
+
+	it("looks tags up for the doctype with the trimmed query", async () => {
+		const call = vi.fn(async () => ["urgent"]);
+		const { options, search } = useTagSearch(call, "CRM Deal", ref([]));
+		await search(" urg ");
+		expect(call).toHaveBeenCalledWith("frappe.desk.doctype.tag.tag.get_tags", {
+			doctype: "CRM Deal",
+			txt: "urg",
+		});
+		expect(options.value).toEqual([{ label: "urgent", value: "urgent" }]);
+	});
+});

--- a/frontend/src/pages/record/quickActionBuiltins.ts
+++ b/frontend/src/pages/record/quickActionBuiltins.ts
@@ -3,11 +3,13 @@
 import type { QuickAction, RecordPageApi } from "@/recordPage";
 import { routeFor } from "@/router/routeFor";
 
-export function quickActionBuiltins(perms: Record<string, any>): QuickAction[] {
+export function quickActionBuiltins(perms: Record<string, any>, tagged = false): QuickAction[] {
   const actions: QuickAction[] = [];
   if (perms.print) actions.push({ name: "print", label: "Print", icon: "lucide-printer", run: print });
   actions.push({ name: "copy_link", label: "Copy link", icon: "lucide-link", run: copyLink });
   if (perms.delete) actions.push({ name: "delete", label: "Delete", icon: "lucide-trash-2", run: remove });
+  // Only while the record has no tag: a tagged record has the chips' own "+" instead.
+  if (perms.write && !tagged) actions.push({ name: "tags", label: "Tags", icon: "lucide-tag", tagging: true });
   return actions;
 }
 

--- a/frontend/src/pages/record/tests/builtinActions.test.ts
+++ b/frontend/src/pages/record/tests/builtinActions.test.ts
@@ -1,9 +1,9 @@
-// The framework's own quick actions: which ones a right unlocks, and what delete does.
+// The framework's own actions: which ones a right unlocks, where each sits, and what delete does.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/router/routeFor", () => ({ routeFor: (doctype: string) => ({ name: "list", doctype }) }));
 
-import { quickActionBuiltins } from "../quickActionBuiltins";
+import { headerMenuBuiltins, quickActionBuiltins } from "../builtinActions";
 
 const names = (perms: Record<string, any>, tagged = false) =>
   quickActionBuiltins(perms, tagged).map((a) => a.name);
@@ -25,9 +25,13 @@ beforeEach(() => {
 });
 
 describe("quickActionBuiltins", () => {
-  it("seeds copy_link always, print and delete only with the right", () => {
+  it("seeds copy_link always and print only with the right; delete is the header's", () => {
     expect(names({})).toEqual(["copy_link"]);
-    expect(names({ print: 1, delete: 1 })).toEqual(["print", "copy_link", "delete"]);
+    expect(names({ print: 1, delete: 1 })).toEqual(["print", "copy_link"]);
+    expect(headerMenuBuiltins({}).map((item) => item.name)).toEqual([]);
+    const [remove] = headerMenuBuiltins({ delete: 1 });
+    expect(remove).toMatchObject({ name: "delete", label: "Delete" });
+    expect(remove.display).toBeUndefined();
   });
 
   it("seeds tags with write, only while the record has none", () => {
@@ -39,7 +43,7 @@ describe("quickActionBuiltins", () => {
 
   it("deletes after a confirmed danger dialog, then leaves for the list", async () => {
     const page = fakePage(true);
-    await quickActionBuiltins({ delete: 1 })[1].run!(page);
+    await headerMenuBuiltins({ delete: 1 })[0].run!(page);
     expect(page.call).toHaveBeenCalledWith("frappe.client.delete", {
       doctype: "CRM Deal",
       name: "CRM-DEAL-1",
@@ -49,7 +53,7 @@ describe("quickActionBuiltins", () => {
 
   it("does nothing when the dialog is dismissed", async () => {
     const page = fakePage(null);
-    await quickActionBuiltins({ delete: 1 })[1].run!(page);
+    await headerMenuBuiltins({ delete: 1 })[0].run!(page);
     expect(page.call).not.toHaveBeenCalled();
     expect(page.router.push).not.toHaveBeenCalled();
   });

--- a/frontend/src/pages/record/tests/quickActionBuiltins.test.ts
+++ b/frontend/src/pages/record/tests/quickActionBuiltins.test.ts
@@ -5,7 +5,8 @@ vi.mock("@/router/routeFor", () => ({ routeFor: (doctype: string) => ({ name: "l
 
 import { quickActionBuiltins } from "../quickActionBuiltins";
 
-const names = (perms: Record<string, any>) => quickActionBuiltins(perms).map((a) => a.name);
+const names = (perms: Record<string, any>, tagged = false) =>
+  quickActionBuiltins(perms, tagged).map((a) => a.name);
 
 function fakePage(confirmed: true | null) {
   return {
@@ -27,6 +28,13 @@ describe("quickActionBuiltins", () => {
   it("seeds copy_link always, print and delete only with the right", () => {
     expect(names({})).toEqual(["copy_link"]);
     expect(names({ print: 1, delete: 1 })).toEqual(["print", "copy_link", "delete"]);
+  });
+
+  it("seeds tags with write, only while the record has none", () => {
+    expect(names({ write: 1 })).toEqual(["copy_link", "tags"]);
+    expect(names({ write: 1 }, true)).toEqual(["copy_link"]);
+    expect(names({}, false)).toEqual(["copy_link"]);
+    expect(quickActionBuiltins({ write: 1 }).at(-1)).toMatchObject({ tagging: true });
   });
 
   it("deletes after a confirmed danger dialog, then leaves for the list", async () => {

--- a/frontend/src/pages/record/tests/recordHeader.test.ts
+++ b/frontend/src/pages/record/tests/recordHeader.test.ts
@@ -1,0 +1,72 @@
+// The header's right-hand order: a script's controls, then the `⋯` menu, then Save.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApp, defineComponent, h, nextTick } from "vue";
+
+// Hoisted with the mocks, so each factory can reach it.
+const { Plain } = vi.hoisted(() => ({
+  Plain: (tag: string) =>
+    defineComponent({
+      inheritAttrs: false,
+      props: { label: String },
+      setup: (props, { attrs, slots }) =>
+        () => h(tag, { ...attrs, "data-label": props.label }, slots.default?.()),
+    }),
+}));
+
+vi.mock("frappe-ui", () => ({
+  Button: Plain("button"),
+  Dropdown: Plain("div"),
+  Tooltip: Plain("span"),
+}));
+
+vi.mock("vue-router", () => ({
+  RouterLink: Plain("a"),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+import RecordHeader from "../RecordHeader.vue";
+import type { HeaderProjection } from "@/recordPage";
+
+const mounted: ReturnType<typeof createApp>[] = [];
+
+afterEach(() => {
+  for (const app of mounted.splice(0)) app.unmount();
+  document.body.innerHTML = "";
+});
+
+const control = (name: string) => ({ kind: "button" as const, item: { name, label: name } });
+
+async function mount(projection: HeaderProjection) {
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  const app = createApp(
+    defineComponent({
+      render: () => h(RecordHeader, { projection, dirty: false, saving: false }),
+    }),
+  );
+  app.mount(root);
+  mounted.push(app);
+  await nextTick();
+  return root;
+}
+
+const rightHand = (root: HTMLElement) =>
+  [...root.querySelectorAll<HTMLElement>("[data-label]")]
+    .map((el) => el.dataset.label)
+    .filter((label) => label !== "crumb");
+
+describe("the right-hand order", () => {
+  it("draws the menu at Save's left, whatever the projection's order", async () => {
+    const root = await mount({
+      left: [],
+      controls: [control("archive"), control("save"), control("export")],
+      bands: [{ group: "actions", items: [{ item: { name: "delete", label: "Delete" } }] }],
+    });
+    expect(rightHand(root)).toEqual(["archive", "export", "More actions", "save"]);
+  });
+
+  it("draws no menu without a band, and no Save once a script hid it", async () => {
+    const root = await mount({ left: [], controls: [control("export")], bands: [] });
+    expect(rightHand(root)).toEqual(["export"]);
+  });
+});

--- a/frontend/src/pages/record/tests/recordHeader.test.ts
+++ b/frontend/src/pages/record/tests/recordHeader.test.ts
@@ -55,18 +55,23 @@ const rightHand = (root: HTMLElement) =>
     .map((el) => el.dataset.label)
     .filter((label) => label !== "crumb");
 
+const band = { group: "actions", items: [{ item: { name: "delete", label: "Delete" } }] };
+
 describe("the right-hand order", () => {
-  it("draws the menu at Save's left, whatever the projection's order", async () => {
+  it("slots the menu in at Save's left and keeps the projection's order around it", async () => {
     const root = await mount({
       left: [],
       controls: [control("archive"), control("save"), control("export")],
-      bands: [{ group: "actions", items: [{ item: { name: "delete", label: "Delete" } }] }],
+      bands: [band],
     });
-    expect(rightHand(root)).toEqual(["archive", "export", "More actions", "save"]);
+    expect(rightHand(root)).toEqual(["archive", "More actions", "save", "export"]);
   });
 
-  it("draws no menu without a band, and no Save once a script hid it", async () => {
-    const root = await mount({ left: [], controls: [control("export")], bands: [] });
-    expect(rightHand(root)).toEqual(["export"]);
+  it("draws the menu last once a script hid Save, and none without a band", async () => {
+    const hidden = await mount({ left: [], controls: [control("export")], bands: [band] });
+    expect(rightHand(hidden)).toEqual(["export", "More actions"]);
+
+    const bare = await mount({ left: [], controls: [control("save")], bands: [] });
+    expect(rightHand(bare)).toEqual(["save"]);
   });
 });


### PR DESCRIPTION
Closes the build task [Task: make the panel's people built-in editable — assign, share and tag](https://github.com/frappe/frappe/issues/42760) on the record-page map #42271.

## What changes

The record panel's `people` built-in edits instead of only reading. Assign and unassign, share and unshare, and tag and untag all work from the panel of the generated record page.

- **Assign** — the avatar stack is the trigger of a `MultiSelect` over a server user search. Each pick is one call to `frappe.desk.form.assign_to.add` or `remove`.
- **Share** — the row opens a dialog on the page's own stack through `page.dialog.open`, handed the live panel context so its list follows each share. A pick calls `frappe.share.add` with read and write; the row's X calls `frappe.share.set_permission` with `read` set to `0`, which drops the higher rights and deletes the empty share.
- **Tags** — stay on `identity`, as CRM has them. The framework seeds a `tags` quick action while the record has none; it is the tag picker's own trigger, a `MultiSelect` over `get_tags` with a create row. Once a tag lands the action goes and the chips carry their own "+"; a chip's X calls `remove_tag`. A comma in a new name is refused, since the server joins tags with commas.
- **The gate** — assign and tags edit with `docinfo.permissions.write`; share edits with `docinfo.permissions.share`. Without the right the row reads, and still names the people.
- **The re-read** — after every call the host re-reads the sidecar alone through `frappe.desk.form.load.get_docinfo`, guarded by the page's load generation. Nothing is painted from a call's answer, so the row never disagrees with the server.

- **The quick actions row fits its width**, as CRM's does: buttons are named from the left while the width lasts, then show their icon, then fold into a `⋯` menu. A tag action folded into the menu opens its picker anchored under the menu. At the panel's minimum width the three framework actions still fit named; the fold shows once a script adds more.
- **Delete moves to the header's `⋯`**, as CRM's record menu has it. It is a header item with no `display`, so the projection files it under the menu; `hide('delete')` still works by name.

`page.panelSections` gains no verb. `frontend/SCRIPTING.md` gains a *The people* section that names the endpoints, the gate and how a script assigns through `page.call`.

## Aligned with the CRM record page

A second commit compares the panel against the CRM v2 reference record page and fixes what differed:

- **The head is one block.** The quick actions right after `identity` draw inside it, between the title and the tags, as the reference draws them; a script that moves them elsewhere, or gives them a header, gets a section of their own as before. Every section body pads 12px top and bottom.
- **The header's `⋯` sits at Save's left**, the reference's order. Save stays last wherever a script places it.
- **The share dialog's search is a text input**, as the reference's is, with the list at the input's width. On frappe-ui beta.63 a `null` model lets reka keep the pick as its own value and write the label into the box; `''` keeps it controlled and empty.
- Avatars grow on hover; the assignee chevron is the reference's size; the quick actions share one tooltip group, so the first hover waits for nothing.

## Walk

Walked headless on `crm.localhost` on a real CRM Deal with the coverage battery off: assign a user, share with them from the text input and see the box clear, stop sharing, create the first tag from the quick action, remove it from its chip, unassign. Every call hit its endpoint, `get_docinfo` followed each, the console stayed clean, and the deal ended as it started.

| Before | Assigned | Tagged |
| --- | --- | --- |
| ![before](https://raw.githubusercontent.com/shariquerik/frappe/refs/heads/assets/record-people-42760/pr-before.png) | ![assigned](https://raw.githubusercontent.com/shariquerik/frappe/refs/heads/assets/record-people-42760/pr-assigned.png) | ![tagged](https://raw.githubusercontent.com/shariquerik/frappe/refs/heads/assets/record-people-42760/pr-tagged.png) |

| Share dialog | Overflow, with a script's extra actions at the minimum width | Header: `⋯`, then Save |
| --- | --- | --- |
| ![share dialog](https://raw.githubusercontent.com/shariquerik/frappe/refs/heads/assets/record-people-42760/pr-share-dialog.png) | ![overflow](https://raw.githubusercontent.com/shariquerik/frappe/refs/heads/assets/record-people-42760/pr-overflow.png) | ![header](https://raw.githubusercontent.com/shariquerik/frappe/refs/heads/assets/record-people-42760/pr-header.png) |

## Pre-close gates

- **Cache key:** none added. The user search is `frappe.client.get_list` on `User` with a page of 10, per keystroke after a 250 ms debounce, and a stale answer is dropped. The tag search is `get_tags`, the same way.
- **Permission check:** the client gate reads `docinfo.permissions`; the server checks on its own in each endpoint (`check_permission` in `assign_to`, `check_share_permission` in `share`, `check_permission("write")` in `update_tags`).
- **Cold load cost:** none. No new request on load; the searches run on first open of a picker.
- Tests: 62 files / 750 tests (was 56 / 714), across `people.test.ts`, `remoteSearch.test.ts`, `recordPeople.test.ts`, `fittedActions.test.ts`, `builtinActions.test.ts`, `panelLayout.test.ts` and `recordHeader.test.ts`.
- `/quality-code-review` ran in a fresh subagent and asked for changes; the AGENTS.md comment check passed. Fixed from it: overlapping sidecar re-reads now carry a read counter, so a slower older read cannot paint over a newer one; every picker resets its query and re-searches on open, since listening to the query hands its ownership to the caller; the share dialog and the avatar overflow are tested; `Administrator` and `Guest` are left out of the user search; a dead list branch in `tagsOf` is gone. A second fresh review of the fitting commit found one bug, the anchor's open flag outliving a folded tag action that a pick removed, fixed with a watch and covered by an overflow test; its cleanups (initial fit values, a three-line comment, an unread marker, the menu row's icon fallback) are in. Answered without a change: share sends no notification, as CRM's dialog sends none; a failed search shows in the empty state only, since a toast per keystroke would spam. A third fresh review of the alignment commit asked for two changes, both in: a labelled `quick_actions` is never embedded, so a script's header for it still draws; and the header's order has a DOM test. Its nit on the image case is left as a known divergence: with an `image_field` the actions draw under the image row, where the reference puts them beside the picture. Greptile on the alignment commit found one real thing, fixed in `1331a103d7`: pinning Save last ignored a script's `move()` on it, so the controls now draw in the projection's order with the menu slotted in at Save's left. Its earlier thread on a failed sidecar re-read rejecting unhandled is fixed in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


>no-docs
