### PR TITLE
fix: attach the site database to DuckDB with its own scanner

### DIFF
--- a/frappe/core/doctype/duckdb_sync/duckdb_sync.py
+++ b/frappe/core/doctype/duckdb_sync/duckdb_sync.py
@@ -168,19 +168,35 @@ def sync_using_pyarrow(conn, dt, duck_tb):
 			del arrow_table
 
 
+def as_dsn_value(value):
+	"""Quote one connection string value, which escapes with a backslash."""
+	escaped = str(value).replace("\\", "\\\\").replace("'", "\\'")
+	return f"'{escaped}'"
+
+
+def as_sql_literal(value):
+	"""Quote one SQL string literal, which escapes by doubling the quote."""
+	escaped = str(value).replace("'", "''")
+	return f"'{escaped}'"
+
+
 def get_attach_query():
 	"""Attach the site database through the DuckDB scanner that matches its engine."""
 	is_postgres = frappe.db.db_type == "postgres"
-	extension = "postgres" if is_postgres else "mysql"
-	database_key = "dbname" if is_postgres else "database"
-	dsn = (
-		f"user={frappe.conf.db_user or frappe.conf.db_name} "
-		f"password={frappe.conf.db_password} "
-		f"host={frappe.conf.db_host or '127.0.0.1'} "
-		f"{database_key}={frappe.conf.db_name} "
-		f"port={frappe.conf.db_port or (5432 if is_postgres else 3306)}"
-	)
-	return f"attach '{dsn}' as {SOURCE_DB_ALIAS} (TYPE {extension});"
+	settings = {
+		"user": frappe.conf.db_user or frappe.conf.db_name,
+		"password": frappe.conf.db_password,
+		"host": frappe.conf.db_host or "127.0.0.1",
+		"dbname" if is_postgres else "database": frappe.conf.db_name,
+		"port": frappe.conf.db_port or (5432 if is_postgres else 3306),
+	}
+	dsn = " ".join(f"{key}={as_dsn_value(value)}" for key, value in settings.items())
+
+	options = ["TYPE postgres" if is_postgres else "TYPE mysql"]
+	if is_postgres:
+		options.append(f"SCHEMA {as_sql_literal(frappe.db.db_schema)}")
+
+	return f"attach {as_sql_literal(dsn)} as {SOURCE_DB_ALIAS} ({', '.join(options)});"
 
 
 def sync_using_extension(conn, dt, duck_tb):

--- a/frappe/core/doctype/duckdb_sync/duckdb_sync.py
+++ b/frappe/core/doctype/duckdb_sync/duckdb_sync.py
@@ -9,6 +9,8 @@ from frappe.database import get_duckdb
 from frappe.database.duckdb.schema import DuckDBTable
 from frappe.model.document import Document
 
+SOURCE_DB_ALIAS = "source_db"
+
 
 class DuckDBSync(Document):
 	# begin: auto-generated types
@@ -166,16 +168,29 @@ def sync_using_pyarrow(conn, dt, duck_tb):
 			del arrow_table
 
 
+def get_attach_query():
+	"""Attach the site database through the DuckDB scanner that matches its engine."""
+	is_postgres = frappe.db.db_type == "postgres"
+	extension = "postgres" if is_postgres else "mysql"
+	database_key = "dbname" if is_postgres else "database"
+	dsn = (
+		f"user={frappe.conf.db_user or frappe.conf.db_name} "
+		f"password={frappe.conf.db_password} "
+		f"host={frappe.conf.db_host or '127.0.0.1'} "
+		f"{database_key}={frappe.conf.db_name} "
+		f"port={frappe.conf.db_port or (5432 if is_postgres else 3306)}"
+	)
+	return f"attach '{dsn}' as {SOURCE_DB_ALIAS} (TYPE {extension});"
+
+
 def sync_using_extension(conn, dt, duck_tb):
 	try:
 		conn.execute(f'delete from "{duck_tb.table_name}";').fetchall()
-		conn.sql(
-			f"attach 'user={frappe.conf.db_name} password={frappe.conf.db_password} host={frappe.conf.db_host} database={frappe.conf.db_name} port={frappe.conf.db_port}' as mariadb_db (TYPE mysql);"
-		)
+		conn.sql(get_attach_query())
 		columns = frappe.get_meta(dt).get_valid_columns()
 		# quotted fields
 		columns_sql = ", ".join([f'"{x}"' for x in columns])
-		query = f'insert into "{duck_tb.table_name}" ({columns_sql}) select {columns_sql} from mariadb_db."{duck_tb.table_name}";'
+		query = f'insert into "{duck_tb.table_name}" ({columns_sql}) select {columns_sql} from {SOURCE_DB_ALIAS}."{duck_tb.table_name}";'
 		conn.sql(query)
 	except Exception as e:
 		import re

--- a/frappe/core/doctype/duckdb_sync/duckdb_sync.py
+++ b/frappe/core/doctype/duckdb_sync/duckdb_sync.py
@@ -168,10 +168,14 @@ def sync_using_pyarrow(conn, dt, duck_tb):
 			del arrow_table
 
 
-def as_dsn_value(value):
-	"""Quote one connection string value, which escapes with a backslash."""
-	escaped = str(value).replace("\\", "\\\\").replace("'", "\\'")
-	return f"'{escaped}'"
+def as_dsn_value(value, quote):
+	"""Quote one connection string value, which escapes with a backslash.
+
+	The PostgreSQL scanner reads single quoted values and the MySQL scanner double quoted
+	ones. Either scanner passes the other character through untouched.
+	"""
+	escaped = str(value).replace("\\", "\\\\").replace(quote, f"\\{quote}")
+	return f"{quote}{escaped}{quote}"
 
 
 def as_sql_literal(value):
@@ -190,7 +194,8 @@ def get_attach_query():
 		"dbname" if is_postgres else "database": frappe.conf.db_name,
 		"port": frappe.conf.db_port or (5432 if is_postgres else 3306),
 	}
-	dsn = " ".join(f"{key}={as_dsn_value(value)}" for key, value in settings.items())
+	quote = "'" if is_postgres else '"'
+	dsn = " ".join(f"{key}={as_dsn_value(value, quote)}" for key, value in settings.items())
 
 	options = ["TYPE postgres" if is_postgres else "TYPE mysql"]
 	if is_postgres:

--- a/frappe/core/doctype/duckdb_sync/test_duckdb_sync.py
+++ b/frappe/core/doctype/duckdb_sync/test_duckdb_sync.py
@@ -1,17 +1,20 @@
 # Copyright (c) 2026, Frappe Technologies and Contributors
 # See license.txt
 
+from contextlib import closing
+from datetime import date
 from unittest.mock import patch
 
 import frappe
-from frappe.core.doctype.duckdb_sync.duckdb_sync import get_attach_query
+from frappe.core.doctype.duckdb_sync.duckdb_sync import (
+	get_attach_query,
+	is_data_sync_pending,
+	sync_data_to_duckdb,
+)
+from frappe.database import delete_duckdb_file, get_duckdb
 from frappe.tests import IntegrationTestCase, UnitTestCase
 
-# On IntegrationTestCase, the doctype test records and all
-# link-field test record dependencies are recursively loaded
-# Use these module variables to add/remove to/from that list
-EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
-IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["User"]
 
 SITE_CONFIG = {
 	"db_user": "site_user",
@@ -80,9 +83,90 @@ class UnitTestDuckDBSync(UnitTestCase):
 
 
 class IntegrationTestDuckDBSync(IntegrationTestCase):
-	"""
-	Integration tests for DuckDBSync.
-	Use this class for testing interactions between multiple components.
-	"""
+	def setUp(self):
+		super().setUp()
+		self.enterContext(self.set_user("test@example.com"))
+		self.todos = []
+		self.sync = None
+		self.schema_created = False
+		self.addCleanup(self.cleanup_sync)
+		for status, priority in (("Open", "High"), ("Closed", "Low")):
+			self.todos.append(
+				frappe.get_doc(
+					doctype="ToDo",
+					description=f"DuckDB {status}: café, 'quotes', and \\slashes at example.com",
+					status=status,
+					priority=priority,
+					date=date(2026, 1, 2),
+				).insert()
+			)
+		# The scanner uses a separate connection and cannot read uncommitted fixtures.
+		frappe.db.commit()
+		self.expected_rows = [
+			(todo.name, todo.description, todo.status, todo.priority, date(2026, 1, 2), todo.owner)
+			for todo in self.todos
+		]
 
-	pass
+	def test_extension_sync_copies_rows_and_marks_completion(self):
+		self.create_sync()
+		self.assert_synced_rows(self.expected_rows)
+
+	def test_postgres_extension_reads_the_configured_schema(self):
+		if frappe.db.db_type != "postgres":
+			self.skipTest("PostgreSQL schemas are not available on MariaDB")
+
+		from psycopg2 import sql
+
+		frappe.db.sql("CREATE SCHEMA duckdb_sync_test")
+		self.schema_created = True
+		frappe.db.sql(
+			sql.SQL('CREATE TABLE duckdb_sync_test."tabToDo" AS TABLE {}."tabToDo"')
+			.format(sql.Identifier(frappe.db.db_schema))
+			.as_string(frappe.db._conn)
+		)
+		frappe.db.sql(
+			'UPDATE duckdb_sync_test."tabToDo" SET description = %s WHERE name = %s',
+			("Only in the configured schema", self.todos[0].name),
+		)
+		frappe.db.commit()
+
+		expected_rows = [
+			(self.todos[0].name, "Only in the configured schema", *self.expected_rows[0][2:]),
+			self.expected_rows[1],
+		]
+		self.create_sync()
+		with patch.dict(frappe.conf, {"db_schema": "duckdb_sync_test"}):
+			self.assert_synced_rows(expected_rows)
+
+	def create_sync(self):
+		settings = frappe.get_doc("System Settings")
+		settings.sync_in_batch = 0
+		settings.save()
+		self.sync = frappe.get_doc(doctype="DuckDB Sync", doc_type="ToDo").insert()
+		self.sync.sync_schema()
+		self.assertTrue(is_data_sync_pending(self.sync.name))
+
+	def assert_synced_rows(self, expected_rows):
+		with patch("frappe.enqueue"):
+			sync_data_to_duckdb(self.sync.name)
+
+		self.assertFalse(is_data_sync_pending(self.sync.name))
+		with closing(get_duckdb(filename=self.sync.filename)) as connection:
+			rows = connection.execute(
+				'FROM "tabToDo" SELECT name, description, status, priority, date, owner WHERE name IN (?, ?)',
+				[todo.name for todo in self.todos],
+			).fetchall()
+			self.assertCountEqual(rows, expected_rows)
+			self.assertEqual(
+				connection.sql('SELECT count(*) FROM "tabToDo"').fetchone()[0], frappe.db.count("ToDo")
+			)
+
+	def cleanup_sync(self):
+		frappe.db.rollback()
+		if self.sync:
+			delete_duckdb_file(self.sync.filename)
+		if self.schema_created:
+			frappe.db.sql("DROP SCHEMA IF EXISTS duckdb_sync_test CASCADE")
+		for todo in self.todos:
+			frappe.delete_doc("ToDo", todo.name, delete_permanently=True)
+		frappe.db.commit()

--- a/frappe/core/doctype/duckdb_sync/test_duckdb_sync.py
+++ b/frappe/core/doctype/duckdb_sync/test_duckdb_sync.py
@@ -1,14 +1,82 @@
 # Copyright (c) 2026, Frappe Technologies and Contributors
 # See license.txt
 
-# import frappe
-from frappe.tests import IntegrationTestCase
+from unittest.mock import patch
+
+import frappe
+from frappe.core.doctype.duckdb_sync.duckdb_sync import get_attach_query
+from frappe.tests import IntegrationTestCase, UnitTestCase
 
 # On IntegrationTestCase, the doctype test records and all
 # link-field test record dependencies are recursively loaded
 # Use these module variables to add/remove to/from that list
 EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+SITE_CONFIG = {
+	"db_user": "site_user",
+	"db_password": "pa'ss\"w\\ord",
+	"db_host": "db.example.com",
+	"db_name": "site_db",
+	"db_port": 6000,
+}
+
+
+def read_dsn(query):
+	"""The connection string the scanner receives, after SQL undoes its own quoting."""
+	literal = query[query.index("'") + 1 : query.rindex("' as ")]
+	return literal.replace("''", "'")
+
+
+def read_dsn_value(dsn, key, quote):
+	"""One value the scanner reads back, after it undoes the backslash escapes."""
+	characters = iter(dsn[dsn.index(f"{key}={quote}") + len(key) + 2 :])
+	value = ""
+	for character in characters:
+		if character == quote:
+			return value
+		value += next(characters) if character == "\\" else character
+	raise ValueError(f"{key} is not terminated")
+
+
+class UnitTestDuckDBSync(UnitTestCase):
+	def get_query(self, db_type, db_schema="public", **overrides):
+		conf = frappe._dict({**SITE_CONFIG, **overrides})
+		database = frappe._dict(db_type=db_type, db_schema=db_schema)
+		with patch.object(frappe.local, "conf", conf), patch.object(frappe.local, "db", database):
+			return get_attach_query()
+
+	def test_postgres_uses_its_own_scanner_and_the_site_schema(self):
+		query = self.get_query("postgres", db_schema="alt_schema")
+		dsn = read_dsn(query)
+
+		self.assertIn("(TYPE postgres, SCHEMA 'alt_schema')", query)
+		self.assertIn("dbname='site_db'", dsn)
+		self.assertIn("port='6000'", dsn)
+
+	def test_mariadb_uses_the_mysql_scanner_with_double_quoted_values(self):
+		query = self.get_query("mariadb")
+		dsn = read_dsn(query)
+
+		self.assertIn("(TYPE mysql)", query)
+		self.assertNotIn("SCHEMA", query)
+		self.assertIn('database="site_db"', dsn)
+		# The MySQL scanner keeps a single quote in the value and cannot read the port.
+		self.assertIn('port="6000"', dsn)
+
+	def test_credentials_survive_the_scanner_and_sql_quoting(self):
+		for db_type, quote in (("postgres", "'"), ("mariadb", '"')):
+			with self.subTest(db_type=db_type):
+				dsn = read_dsn(self.get_query(db_type))
+				self.assertEqual(read_dsn_value(dsn, "password", quote), SITE_CONFIG["db_password"])
+				self.assertEqual(read_dsn_value(dsn, "user", quote), SITE_CONFIG["db_user"])
+
+	def test_host_port_and_user_fall_back(self):
+		dsn = read_dsn(self.get_query("postgres", db_host=None, db_port=None, db_user=None))
+
+		self.assertIn("host='127.0.0.1'", dsn)
+		self.assertIn("port='5432'", dsn)
+		self.assertIn("user='site_db'", dsn)
 
 
 class IntegrationTestDuckDBSync(IntegrationTestCase):

--- a/frappe/core/doctype/duckdb_sync/test_duckdb_sync.py
+++ b/frappe/core/doctype/duckdb_sync/test_duckdb_sync.py
@@ -1,20 +1,18 @@
 # Copyright (c) 2026, Frappe Technologies and Contributors
 # See license.txt
 
-from contextlib import closing
-from datetime import date
 from unittest.mock import patch
 
 import frappe
 from frappe.core.doctype.duckdb_sync.duckdb_sync import (
+	DuckDBSync,
 	get_attach_query,
 	is_data_sync_pending,
 	sync_data_to_duckdb,
 )
-from frappe.database import delete_duckdb_file, get_duckdb
 from frappe.tests import IntegrationTestCase, UnitTestCase
 
-EXTRA_TEST_RECORD_DEPENDENCIES = ["User"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Role", "User"]
 
 SITE_CONFIG = {
 	"db_user": "site_user",
@@ -83,90 +81,53 @@ class UnitTestDuckDBSync(UnitTestCase):
 
 
 class IntegrationTestDuckDBSync(IntegrationTestCase):
-	def setUp(self):
-		super().setUp()
-		self.enterContext(self.set_user("test@example.com"))
-		self.todos = []
-		self.sync = None
-		self.schema_created = False
-		self.addCleanup(self.cleanup_sync)
-		for status, priority in (("Open", "High"), ("Closed", "Low")):
-			self.todos.append(
-				frappe.get_doc(
-					doctype="ToDo",
-					description=f"DuckDB {status}: café, 'quotes', and \\slashes at example.com",
-					status=status,
-					priority=priority,
-					date=date(2026, 1, 2),
-				).insert()
-			)
-		# The scanner uses a separate connection and cannot read uncommitted fixtures.
-		frappe.db.commit()
-		self.expected_rows = [
-			(todo.name, todo.description, todo.status, todo.priority, date(2026, 1, 2), todo.owner)
-			for todo in self.todos
-		]
-
 	def test_extension_sync_copies_rows_and_marks_completion(self):
-		self.create_sync()
-		self.assert_synced_rows(self.expected_rows)
+		import duckdb
+
+		with self.set_user("test@example.com"), duckdb.connect(":memory:") as connection:
+			expected_rows = frappe.get_list(
+				"Role",
+				filters={"name": ["in", ["_Test Role", "_Test Role 4"]]},
+				fields=["name", "role_name", "desk_access", "disabled", "creation", "owner"],
+				as_list=True,
+			)
+			self.assertEqual(len(expected_rows), 2)
+			settings = frappe.get_doc("System Settings")
+			settings.sync_in_batch = 0
+			settings.save()
+			sync = frappe.get_doc(doctype="DuckDB Sync", doc_type="Role").insert()
+
+			# Cursors share the in-memory database and let the sync close its own connection.
+			with patch.object(DuckDBSync, "get_duckdb_conn", side_effect=connection.cursor):
+				sync.sync_schema()
+				self.assertTrue(is_data_sync_pending(sync.name))
+				with patch("frappe.enqueue"):
+					sync_data_to_duckdb(sync.name)
+
+			self.assertFalse(is_data_sync_pending(sync.name))
+			rows = connection.execute(
+				'FROM "tabRole" SELECT name, role_name, desk_access, disabled, creation, owner '
+				"WHERE name IN (?, ?)",
+				["_Test Role", "_Test Role 4"],
+			).fetchall()
+			self.assertCountEqual(rows, expected_rows)
+			self.assertEqual(
+				connection.sql('SELECT count(*) FROM "tabRole"').fetchone()[0], frappe.db.count("Role")
+			)
 
 	def test_postgres_extension_reads_the_configured_schema(self):
 		if frappe.db.db_type != "postgres":
 			self.skipTest("PostgreSQL schemas are not available on MariaDB")
 
-		from psycopg2 import sql
+		import duckdb
 
-		frappe.db.sql("CREATE SCHEMA duckdb_sync_test")
-		self.schema_created = True
-		frappe.db.sql(
-			sql.SQL('CREATE TABLE duckdb_sync_test."tabToDo" AS TABLE {}."tabToDo"')
-			.format(sql.Identifier(frappe.db.db_schema))
-			.as_string(frappe.db._conn)
-		)
-		frappe.db.sql(
-			'UPDATE duckdb_sync_test."tabToDo" SET description = %s WHERE name = %s',
-			("Only in the configured schema", self.todos[0].name),
-		)
-		frappe.db.commit()
-
-		expected_rows = [
-			(self.todos[0].name, "Only in the configured schema", *self.expected_rows[0][2:]),
-			self.expected_rows[1],
-		]
-		self.create_sync()
-		with patch.dict(frappe.conf, {"db_schema": "duckdb_sync_test"}):
-			self.assert_synced_rows(expected_rows)
-
-	def create_sync(self):
-		settings = frappe.get_doc("System Settings")
-		settings.sync_in_batch = 0
-		settings.save()
-		self.sync = frappe.get_doc(doctype="DuckDB Sync", doc_type="ToDo").insert()
-		self.sync.sync_schema()
-		self.assertTrue(is_data_sync_pending(self.sync.name))
-
-	def assert_synced_rows(self, expected_rows):
-		with patch("frappe.enqueue"):
-			sync_data_to_duckdb(self.sync.name)
-
-		self.assertFalse(is_data_sync_pending(self.sync.name))
-		with closing(get_duckdb(filename=self.sync.filename)) as connection:
-			rows = connection.execute(
-				'FROM "tabToDo" SELECT name, description, status, priority, date, owner WHERE name IN (?, ?)',
-				[todo.name for todo in self.todos],
+		with (
+			self.set_user("test@example.com"),
+			duckdb.connect(":memory:") as connection,
+			patch.dict(frappe.conf, {"db_schema": "pg_catalog"}),
+		):
+			connection.sql(get_attach_query())
+			rows = connection.sql(
+				"SELECT nspname FROM source_db.pg_namespace WHERE nspname = 'pg_catalog'"
 			).fetchall()
-			self.assertCountEqual(rows, expected_rows)
-			self.assertEqual(
-				connection.sql('SELECT count(*) FROM "tabToDo"').fetchone()[0], frappe.db.count("ToDo")
-			)
-
-	def cleanup_sync(self):
-		frappe.db.rollback()
-		if self.sync:
-			delete_duckdb_file(self.sync.filename)
-		if self.schema_created:
-			frappe.db.sql("DROP SCHEMA IF EXISTS duckdb_sync_test CASCADE")
-		for todo in self.todos:
-			frappe.delete_doc("ToDo", todo.name, delete_permanently=True)
-		frappe.db.commit()
+			self.assertEqual(rows, [("pg_catalog",)])


### PR DESCRIPTION
DuckDB Sync fails on PostgreSQL when **Sync In Batches** is disabled. The extension path always uses the MySQL scanner and sends MySQL traffic to the PostgreSQL port:

```text
IO Error: Failed to connect to MySQL database
Lost connection to MySQL server at 'reading initial communication packet'
```

Select the scanner from `frappe.db.db_type`. Use PostgreSQL's `dbname` key and configured schema. Respect `db_user` and the standard host, port, and user fallbacks. Quote connection values for each scanner, then quote the complete SQL literal. Use `source_db` as the attachment alias for both engines.

`sync_in_batch` defaults to **1** in System Settings. The batched PyArrow path already supports PostgreSQL. This change fixes the extension path when batching is disabled.

Validation:

- The earlier manual check copied all 693,917 rows from a restored PostgreSQL site.
- Integration tests run as `test@example.com` with its existing permissions. They read framework-managed Role fixtures into an in-memory DuckDB database and check values, timestamps, owners, row counts, and sync completion.
- A PostgreSQL test reads the existing `pg_catalog` schema to verify non-public schema selection.
- PostgreSQL: four unit tests and both integration tests pass.
- MariaDB: four unit tests and the sync integration test pass. The PostgreSQL schema test is skipped.
- Removing the schema option makes the catalog lookup fail. Using PostgreSQL quoting for MySQL makes the sync test fail.
- `pre-commit run --all-files` passes.

Run the tests on a dedicated test site for each engine:

```sh
bench --site <test-site> run-tests --module frappe.core.doctype.duckdb_sync.test_duckdb_sync --skip-before-tests
```
