### PR TITLE
fix(report): resolve custom columns chained off other custom columns

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -342,11 +342,19 @@ def add_custom_column_data(custom_columns, result):
 			doctype_names_from_custom_field.append(doctype_name)
 		column["fieldname"] = column["fieldname"].split("-")[0]
 
-	custom_column_data = get_data_for_custom_report(custom_columns, result)
+	pending_columns = custom_columns
 
-	for column in custom_columns:
-		key = (column.get("doctype"), column.get("fieldname"))
-		if key in custom_column_data:
+	while pending_columns:
+		custom_column_data = get_data_for_custom_report(pending_columns, result)
+		unresolved_columns = []
+
+		for column in pending_columns:
+			key = (column.get("doctype"), column.get("fieldname"))
+			if key not in custom_column_data:
+				# a column linked to another custom column resolves only once that one is filled in
+				unresolved_columns.append(column)
+				continue
+
 			for row in result:
 				link_field = column.get("link_field")
 
@@ -362,6 +370,11 @@ def add_custom_column_data(custom_columns, result):
 				if key[0] in doctype_names_from_custom_field:
 					column["fieldname"] = column.get("id")
 				row[column.get("fieldname")] = custom_column_data.get(key).get(row_reference)
+
+		if len(unresolved_columns) == len(pending_columns):
+			break
+
+		pending_columns = unresolved_columns
 
 	return result
 

--- a/frappe/tests/test_query_report.py
+++ b/frappe/tests/test_query_report.py
@@ -5,7 +5,13 @@ import datetime
 import json
 
 import frappe
-from frappe.desk.query_report import build_xlsx_data, export_query, format_fields, run
+from frappe.desk.query_report import (
+	add_custom_column_data,
+	build_xlsx_data,
+	export_query,
+	format_fields,
+	run,
+)
 from frappe.tests import IntegrationTestCase
 from frappe.utils.xlsxutils import XLSXMetadata, XLSXStyleBuilder, make_xlsx
 
@@ -448,6 +454,24 @@ data = columns, result
 		except Exception as e:
 			raise e
 			frappe.db.rollback()
+
+	def test_custom_column_linked_to_another_custom_column(self):
+		"""Test custom column that looks up its value through another custom column"""
+
+		frappe.set_user("Administrator")
+		todo = frappe.get_doc({"doctype": "ToDo", "description": "Follow up on renewal"}).insert()
+
+		custom_columns = [
+			{"fieldname": "owner", "doctype": "ToDo", "link_field": {"fieldname": "todo", "names": []}},
+			{"fieldname": "email", "doctype": "User", "link_field": {"fieldname": "owner", "names": []}},
+		]
+
+		result = add_custom_column_data(custom_columns, [{"todo": todo.name}])
+
+		self.assertDictEqual(
+			{"todo": todo.name, "owner": "Administrator", "email": "admin@example.com"},
+			result[0],
+		)
 
 	def test_xlsx_styles_structure(self):
 		"""build_xlsx_data with build_styles=True returns a well-formed styles dict"""


### PR DESCRIPTION
## Problem

Custom reports let you add a column that pulls a field from a linked document. You can then add another column that looks up through the column you just added; the value shows up in the browser as soon as you add it, but it is gone the next time the report runs.

`add_custom_column_data` collects the link values for every added column in one go, before any of them are written into the rows. A column pointing at a base report column finds its values. A column pointing at another added column finds nothing, because that column's cells are still empty at the time the lookup runs, so it has no names to fetch and gets skipped without an error.

## Fix

Resolve in passes. Columns that came back empty are retried once the earlier ones have written their values into the rows, and the loop stops as soon as a pass resolves nothing new.

Reports that only go one level deep still finish in a single pass and issue no extra queries.

## Before/After

https://github.com/user-attachments/assets/0c81edd3-4bb5-4824-a637-605403104b64

https://github.com/user-attachments/assets/91d9e211-c084-42df-aa50-ca8a9d2f9acd

---

Closes #42429