### PR TITLE
fix(search): treat page_length=0 as no limit in link search

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -129,6 +129,11 @@ def search_widget(
 			ignore_user_permissions = False
 
 	start = cint(start)
+	page_length = cint(page_length)
+
+	# get_link_options() sends 0 to mean "no limit", but `LIMIT 0` and values[0:0] below mean nothing
+	if page_length <= 0:
+		page_length = PAGE_LENGTH_FOR_LINK_VALIDATION
 
 	if isinstance(filters, str):
 		filters = json.loads(filters)

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -190,6 +190,32 @@ class TestSearch(IntegrationTestCase):
 
 				self.assertEqual(pages, [expected[0:3], expected[3:6], expected[6:9], []])
 
+	def test_page_length_zero_returns_all_options(self):
+		# `frappe.db.get_link_options()` (MultiSelectList filters) sends page_length=0 for "no limit"
+		titles = [f"Search Option {i:02d}" for i in range(1, 13)]
+
+		for translated_doctype in (0, 1):
+			doctype = f"Test Search No Limit {translated_doctype}"
+			if frappe.db.exists("DocType", doctype):
+				frappe.delete_doc("DocType", doctype, force=True)
+			new_doctype(
+				name=doctype,
+				translated_doctype=translated_doctype,
+				autoname="field:title",
+				fields=[{"label": "Title", "fieldname": "title", "fieldtype": "Data"}],
+			).insert()
+			self.addCleanup(partial(frappe.delete_doc, "DocType", doctype, force=True, ignore_missing=True))
+
+			# creating the doctype implicitly commits, so rows can outlive a previous run
+			frappe.db.delete(doctype)
+			for title in titles:
+				frappe.get_doc({"doctype": doctype, "title": title}).insert()
+
+			for query in (None, "frappe.tests.test_search.limited_query"):
+				with self.subTest(translated_doctype=translated_doctype, query=query):
+					results = search_widget(doctype=doctype, txt="", query=query, page_length=0)
+					self.assertEqual(len(results), len(titles))
+
 	def test_validate_and_sanitize_search_inputs(self):
 		# should raise error if searchfield is injectable
 		self.assertRaises(
@@ -835,6 +861,21 @@ def paginated_query(
 		limit_page_length=page_len,
 		as_list=True,
 	)
+
+
+@whitelist_for_tests()
+@frappe.validate_and_sanitize_search_inputs
+def limited_query(
+	doctype: str,
+	txt: str,
+	searchfield: str,
+	start: int,
+	page_len: int,
+	filters: str | list | dict[str, Any],
+):
+	# app level link queries push page_len straight into the SQL limit, where 0 means "no rows"
+	table = frappe.qb.DocType(doctype)
+	return frappe.qb.from_(table).select(table.name).offset(start).limit(page_len).run()
 
 
 def setup_test_link_field_order(TestCase):


### PR DESCRIPTION
`get_link_options()` sends `page_length=0` to mean "no limit" (#42147), but only `frappe.get_list()` reads it that way — raw-SQL link queries get `LIMIT 0` and translated-doctype paging becomes `values[0:0]`, so every `MultiSelectList` filter on a translated doctype (Item Group, Territory, Customer Group) shows "No values to show".
Normalizes `page_length <= 0` to `PAGE_LENGTH_FOR_LINK_VALIDATION` (25k) once in `search_widget` so all three branches agree; this also caps the unbounded full-table fetch `0` currently triggers for non-translated doctypes.
