### PR TITLE
fix(ci): Dereference symlink in pre-build asset packaging

### DIFF
--- a/.github/workflows/build-and-commit-assets.yml
+++ b/.github/workflows/build-and-commit-assets.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Package assets
         working-directory: apps/frappe
-        run: tar czf frappe-assets.tar.gz -C ../../sites/assets/frappe dist
+        run: tar -czhf frappe-assets.tar.gz -C ../../sites/assets/frappe dist
 
       - name: Upload to rolling release
         working-directory: apps/frappe


### PR DESCRIPTION
Else, the tar archive points to some symlink in node_modules, which is non-existent in pre-built assets.