### PR TITLE
fix(print): show Link titles in print previews

### DIFF
--- a/frappe/tests/test_printview.py
+++ b/frappe/tests/test_printview.py
@@ -1,10 +1,57 @@
+from unittest.mock import patch
+
 import frappe
 from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.tests import IntegrationTestCase
 from frappe.www.printview import get_html_and_style
 
+EXTRA_TEST_RECORD_DEPENDENCIES = ["User"]
+
 
 class PrintViewTest(IntegrationTestCase):
+	def test_print_preview_displays_link_titles(self):
+		from frappe.www.printpreview import get_context
+
+		doc, links = self._make_linked_print_doc()
+		custom_format = frappe.get_doc(
+			doctype="Print Format",
+			name=frappe.generate_hash(),
+			doc_type=doc.doctype,
+			custom_format=1,
+			html="""
+				{{ doc.get_formatted('reference') }}
+				{{ doc.entries[0].get_formatted('reference', doc) }}
+			""",
+		).insert()
+		for print_format in ("Standard", custom_format.name):
+			with self.subTest(print_format=print_format):
+				params = frappe._dict(doctype=doc.doctype, name=doc.name, print_format=print_format)
+				with self.set_user("test@example.com"), patch.object(frappe.local, "form_dict", params):
+					context = frappe._dict()
+					get_context(context)
+				self._assert_print_link_titles(context.body, doc, links)
+
+	def test_builder_preview_displays_link_titles(self):
+		from frappe.utils.print_format_generator import (
+			download_builder_preview_pdf,
+			render_builder_preview,
+		)
+		from frappe.www.printview import resolve_print_format
+
+		doc, links = self._make_linked_print_doc()
+		print_format, _ = resolve_print_format("Standard", doc.meta)
+		print_format.pdf_generator = "chrome"
+		with self.set_user("test@example.com"):
+			html = render_builder_preview(print_format.as_dict(), doc.doctype, doc.name)
+			self._assert_print_link_titles(html, doc, links)
+			with (
+				patch("frappe.utils.pdf.get_chrome_pdf", return_value=b"pdf") as render_pdf,
+				patch.object(frappe.local, "response", frappe._dict()),
+			):
+				download_builder_preview_pdf(print_format.as_dict(), doc.doctype, doc.name)
+				self.assertEqual(frappe.local.response.filecontent, b"pdf")
+			self._assert_print_link_titles(render_pdf.call_args.kwargs["html"], doc, links)
+
 	def test_print_view_without_errors(self):
 		user = frappe.get_last_doc("User")
 
@@ -148,3 +195,43 @@ class PrintViewTest(IntegrationTestCase):
 		# without a doctype default it still degrades to the built-in format
 		drop_default()
 		self.assertIsNone(get_print_format_doc("None", frappe.get_meta("Note")))
+
+	def _make_linked_print_doc(self):
+		linked_doctype = new_doctype(title_field="some_fieldname", show_title_field_in_link=1).insert()
+		link_field = {
+			"fieldname": "reference",
+			"label": "Reference",
+			"fieldtype": "Link",
+			"options": linked_doctype.name,
+			"in_list_view": 1,
+		}
+		child_doctype = new_doctype(istable=1, fields=[link_field]).insert()
+		doctype = new_doctype(
+			fields=[
+				link_field,
+				{
+					"fieldname": "entries",
+					"label": "Entries",
+					"fieldtype": "Table",
+					"options": child_doctype.name,
+				},
+			]
+		).insert()
+		links = [
+			frappe.get_doc(doctype=linked_doctype.name, some_fieldname=title).insert()
+			for title in ("Parent Link Title", "Child Link Title")
+		]
+		doc = frappe.get_doc(
+			doctype=doctype.name,
+			reference=links[0].name,
+			entries=[{"reference": links[1].name}],
+		).insert()
+		return doc, links
+
+	def _assert_print_link_titles(self, html, doc, links):
+		for link in links:
+			self.assertIn(link.some_fieldname, html)
+			self.assertNotIn(link.name, html)
+		stored_doc = frappe.get_doc(doc.doctype, doc.name)
+		self.assertEqual(stored_doc.reference, links[0].name)
+		self.assertEqual(stored_doc.entries[0].reference, links[1].name)

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -37,11 +37,10 @@ def download_pdf(
 	letterhead: str | None = None,
 	settings: str | dict | None = None,
 ):
-	from frappe.www.printview import resolve_print_format, set_link_titles, validate_print
+	from frappe.www.printview import resolve_print_format, validate_print
 
 	doc = frappe.get_doc(doctype, name)
 	validate_print(doc)
-	set_link_titles(doc)
 	print_format, is_beta = resolve_print_format(print_format, doc.meta)
 	if not is_beta:
 		# jinja formats have no layout for the generator — hand off to the

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -59,8 +59,6 @@ def get_context(context) -> PrintContext:
 	else:
 		doc = frappe.get_lazy_doc(frappe.form_dict.doctype, frappe.form_dict.name)
 
-	set_link_titles(doc)
-
 	settings = frappe.parse_json(frappe.form_dict.settings)
 
 	letterhead = frappe.form_dict.letterhead or None
@@ -337,7 +335,6 @@ def get_html_and_style(
 	else:
 		document = frappe.get_doc(frappe.parse_json(doc), check_permission=True)
 
-	set_link_titles(document)
 	print_format, is_beta = resolve_print_format(print_format, document.meta)
 
 	if is_beta:
@@ -452,12 +449,13 @@ def validate_print(doc: "Document", print_settings: dict | None = None) -> None:
 
 
 def run_before_print(doc: "Document", print_settings: dict) -> None:
-	"""Flag the document as printing and fire its ``before_print`` hook.
+	"""Prepare Link titles and fire the document's ``before_print`` hook.
 
 	Shared by the legacy template renderer and the builder generator so both
 	prepare the document the same way before rendering."""
 	doc.flags.in_print = True
 	doc.flags.print_settings = print_settings
+	set_link_titles(doc)
 	doc.run_method("before_print", print_settings)
 
 


### PR DESCRIPTION
Print previews showed internal IDs for Link fields with title display enabled. The new preview and builder paths skipped Link title setup.

Move that setup into shared print preparation. Standard and custom previews, builder previews, and PDFs now use the same title lookup. Stored Link IDs stay unchanged.

Validation:
- 8 Frappe print tests passed, including parent and child Link fields as a regular user and title checks on the HTML passed to PDF rendering.
- 8 ERPNext serial/batch print tests passed on MariaDB.
- Confirmed the reported Purchase Receipt preview shows the batch number on PostgreSQL.
- All pre-commit checks passed.
