### PR TITLE
fix: add include filters option to report builder print settings

### DIFF
--- a/frappe/public/js/frappe/form/print_utils.js
+++ b/frappe/public/js/frappe/form/print_utils.js
@@ -5,7 +5,8 @@ frappe.ui.get_print_settings = function (
 	pick_columns,
 	is_query_report = false,
 	title = null,
-	default_print_format = null
+	default_print_format = null,
+	show_include_filters = false
 ) {
 	var print_settings = locals[":Print Settings"]["Print Settings"];
 
@@ -81,7 +82,7 @@ frappe.ui.get_print_settings = function (
 		});
 	}
 
-	if (is_query_report) {
+	if (is_query_report || show_include_filters) {
 		columns.push({
 			label: __("Include filters"),
 			fieldtype: "Check",

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1669,17 +1669,28 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 						rows_in_order.push(total_data);
 					}
 
-					frappe.ui.get_print_settings(false, (print_settings) => {
-						var title = this.report_name || __(this.doctype);
-						frappe.render_grid({
-							title: title,
-							subtitle: this.get_filters_html_for_print(),
-							print_settings: print_settings,
-							columns: this.columns,
-							data: rows_in_order,
-							can_use_smaller_font: 1,
-						});
-					});
+					frappe.ui.get_print_settings(
+						false,
+						(print_settings) => {
+							var title = this.report_name || __(this.doctype);
+							frappe.render_grid({
+								title: title,
+								subtitle: print_settings?.include_filters
+									? this.get_filters_html_for_print()
+									: null,
+								print_settings: print_settings,
+								columns: this.columns,
+								data: rows_in_order,
+								can_use_smaller_font: 1,
+							});
+						},
+						null,
+						null,
+						false,
+						null,
+						null,
+						true
+					);
 				},
 			},
 			{


### PR DESCRIPTION
## What is this change?

Add an "Include Filters" option to Report Builder print settings.

Report Builder prints currently include applied filters by default without giving the user an option to exclude them.

This change allows users to choose whether applied filters should be included in the printed report.

## How did you test it?

Tested manually in Frappe v17:

- Applied filters in Report Builder and printed with "Include filters" checked.
- Verified that the filter summary appears in the printed report.
- Unchecked "Include filters" and printed again.
- Verified that the filter summary is omitted while the filtered report data remains correct.

Also verified:
- Prettier passes.
- ESLint passes.
- `git diff --check` passes.

Closes #42126