### PR TITLE
fix(grid): make child table heading text visible in dark mode

### DIFF
--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -19,7 +19,7 @@
 
 .grid-heading-row {
 	border-bottom: 1px solid var(--table-border-color);
-	color: var(--gray-600);
+	color: var(--text-muted);
 	@include get_textstyle("sm", "regular");
 	height: 32px;
 	padding: 0 !important;


### PR DESCRIPTION
**Before:**

<img width="1330" height="175" alt="image" src="https://github.com/user-attachments/assets/55bf158f-1eb1-481e-ae79-e8eebfd03037" />


**After:**
<img width="1347" height="172" alt="image" src="https://github.com/user-attachments/assets/3822ebe1-606a-466b-9ce5-c9606255a93f" />
