### PR TITLE
fix(datepicker): keep RTL languages from flipping nav arrows

### DIFF
--- a/frappe/public/scss/common/datepicker.scss
+++ b/frappe/public/scss/common/datepicker.scss
@@ -2,7 +2,6 @@
 // minifier dedupes identical legal comments, which would break begin/end pairing.
 /*!rtl:begin:ignore:datepicker*/
 @import "~air-datepicker/dist/css/datepicker.min";
-/*!rtl:end:ignore:datepicker*/
 
 .datepicker {
 	direction: ltr;
@@ -121,3 +120,5 @@
 		}
 	}
 }
+
+/*!rtl:end:ignore:datepicker*/


### PR DESCRIPTION
**Before**
<img width="479" height="366" alt="image" src="https://github.com/user-attachments/assets/e35fb3d6-2f34-43ca-8b3c-6c253f8a1227" />

**Fix**
Extend the rtl:ignore block to cover the entire .datepicker ruleset, since the calendar is meant to always render left-to-right regardless of UI language.

<img width="479" height="366" alt="image" src="https://github.com/user-attachments/assets/93f36348-abbd-402d-9196-fc50ddf43ebd" />


